### PR TITLE
refactor(ops): consolidate the canonical Extra weekly pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,55 +21,39 @@ help:
 	@echo ''
 	@echo 'Usage: make <target> [ENV=local|production]'
 	@echo ''
-	@echo '── Golden Path ───────────────────────────────────────────────────'
-	@echo '  golden-path     Pipeline completo: db-up → bootstrap → crawl'
-	@echo '                 (pncp+pcp+compras_gov) → freshness → reports'
-	@echo '                 (Excel+PDF). Idempotente.'
-	@echo '  golden-path-quick  Igual golden-path mas pula freshness+reports'
-	@echo '                 (via --skip-freshness --skip-reports)'
-	@echo '  GOLDEN_PATH_FLAGS= Passe flags extras para golden_path.py,'
-	@echo '                 ex: make golden-path GOLDEN_PATH_FLAGS="--verbose"'
-	@echo ''
-	@echo '── Pipeline ──────────────────────────────────────────────────────'
-	@echo '  run-pipeline   Executa pipeline completo (bootstrap → crawl →'
-	@echo '                 intel → relatório)'
-	@echo '  run-crawl      Ingestão: crawl PNCP modo full'
-	@echo '  run-report     Relatórios: panorama + Excel'
-	@echo '  report-executivo  Relatorio executivo PDF + Excel (Extra Construtora)'
-	@echo ''
-	@echo '── Ciclo semanal Extra (CANÔNICO) ─────────────────────────────────'
-	@echo '  extra-weekly    Ciclo operacional semanal: collect→process→quality'
-	@echo '                 →intelligence→delivery (manifest+MD+Excel+CSV)'
+	@echo '── PRODUCT (canonical weekly cycle) ─────────────────────────────'
+	@echo '  extra-weekly    ONLY product ops entry for Extra consultive pack'
 	@echo '                 python -m scripts.ops.weekly_cycle --strict'
-	@echo '  WEEKLY_FLAGS=   Flags extras, ex: --force-collect --skip-collect'
+	@echo '  WEEKLY_FLAGS=   Extra flags for weekly_cycle'
 	@echo ''
-	@echo '── Testes ─────────────────────────────────────────────────────────'
-	@echo '  test           Roda testes (exceto slow) com cobertura'
-	@echo '  test-all       Roda todos os testes (inclui slow) com cobertura'
-	@echo '  resilient-smoke       Contrato/fail-closed/checkpoint/DLQ/chaos controlado'
-	@echo '  resilient-local-cycle Ciclo canônico local com fixtures (sem VPS/internet)'
-	@echo '  resilience-gate       Gate completo de prontidão técnica pré-VPS'
+	@echo '── ENGINEERING (not product orchestrator) ───────────────────────'
+	@echo '  verify          Canonical engineering check: lint + weekly tests'
+	@echo '  lint / lint-fix  Ruff check / autofix'
+	@echo '  test / test-all   Pytest suites'
 	@echo ''
-	@echo '── Lint ───────────────────────────────────────────────────────────'
-	@echo '  lint           Verifica lint + formatação (read-only)'
-	@echo '  lint-fix       Corrige lint + formata automaticamente'
+	@echo '── DIAGNOSTIC (not product) ─────────────────────────────────────'
+	@echo '  golden-path / golden-path-quick   Validation pipelines'
+	@echo '  resilient-local-cycle / resilient-smoke / resilience-gate'
 	@echo ''
-	@echo '── Ambiente ───────────────────────────────────────────────────────'
-	@echo '  clean          Remove __pycache__, .pytest_cache, .mypy_cache,'
-	@echo '                 output/runs/*'
-	@echo '  bootstrap      Sobe infra local (idempotente)'
-	@echo '  db-up          Sobe banco PostgreSQL via Docker Compose'
-	@echo '  db-down        Derruba banco PostgreSQL via Docker Compose'
+	@echo '── LEGACY / COMPONENT ───────────────────────────────────────────'
+	@echo '  run-pipeline    LEGACY composite (prefer extra-weekly)'
+	@echo '  run-crawl / run-report / report-executivo'
 	@echo ''
-	@echo '── ENV ────────────────────────────────────────────────────────────'
+	@echo '── Ambiente ─────────────────────────────────────────────────────'
+	@echo '  clean / bootstrap / db-up / db-down'
+	@echo ''
+	@echo '── ENV ──────────────────────────────────────────────────────────'
 	@echo '  current: $(ENV)'
 	@echo '  use: make <target> ENV=production'
+	@echo ''
+	@echo 'Classification: docs/canonical-entry-points.yaml (entrypoint_classification)'
 
 # ── Golden Path ─────────────────────────────────────────────────────────────
 
 .PHONY: golden-path
 golden-path:
