### PR TITLE
docs: reconcile canonical docs with ARCH-RESET architecture decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — Extra Consultoria
 
+## [Unreleased] — ARCH-RESET-2026-07-20
+
+- Campanha de reset arquitetural: baseline, entrypoints, spikes OCDS/quality/EGHJ, prova live semanal limitada.
+- Draft PRs #54–#60; decisões em ADRs 023–029 (quando mergeadas).
+- **Sem** selos LOCAL_READY / 95% / VPS_OPERATIONAL.
+
+
 Formato baseado em [Keep a Changelog](https://keepachangelog.com/).  
 O histórico de git (`git log`) permanece a fonte de verdade de commits; este arquivo resume marcos operacionais.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Extra Consultoria — Inteligência em Licitações
 
+> **Arquitetura (2026-07-20):** monólito modular local-first · produto semanal `make extra-weekly` ·  
+> campanha `ARCH-RESET-2026-07-20` em `docs/ops/campaigns/ARCH-RESET-2026-07-20/` ·  
+> overview `docs/architecture/overview.md`. **Sem claims** de LOCAL_READY / cobertura 95%.
+
+
 Plataforma CLI de consultoria estratégica para licitações públicas.
 Single-client: Extra Construtora.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -54,6 +54,12 @@ make extra-weekly
 # equivalente:
 python3 -m scripts.ops.weekly_cycle --strict
 # flags úteis: WEEKLY_FLAGS="--force-collect" | "--skip-collect" | "--lookback-days 7"
+#
+# Engenharia (não substitui o ciclo de produto; ver PR ARCH-RESET #56):
+# make verify
+#
+# Arquitetura-alvo (1 página): docs/architecture/overview.md
+# Campanha: docs/ops/campaigns/ARCH-RESET-2026-07-20/FINAL-REPORT.md
 
 # Coverage / operational outputs (componentes internos)
 python3 -m scripts.reports.operational_outputs --dsn "$LOCAL_DATALAKE_DSN" --out output/ops-lists --json

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,57 @@
+# Architecture overview — Extra Consultoria
+
+**Status:** canônico (pós ARCH-RESET-2026-07-20, sujeito a merge das PRs da campanha)  
+**Baseline main inspected:** `d6d9e19`
+
+## One-page target
+
+```text
+Sources (PNCP, portals…)
+        │ collect
+        ▼
+ PostgreSQL 16  (operational truth)
+        │
+        ▼
+ normalize → reconcile → quality → intelligence → decision → delivery
+        │
+        ▼
+ make extra-weekly  →  MD + CSV + Excel (+ PDF residual)  · shared run_id
+```
+
+**Engineering (not product):** `make verify` (when PR #56 merged) · pytest · ruff · source contracts.
+
+## Canonical product entry
+
+| Class | Command | Module |
+|-------|---------|--------|
+| **product_canonical** | `make extra-weekly` | `scripts.ops.weekly_cycle` |
+| diagnostic | `make golden-path` | `scripts.golden_path` |
+| legacy_composite | `make run-pipeline` | Makefile composite |
+| campaign_governance | `force-next` | `squads/extra-dod-roi` |
+
+Contract file: `docs/canonical-entry-points.yaml` (v1.1+ when PR #56 lands).
+
+## Non-goals
+
+- Kubernetes / Kafka / Redis-required / Airflow / microservices  
+- Second canonical database  
+- LLM authority over coverage, freshness, identity, money, legal status  
+- Auto-merge of PRs  
+
+## Key ADRs (campaign)
+
+| ADR | Topic |
+|-----|--------|
+| ADR-023 | Architecture reset campaign charter |
+| ADR-024 | OCDS as semantic reference (not physical model) |
+| ADR-025 | Canonical Python/SQL quality contract |
+| ADR-026 | dbt snapshots rejected for ops core |
+| ADR-027 | Keep document parser stack |
+| ADR-028 | Deterministic identity first; Splink deferred |
+| ADR-029 | Keep openpyxl + ReportLab |
+
+Full index: `docs/architecture/adr/INDEX.md`.
+
+## Campaign evidence root
+
+`docs/ops/campaigns/ARCH-RESET-2026-07-20/`

--- a/docs/ops/NEXT-DEV-STEP.md
+++ b/docs/ops/NEXT-DEV-STEP.md
@@ -1,29 +1,43 @@
 # Próximo passo de desenvolvimento (sem reconstruir contexto)
 
-**Atualizado:** 2026-07-18  
-**Branch épica:** `epic/advance-30d-local-ready-20260718`  
-**Campanha:** ADVANCE-30D-LOCAL-READY
+**Atualizado:** 2026-07-20  
+**Campanha arquitetural ativa:** `ARCH-RESET-2026-07-20`  
+**Relatório:** `docs/ops/campaigns/ARCH-RESET-2026-07-20/FINAL-REPORT.md`  
+**Overview:** `docs/architecture/overview.md`
 
-## Comando único
+## Prioridade humana (merge queue)
+
+1. Revisar/mergear draft PRs **#54 → #55 → #56** (baseline, tests, entrypoints).  
+2. Revisar spikes **#57 #58 #60** e evidência live **#59**.  
+3. Decidir **#52** (decision loop MERGE_CANDIDATE) vs **#53** (ledger thin).  
+4. Manter CTO stack **#48–#51** fora do caminho de produto até decisão explícita.
+
+## Comandos de produto / engenharia
 
 ```bash
+# Produto consultivo semanal (canônico)
+make extra-weekly
+
+# Engenharia (quando PR #56 em main)
+make verify
+
+# Ranking DoD ROI (governança de campanha, não pipeline de produto)
 python3 squads/extra-dod-roi/scripts/cli.py force-next
 ```
-
-Isso re-rankeia, materializa a story AIOX Draft do `ranking[0]` e bloqueia implementação até `@po` Ready.
 
 ## Estado honesto
 
 | Item | Estado |
 |------|--------|
-| Cobertura operacional | **0%** (meta 95%) — prioridade de produto |
+| Arquitetura-alvo | Decidida (ADR-023+); implementação em draft PRs |
+| Cobertura operacional 95% | **NÃO claimada** |
 | LOCAL_READY | **NOT_READY** |
-| PG local (extra-test-db) | porta 5433; schema ainda precisa de migrations completas |
-| DOE-SC / VPS pay / aceite Tiago | **BLOCKED_EXTERNAL** / humano |
+| Live weekly (limitado) | **Prova em #59** (exit 0, 1 opp; contratos degradados) |
+| Suíte completa global | **Debt** (SKIPPED≠verde) |
 
 ## Artefatos
 
-- Scorecard: `squads/extra-dod-roi/state/campaigns/advance-30d-20260718/scorecard.json`
-- Manifesto: `.../MANIFEST.md`
+- Campanha: `docs/ops/campaigns/ARCH-RESET-2026-07-20/`
 - Glossário: `docs/GLOSSARY.md`
 - Changelog: `CHANGELOG.md`
+- Entry points: `docs/canonical-entry-points.yaml`

--- a/docs/ops/campaigns/ARCH-RESET-2026-07-20/FINAL-REPORT.md
+++ b/docs/ops/campaigns/ARCH-RESET-2026-07-20/FINAL-REPORT.md
@@ -1,0 +1,66 @@
+# FINAL-REPORT — ARCH-RESET-2026-07-20
+
+**Campaign verdict:** `PARTIAL_WITH_BLOCKERS` (human merge queue)  
+**Main baseline:** `d6d9e1984e348d64a669546613e192e4ebf610cd`
+
+## Architecture decision
+
+Keep **modular monolith**, local-first, PostgreSQL 16, CLI/Make.  
+Single product weekly pipeline: **`make extra-weekly`**.  
+OSS adopted only when proven; most external recommendations rejected or deferred.
+
+## OSS scoreboard
+
+| Component | Decision |
+|-----------|----------|
+| OCDS | ADOPT_AS_REFERENCE |
+| Quality contract | ADOPT_PYTHON_SQL_NATIVE |
+| dbt snapshots | REJECTED_SPIKE |
+| Soda dual path | REJECT now |
+| Splink | REJECTED_SPIKE_FOR_NOW |
+| PyMuPDF | AGPL gate — not adopted |
+| XlsxWriter / fpdf2 | REFERENCE_ONLY — keep openpyxl+ReportLab |
+| rule-engine | REJECT now — reuse PR #52 |
+
+## Campaign draft PRs (open)
+
+| PR | Role |
+|----|------|
+| #54 | Baseline + disposition + ADR-023 |
+| #55 | Characterization tests |
+| #56 | Entrypoint classify + verify |
+| #57 | OCDS spike |
+| #58 | Quality spike |
+| #59 | Live weekly proof + #52 eval |
+| #60 | Spikes E/G/H/J |
+
+## Existing product PRs
+
+| PR | Disposition |
+|----|-------------|
+| #52 | MERGE_CANDIDATE (decision loop) |
+| #53 | REBASE_AND_REDUCE (ledger) |
+| #48–#51 | KEEP_DRAFT / SUPERSEDE (CTO stack) |
+
+## Live proof summary
+
+- Live cycle `weekly-20260720T123303Z-da1515c9a6` exit **0**, 1 opportunity, contracts degraded (429/503).  
+- Human accept: PENDING_HUMAN.  
+- No LOCAL_READY / 95% claims.
+
+## Human merge order
+
+1. #54 → #55 → #56  
+2. #57 · #58 · #60 (parallel)  
+3. #59  
+4. #52 after suite honesty  
+5. thin #53  
+6. cleanup later  
+
+## Residual blockers
+
+- Draft PRs not merged to main  
+- Full suite global debt  
+- Coverage still not 95%  
+- Contracts source health degraded  
+- Docs on main still pre-campaign until merges

--- a/docs/ops/campaigns/ARCH-RESET-2026-07-20/STATUS.md
+++ b/docs/ops/campaigns/ARCH-RESET-2026-07-20/STATUS.md
@@ -1,0 +1,11 @@
+# STATUS — ARCH-RESET-2026-07-20
+
+| Field | Value |
+|-------|--------|
+| Verdict | **PARTIAL_WITH_BLOCKERS** |
+| Baseline SHA | `d6d9e19` |
+| Live weekly | Evidence in PR #59 |
+| OSS production adoptions | **None** (OCDS reference + quality IDs only) |
+| Human queue | Merge #54–#60; decide #52/#53; park #48–#51 |
+
+See `FINAL-REPORT.md`.

--- a/tests/test_arch_reset_docs_pointers.py
+++ b/tests/test_arch_reset_docs_pointers.py
@@ -1,0 +1,21 @@
+"""Ensure architecture rebaseline pointers exist (ARCH-RESET docs PR)."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_overview_and_campaign_exist() -> None:
+    assert (ROOT / "docs/architecture/overview.md").is_file()
+    assert (ROOT / "docs/ops/campaigns/ARCH-RESET-2026-07-20/FINAL-REPORT.md").is_file()
+
+
+def test_development_points_to_extra_weekly() -> None:
+    text = (ROOT / "docs/DEVELOPMENT.md").read_text(encoding="utf-8")
+    assert "extra-weekly" in text
+    assert "weekly_cycle" in text
+
+
+def test_next_dev_step_mentions_arch_reset() -> None:
+    text = (ROOT / "docs/ops/NEXT-DEV-STEP.md").read_text(encoding="utf-8")
+    assert "ARCH-RESET-2026-07-20" in text
+    assert "LOCAL_READY" in text


### PR DESCRIPTION
## Outcome

Canonical documentation pointers aligned with **ARCH-RESET-2026-07-20** (overview, FINAL-REPORT, NEXT-DEV-STEP, DEVELOPMENT, README, CHANGELOG). **No DoD checkbox mass flips.**

## Problem

Main docs still describe older campaigns as the primary “next step” while architecture decisions live in draft PRs.

## Scope

### Included
- `docs/architecture/overview.md`
- Campaign STATUS + FINAL-REPORT
- NEXT-DEV-STEP rewrite
- Thin DEVELOPMENT/README/CHANGELOG pointers
- Consistency tests

### Excluded
- Merging code PRs
- Full AGENTS/CLAUDE rewrite of AIOX protocol
- DoD requirement deletions

## Validation

```bash
python3 -m pytest tests/test_arch_reset_docs_pointers.py -q
# 3 passed
```

## Forbidden claims

LOCAL_READY / 95% / VPS / architecture fully landed on main (still draft queue)

## Review recommendation

**DRAFT** — ideally after or with #54–#56