-	@echo '==> [$(ENV)] Golden Path — Pipeline de validação completa'
+	@echo '==> [$(ENV)] DIAGNOSTIC golden-path (not product weekly cycle)'
+	@echo '    Class: diagnostic'
 	$(MAKE) db-up
 	$(MAKE) bootstrap
 	python $(SCRIPTS_DIR)/golden_path.py $(GOLDEN_PATH_FLAGS)
@@ -85,7 +69,9 @@ golden-path-quick:
 
 .PHONY: run-pipeline
 run-pipeline:
-	@echo '==> [$(ENV)] Pipeline completo: bootstrap → crawl → intel → relatório'
+	@echo '==> [$(ENV)] LEGACY composite pipeline (NOT Extra product canonical)'
+	@echo '    Prefer: make extra-weekly'
+	@echo '    Class: legacy_composite'
 	$(MAKE) bootstrap
 	$(MAKE) run-crawl
 	python $(SCRIPTS_DIR)/intel_pipeline.py --auto
@@ -103,9 +89,22 @@ run-report:
 
 .PHONY: extra-weekly
 extra-weekly:
-	@echo '==> [$(ENV)] Ciclo semanal canônico Extra Construtora'
+	@echo '==> [$(ENV)] PRODUCT CANONICAL — Extra weekly consultive cycle'
 	@echo '    Entry point: python -m scripts.ops.weekly_cycle --strict'
+	@echo '    Class: product_canonical (see docs/canonical-entry-points.yaml)'
 	python3 -m scripts.ops.weekly_cycle --strict $(WEEKLY_FLAGS)
+
+.PHONY: verify
+verify:
+	@echo '==> [$(ENV)] ENGINEERING verify — not a product orchestrator'
+	@echo '    Class: engineering (lint + weekly unit tests)'
+	ruff check $(SCRIPTS_DIR)/ops/weekly_cycle.py $(SCRIPTS_DIR)/ops/canonical_entry_points.py
+	python3 -m pytest $(TESTS_DIR)/test_weekly_cycle.py -q --tb=line --no-cov
+	@if [ -f $(TESTS_DIR)/architecture/test_weekly_characterization.py ]; then \
+		python3 -m pytest $(TESTS_DIR)/architecture/test_weekly_characterization.py -q --tb=line --no-cov; \
+	fi
+	python3 -m scripts.ops.canonical_entry_points --json >/dev/null
+	@echo '==> verify OK'
 
 .PHONY: report-executivo
 report-executivo:

--- a/docs/canonical-entry-points.yaml
+++ b/docs/canonical-entry-points.yaml
@@ -1,14 +1,48 @@
 # Canonical entry-point contract (DoD §32.1)
 # All tool adapters (CLAUDE.md, AGENTS.md, Cursor rules) MUST reference
 # docs/DEVELOPMENT.md and MUST NOT invent parallel product requirements.
-version: "1.0"
-updated_at: "2026-07-18"
+#
+# ARCH-RESET-2026-07-20 PR C: explicit classification — one product weekly cycle.
+version: "1.1"
+updated_at: "2026-07-20"
 canonical_guide: docs/DEVELOPMENT.md
+product_canonical_command: extra-weekly
+product_canonical_module: scripts.ops.weekly_cycle
+engineering_verify_command: verify
 precedence:
   - DOD.md
   - ADR vigente
   - codigo testado
   - evidencia reproduzivel
+
+# Classes: product_canonical | engineering | diagnostic | legacy_composite | component | campaign_governance
+entrypoint_classification:
+  product_canonical:
+    - make: extra-weekly
+      module: scripts.ops.weekly_cycle
+      note: Only product ops entry for Extra weekly consultive pack
+  engineering:
+    - make: verify
+      note: Lint + weekly unit tests; not a product orchestrator
+    - make: lint
+    - make: test
+  diagnostic:
+    - make: golden-path
+      module: scripts.golden_path
+    - make: golden-path-quick
+    - make: resilient-local-cycle
+    - make: resilient-smoke
+    - make: resilience-gate
+  legacy_composite:
+    - make: run-pipeline
+      note: Prefer extra-weekly for Extra product pack
+  component:
+    - make: run-crawl
+    - make: run-report
+    - make: report-executivo
+  campaign_governance:
+    - command: python3 squads/extra-dod-roi/scripts/cli.py force-next
+      note: DoD ROI campaign; not product weekly
 
 commands:
   setup: |
@@ -16,16 +50,21 @@ commands:
     pip install -r requirements.txt
     python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
   validate: |
-    python3 -m pytest tests/ -q --tb=no -x
-    ruff check scripts/
+    # Engineering path — prefer: make verify
+    make verify
     python3 -m scripts.ops.source_contract_tests --json
+  verify: |
+    # ENGINEERING (not product)
+    make verify
   golden_path: |
+    # DIAGNOSTIC (not product weekly)
     python3 -m scripts.golden_path --dsn "$LOCAL_DATALAKE_DSN"
   weekly: |
-    # CANONICAL weekly operational cycle for Extra Construtora
+    # CANONICAL weekly operational cycle for Extra Construtora (product)
     make extra-weekly
     # equivalent: python3 -m scripts.ops.weekly_cycle --strict
   campaign: |
+    # Campaign governance — not product weekly
     python3 squads/extra-dod-roi/scripts/cli.py force-next
 
 # Substrings that every entry-point adapter must mention (or point to DEVELOPMENT.md)
@@ -35,6 +74,7 @@ required_command_tokens:
   - scripts.ops.apply_migrations
   - force-next
   - LOCAL_DATALAKE_DSN
+  - extra-weekly
 
 required_doc_tokens:
   - DOD.md

--- a/tests/test_entrypoint_classification.py
+++ b/tests/test_entrypoint_classification.py
@@ -1,0 +1,39 @@
+"""ARCH-RESET PR C — entrypoint classification contract."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_product_canonical_is_extra_weekly_only() -> None:
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    assert data["product_canonical_command"] == "extra-weekly"
+    assert data["product_canonical_module"] == "scripts.ops.weekly_cycle"
+    classes = data["entrypoint_classification"]
+    product = classes["product_canonical"]
+    assert len(product) == 1
+    assert product[0]["make"] == "extra-weekly"
+    # competing surfaces must not be product_canonical
+    for row in classes.get("legacy_composite", []) + classes.get("diagnostic", []):
+        assert row.get("make") != "extra-weekly"
+
+
+def test_makefile_has_verify_and_extra_weekly() -> None:
+    mk = (ROOT / "Makefile").read_text(encoding="utf-8")
+    assert re.search(r"^extra-weekly:", mk, flags=re.M)
+    assert re.search(r"^verify:", mk, flags=re.M)
+    assert "scripts.ops.weekly_cycle" in mk
+    assert "PRODUCT CANONICAL" in mk or "product_canonical" in mk
+    assert "LEGACY composite" in mk or "legacy_composite" in mk
+
+
+def test_engineering_verify_not_listed_as_product() -> None:
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    eng = {r.get("make") for r in data["entrypoint_classification"]["engineering"]}
+    assert "verify" in eng
+    prod = {r.get("make") for r in data["entrypoint_classification"]["product_canonical"]}
+    assert "verify" not in prod


### PR DESCRIPTION
## Outcome

Explicit classification of Make/entrypoints: **one product canonical** (`make extra-weekly`), **engineering** (`make verify`), diagnostic/legacy labeled. Weekly cycle implementation unchanged.

## Problem

`golden-path`, `run-pipeline`, and `extra-weekly` all looked like “run the system,” creating dual product narratives.

## Baseline

- Base: `origin/main` `d6d9e19`
- Related: draft PR #54 (baseline), #55 (characterization)

## Scope

### Included
- Makefile help + target class banners
- `make verify` (ruff subset + `test_weekly_cycle` + entry-point contract)
- `docs/canonical-entry-points.yaml` v1.1 + `entrypoint_classification`
- `tests/test_entrypoint_classification.py`

### Excluded
- Removing legacy targets (still present; reclassified)
- OSS / dbt / decision rules / DoD flips
- Merges of #48–#53

## Architecture

Supports ADR-023 one-product-pipeline goal via Branch-by-Abstraction (classification first, deletion later).

## Before / After

| | Before | After |
|--|--------|-------|
| Product entry | Ambiguous among several Make targets | **extra-weekly only** as product_canonical |
| Engineering check | ad-hoc | **make verify** |
| run-pipeline | Looked full product | **legacy_composite** banner |
| golden-path | Looked full product | **diagnostic** banner |

## DOD impact

None flipped. Aligns toward single pipeline honesty.

## Validation

```bash
make verify
# ruff OK; 24 passed weekly unit (+1 skip); entry-point contract ok
python3 -m pytest tests/test_entrypoint_classification.py tests/test_weekly_cycle.py -q --tb=line --no-cov
# 27 passed, 1 skipped
```

## Evidence

Commands above.

## Dependencies and licensing

None.

## Migration

Operators use `make extra-weekly` for product; `make verify` for engineering. Legacy targets remain until cleanup PR.

## Rollback

`git revert` single commit / close draft.

## Allowed claims

- Entrypoints classified; engineering verify added

## Forbidden claims

- LOCAL_READY / 95% / VPS / full architecture reset complete

## Review recommendation

**DRAFT** → READY_FOR_HUMAN_REVIEW after CI.