### PR TITLE
feat(coverage): entity freshness by capability + strict weekly fail-closed

### DIFF
--- a/DOD.md
+++ b/DOD.md
@@ -30,7 +30,7 @@
 - [x] Testes críticos deste ciclo: **74 passed**; golden path estrito PCP: `gp-20260717-102949`, exit code 0, 184 fetched, 7 inserted. O golden path PNCP falhou por timeout e permanece evidência de source health degradado.
 - [x] CI obrigatório da PR #10 verde: ruff, mypy, testes críticos, bandit e pip-audit. Evidência: GitHub Actions run `29585067851`, merge commit `d2d66d725849ab5be3a534aa085775be50cbd702`.
 - [ ] Suíte global completa verde. O workflow marcou `Test All (full suite)` como `skipped`; a execução local ampla encontrou dívida de ambiente/schema em views canônicas e testes dependentes de banco.
-- [ ] Freshness coverage mensurável por entidade dentro dos SLAs.
+- [x] Freshness coverage mensurável por entidade dentro dos SLAs. Evidência: campanha `ENTITY-FRESHNESS-01` · `output/coverage/freshness-editais.json` + `freshness-contracts.json` (1.093 entity_ids únicos cada; capability explícita; SLA `coverage-sla-v1`) · engine `scripts/coverage/freshness_by_entity.py` mapeia `pipeline_evidence_promote` (run_id/raw_sha256/last_seen_at) por capability · migration `058_entity_source_binding_capability` (Option A) · ADR-028 · strict fail-closed · `docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/` · observado as_of 2026-07-20: editais FRESH=0/STALE=408/NEVER=685; contratos FRESH=365/NEVER=728 (**sem claim de 95%**).
 - [ ] Recall independente e estratificado ≥95%.
 - [ ] Cobertura operacional ≥95% (mínimo **1.039/1.093** entidades).
 

--- a/config/coverage_slas.yaml
+++ b/config/coverage_slas.yaml
@@ -1,13 +1,25 @@
 # Coverage contract SLA windows — configurable per evidence class.
-# Used by scripts/coverage/coverage_contract.py for freshness and
-# operational_source_coverage. Do NOT hardcode these values in callers.
+# Used by scripts/coverage/coverage_contract.py and
+# scripts/coverage/freshness_by_entity.py. Do NOT hardcode in callers.
 #
 # Keys:
 #   *_hours  — rolling window in hours from as_of
 #   *_days   — rolling window in days from as_of
+#   sla_version — stamped into entity freshness reports (ADR-028)
+
+sla_version: "coverage-sla-v1"
 
 open_opportunities_hours: 24
 official_diaries_hours: 24
 contracts_amendments_hours: 72
 historical_consolidated_days: 7
 cadastral_data_days: 30
+
+# Capability → SLA key mapping (entity-level freshness)
+capabilities:
+  notices_or_bids:
+    sla_id: "sla.notices_or_bids.open_opportunities"
+    hours_key: open_opportunities_hours
+  contracts:
+    sla_id: "sla.contracts.amendments"
+    hours_key: contracts_amendments_hours

--- a/db/migrations/058_entity_source_binding_capability.sql
+++ b/db/migrations/058_entity_source_binding_capability.sql
@@ -1,0 +1,110 @@
+-- ============================================================================
+-- Migration 058: Entity Source Binding with capability (Option A)
+-- ============================================================================
+-- Purpose: Capability-aware entity↔source bindings for freshness and coverage.
+-- Distinguishes at least notices_or_bids vs contracts per entity-source pair.
+--
+-- Decision (ENTITY-FRESHNESS-01 Architecture/Data Squad): Option A —
+-- capability column on binding with UNIQUE (canonical_id, source_id, capability).
+-- Smaller than redesigning entity_source_registry (053); preserves history;
+-- allows multiple capabilities per entity-source without event bus.
+--
+-- Dependencies: 053_entity_source_registry (soft — no hard FK to allow seed-first)
+-- Rollback: DROP TABLE IF EXISTS public.entity_source_binding;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.entity_source_binding (
+    id                      BIGSERIAL PRIMARY KEY,
+
+    -- Identity (canonical_id aligns with entity_source_registry)
+    canonical_id            TEXT NOT NULL,
+    source_id               TEXT NOT NULL,
+    capability              TEXT NOT NULL
+                            CHECK (capability IN (
+                                'notices_or_bids',
+                                'contracts'
+                            )),
+
+    -- Applicability / access
+    applicability           TEXT NOT NULL DEFAULT 'unknown'
+                            CHECK (applicability IN (
+                                'applicable',
+                                'not_applicable',
+                                'unknown'
+                            )),
+    acquisition_method      TEXT NOT NULL DEFAULT 'unknown'
+                            CHECK (acquisition_method IN (
+                                'api', 'html', 'pdf', 'ckan', 'manual', 'none', 'unknown'
+                            )),
+    portal_url              TEXT,
+    external_org_id         TEXT,
+    confidence              DOUBLE PRECISION NOT NULL DEFAULT 0.0
+                            CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    -- Operational / freshness denormalized hints (source of truth is evidence)
+    status                  TEXT NOT NULL DEFAULT 'active'
+                            CHECK (status IN (
+                                'active', 'blocked', 'deprecated'
+                            )),
+    last_attempt_at         TIMESTAMPTZ,
+    last_success_at         TIMESTAMPTZ,
+    last_verified_at        TIMESTAMPTZ,
+    current_blocker         TEXT,
+    next_action             TEXT NOT NULL DEFAULT 'review_binding',
+    evidence_ref            TEXT,
+    notes                   TEXT,
+
+    -- Audit
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uq_entity_source_binding_cap
+        UNIQUE (canonical_id, source_id, capability)
+);
+
+CREATE INDEX IF NOT EXISTS idx_esb_canonical
+    ON public.entity_source_binding (canonical_id);
+
+CREATE INDEX IF NOT EXISTS idx_esb_source
+    ON public.entity_source_binding (source_id);
+
+CREATE INDEX IF NOT EXISTS idx_esb_capability
+    ON public.entity_source_binding (capability);
+
+CREATE INDEX IF NOT EXISTS idx_esb_applicability
+    ON public.entity_source_binding (applicability);
+
+CREATE INDEX IF NOT EXISTS idx_esb_status
+    ON public.entity_source_binding (status);
+
+COMMENT ON TABLE public.entity_source_binding IS
+    'Capability-aware entity↔source binding (ADR-028 Option A). '
+    'Unique on (canonical_id, source_id, capability).';
+
+COMMENT ON COLUMN public.entity_source_binding.capability IS
+    'notices_or_bids | contracts — dual metric; never conflate';
+
+COMMENT ON COLUMN public.entity_source_binding.applicability IS
+    'applicable | not_applicable | unknown — unknown ≠ covered';
+
+CREATE OR REPLACE FUNCTION public.entity_source_binding_touch_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_entity_source_binding_updated_at
+    ON public.entity_source_binding;
+
+CREATE TRIGGER trg_entity_source_binding_updated_at
+    BEFORE UPDATE ON public.entity_source_binding
+    FOR EACH ROW
+    EXECUTE FUNCTION public.entity_source_binding_touch_updated_at();
+
+COMMIT;

--- a/docs/architecture/adr/ADR-028-entity-freshness-by-capability.md
+++ b/docs/architecture/adr/ADR-028-entity-freshness-by-capability.md
@@ -1,0 +1,106 @@
+# ADR-028 — Entity Freshness by Capability
+
+| Campo | Valor |
+|-------|-------|
+| **Status** | Accepted |
+| **Data** | 2026-07-20 |
+| **Decisores** | Architecture Squad, Data Squad, QA Squad, Product Squad |
+| **Campanha** | ENTITY-FRESHNESS-01 |
+| **Relacionados** | ADR-018, ADR-019, ADR-020, ADR-021 |
+
+---
+
+## Contexto
+
+O DOD exige: *“Freshness coverage mensurável por entidade dentro dos SLAs.”*
+
+Estado anterior:
+
+- `scripts.freshness_gate` e freshness de `weekly_cycle` operam **por fonte** (MAX `ingested_at`).
+- `scripts.coverage.entity_freshness` classifica entidade com status restrito (`fresh|stale|never`) e **não** separa editais vs contratos.
+- `MAX(ingested_at)` global ou por fonte **não** prova freshness de cada uma das 1.093 entidades.
+
+## Decisão
+
+### 1. Freshness é por (entity_id, capability)
+
+Capabilities canônicas:
+
+| capability | Relatório | SLA default |
+|------------|-----------|-------------|
+| `notices_or_bids` | `output/coverage/freshness-editais.json` | `open_opportunities_hours` (24h) |
+| `contracts` | `output/coverage/freshness-contracts.json` | `contracts_amendments_hours` (72h) |
+
+### 2. List identity
+
+Cada relatório deve conter **exatamente** `EXPECTED_UNIVERSE = 1093` `entity_id` distintos:
+
+- `covered + uncovered = 1093`
+- zero duplicatas
+- 1092 ou 1094 → falha fechada
+
+### 3. Estados permitidos
+
+```
+FRESH | STALE | NEVER | INCOMPLETE | BLOCKED | NOT_APPLICABLE | UNKNOWN
+```
+
+Regras fail-closed:
+
+- `UNKNOWN`, `NEVER`, `BLOCKED`, `INCOMPLETE` **nunca** promovem a `FRESH`
+- Linha sem proveniência (`run_id` + `content_hash` + timestamp verificável) **nunca** é `FRESH`
+- `age_hours` ausente permanece `null` (não vira 0)
+- Timestamp futuro → `INCOMPLETE` (não `FRESH`)
+- `NOT_APPLICABLE` fora do numerador de freshness
+
+### 4. Proveniência obrigatória por linha
+
+Campos mínimos: `entity_id`, `capability`, `source_id` ou ausência explícita, `applicability`,
+`last_attempt_at`, `last_success_at`, `last_verified_at`, `sla_id`, `sla_hours`, `age_hours`,
+`freshness_status`, `run_id`, `raw_uri`/`artifact_ref`, `content_hash`, `blocker`,
+`next_action`, `as_of`, `adapter_version`.
+
+### 5. SLA versionado
+
+`config/coverage_slas.yaml` carrega `sla_version`. Relatórios carimbam `sla_version` e `sla_id`.
+
+### 6. ESR capability (Opção A)
+
+Tabela `entity_source_binding` com coluna `capability` e UNIQUE
+`(canonical_id, source_id, capability)`. Permite múltiplas capabilities por entidade-fonte
+sem redesenhar `entity_source_registry` (053).
+
+### 7. Path canônico
+
+- Engine: `scripts.coverage.freshness_by_entity`
+- Operacional: `scripts.ops.weekly_cycle` (strict rejeita relatórios incompletos)
+- Workspace permanece fachada
+
+## Alternativas rejeitadas
+
+| Alternativa | Motivo |
+|-------------|--------|
+| Freshness só por fonte | Não atende DOD “por entidade” |
+| Tabela filha `entity_source_capability` (Opção B) | Extra hop sem ganho; Opção A cobre multi-cap |
+| Framework genérico / event bus | Fora do raio; YAGNI |
+| Promover com MAX global | Falso positivo massivo |
+
+## Consequências
+
+- Relatórios nominais com gaps explícitos (blocker + next_action)
+- Strict mode passa a exigir dual report completo
+- Percentual observado pode ser registrado sem claim de 95%
+
+## Critérios de aceite
+
+- [x] Dual report 1093×2 com list identity
+- [x] Status set + proveniência fail-closed
+- [x] Testes adversariais
+- [x] Strict rejeita incompleto
+- [x] Item DOD de mensurabilidade fechado com evidência (sem 95%)
+
+## Referências
+
+- `docs/ops/campaigns/ENTITY-FRESHNESS-01/`
+- `scripts/coverage/freshness_by_entity.py`
+- `db/migrations/058_entity_source_binding_capability.sql`

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -11,6 +11,7 @@
 | ADR-020 | Operational data not in git | **Vigente** |
 | ADR-021 | Adapter architecture PNCP 429 fail-closed | **Vigente** |
 | ADR-022 | Client profile sole commercial law | **Vigente** |
+| ADR-028 | Entity freshness by capability | **Vigente** (ENTITY-FRESHNESS-01) |
 
 ## ADRs revogadas / supersedidas
 

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/HANDOFF-FINAL.md
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/HANDOFF-FINAL.md
@@ -1,0 +1,105 @@
+# HANDOFF-FINAL — ENTITY-FRESHNESS-01
+
+| Campo | Valor |
+|-------|-------|
+| **Campanha** | ENTITY-FRESHNESS-ACCEPTANCE-SPINE-01 |
+| **Status** | **SUCCESS** (mensurabilidade fechada) |
+| **Data** | 2026-07-20 |
+| **Branch base** | `fix/weekly-strict-fail-closed` (PR #63 fail-closed reutilizado) |
+| **Migration** | `058_entity_source_binding_capability` |
+| **ADR** | ADR-028 (vigente) |
+
+## Resultado mensurável
+
+| Artefato | entity_ids únicos | covered+uncovered | capability | Status (as_of 2026-07-20) |
+|----------|-------------------|-------------------|------------|---------------------------|
+| `output/coverage/freshness-editais.json` | **1093** | covered+uncovered=1093 | `notices_or_bids` | FRESH=0 · STALE=408 · NEVER=685 |
+| `output/coverage/freshness-contracts.json` | **1093** | covered+uncovered=1093 | `contracts` | FRESH=365 · NEVER=728 |
+
+- List identity: **ok** em ambos (`evidence/list-identity.json`)
+- Status set: FRESH/STALE/NEVER/INCOMPLETE/BLOCKED/NOT_APPLICABLE/UNKNOWN
+- Proveniência: `pipeline_evidence_promote` → `run_id` / `raw_sha256` / `last_seen_at` / `raw_uri` por entidade
+- Separação observation-level: fontes `pncp` (editais) vs `pncp_contracts` (contratos) — não só label de SLA
+- SLA: `coverage-sla-v1` (editais 24h / contratos 72h)
+- **Sem claim de freshness ≥95%** (contratos ~33% FRESH é observação, não meta fechada)
+
+## Decisões de squad (Fase Zero)
+
+1. **ESR capability = Opção A** — coluna `capability` em `entity_source_binding` com UNIQUE `(canonical_id, source_id, capability)`.
+2. **PR #63** reutilizada seletivamente (fail-closed weekly); sem merge wholesale #54–#64.
+3. **Engine puro** em `scripts/coverage/freshness_by_entity.py` (sem DB para classificação adversarial).
+4. **DOD**: apenas o item de mensurabilidade de freshness marcado.
+
+## Aceite (checklist)
+
+1. [x] Dois relatórios existem
+2. [x] 1.093 entity_ids únicos cada
+3. [x] covered + uncovered = 1.093
+4. [x] Sem duplicidades
+5. [x] Capability explícita
+6. [x] SLA versionado
+7. [x] Cálculo por entidade (não só fonte/tabela)
+8. [x] `MAX(ingested_at)` global não promove entidades
+9. [x] Ausência não vira zero/FRESH
+10. [x] Determinístico para mesmos inputs
+11. [x] Testes adversariais passam
+12. [x] Strict rejeita relatórios incompletos
+13. [x] Gates locais verdes (pytest/ruff/bandit/pip-audit)
+14. [x] DOD/ADR/HANDOFF atualizados com evidência
+
+## Claims
+
+**Permitidos**
+
+- freshness é mensurável por entidade
+- 1.093 entidades estão representadas
+- editais e contratos são separados
+- estado observado e gaps são nominais
+- modo strict falha fechado
+
+**Proibidos (não reivindicados)**
+
+- cobertura operacional ≥95%
+- freshness ≥95%
+- recall ≥95%
+- LOCAL_READY / VPS_OPERATIONAL / PROJECT_DONE
+- proxy de presença como cobertura operacional
+- MAX(ingested_at) global como freshness das 1.093 entidades
+
+## Comandos de verificação
+
+```bash
+python -m pytest tests/test_weekly_cycle.py -q --no-cov
+python -m pytest tests/test_freshness_by_entity.py -q --no-cov
+python -m pytest tests/ -k "freshness or source_registry or weekly_cycle" -q --no-cov
+python -m scripts.coverage.freshness_by_entity --strict
+ruff check scripts/coverage/freshness_by_entity.py scripts/source_registry/bindings.py scripts/ops/weekly_cycle.py
+```
+
+## Arquivos principais
+
+- `scripts/coverage/freshness_by_entity.py` (engine)
+- `scripts/source_registry/bindings.py` + `db/migrations/058_*.sql`
+- `scripts/ops/weekly_cycle.py` (strict + dual report gate)
+- `docs/architecture/adr/ADR-028-entity-freshness-by-capability.md`
+- `docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/*`
+
+## Skeptic remediation (2026-07-20 re-pass)
+
+| Gap | Fix |
+|-----|-----|
+| `last_success_at` dropado sem override | `observation_from_registry_row` usa promote + fallback capability-aware |
+| promote evidence não mapeada | `_extract_capability_evidence` lê run_id/raw_sha256/raw_uri/last_seen_at |
+| dual report só SLA-label | filtro de `sources` por capability (pncp vs pncp_contracts) |
+| migration só texto | `evidence/esr-capability-validation.json` + `{SCRATCH}/esr_capability.log` (DSN down → structural PASS honesto) |
+
+## Próximos passos (fora desta campanha)
+
+- Coletar/evidenciar por entidade para reduzir NEVER/STALE (sem reabrir este item como “95%”)
+- Campanhas separadas para cobertura operacional 95% e recall ≥95%
+- Merge da PR #63 + esta branch após review humano / CI remoto
+- Aplicar migration 058 quando LOCAL_DATALAKE_DSN estiver up
+
+## Revisão manual registrada
+
+Implementação e gates locais executados na sessão 2026-07-20 (incl. re-pass pós-skeptic). Wave 1 fail-closed validada. Dual reports regeneráveis via CLI com proveniência real. Parar em SUCCESS — **não** iniciar trabalho de cobertura 95% nesta campanha.

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/PLAN.md
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/PLAN.md
@@ -1,0 +1,62 @@
+# ENTITY-FRESHNESS-01 — Campaign Plan
+
+| Campo | Valor |
+|-------|-------|
+| **ID** | ENTITY-FRESHNESS-ACCEPTANCE-SPINE-01 |
+| **Base** | `origin/main` + branch `fix/weekly-strict-fail-closed` (PR #63) |
+| **Objetivo único** | Tornar freshness **mensurável, reproduzível, fail-closed e nominal** para 1.093 entidades × capabilities `notices_or_bids` e `contracts` |
+| **Não-objetivo** | Atingir 95% freshness / cobertura operacional / recall |
+
+## Squad decisions (Fase Zero)
+
+### Architecture Squad
+
+| Decisão | Escolha | Razão |
+|---------|---------|-------|
+| Capability no ESR | **Opção A** — coluna `capability` em `entity_source_binding` com UNIQUE `(canonical_id, source_id, capability)` | Menor migração vs redesenho do registry 053; multi-capability por entidade-fonte; integridade relacional; sem event bus |
+| Separação editais/contratos | Relatórios distintos + capability explícita por linha | DOD exige dual-metric |
+| Path canônico | `scripts.ops.weekly_cycle` + engine `scripts.coverage.freshness_by_entity` | CLI-first; workspace só fachada |
+| PR #63 | Reutilizar seletivamente fail-closed (já em `fix/weekly-strict-fail-closed`) | Sem merge wholesale #54–#64 |
+
+### Data Squad
+
+| Decisão | Escolha |
+|---------|---------|
+| Migration | `058_entity_source_binding_capability.sql` (additive) |
+| Identity | `canonical_id` do ESR = `entity_id` nos relatórios de freshness |
+| SLA versionado | `config/coverage_slas.yaml` com `sla_version` + hours por capability |
+| Histórico | Registry 053 preservado; binding é tabela nova |
+
+### QA Squad
+
+| Decisão | Escolha |
+|---------|---------|
+| Testes adversariais | `tests/test_freshness_by_entity.py` (funções puras) |
+| Strict false-green | `tests/test_weekly_cycle.py` (universe=0, never, contracts fail, limit=5) |
+| List identity | Fail closed em 1092/1094/duplicatas |
+| Evidência | `docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/` |
+
+### Product Squad
+
+| Decisão | Escolha |
+|---------|---------|
+| Item DOD | Somente linha: “Freshness coverage mensurável por entidade dentro dos SLAs.” |
+| Claims | Mensurável / 1093 representadas / separado / strict fail-closed — **nunca** 95% nesta campanha |
+| Outputs | `output/coverage/freshness-editais.json` e `freshness-contracts.json` (fora do Git) |
+
+## Waves
+
+1. **T1 Strict readiness** — `weekly_cycle` fail-closed (PR #63 base).
+2. **T2 Contract/ADR** — freshness por entidade+capability.
+3. **T3 ESR capability** — migration + binding.
+4. **T4 Engine** — pure classification + dual reports.
+5. **Integração serial** — wire + DOD + HANDOFF.
+
+## SUCCESS criteria
+
+- Ambos relatórios com 1.093 `entity_id` únicos
+- List identity ok
+- Strict rejeita incompleto
+- Testes obrigatórios passam
+- Somente o item de freshness do DOD marcado
+- Claims forbidden respeitados

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/acceptance-matrix.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/acceptance-matrix.json
@@ -1,0 +1,91 @@
+{
+  "campaign_id": "ENTITY-FRESHNESS-01",
+  "dod_item": "Freshness coverage mensurável por entidade dentro dos SLAs.",
+  "dod_path": "DOD.md",
+  "rows": [
+    {
+      "id": "AM-01",
+      "requirement": "Relatórios dual capability com exatamente 1093 entity_ids únicos cada",
+      "implementation": "scripts/coverage/freshness_by_entity.py::build_capability_report",
+      "test": "tests/test_freshness_by_entity.py::test_report_cardinality_1093",
+      "evidence": "output/coverage/freshness-editais.json;output/coverage/freshness-contracts.json;evidence/list-identity.json"
+    },
+    {
+      "id": "AM-02",
+      "requirement": "Campos obrigatórios por entidade + status set fechado",
+      "implementation": "scripts/coverage/freshness_by_entity.py::REQUIRED_FIELDS,ALLOWED_STATUSES",
+      "test": "tests/test_freshness_by_entity.py::test_required_fields_and_status_set",
+      "evidence": "evidence/freshness-summary.json"
+    },
+    {
+      "id": "AM-03",
+      "requirement": "UNKNOWN/NEVER/BLOCKED/INCOMPLETE e sem proveniência nunca viram FRESH",
+      "implementation": "scripts/coverage/freshness_by_entity.py::classify_freshness_status",
+      "test": "tests/test_freshness_by_entity.py::test_adversarial_no_false_fresh",
+      "evidence": "evidence/test-results.json"
+    },
+    {
+      "id": "AM-04",
+      "requirement": "MAX(ingested_at) global não promove entidades",
+      "implementation": "scripts/coverage/freshness_by_entity.py::classify_from_observation (per-entity only)",
+      "test": "tests/test_freshness_by_entity.py::test_source_level_timestamp_does_not_promote_all",
+      "evidence": "evidence/test-results.json"
+    },
+    {
+      "id": "AM-05",
+      "requirement": "Ausência explícita; não coerção a zero/FRESH",
+      "implementation": "scripts/coverage/freshness_by_entity.py::age_hours None preservation",
+      "test": "tests/test_freshness_by_entity.py::test_missing_timestamp_not_zero",
+      "evidence": "evidence/test-results.json"
+    },
+    {
+      "id": "AM-06",
+      "requirement": "SLA versionado e cálculo por entidade+capability",
+      "implementation": "config/coverage_slas.yaml + resolve_sla",
+      "test": "tests/test_freshness_by_entity.py::test_sla_versioned_per_capability",
+      "evidence": "evidence/freshness-summary.json"
+    },
+    {
+      "id": "AM-07",
+      "requirement": "List identity fail-closed em duplicata e cardinality errada",
+      "implementation": "scripts/coverage/freshness_by_entity.py::assert_list_identity",
+      "test": "tests/test_freshness_by_entity.py::test_list_identity_rejects_wrong_cardinality",
+      "evidence": "evidence/list-identity.json"
+    },
+    {
+      "id": "AM-08",
+      "requirement": "Strict fail-closed (universo0/never/contracts fail/limit5/excel)",
+      "implementation": "scripts/ops/weekly_cycle.py::evaluate_readiness",
+      "test": "tests/test_weekly_cycle.py::test_pr59_false_green_regression",
+      "evidence": "evidence/test-results.json"
+    },
+    {
+      "id": "AM-09",
+      "requirement": "Strict rejeita relatório de freshness incompleto/ausente",
+      "implementation": "scripts/ops/weekly_cycle.py::evaluate_entity_freshness_reports",
+      "test": "tests/test_weekly_cycle.py::test_strict_rejects_incomplete_entity_freshness_reports",
+      "evidence": "evidence/test-results.json"
+    },
+    {
+      "id": "AM-10",
+      "requirement": "ESR capability-aware bindings (notices_or_bids | contracts)",
+      "implementation": "db/migrations/058_entity_source_binding_capability.sql + scripts/source_registry/bindings.py",
+      "test": "tests/unit/source_registry/test_entity_source_binding.py",
+      "evidence": "evidence/freshness-summary.json#migration_version"
+    },
+    {
+      "id": "AM-11",
+      "requirement": "Determinismo para mesmos inputs",
+      "implementation": "scripts/coverage/freshness_by_entity.py::build_capability_report stable sort",
+      "test": "tests/test_freshness_by_entity.py::test_deterministic_report",
+      "evidence": "evidence/list-identity.json"
+    },
+    {
+      "id": "AM-12",
+      "requirement": "DOD item único atualizado com evidência; claims permitidos",
+      "implementation": "DOD.md + HANDOFF-FINAL.md",
+      "test": "manual_diff_only_freshness_item",
+      "evidence": "docs/ops/campaigns/ENTITY-FRESHNESS-01/HANDOFF-FINAL.md"
+    }
+  ]
+}

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/dependency-dag.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/dependency-dag.json
@@ -1,0 +1,29 @@
+{
+  "campaign_id": "ENTITY-FRESHNESS-01",
+  "nodes": [
+    {"id": "P0", "name": "phase_zero_artifacts", "wave": 0},
+    {"id": "T1", "name": "strict_readiness", "wave": 1, "worktree": "wt/entity-freshness-strict"},
+    {"id": "T2", "name": "contract_adr", "wave": 2, "worktree": "wt/entity-freshness-contract"},
+    {"id": "T3", "name": "esr_capability", "wave": 2, "worktree": "wt/entity-freshness-esr"},
+    {"id": "T4", "name": "freshness_engine", "wave": 2, "worktree": "wt/entity-freshness-engine"},
+    {"id": "W3", "name": "serial_integration", "wave": 3, "worktree": null},
+    {"id": "EV", "name": "evidence_dod_handoff", "wave": 3, "worktree": null}
+  ],
+  "edges": [
+    {"from": "P0", "to": "T1"},
+    {"from": "T1", "to": "T2", "gate": "manual_validation_wave1"},
+    {"from": "T1", "to": "T3", "gate": "manual_validation_wave1"},
+    {"from": "T1", "to": "T4", "gate": "manual_validation_wave1"},
+    {"from": "T2", "to": "W3"},
+    {"from": "T3", "to": "W3"},
+    {"from": "T4", "to": "W3"},
+    {"from": "W3", "to": "EV"}
+  ],
+  "collision_rules": {
+    "weekly_cycle.py": ["T1", "W3"],
+    "coverage_contract.py": ["W3"],
+    "DOD.md": ["EV"],
+    "freshness_by_entity.py": ["T4"],
+    "058_entity_source_binding_capability.sql": ["T3"]
+  }
+}

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/esr-capability-validation.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/esr-capability-validation.json
@@ -1,0 +1,27 @@
+{
+  "as_of": "2026-07-20T23:03:36.556356+00:00",
+  "migration": "058_entity_source_binding_capability",
+  "structural_checks": {
+    "file_exists": true,
+    "creates_table": true,
+    "capability_notices_or_bids": true,
+    "capability_contracts": true,
+    "unique_triple": true,
+    "applicability_vocab": true,
+    "indexes": true,
+    "does_not_drop_registry_table": true,
+    "idempotent_create": true,
+    "option_a_capability_column": true
+  },
+  "structural_pass": true,
+  "live": {
+    "dsn_reachable": false,
+    "migration_applied": false,
+    "table_exists": false,
+    "constraint_exists": false,
+    "duplicate_rejected": null,
+    "multi_capability_ok": null,
+    "error": "OperationalError: connection to server at \"127.0.0.1\", port 5433 failed: timeout expired\n"
+  },
+  "acceptance": "PASS structural; live apply deferred — DSN unreachable at validation time"
+}

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/freshness-summary.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/freshness-summary.json
@@ -1,0 +1,85 @@
+{
+  "campaign_id": "ENTITY-FRESHNESS-01",
+  "denominator": 1093,
+  "unique_entity_count": {
+    "notices_or_bids": 1093,
+    "contracts": 1093
+  },
+  "status_counts": {
+    "notices_or_bids": {
+      "BLOCKED": 0,
+      "FRESH": 0,
+      "INCOMPLETE": 0,
+      "NEVER": 685,
+      "NOT_APPLICABLE": 0,
+      "STALE": 408,
+      "UNKNOWN": 0
+    },
+    "contracts": {
+      "BLOCKED": 0,
+      "FRESH": 365,
+      "INCOMPLETE": 0,
+      "NEVER": 728,
+      "NOT_APPLICABLE": 0,
+      "STALE": 0,
+      "UNKNOWN": 0
+    }
+  },
+  "capability": [
+    "notices_or_bids",
+    "contracts"
+  ],
+  "as_of": "2026-07-20T12:00:00+00:00",
+  "sla_version": "coverage-sla-v1",
+  "git_sha": "06af835c3944de313371ccc0e5d75f7909dc9887",
+  "migration_version": "058_entity_source_binding_capability",
+  "observed_fresh_pct": {
+    "notices_or_bids": 0.0,
+    "contracts": 33.3943
+  },
+  "provenance_mapped": {
+    "notices_or_bids": {
+      "with_run_id": 288,
+      "with_content_hash": 288,
+      "with_last_success": 408
+    },
+    "contracts": {
+      "with_run_id": 365,
+      "with_content_hash": 365,
+      "with_last_success": 365
+    }
+  },
+  "observation_level_dual_split_entities": 1093,
+  "test_commands": [
+    "python -m pytest tests/test_weekly_cycle.py -q --no-cov",
+    "python -m pytest tests/test_freshness_by_entity.py -q --no-cov",
+    "python -m pytest tests/ -k 'freshness or source_registry or weekly_cycle' -q --no-cov",
+    "ruff check scripts/coverage/freshness_by_entity.py scripts/source_registry/bindings.py scripts/ops/weekly_cycle.py",
+    "python -m scripts.coverage.freshness_by_entity --as-of 2026-07-20T12:00:00+00:00 --strict"
+  ],
+  "CI_run": "local gates green; remote CI not claimed; DSN 5433 unreachable — migration structural pass in esr-capability-validation.json",
+  "limitations": [
+    "Editais observed FRESH=0 (STALE=408, NEVER=685) under 24h SLA as_of 2026-07-20 — promote last_seen often older than SLA",
+    "Contracts observed FRESH=365/1093 (33.39%) — recorded, NOT a 95% claim or campaign success criterion",
+    "pipeline_evidence_promote mapped per capability via sources (pncp vs pncp_contracts)",
+    "MAX(ingested_at) global is never used to promote entities",
+    "Live migration apply deferred: LOCAL_DATALAKE_DSN timeout; structural SQL validation PASS"
+  ],
+  "claims_allowed": [
+    "freshness é mensurável por entidade",
+    "1.093 entidades estão representadas",
+    "editais e contratos são separados",
+    "estado observado e gaps são nominais",
+    "modo strict falha fechado"
+  ],
+  "claims_forbidden": [
+    "cobertura operacional ≥95%",
+    "freshness ≥95%",
+    "recall ≥95%",
+    "LOCAL_READY",
+    "VPS_OPERATIONAL",
+    "PROJECT_DONE",
+    "proxy de presença como cobertura operacional",
+    "MAX(ingested_at) global como freshness de 1.093 entidades"
+  ]
+}

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/list-identity.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/list-identity.json
@@ -1,0 +1,61 @@
+{
+  "generated_at": "2026-07-20T23:04:13.934058+00:00",
+  "expected_universe": 1093,
+  "editais": {
+    "report": "freshness-editais.json",
+    "capability": "notices_or_bids",
+    "row_count": 1093,
+    "unique_entity_count": 1093,
+    "duplicate_count": 0,
+    "covered": 0,
+    "uncovered": 1093,
+    "covered_plus_uncovered": 1093,
+    "list_identity_ok": true,
+    "status_counts": {
+      "BLOCKED": 0,
+      "FRESH": 0,
+      "INCOMPLETE": 0,
+      "NEVER": 685,
+      "NOT_APPLICABLE": 0,
+      "STALE": 408,
+      "UNKNOWN": 0
+    },
+    "sla_version": "coverage-sla-v1",
+    "sla_id": "sla.notices_or_bids.open_opportunities",
+    "as_of": "2026-07-20T12:00:00+00:00",
+    "with_run_id": 288,
+    "with_content_hash": 288,
+    "with_last_success": 408
+  },
+  "contracts": {
+    "report": "freshness-contracts.json",
+    "capability": "contracts",
+    "row_count": 1093,
+    "unique_entity_count": 1093,
+    "duplicate_count": 0,
+    "covered": 365,
+    "uncovered": 728,
+    "covered_plus_uncovered": 1093,
+    "list_identity_ok": true,
+    "status_counts": {
+      "BLOCKED": 0,
+      "FRESH": 365,
+      "INCOMPLETE": 0,
+      "NEVER": 728,
+      "NOT_APPLICABLE": 0,
+      "STALE": 0,
+      "UNKNOWN": 0
+    },
+    "sla_version": "coverage-sla-v1",
+    "sla_id": "sla.contracts.amendments",
+    "as_of": "2026-07-20T12:00:00+00:00",
+    "with_run_id": 365,
+    "with_content_hash": 365,
+    "with_last_success": 365
+  },
+  "both_ok": true,
+  "observation_level_dual_split": {
+    "entities_with_differing_observations": 1093,
+    "ok": true
+  }
+}

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/test-results.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/evidence/test-results.json
@@ -1,0 +1,90 @@
+{
+  "generated_at": "2026-07-20T23:05:28.678481+00:00",
+  "git_sha": "06af835c3944de313371ccc0e5d75f7909dc9887",
+  "suites": {
+    "test_freshness_by_entity": {
+      "result": "27 passed"
+    },
+    "test_weekly_cycle": {
+      "result": "see final run"
+    },
+    "k_filter": {
+      "result": "re-run required"
+    },
+    "ruff": {
+      "result": "All checks passed"
+    },
+    "report_generation": {
+      "result": "exit 0 strict; blockers=[]",
+      "editais_status_counts": {
+        "BLOCKED": 0,
+        "FRESH": 0,
+        "INCOMPLETE": 0,
+        "NEVER": 685,
+        "NOT_APPLICABLE": 0,
+        "STALE": 408,
+        "UNKNOWN": 0
+      },
+      "contracts_status_counts": {
+        "BLOCKED": 0,
+        "FRESH": 365,
+        "INCOMPLETE": 0,
+        "NEVER": 728,
+        "NOT_APPLICABLE": 0,
+        "STALE": 0,
+        "UNKNOWN": 0
+      }
+    },
+    "esr_migration_058": {
+      "as_of": "2026-07-20T23:03:36.556356+00:00",
+      "migration": "058_entity_source_binding_capability",
+      "structural_checks": {
+        "file_exists": true,
+        "creates_table": true,
+        "capability_notices_or_bids": true,
+        "capability_contracts": true,
+        "unique_triple": true,
+        "applicability_vocab": true,
+        "indexes": true,
+        "does_not_drop_registry_table": true,
+        "idempotent_create": true,
+        "option_a_capability_column": true
+      },
+      "structural_pass": true,
+      "live": {
+        "dsn_reachable": false,
+        "migration_applied": false,
+        "table_exists": false,
+        "constraint_exists": false,
+        "duplicate_rejected": null,
+        "multi_capability_ok": null,
+        "error": "OperationalError: connection to server at \"127.0.0.1\", port 5433 failed: timeout expired\n"
+      },
+      "acceptance": "PASS structural; live apply deferred — DSN unreachable at validation time"
+    },
+    "test_weekly_cycle_plus_binding": {
+      "result": "81 passed, 1 skipped"
+    },
+    "k_filter_freshness_or_source_registry_or_weekly_cycle": {
+      "result": "146 passed, 1 skipped, 2211 deselected"
+    },
+    "mypy_campaign_modules": {
+      "result": "freshness_by_entity clean; pre-existing unused-ignore in models.py only"
+    }
+  },
+  "false_green_regression": {
+    "scenario": "universe=0 freshness=never contracts=failure limit=5 Excel ok",
+    "exit_code_nonzero": true,
+    "consultive_ready": false,
+    "blockers_non_empty": true
+  },
+  "skeptic_remediation": {
+    "provenance_mapped_from_pipeline_evidence_promote": true,
+    "last_success_not_dropped": true,
+    "editais_stale_408_not_all_never": true,
+    "contracts_fresh_365_from_pncp_contracts_evidence": true,
+    "capability_observation_split_entities": 1093,
+    "migration_structural_pass": true,
+    "migration_live_dsn": "unreachable — honest ENV_UNAVAILABLE in esr-capability-validation.json"
+  }
+}

--- a/docs/ops/campaigns/ENTITY-FRESHNESS-01/file-ownership.json
+++ b/docs/ops/campaigns/ENTITY-FRESHNESS-01/file-ownership.json
@@ -1,0 +1,64 @@
+{
+  "campaign_id": "ENTITY-FRESHNESS-01",
+  "waves": {
+    "1": {
+      "T1": {
+        "exclusive": [
+          "scripts/ops/weekly_cycle.py",
+          "tests/test_weekly_cycle.py"
+        ],
+        "read_only_deps": [
+          "config/coverage_slas.yaml"
+        ]
+      }
+    },
+    "2": {
+      "T2": {
+        "exclusive": [
+          "docs/architecture/adr/ADR-018-coverage-contract-multi-metric.md",
+          "docs/architecture/adr/ADR-019-entity-source-registry-canonical.md",
+          "docs/architecture/adr/ADR-028-entity-freshness-by-capability.md",
+          "docs/architecture/adr/INDEX.md"
+        ]
+      },
+      "T3": {
+        "exclusive": [
+          "db/migrations/058_entity_source_binding_capability.sql",
+          "scripts/source_registry/models.py",
+          "scripts/source_registry/persistence.py",
+          "scripts/source_registry/bindings.py",
+          "tests/unit/source_registry/test_entity_source_binding.py"
+        ],
+        "forbidden": [
+          "scripts/ops/weekly_cycle.py",
+          "scripts/coverage/coverage_contract.py"
+        ]
+      },
+      "T4": {
+        "exclusive": [
+          "scripts/coverage/freshness_by_entity.py",
+          "tests/test_freshness_by_entity.py",
+          "tests/fixtures/freshness/",
+          "config/coverage_slas.yaml"
+        ],
+        "forbidden": [
+          "scripts/ops/weekly_cycle.py",
+          "db/migrations/"
+        ]
+      }
+    },
+    "3": {
+      "W3": {
+        "exclusive": [
+          "scripts/coverage/coverage_contract.py",
+          "scripts/ops/weekly_cycle.py",
+          "tests/test_weekly_cycle.py",
+          "tests/test_freshness_by_entity.py",
+          "docs/architecture/adr/INDEX.md",
+          "DOD.md",
+          "docs/ops/campaigns/ENTITY-FRESHNESS-01/"
+        ]
+      }
+    }
+  }
+}

--- a/scripts/coverage/coverage_contract.py
+++ b/scripts/coverage/coverage_contract.py
@@ -409,6 +409,7 @@ class SLAConfig:
     contracts_amendments_hours: int = 72
     historical_consolidated_days: int = 7
     cadastral_data_days: int = 30
+    sla_version: str = "coverage-sla-v1"
 
     def default_freshness_hours(self) -> int:
         """Most permissive operational freshness window for entity-level checks.
@@ -426,6 +427,10 @@ class SLAConfig:
 
     def cadastral_timedelta(self) -> timedelta:
         return timedelta(days=self.cadastral_data_days)
+
+    def contracts_freshness_hours(self) -> int:
+        """SLA hours for contracts capability (entity-level dual metric)."""
+        return int(self.contracts_amendments_hours)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -546,6 +551,7 @@ def load_sla_config(path: Path | str | None = None) -> SLAConfig:
         contracts_amendments_hours=int(raw.get("contracts_amendments_hours", 72)),
         historical_consolidated_days=int(raw.get("historical_consolidated_days", 7)),
         cadastral_data_days=int(raw.get("cadastral_data_days", 30)),
+        sla_version=str(raw.get("sla_version") or "coverage-sla-v1"),
     )
 
 

--- a/scripts/coverage/freshness_by_entity.py
+++ b/scripts/coverage/freshness_by_entity.py
@@ -1,0 +1,1187 @@
+#!/usr/bin/env python3
+"""Entity-level freshness by capability (editais / contracts).
+
+Pure classification + dual report generation for the 1.093-entity universe.
+
+Rules (ADR-028 / ENTITY-FRESHNESS-01):
+  - One row per entity per capability report
+  - Statuses: FRESH STALE NEVER INCOMPLETE BLOCKED NOT_APPLICABLE UNKNOWN
+  - UNKNOWN/NEVER/BLOCKED/INCOMPLETE and unprovenanced rows never become FRESH
+  - age_hours absence stays None (never coerced to 0)
+  - Global MAX(ingested_at) must not promote individual entities
+  - List identity: exactly EXPECTED_UNIVERSE distinct entity_ids
+
+Usage::
+
+    python3 -m scripts.coverage.freshness_by_entity \\
+        --registry data/entity_source_registry.jsonl \\
+        --output-dir output/coverage/
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+EXPECTED_UNIVERSE = 1093
+UNIVERSE_VERSION = "extra-sc-raio-200km-v1"
+ADAPTER_VERSION = "freshness_by_entity/1.0.0"
+MIGRATION_VERSION = "058_entity_source_binding_capability"
+
+CAPABILITY_EDITAIS = "notices_or_bids"
+CAPABILITY_CONTRACTS = "contracts"
+CAPABILITIES: tuple[str, ...] = (CAPABILITY_EDITAIS, CAPABILITY_CONTRACTS)
+
+ALLOWED_STATUSES: frozenset[str] = frozenset(
+    {
+        "FRESH",
+        "STALE",
+        "NEVER",
+        "INCOMPLETE",
+        "BLOCKED",
+        "NOT_APPLICABLE",
+        "UNKNOWN",
+    }
+)
+
+# Statuses that must never be promoted / never count as covered fresh
+NON_FRESH_HARD: frozenset[str] = frozenset(
+    {"UNKNOWN", "NEVER", "BLOCKED", "INCOMPLETE"}
+)
+
+REQUIRED_FIELDS: tuple[str, ...] = (
+    "entity_id",
+    "capability",
+    "source_id",
+    "applicability",
+    "last_attempt_at",
+    "last_success_at",
+    "last_verified_at",
+    "sla_id",
+    "sla_hours",
+    "age_hours",
+    "freshness_status",
+    "run_id",
+    "raw_uri",
+    "artifact_ref",
+    "content_hash",
+    "blocker",
+    "next_action",
+    "as_of",
+    "adapter_version",
+)
+
+DEFAULT_SLA_PATH = _PROJECT_ROOT / "config" / "coverage_slas.yaml"
+DEFAULT_REGISTRY = _PROJECT_ROOT / "data" / "entity_source_registry.jsonl"
+DEFAULT_OUTPUT = _PROJECT_ROOT / "output" / "coverage"
+
+REPORT_FILENAMES = {
+    CAPABILITY_EDITAIS: "freshness-editais.json",
+    CAPABILITY_CONTRACTS: "freshness-contracts.json",
+}
+
+
+@dataclass(frozen=True)
+class SlaResolution:
+    sla_id: str
+    sla_hours: int
+    sla_version: str
+    capability: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EntityObservation:
+    """Per-entity observation for one capability. Absence is explicit None."""
+
+    entity_id: str
+    capability: str
+    source_id: str | None = None
+    applicability: str = "unknown"
+    last_attempt_at: datetime | None = None
+    last_success_at: datetime | None = None
+    last_verified_at: datetime | None = None
+    run_id: str | None = None
+    raw_uri: str | None = None
+    artifact_ref: str | None = None
+    content_hash: str | None = None
+    blocker: str | None = None
+    next_action: str | None = None
+    status_hint: str | None = None  # e.g. blocked binding
+
+
+@dataclass
+class EntityFreshnessRecord:
+    entity_id: str
+    capability: str
+    source_id: str | None
+    applicability: str
+    last_attempt_at: str | None
+    last_success_at: str | None
+    last_verified_at: str | None
+    sla_id: str
+    sla_hours: int
+    age_hours: float | None
+    freshness_status: str
+    run_id: str | None
+    raw_uri: str | None
+    artifact_ref: str | None
+    content_hash: str | None
+    blocker: str | None
+    next_action: str | None
+    as_of: str
+    adapter_version: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ListIdentity:
+    expected: int
+    unique_entity_count: int
+    duplicate_count: int
+    covered: int
+    uncovered: int
+    ok: bool
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CapabilityReport:
+    capability: str
+    as_of: str
+    sla_version: str
+    sla_id: str
+    sla_hours: int
+    denominator: int
+    unique_entity_count: int
+    status_counts: dict[str, int]
+    covered: int
+    uncovered: int
+    list_identity: ListIdentity
+    entities: list[EntityFreshnessRecord] = field(default_factory=list)
+    adapter_version: str = ADAPTER_VERSION
+    migration_version: str = MIGRATION_VERSION
+    universe_version: str = UNIVERSE_VERSION
+    limitations: list[str] = field(default_factory=list)
+    claims_allowed: list[str] = field(default_factory=list)
+    claims_forbidden: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "capability": self.capability,
+            "as_of": self.as_of,
+            "sla_version": self.sla_version,
+            "sla_id": self.sla_id,
+            "sla_hours": self.sla_hours,
+            "denominator": self.denominator,
+            "unique_entity_count": self.unique_entity_count,
+            "status_counts": dict(self.status_counts),
+            "covered": self.covered,
+            "uncovered": self.uncovered,
+            "list_identity": self.list_identity.to_dict(),
+            "entities": [e.to_dict() for e in self.entities],
+            "adapter_version": self.adapter_version,
+            "migration_version": self.migration_version,
+            "universe_version": self.universe_version,
+            "limitations": list(self.limitations),
+            "claims_allowed": list(self.claims_allowed),
+            "claims_forbidden": list(self.claims_forbidden),
+        }
+
+
+class FreshnessIdentityError(ValueError):
+    """Raised when list identity fails (duplicates or wrong cardinality)."""
+
+
+class FreshnessReportIncompleteError(ValueError):
+    """Raised when a report is missing fields or incomplete for strict mode."""
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Minimal YAML subset for sla config without PyYAML dependency."""
+    result: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(0, result)]
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        line = raw.strip()
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+        if line.endswith(":") and ":" == line[-1] and line.count(":") == 1:
+            key = line[:-1].strip()
+            child: dict[str, Any] = {}
+            parent[key] = child
+            stack.append((indent + 2, child))
+            continue
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if val == "":
+            child = {}
+            parent[key] = child
+            stack.append((indent + 2, child))
+            continue
+        if val.isdigit() or (val.startswith("-") and val[1:].isdigit()):
+            parent[key] = int(val)
+        else:
+            parent[key] = val
+    return result
+
+
+def load_sla_document(path: Path | str | None = None) -> dict[str, Any]:
+    sla_path = Path(path) if path else DEFAULT_SLA_PATH
+    if not sla_path.is_file():
+        return {
+            "sla_version": "coverage-sla-v0-defaults",
+            "open_opportunities_hours": 24,
+            "contracts_amendments_hours": 72,
+            "capabilities": {
+                CAPABILITY_EDITAIS: {
+                    "sla_id": "sla.notices_or_bids.open_opportunities",
+                    "hours_key": "open_opportunities_hours",
+                },
+                CAPABILITY_CONTRACTS: {
+                    "sla_id": "sla.contracts.amendments",
+                    "hours_key": "contracts_amendments_hours",
+                },
+            },
+        }
+    text = sla_path.read_text(encoding="utf-8")
+    try:
+        import yaml
+    except ImportError:
+        return _parse_simple_yaml(text)
+    try:
+        loaded = yaml.safe_load(text) or {}
+    except Exception:
+        return _parse_simple_yaml(text)
+    if isinstance(loaded, dict):
+        return loaded
+    return _parse_simple_yaml(text)
+
+
+def resolve_sla(capability: str, sla_doc: Mapping[str, Any] | None = None) -> SlaResolution:
+    """Resolve versioned SLA for a capability. Pure."""
+    doc = dict(sla_doc) if sla_doc is not None else load_sla_document()
+    if capability not in CAPABILITIES:
+        raise ValueError(f"unknown capability: {capability!r}")
+    caps = doc.get("capabilities") or {}
+    cap_cfg = caps.get(capability) or {}
+    hours_key = str(cap_cfg.get("hours_key") or (
+        "open_opportunities_hours"
+        if capability == CAPABILITY_EDITAIS
+        else "contracts_amendments_hours"
+    ))
+    default_hours = 24 if capability == CAPABILITY_EDITAIS else 72
+    hours = int(doc.get(hours_key, default_hours))
+    sla_id = str(
+        cap_cfg.get("sla_id")
+        or (
+            "sla.notices_or_bids.open_opportunities"
+            if capability == CAPABILITY_EDITAIS
+            else "sla.contracts.amendments"
+        )
+    )
+    sla_version = str(doc.get("sla_version") or "coverage-sla-v0-defaults")
+    return SlaResolution(
+        sla_id=sla_id,
+        sla_hours=hours,
+        sla_version=sla_version,
+        capability=capability,
+    )
+
+
+def calculate_age_hours(
+    last_success_at: datetime | None,
+    *,
+    as_of: datetime,
+) -> float | None:
+    """Return age in hours, or None when timestamp is absent. Never coerce to 0."""
+    if last_success_at is None:
+        return None
+    ts = last_success_at
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    now = as_of if as_of.tzinfo is not None else as_of.replace(tzinfo=UTC)
+    return (now - ts).total_seconds() / 3600.0
+
+
+def has_provenance(
+    *,
+    run_id: str | None,
+    content_hash: str | None,
+    last_success_at: datetime | None,
+) -> bool:
+    """Provenance required for FRESH: run_id + content_hash + success timestamp."""
+    if not run_id or not str(run_id).strip():
+        return False
+    if not content_hash or not str(content_hash).strip():
+        return False
+    if last_success_at is None:
+        return False
+    return True
+
+
+def classify_freshness_status(
+    *,
+    last_success_at: datetime | None,
+    as_of: datetime,
+    sla_hours: int,
+    applicability: str = "unknown",
+    status_hint: str | None = None,
+    run_id: str | None = None,
+    content_hash: str | None = None,
+    partial_execution: bool = False,
+) -> tuple[str, float | None]:
+    """Classify one entity observation. Pure. Never promotes garbage to FRESH.
+
+    Returns (freshness_status, age_hours).
+    """
+    age = calculate_age_hours(last_success_at, as_of=as_of)
+
+    if applicability == "not_applicable":
+        return "NOT_APPLICABLE", age
+
+    if status_hint == "blocked" or status_hint == "BLOCKED":
+        return "BLOCKED", age
+
+    if partial_execution:
+        return "INCOMPLETE", age
+
+    if last_success_at is None:
+        # Attempt without success → NEVER (not zero, not FRESH)
+        return "NEVER", None
+
+    if age is not None and age < 0:
+        # Future timestamp — incomplete / unreliable
+        return "INCOMPLETE", age
+
+    provenanced = has_provenance(
+        run_id=run_id,
+        content_hash=content_hash,
+        last_success_at=last_success_at,
+    )
+    if not provenanced:
+        # Timestamp without provenance cannot be FRESH
+        if age is not None and age <= float(sla_hours):
+            return "INCOMPLETE", age
+        if age is not None and age > float(sla_hours):
+            return "STALE", age
+        return "UNKNOWN", age
+
+    if age is not None and age <= float(sla_hours):
+        return "FRESH", age
+    return "STALE", age
+
+
+def _iso(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.isoformat()
+
+
+def classify_observation(
+    obs: EntityObservation,
+    *,
+    sla: SlaResolution,
+    as_of: datetime,
+    partial_execution: bool = False,
+) -> EntityFreshnessRecord:
+    """Build one entity freshness record from an observation. Pure."""
+    status, age = classify_freshness_status(
+        last_success_at=obs.last_success_at,
+        as_of=as_of,
+        sla_hours=sla.sla_hours,
+        applicability=obs.applicability,
+        status_hint=obs.status_hint,
+        run_id=obs.run_id,
+        content_hash=obs.content_hash,
+        partial_execution=partial_execution,
+    )
+    if status not in ALLOWED_STATUSES:
+        status = "UNKNOWN"
+
+    # Fail-closed: never allow FRESH if hard non-fresh conditions
+    if status == "FRESH" and not has_provenance(
+        run_id=obs.run_id,
+        content_hash=obs.content_hash,
+        last_success_at=obs.last_success_at,
+    ):
+        status = "INCOMPLETE"
+
+    blocker = obs.blocker
+    next_action = obs.next_action
+    if status == "NEVER":
+        blocker = blocker or "no_success_observation"
+        next_action = next_action or "collect_and_verify"
+    elif status == "STALE":
+        blocker = blocker or "sla_exceeded"
+        next_action = next_action or "refresh_source"
+    elif status == "INCOMPLETE":
+        blocker = blocker or "incomplete_provenance_or_partial"
+        next_action = next_action or "complete_pipeline_and_hash"
+    elif status == "BLOCKED":
+        blocker = blocker or "source_blocked"
+        next_action = next_action or "unblock_source"
+    elif status == "UNKNOWN":
+        blocker = blocker or "unknown_state"
+        next_action = next_action or "map_and_observe"
+    elif status == "NOT_APPLICABLE":
+        blocker = blocker or "not_applicable"
+        next_action = next_action or "none"
+    elif status == "FRESH":
+        blocker = blocker or None
+        next_action = next_action or "monitor"
+
+    return EntityFreshnessRecord(
+        entity_id=str(obs.entity_id),
+        capability=sla.capability,
+        source_id=obs.source_id,  # explicit None preserved
+        applicability=obs.applicability,
+        last_attempt_at=_iso(obs.last_attempt_at),
+        last_success_at=_iso(obs.last_success_at),
+        last_verified_at=_iso(obs.last_verified_at),
+        sla_id=sla.sla_id,
+        sla_hours=sla.sla_hours,
+        age_hours=round(age, 6) if age is not None else None,
+        freshness_status=status,
+        run_id=obs.run_id,
+        raw_uri=obs.raw_uri,
+        artifact_ref=obs.artifact_ref,
+        content_hash=obs.content_hash,
+        blocker=blocker,
+        next_action=next_action,
+        as_of=_iso(as_of) or as_of.isoformat(),
+        adapter_version=ADAPTER_VERSION,
+    )
+
+
+def assert_list_identity(
+    records: Sequence[EntityFreshnessRecord],
+    *,
+    expected: int = EXPECTED_UNIVERSE,
+) -> ListIdentity:
+    """Validate list identity. Raises FreshnessIdentityError on failure."""
+    ids = [r.entity_id for r in records]
+    unique = set(ids)
+    dup = len(ids) - len(unique)
+    covered = sum(1 for r in records if r.freshness_status == "FRESH")
+    # NOT_APPLICABLE is neither covered nor "missing" in the freshness numerator;
+    # uncovered = all non-FRESH (including N/A) for cardinality: covered+uncovered == n
+    uncovered = len(records) - covered
+    ok = (
+        len(ids) == expected
+        and len(unique) == expected
+        and dup == 0
+        and covered + uncovered == expected
+    )
+    reason = ""
+    if len(unique) != expected:
+        reason = f"unique_entity_count={len(unique)} expected={expected}"
+    elif dup > 0:
+        reason = f"duplicates={dup}"
+    elif len(ids) != expected:
+        reason = f"row_count={len(ids)} expected={expected}"
+    identity = ListIdentity(
+        expected=expected,
+        unique_entity_count=len(unique),
+        duplicate_count=dup,
+        covered=covered,
+        uncovered=uncovered,
+        ok=ok,
+        reason=reason,
+    )
+    if not ok:
+        raise FreshnessIdentityError(
+            f"list identity failed: {reason or 'unknown'}; "
+            f"rows={len(ids)} unique={len(unique)} dups={dup}"
+        )
+    return identity
+
+
+def validate_record_fields(record: EntityFreshnessRecord) -> list[str]:
+    """Return list of missing required field names (empty if complete)."""
+    data = record.to_dict()
+    missing: list[str] = []
+    for key in REQUIRED_FIELDS:
+        if key not in data:
+            missing.append(key)
+    if record.freshness_status not in ALLOWED_STATUSES:
+        missing.append(f"invalid_status:{record.freshness_status}")
+    if not record.capability:
+        missing.append("capability")
+    return missing
+
+
+def build_capability_report(
+    observations: Sequence[EntityObservation],
+    *,
+    capability: str,
+    as_of: datetime | None = None,
+    sla_doc: Mapping[str, Any] | None = None,
+    expected_universe: int = EXPECTED_UNIVERSE,
+    partial_execution: bool = False,
+    strict_identity: bool = True,
+    limitations: Sequence[str] | None = None,
+) -> CapabilityReport:
+    """Build dual-metric report for one capability. Deterministic for same inputs."""
+    as_of = as_of or datetime.now(UTC)
+    if as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=UTC)
+    sla = resolve_sla(capability, sla_doc)
+
+    # Dedup by entity_id preserving first occurrence order for determinism
+    # (caller should pass stable sorted list)
+    by_id: dict[str, EntityObservation] = {}
+    for obs in observations:
+        if obs.capability and obs.capability != capability:
+            continue
+        eid = str(obs.entity_id)
+        if eid in by_id:
+            if strict_identity:
+                raise FreshnessIdentityError(f"duplicate entity_id in input: {eid}")
+            continue
+        by_id[eid] = obs
+
+    # Sort for deterministic output
+    ordered = [by_id[k] for k in sorted(by_id.keys())]
+    records = [
+        classify_observation(
+            obs,
+            sla=sla,
+            as_of=as_of,
+            partial_execution=partial_execution,
+        )
+        for obs in ordered
+    ]
+
+    status_counts: dict[str, int] = {s: 0 for s in sorted(ALLOWED_STATUSES)}
+    for r in records:
+        status_counts[r.freshness_status] = status_counts.get(r.freshness_status, 0) + 1
+
+    if strict_identity:
+        identity = assert_list_identity(records, expected=expected_universe)
+    else:
+        ids = [r.entity_id for r in records]
+        unique = set(ids)
+        covered = sum(1 for r in records if r.freshness_status == "FRESH")
+        identity = ListIdentity(
+            expected=expected_universe,
+            unique_entity_count=len(unique),
+            duplicate_count=len(ids) - len(unique),
+            covered=covered,
+            uncovered=len(records) - covered,
+            ok=len(unique) == expected_universe and len(ids) == expected_universe,
+            reason="" if len(unique) == expected_universe else "cardinality_mismatch",
+        )
+
+    claims_allowed = [
+        "freshness é mensurável por entidade",
+        f"{len(records)} entidades estão representadas neste relatório"
+        if identity.ok
+        else "relatório presente mas list identity inválida",
+        "editais e contratos são separados",
+        "estado observado e gaps são nominais",
+        "modo strict falha fechado",
+    ]
+    claims_forbidden = [
+        "cobertura operacional ≥95%",
+        "freshness ≥95%",
+        "recall ≥95%",
+        "LOCAL_READY",
+        "VPS_OPERATIONAL",
+        "PROJECT_DONE",
+        "proxy de presença como cobertura operacional",
+        "MAX(ingested_at) global como freshness de 1.093 entidades",
+    ]
+
+    lim = list(limitations or [])
+    lim.append(
+        "Entity-level freshness; source-level MAX(ingested_at) does not promote entities"
+    )
+    lim.append(f"SLA version={sla.sla_version} sla_id={sla.sla_id} hours={sla.sla_hours}")
+
+    return CapabilityReport(
+        capability=capability,
+        as_of=_iso(as_of) or as_of.isoformat(),
+        sla_version=sla.sla_version,
+        sla_id=sla.sla_id,
+        sla_hours=sla.sla_hours,
+        denominator=expected_universe,
+        unique_entity_count=identity.unique_entity_count,
+        status_counts=status_counts,
+        covered=identity.covered,
+        uncovered=identity.uncovered,
+        list_identity=identity,
+        entities=records,
+        limitations=lim,
+        claims_allowed=claims_allowed,
+        claims_forbidden=claims_forbidden,
+    )
+
+
+def validate_capability_report_strict(report: CapabilityReport | Mapping[str, Any]) -> list[str]:
+    """Return blockers if report is incomplete for strict consultive use."""
+    blockers: list[str] = []
+    data = report.to_dict() if isinstance(report, CapabilityReport) else dict(report)
+
+    entities = data.get("entities") or []
+    if not entities:
+        blockers.append("freshness_report_empty")
+        return blockers
+
+    unique_ids = {str(e.get("entity_id")) for e in entities if isinstance(e, dict)}
+    if len(entities) != EXPECTED_UNIVERSE:
+        blockers.append(
+            f"freshness_report_cardinality:{data.get('capability')}:{len(entities)}"
+        )
+    if len(unique_ids) != EXPECTED_UNIVERSE:
+        blockers.append(
+            f"freshness_report_unique:{data.get('capability')}:{len(unique_ids)}"
+        )
+    if len(entities) != len(unique_ids):
+        blockers.append(f"freshness_report_duplicates:{data.get('capability')}")
+
+    for e in entities:
+        if not isinstance(e, dict):
+            blockers.append("freshness_report_invalid_row")
+            continue
+        if not e.get("capability"):
+            blockers.append("freshness_report_missing_capability")
+        status = e.get("freshness_status")
+        if status not in ALLOWED_STATUSES:
+            blockers.append(f"freshness_report_invalid_status:{status}")
+        if status == "FRESH":
+            if not e.get("run_id") or not e.get("content_hash") or not e.get("last_success_at"):
+                blockers.append("freshness_report_fresh_without_provenance")
+
+    covered = int(data.get("covered") or 0)
+    uncovered = int(data.get("uncovered") or 0)
+    if covered + uncovered != EXPECTED_UNIVERSE and len(entities) == EXPECTED_UNIVERSE:
+        blockers.append("freshness_report_covered_uncovered_mismatch")
+
+    # Dedup
+    seen: set[str] = set()
+    out: list[str] = []
+    for b in blockers:
+        if b not in seen:
+            seen.add(b)
+            out.append(b)
+    return out
+
+
+def evaluate_entity_freshness_reports(
+    *,
+    editais_report: CapabilityReport | Mapping[str, Any] | None,
+    contracts_report: CapabilityReport | Mapping[str, Any] | None,
+) -> list[str]:
+    """Strict evaluation of both capability reports. Empty list = ok."""
+    blockers: list[str] = []
+    if editais_report is None:
+        blockers.append("freshness_report_missing:notices_or_bids")
+    else:
+        blockers.extend(validate_capability_report_strict(editais_report))
+    if contracts_report is None:
+        blockers.append("freshness_report_missing:contracts")
+    else:
+        blockers.extend(validate_capability_report_strict(contracts_report))
+    return blockers
+
+
+# ---------------------------------------------------------------------------
+# Registry / observation loading (capability-aware, provenance-preserving)
+# ---------------------------------------------------------------------------
+
+# Source ids that may back each capability observation. Contracts must not
+# reuse notices-only promote rows (and vice-versa) — dual metric is observation-level.
+CAPABILITY_SOURCE_IDS: dict[str, frozenset[str]] = {
+    CAPABILITY_EDITAIS: frozenset(
+        {
+            "pncp",
+            "pcp",
+            "sc_compras",
+            "ciga_dom",
+            "ciga_ckan",
+            "dom_sc",
+            "doe_sc",
+            "compras_gov",
+            "transparencia",
+            "tce_sc",
+        }
+    ),
+    CAPABILITY_CONTRACTS: frozenset(
+        {
+            "pncp_contracts",
+            "contracts",
+        }
+    ),
+}
+
+# Evidence types that carry crawl provenance usable for freshness.
+PROVENANCE_EVIDENCE_TYPES: frozenset[str] = frozenset(
+    {
+        "pipeline_evidence_promote",
+    }
+)
+
+
+def load_entity_ids_from_registry(path: Path | str | None = None) -> list[str]:
+    """Load ordered unique canonical_ids from JSONL registry (or seed CSV fallback)."""
+    reg = Path(path) if path else DEFAULT_REGISTRY
+    ids: list[str] = []
+    if reg.is_file() and reg.suffix == ".jsonl":
+        with reg.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                cid = row.get("canonical_id") or row.get("entity_id")
+                if cid:
+                    ids.append(str(cid))
+        return ids
+
+    seed = _PROJECT_ROOT / "config" / "target_entities_200km.csv"
+    if seed.is_file():
+        import csv
+
+        with seed.open(encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                cnpj = (row.get("cnpj") or "").strip()
+                name = (row.get("canonical_name") or row.get("name") or "").strip()
+                slug = (
+                    name.upper()
+                    .replace(" ", "_")
+                    .replace("-", "_")
+                    .replace("/", "_")
+                )
+                # Match builder convention when possible
+                cid = row.get("canonical_id")
+                if not cid:
+                    cid = f"{cnpj}:{slug}" if cnpj else slug
+                ids.append(str(cid))
+        return ids
+
+    raise FileNotFoundError(f"No registry or seed at {reg} / {seed}")
+
+
+def _evidence_sources(ev: Mapping[str, Any]) -> set[str]:
+    raw = ev.get("sources") or []
+    if isinstance(raw, str):
+        return {raw}
+    return {str(s) for s in raw if s}
+
+
+def _evidence_matches_capability(ev: Mapping[str, Any], capability: str) -> bool:
+    """True when this evidence row is attributable to the capability."""
+    cap_sources = CAPABILITY_SOURCE_IDS.get(capability, frozenset())
+    ev_cap = str(ev.get("capability") or "")
+    if capability == CAPABILITY_CONTRACTS:
+        if ev_cap in {"contracts", "historical_contracts", CAPABILITY_CONTRACTS}:
+            return True
+        srcs = _evidence_sources(ev)
+        # Pure contracts evidence, or mixed promote that includes contracts source
+        return bool(srcs & cap_sources)
+    # notices_or_bids: need at least one notices source; pure contracts-only does NOT match
+    if ev_cap in {"notices_or_bids", "open_opportunities", "bids", "editais"}:
+        return True
+    srcs = _evidence_sources(ev)
+    notices_hit = bool(srcs & CAPABILITY_SOURCE_IDS[CAPABILITY_EDITAIS])
+    contracts_only = bool(srcs) and srcs <= CAPABILITY_SOURCE_IDS[CAPABILITY_CONTRACTS]
+    if contracts_only:
+        return False
+    return notices_hit
+
+
+def _extract_capability_evidence(
+    row: Mapping[str, Any],
+    capability: str,
+) -> dict[str, Any] | None:
+    """Pick the best per-entity evidence for one capability (never global MAX).
+
+    Prefers pipeline_evidence_promote rows whose sources match the capability.
+    Returns a flat dict with last_success_at, run_id, content_hash, raw_uri, source_id.
+    """
+    evidences = row.get("evidences") or []
+    if not isinstance(evidences, list):
+        return None
+
+    candidates: list[tuple[datetime, dict[str, Any]]] = []
+    for ev in evidences:
+        if not isinstance(ev, dict):
+            continue
+        ev_type = str(ev.get("type") or "")
+        if ev_type not in PROVENANCE_EVIDENCE_TYPES and not (
+            ev.get("run_id") or ev.get("pipeline_run_id")
+        ):
+            continue
+        if not _evidence_matches_capability(ev, capability):
+            continue
+        ts = _parse_dt(ev.get("last_seen_at") or ev.get("last_success_at") or ev.get("attempted_at"))
+        if ts is None:
+            # Provenance without timestamp still useful for incomplete classification
+            ts = datetime.min.replace(tzinfo=UTC)
+        candidates.append((ts, ev))
+
+    if not candidates:
+        return None
+
+    # Most recent last_seen for this capability only
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    best_ts, best = candidates[0]
+    srcs = sorted(_evidence_sources(best))
+    cap_sources = CAPABILITY_SOURCE_IDS.get(capability, frozenset())
+    preferred = [s for s in srcs if s in cap_sources]
+    source_id = preferred[0] if preferred else (srcs[0] if srcs else None)
+    run_id = best.get("run_id") or best.get("pipeline_run_id")
+    content_hash = best.get("raw_sha256") or best.get("content_hash")
+    raw_uri = best.get("raw_uri")
+    artifact_ref = best.get("provenance_source") or best.get("reconciliation_id")
+    last_success = _parse_dt(best.get("last_seen_at") or best.get("last_success_at"))
+    last_attempt = _parse_dt(best.get("attempted_at") or best.get("last_attempt_at"))
+    stages_raw = best.get("stages")
+    stages: dict[str, Any] = stages_raw if isinstance(stages_raw, dict) else {}
+    last_verified = last_success if stages.get("verified_within_sla") else None
+
+    return {
+        "source_id": source_id,
+        "last_success_at": last_success,
+        "last_attempt_at": last_attempt,
+        "last_verified_at": last_verified,
+        "run_id": str(run_id) if run_id else None,
+        "content_hash": str(content_hash) if content_hash else None,
+        "raw_uri": str(raw_uri) if raw_uri else None,
+        "artifact_ref": str(artifact_ref) if artifact_ref else None,
+        "partial_execution": bool(
+            stages
+            and not all(
+                stages.get(k) is True
+                for k in ("mapped", "accessible", "collected", "normalized", "reconciled")
+            )
+        ),
+    }
+
+
+def _fallback_capability_timestamp(
+    row: Mapping[str, Any],
+    capability: str,
+) -> datetime | None:
+    """Use registry last_success_at only when plataformas imply this capability.
+
+    Does not invent provenance (run_id/hash) — classifier will yield
+    INCOMPLETE/STALE/NEVER rather than FRESH without hash+run.
+    """
+    last = _parse_dt(row.get("last_success_at"))
+    if last is None:
+        return None
+    plats = {str(p) for p in (row.get("plataformas") or []) if p}
+    cap_sources = CAPABILITY_SOURCE_IDS.get(capability, frozenset())
+    if not (plats & cap_sources):
+        return None
+    # For contracts require explicit contracts platform — never promote from
+    # notices-only last_success_at
+    if capability == CAPABILITY_CONTRACTS:
+        if not (plats & CAPABILITY_SOURCE_IDS[CAPABILITY_CONTRACTS]):
+            return None
+    return last
+
+
+def observation_from_registry_row(
+    row: Mapping[str, Any],
+    *,
+    capability: str,
+    override: Mapping[str, Any] | None = None,
+) -> EntityObservation:
+    """Build one capability observation from a single ESR row. Pure-ish helper."""
+    ov = dict(override or {})
+    eid = str(row.get("canonical_id") or row.get("entity_id") or "")
+    extracted = _extract_capability_evidence(row, capability) or {}
+
+    def _ov_or_ext(key: str) -> Any:
+        if key in ov:
+            return ov.get(key)
+        return extracted.get(key)
+
+    last_success = _parse_dt(_ov_or_ext("last_success_at"))
+    if last_success is None and "last_success_at" not in ov and not extracted:
+        last_success = _fallback_capability_timestamp(row, capability)
+
+    last_attempt = _parse_dt(_ov_or_ext("last_attempt_at"))
+    if last_attempt is None:
+        last_attempt = _parse_dt(row.get("last_attempt_at"))
+
+    last_verified = _parse_dt(_ov_or_ext("last_verified_at"))
+
+    run_id = _ov_or_ext("run_id")
+    content_hash = _ov_or_ext("content_hash")
+    raw_uri = _ov_or_ext("raw_uri")
+    artifact_ref = _ov_or_ext("artifact_ref")
+    source_id = _ov_or_ext("source_id")
+
+    if source_id is None:
+        plats = [str(p) for p in (row.get("plataformas") or []) if p]
+        cap_sources = CAPABILITY_SOURCE_IDS.get(capability, frozenset())
+        preferred = [p for p in plats if p in cap_sources]
+        source_id = preferred[0] if preferred else None
+
+    status_hint = ov.get("status_hint") if "status_hint" in ov else None
+    if status_hint is None and row.get("access_status") == "blocked":
+        status_hint = "blocked"
+
+    applicability = str(
+        ov.get("applicability")
+        or (
+            "not_applicable"
+            if row.get("current_blocker") == "not_applicable"
+            else "unknown"
+        )
+    )
+
+    return EntityObservation(
+        entity_id=eid,
+        capability=capability,
+        source_id=str(source_id) if source_id else None,
+        applicability=applicability,
+        last_attempt_at=last_attempt,
+        last_success_at=last_success,
+        last_verified_at=last_verified,
+        run_id=str(run_id) if run_id else None,
+        raw_uri=str(raw_uri) if raw_uri else None,
+        artifact_ref=str(artifact_ref) if artifact_ref else None,
+        content_hash=str(content_hash) if content_hash else None,
+        blocker=ov.get("blocker") if "blocker" in ov else row.get("current_blocker"),
+        next_action=ov.get("next_action") if "next_action" in ov else row.get("next_action"),
+        status_hint=str(status_hint) if status_hint else None,
+    )
+
+
+def observations_from_registry(
+    path: Path | str | None = None,
+    *,
+    capability: str,
+    per_entity_overrides: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[EntityObservation]:
+    """Build observations for every registry entity for one capability.
+
+    - Reads per-entity ``pipeline_evidence_promote`` (run_id, raw_sha256, last_seen_at).
+    - Capability filters sources: notices_or_bids vs contracts are observation-level.
+    - Never applies a global MAX(ingested_at) to all entities.
+    - Absence stays explicit (NEVER); timestamp without provenance → not FRESH.
+    """
+    if capability not in CAPABILITIES:
+        raise ValueError(f"unknown capability: {capability}")
+
+    reg = Path(path) if path else DEFAULT_REGISTRY
+    overrides = dict(per_entity_overrides or {})
+    observations: list[EntityObservation] = []
+
+    if reg.is_file() and reg.suffix == ".jsonl":
+        with reg.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                eid = str(row.get("canonical_id") or row.get("entity_id"))
+                observations.append(
+                    observation_from_registry_row(
+                        row,
+                        capability=capability,
+                        override=overrides.get(eid),
+                    )
+                )
+        return observations
+
+    # Fallback: ids only (no evidence)
+    for eid in load_entity_ids_from_registry(reg if reg.is_file() else None):
+        ov = overrides.get(eid) or {}
+        observations.append(
+            EntityObservation(
+                entity_id=eid,
+                capability=capability,
+                source_id=ov.get("source_id"),
+                applicability=str(ov.get("applicability") or "unknown"),
+                last_attempt_at=_parse_dt(ov.get("last_attempt_at")),
+                last_success_at=_parse_dt(ov.get("last_success_at")),
+                last_verified_at=_parse_dt(ov.get("last_verified_at")),
+                run_id=ov.get("run_id"),
+                raw_uri=ov.get("raw_uri"),
+                artifact_ref=ov.get("artifact_ref"),
+                content_hash=ov.get("content_hash"),
+                blocker=ov.get("blocker"),
+                next_action=ov.get("next_action"),
+                status_hint=ov.get("status_hint"),
+            )
+        )
+    return observations
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def write_reports(
+    output_dir: Path | str,
+    *,
+    registry_path: Path | str | None = None,
+    as_of: datetime | None = None,
+    sla_path: Path | str | None = None,
+) -> dict[str, Path]:
+    """Generate both capability reports under output_dir."""
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    as_of = as_of or datetime.now(UTC)
+    sla_doc = load_sla_document(sla_path)
+    written: dict[str, Path] = {}
+    for capability in CAPABILITIES:
+        obs = observations_from_registry(registry_path, capability=capability)
+        report = build_capability_report(
+            obs,
+            capability=capability,
+            as_of=as_of,
+            sla_doc=sla_doc,
+            expected_universe=EXPECTED_UNIVERSE,
+            strict_identity=True,
+        )
+        path = out / REPORT_FILENAMES[capability]
+        path.write_text(
+            json.dumps(report.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+            + "\n",
+            encoding="utf-8",
+        )
+        written[capability] = path
+    return written
+
+
+def load_report(path: Path | str) -> dict[str, Any]:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"freshness report must be a JSON object: {path}")
+    return raw
+
+
+def report_content_fingerprint(report: Mapping[str, Any]) -> str:
+    """Stable fingerprint ignoring wall-clock-only noise if any — full sorted JSON."""
+    payload = json.dumps(report, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Entity-level freshness by capability (editais / contracts)"
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=DEFAULT_REGISTRY,
+        help="Path to entity_source_registry.jsonl",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Directory for freshness-editais.json and freshness-contracts.json",
+    )
+    parser.add_argument(
+        "--sla",
+        type=Path,
+        default=DEFAULT_SLA_PATH,
+        help="Path to coverage_slas.yaml",
+    )
+    parser.add_argument(
+        "--as-of",
+        type=str,
+        default=None,
+        help="ISO timestamp for classification (default: now UTC)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if reports fail list identity or field completeness",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    as_of = _parse_dt(args.as_of) if args.as_of else datetime.now(UTC)
+    try:
+        written = write_reports(
+            args.output_dir,
+            registry_path=args.registry,
+            as_of=as_of,
+            sla_path=args.sla,
+        )
+    except (FreshnessIdentityError, FileNotFoundError, OSError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    editais = load_report(written[CAPABILITY_EDITAIS])
+    contracts = load_report(written[CAPABILITY_CONTRACTS])
+    blockers = evaluate_entity_freshness_reports(
+        editais_report=editais,
+        contracts_report=contracts,
+    )
+    print(
+        json.dumps(
+            {
+                "written": {k: str(v) for k, v in written.items()},
+                "editais_unique": editais.get("unique_entity_count"),
+                "contracts_unique": contracts.get("unique_entity_count"),
+                "editais_status_counts": editais.get("status_counts"),
+                "contracts_status_counts": contracts.get("status_counts"),
+                "blockers": blockers,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    if args.strict and blockers:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/weekly_cycle.py
+++ b/scripts/ops/weekly_cycle.py
@@ -202,6 +202,9 @@ class StrictReadinessPolicy:
         {"excel_ok", "checksums"}
     )
     production_pack_limit: int = PRODUCTION_PACK_LIMIT
+    # When True (or when entity_freshness_reports is passed), dual entity-level
+    # freshness reports must pass list identity + field completeness (ADR-028).
+    require_entity_freshness_reports: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -216,6 +219,7 @@ class StrictReadinessPolicy:
             "require_non_sample_run": self.require_non_sample_run,
             "require_delivery_artifacts": sorted(self.require_delivery_artifacts),
             "production_pack_limit": self.production_pack_limit,
+            "require_entity_freshness_reports": self.require_entity_freshness_reports,
         }
 
 
@@ -1532,6 +1536,25 @@ def _source_blockers(
     return blockers
 
 
+def evaluate_entity_freshness_reports(
+    *,
+    editais_report: dict[str, Any] | None,
+    contracts_report: dict[str, Any] | None,
+) -> list[str]:
+    """Strict dual-report gate (ADR-028). Delegates to freshness_by_entity.
+
+    Incomplete, missing, duplicated, or wrong-cardinality reports yield blockers.
+    """
+    from scripts.coverage.freshness_by_entity import (  # local import: avoid cycle
+        evaluate_entity_freshness_reports as _eval,
+    )
+
+    return _eval(
+        editais_report=editais_report,
+        contracts_report=contracts_report,
+    )
+
+
 def evaluate_readiness(
     stages: list[StageResult],
     runs: list[CollectionRun],
@@ -1540,11 +1563,16 @@ def evaluate_readiness(
     freshness: list[dict[str, Any]] | None = None,
     execution_scope: str = "full",
     policy: StrictReadinessPolicy | None = None,
+    entity_freshness_reports: dict[str, Any] | None = None,
 ) -> ReadinessEvaluation:
     """Centralized exit + consultive readiness evaluation.
 
     Delivery success is necessary but never sufficient.
     Quality of existing rows does not prove collection completeness.
+
+    ``entity_freshness_reports`` optional mapping with keys
+    ``notices_or_bids`` / ``editais`` and ``contracts`` — when provided
+    (or policy.require_entity_freshness_reports), both must pass list identity.
     """
     pol = policy or DEFAULT_STRICT_POLICY
     blockers: list[str] = []
@@ -1692,6 +1720,22 @@ def evaluate_readiness(
             ):
                 blockers.append("opportunities_empty_without_success_zero")
 
+        # Entity-level dual freshness reports (ADR-028 / ENTITY-FRESHNESS-01)
+        if pol.require_entity_freshness_reports or entity_freshness_reports is not None:
+            reports = entity_freshness_reports or {}
+            editais = (
+                reports.get("notices_or_bids")
+                or reports.get("editais")
+                or reports.get("freshness-editais")
+            )
+            contracts = reports.get("contracts") or reports.get("freshness-contracts")
+            blockers.extend(
+                evaluate_entity_freshness_reports(
+                    editais_report=editais,
+                    contracts_report=contracts,
+                )
+            )
+
     # Non-strict: keep historical partial/failure guards for opportunities
     if not strict:
         if opp and opp.terminal_status in {"failure", "partial"}:
@@ -1756,6 +1800,7 @@ def compute_exit_code(
     freshness: list[dict[str, Any]] | None = None,
     execution_scope: str = "full",
     policy: StrictReadinessPolicy | None = None,
+    entity_freshness_reports: dict[str, Any] | None = None,
 ) -> int:
     """Exit code policy (wrapper over evaluate_readiness).
 
@@ -1773,6 +1818,7 @@ def compute_exit_code(
         freshness=freshness,
         execution_scope=execution_scope,
         policy=policy,
+        entity_freshness_reports=entity_freshness_reports,
     ).exit_code
 
 
@@ -1972,10 +2018,53 @@ def run_weekly_cycle(
         report.expected_universe = expected_n
         report.universe_version = UNIVERSE_VERSION
 
+        # Entity-level dual freshness reports (ADR-028) — never source MAX promotion
+        entity_freshness_payload: dict[str, Any] | None = None
+        try:
+            from scripts.coverage.freshness_by_entity import (
+                CAPABILITY_CONTRACTS,
+                CAPABILITY_EDITAIS,
+                write_reports,
+            )
+
+            cov_dir = Path(out) / "coverage"
+            written = write_reports(cov_dir)
+            entity_freshness_payload = {
+                CAPABILITY_EDITAIS: json.loads(
+                    written[CAPABILITY_EDITAIS].read_text(encoding="utf-8")
+                ),
+                CAPABILITY_CONTRACTS: json.loads(
+                    written[CAPABILITY_CONTRACTS].read_text(encoding="utf-8")
+                ),
+            }
+            # Also mirror under output/coverage when using default weekly out
+            mirror = _PROJECT_ROOT / "output" / "coverage"
+            try:
+                mirror.mkdir(parents=True, exist_ok=True)
+                for _cap, _path in written.items():
+                    target = mirror / _path.name
+                    target.write_text(_path.read_text(encoding="utf-8"), encoding="utf-8")
+            except OSError:
+                pass
+            report.products = {
+                **(report.products or {}),
+                "entity_freshness_reports": {
+                    k: str(v) for k, v in written.items()
+                },
+            }
+        except Exception as exc:  # noqa: BLE001 — surface as readiness blocker
+            entity_freshness_payload = None
+            report.limitations = list(report.limitations or []) + [
+                f"entity_freshness_report_generation_failed:{exc}"
+            ]
+
         exec_scope = classify_execution_scope(
             offline=offline,
             limit=limit,
             policy=DEFAULT_STRICT_POLICY,
+        )
+        readiness_policy = StrictReadinessPolicy(
+            require_entity_freshness_reports=strict,
         )
         readiness = evaluate_readiness(
             stages,
@@ -1983,7 +2072,8 @@ def run_weekly_cycle(
             strict=strict,
             freshness=freshness_rows,
             execution_scope=exec_scope,
-            policy=DEFAULT_STRICT_POLICY,
+            policy=readiness_policy,
+            entity_freshness_reports=entity_freshness_payload,
         )
         report.exit_code = readiness.exit_code
         report.execution_scope = readiness.execution_scope

--- a/scripts/ops/weekly_cycle.py
+++ b/scripts/ops/weekly_cycle.py
@@ -57,6 +57,34 @@ EXIT_TECH = 1
 EXIT_UNRELIABLE = 2
 EXIT_BLOCKED = 3
 
+# Canonical Extra universe (raio_200km active entities). Not a free-form magic
+# repeated ad hoc — single constant used by validate_db + readiness policy.
+EXPECTED_UNIVERSE_200KM = 1093
+UNIVERSE_VERSION = "extra-sc-raio-200km-v1"
+
+# Pack size at/above this is treated as production full pack; smaller is sample.
+PRODUCTION_PACK_LIMIT = 50
+
+# Freshness levels that never qualify a source as operationally ready.
+INVALID_FRESHNESS_LEVELS = frozenset(
+    {"never", "unknown", "stale", "unreliable", "incomplete"}
+)
+VALID_FRESHNESS_LEVELS = frozenset({"fresh"})
+
+# Terminal statuses acceptable for a required source in consultive mode.
+OK_SOURCE_TERMINAL = frozenset({"success", "success_zero", "reused_fresh"})
+BAD_SOURCE_TERMINAL = frozenset(
+    {
+        "failure",
+        "blocked",
+        "partial",
+        "interrupted",
+        "running",
+        "unknown",
+        "",
+    }
+)
+
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
@@ -152,6 +180,72 @@ class StageResult:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class StrictReadinessPolicy:
+    """Centralized, deterministic strict consultive readiness contract.
+
+    Registered in the cycle manifest so exit semantics are inspectable.
+    """
+
+    require_expected_universe: bool = True
+    expected_universe_size: int = EXPECTED_UNIVERSE_200KM
+    universe_version: str = UNIVERSE_VERSION
+    universe_tolerance: int = 0
+    required_sources: frozenset[str] = frozenset(
+        {"pncp_opportunities", "pncp_contracts"}
+    )
+    required_freshness_levels: frozenset[str] = VALID_FRESHNESS_LEVELS
+    invalid_freshness_levels: frozenset[str] = INVALID_FRESHNESS_LEVELS
+    require_complete_scope: bool = True
+    require_non_sample_run: bool = True
+    require_delivery_artifacts: frozenset[str] = frozenset(
+        {"excel_ok", "checksums"}
+    )
+    production_pack_limit: int = PRODUCTION_PACK_LIMIT
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "require_expected_universe": self.require_expected_universe,
+            "expected_universe_size": self.expected_universe_size,
+            "universe_version": self.universe_version,
+            "universe_tolerance": self.universe_tolerance,
+            "required_sources": sorted(self.required_sources),
+            "required_freshness_levels": sorted(self.required_freshness_levels),
+            "invalid_freshness_levels": sorted(self.invalid_freshness_levels),
+            "require_complete_scope": self.require_complete_scope,
+            "require_non_sample_run": self.require_non_sample_run,
+            "require_delivery_artifacts": sorted(self.require_delivery_artifacts),
+            "production_pack_limit": self.production_pack_limit,
+        }
+
+
+DEFAULT_STRICT_POLICY = StrictReadinessPolicy()
+
+
+@dataclass(frozen=True)
+class ReadinessEvaluation:
+    """Separated readiness outcome — never a single ambiguous boolean."""
+
+    exit_code: int
+    execution_completed: bool
+    delivery_completed: bool
+    consultive_ready: bool
+    execution_scope: str
+    blockers: tuple[str, ...]
+    policy: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "exit_code": self.exit_code,
+            "execution_completed": self.execution_completed,
+            "delivery_completed": self.delivery_completed,
+            "consultive_ready": self.consultive_ready,
+            "execution_scope": self.execution_scope,
+            "blockers": list(self.blockers),
+            "policy": self.policy,
+        }
+
+
 @dataclass
 class WeeklyCycleReport:
     cycle_id: str
@@ -172,6 +266,16 @@ class WeeklyCycleReport:
     limitations: list[str] = field(default_factory=list)
     human_accept: dict[str, Any] = field(default_factory=dict)
     duration_seconds: float = 0.0
+    # Explicit readiness contract (manifest fields)
+    execution_scope: str = "diagnostic"
+    execution_completed: bool = False
+    delivery_completed: bool = False
+    consultive_ready: bool = False
+    blockers: list[str] = field(default_factory=list)
+    readiness_policy: dict[str, Any] = field(default_factory=dict)
+    universe_200km: int | None = None
+    expected_universe: int = EXPECTED_UNIVERSE_200KM
+    universe_version: str = UNIVERSE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -223,13 +327,21 @@ def stage_validate_db(conn: Any) -> StageResult:
         """,
     )
     n = int((uni[0] or {}).get("n") or 0) if uni else 0
-    detail = {"tables": present, "universe_200km": n, "expected_universe": 1093}
-    if n != 1093:
+    detail = {
+        "tables": present,
+        "universe_200km": n,
+        "expected_universe": EXPECTED_UNIVERSE_200KM,
+        "universe_version": UNIVERSE_VERSION,
+    }
+    if n != EXPECTED_UNIVERSE_200KM:
         return StageResult(
             name="validate_db",
             status="warn",
             detail=detail,
-            error=f"universe_200km={n} != 1093 (scope drift)",
+            error=(
+                f"universe_200km={n} != {EXPECTED_UNIVERSE_200KM} "
+                f"(scope drift; universe_version={UNIVERSE_VERSION})"
+            ),
         )
     return StageResult(name="validate_db", status="ok", detail=detail)
 
@@ -635,6 +747,19 @@ def stage_quality(conn: Any, runs: list[CollectionRun]) -> StageResult:
     except Exception as exc:  # noqa: BLE001
         issues.append(f"identity check error: {exc}")
 
+    # Record-level quality is separate from collection completeness.
+    # A source failure must never yield quality status=ok (would hide run failure).
+    collection_issues: list[str] = []
+    for r in runs:
+        if r.source in DEFAULT_STRICT_POLICY.required_sources and r.terminal_status in BAD_SOURCE_TERMINAL:
+            collection_issues.append(
+                f"required_source_{r.terminal_status}:{r.source}"
+            )
+        elif r.source in DEFAULT_STRICT_POLICY.required_sources and r.terminal_status not in OK_SOURCE_TERMINAL:
+            collection_issues.append(
+                f"required_source_not_ok:{r.source}:{r.terminal_status}"
+            )
+
     opp_run = next((r for r in runs if r.source == "pncp_opportunities"), None)
     if opp_run and opp_run.terminal_status in {"failure", "blocked"}:
         issues.append(f"pncp_opportunities terminal={opp_run.terminal_status}")
@@ -655,10 +780,28 @@ def stage_quality(conn: Any, runs: list[CollectionRun]) -> StageResult:
         "catalog_size": len(catalog),
         "opportunity_counts": counts[0] if counts else {},
         "issues": issues,
-        "runs": [r.terminal_status for r in runs],
+        "collection_issues": collection_issues,
+        "record_quality_ok": not issues,
+        "collection_complete": not collection_issues,
+        "runs": [
+            {"source": r.source, "terminal_status": r.terminal_status} for r in runs
+        ],
     }
-    if any("blocked" == r.terminal_status for r in runs if r.source == "pncp_opportunities"):
-        return StageResult(name="quality", status="blocked", detail=detail, error="; ".join(issues) or "blocked")
+    if any(r.terminal_status == "blocked" for r in runs if r.source == "pncp_opportunities"):
+        return StageResult(
+            name="quality",
+            status="blocked",
+            detail=detail,
+            error="; ".join(issues + collection_issues) or "blocked",
+        )
+    # Collection incompleteness is a quality-stage warning, never ok.
+    if collection_issues:
+        return StageResult(
+            name="quality",
+            status="warn",
+            detail=detail,
+            error="; ".join(collection_issues + issues),
+        )
     if issues:
         return StageResult(name="quality", status="warn", detail=detail, error="; ".join(issues))
     return StageResult(name="quality", status="ok", detail=detail)
@@ -1295,71 +1438,342 @@ def _default_gaps(conn: Any, intel: dict[str, Any]) -> list[dict[str, Any]]:
     return gaps
 
 
-def compute_exit_code(
+def classify_execution_scope(
+    *,
+    offline: bool = False,
+    limit: int = PRODUCTION_PACK_LIMIT,
+    policy: StrictReadinessPolicy | None = None,
+) -> str:
+    """Derive execution scope from runtime flags (code, not free text).
+
+    - fixture: offline / synthetic
+    - sample: pack limit below production threshold (e.g. --limit 5)
+    - full: production pack size and online
+    """
+    pol = policy or DEFAULT_STRICT_POLICY
+    if offline:
+        return "fixture"
+    if int(limit) < int(pol.production_pack_limit):
+        return "sample"
+    return "full"
+
+
+def _freshness_by_source(freshness: list[dict[str, Any]] | None) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in freshness or []:
+        src = str(row.get("source") or "")
+        if src:
+            out[src] = row
+    return out
+
+
+def _universe_from_stages(stages: list[StageResult]) -> tuple[int | None, int]:
+    """Extract observed/expected universe from validate_db stage detail."""
+    vdb = next((s for s in stages if s.name == "validate_db"), None)
+    if vdb is None:
+        return None, EXPECTED_UNIVERSE_200KM
+    detail = vdb.detail or {}
+    expected = int(detail.get("expected_universe") or EXPECTED_UNIVERSE_200KM)
+    if "universe_200km" not in detail:
+        return None, expected
+    try:
+        return int(detail["universe_200km"]), expected
+    except (TypeError, ValueError):
+        return None, expected
+
+
+def _source_blockers(
+    run: CollectionRun | None,
+    *,
+    source: str,
+    freshness_row: dict[str, Any] | None,
+    policy: StrictReadinessPolicy,
+) -> list[str]:
+    """Evaluate one required source against terminal status + freshness rules."""
+    blockers: list[str] = []
+    if run is None:
+        blockers.append(f"required_source_missing:{source}")
+        return blockers
+
+    status = str(run.terminal_status or "")
+    if status in BAD_SOURCE_TERMINAL or status not in OK_SOURCE_TERMINAL:
+        blockers.append(f"required_source_failed:{source}")
+        return blockers
+
+    # success_zero only when request completed, scope complete, source available
+    if status == "success_zero":
+        if not run.request_completed or not run.source_available:
+            blockers.append(f"success_zero_not_valid:{source}")
+        if policy.require_complete_scope and not run.scope_complete:
+            blockers.append(f"success_zero_incomplete_scope:{source}")
+        return blockers
+
+    # success this cycle requires complete scope for opportunities
+    if status == "success":
+        if policy.require_complete_scope and not run.scope_complete:
+            # contracts never re-crawl full API in weekly — success path rare;
+            # still enforce when claimed.
+            blockers.append(f"success_incomplete_scope:{source}")
+        return blockers
+
+    # reused_fresh: must be backed by valid freshness (never/stale/unknown fail)
+    if status == "reused_fresh":
+        level = str((freshness_row or {}).get("level") or "unknown")
+        age = (freshness_row or {}).get("age_hours", "missing")
+        if level in policy.invalid_freshness_levels or level not in policy.required_freshness_levels:
+            blockers.append("freshness_not_valid")
+            blockers.append(f"freshness_not_valid:{source}:{level}")
+        # age_hours=None must never be treated as 0
+        if age is None and level == "fresh":
+            blockers.append(f"freshness_age_unknown:{source}")
+        return blockers
+
+    blockers.append(f"required_source_failed:{source}")
+    return blockers
+
+
+def evaluate_readiness(
     stages: list[StageResult],
     runs: list[CollectionRun],
     *,
     strict: bool = True,
-) -> int:
-    """Exit code policy.
+    freshness: list[dict[str, Any]] | None = None,
+    execution_scope: str = "full",
+    policy: StrictReadinessPolicy | None = None,
+) -> ReadinessEvaluation:
+    """Centralized exit + consultive readiness evaluation.
 
-    EXIT_OK only when critical collection is complete (success / success_zero /
-    reused_fresh of a complete prior run) AND delivery is ok (incl. Excel).
-
-    ``partial`` never yields EXIT_OK — even outside strict mode.
-    ``strict`` additionally fails closed on delivery/artifact defects that
-    non-strict might still surface as products with EXIT_UNRELIABLE.
+    Delivery success is necessary but never sufficient.
+    Quality of existing rows does not prove collection completeness.
     """
+    pol = policy or DEFAULT_STRICT_POLICY
+    blockers: list[str] = []
+
     if any(s.status == "fail" for s in stages if s.name in {"validate_config", "validate_db"}):
-        return EXIT_TECH
+        return ReadinessEvaluation(
+            exit_code=EXIT_TECH,
+            execution_completed=False,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("technical_validation_failed",),
+            policy=pol.to_dict(),
+        )
+
     opp = next((r for r in runs if r.source == "pncp_opportunities"), None)
     if opp and opp.terminal_status == "blocked":
-        return EXIT_BLOCKED
+        return ReadinessEvaluation(
+            exit_code=EXIT_BLOCKED,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("required_source_blocked:pncp_opportunities",),
+            policy=pol.to_dict(),
+        )
     if any(s.status == "blocked" for s in stages):
-        return EXIT_BLOCKED
-    if opp and opp.terminal_status == "failure":
-        return EXIT_UNRELIABLE
-    # Critical partial is never consultively OK
-    if opp and opp.terminal_status == "partial":
-        return EXIT_UNRELIABLE
+        return ReadinessEvaluation(
+            exit_code=EXIT_BLOCKED,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("stage_blocked",),
+            policy=pol.to_dict(),
+        )
 
     delivery = next((s for s in stages if s.name == "delivery"), None)
     quality = next((s for s in stages if s.name == "quality"), None)
     intel = next((s for s in stages if s.name == "intelligence"), None)
 
-    if delivery and delivery.status == "fail":
-        # Missing Excel / incomplete pack is technical delivery failure under strict;
-        # still non-zero outside strict (unreliable for consultive use).
-        return EXIT_TECH if strict else EXIT_UNRELIABLE
-
     if quality and quality.status == "blocked":
-        return EXIT_BLOCKED
+        return ReadinessEvaluation(
+            exit_code=EXIT_BLOCKED,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("quality_blocked",),
+            policy=pol.to_dict(),
+        )
+
+    delivery_completed = bool(
+        delivery
+        and delivery.status == "ok"
+        and (delivery.detail or {}).get("excel_ok")
+        and (
+            (delivery.detail or {}).get("checksums_file")
+            or (delivery.detail or {}).get("product_checksums")
+        )
+    )
+
+    if delivery and delivery.status == "fail":
+        return ReadinessEvaluation(
+            exit_code=EXIT_TECH if strict else EXIT_UNRELIABLE,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("delivery_failed",),
+            policy=pol.to_dict(),
+        )
+
+    # --- Operational readiness (strict consultive contract) ---
+    universe_n, expected_n = _universe_from_stages(stages)
+    if strict and pol.require_expected_universe:
+        if universe_n is None:
+            blockers.append("universe_missing_or_drifted")
+        elif universe_n == 0:
+            blockers.append("universe_missing_or_drifted")
+        elif abs(universe_n - expected_n) > pol.universe_tolerance:
+            blockers.append("universe_missing_or_drifted")
+
+    if strict and pol.require_non_sample_run and execution_scope != "full":
+        blockers.append(f"execution_scope_not_full:{execution_scope}")
+
+    fr_map = _freshness_by_source(freshness)
+    run_by_source = {r.source: r for r in runs}
 
     if strict:
-        if delivery is None or delivery.status != "ok":
-            return EXIT_UNRELIABLE
-        d = delivery.detail or {}
-        if not d.get("excel_ok"):
-            return EXIT_UNRELIABLE
-        if not d.get("checksums_file") and not d.get("product_checksums"):
-            return EXIT_UNRELIABLE
+        for src in sorted(pol.required_sources):
+            blockers.extend(
+                _source_blockers(
+                    run_by_source.get(src),
+                    source=src,
+                    freshness_row=fr_map.get(src),
+                    policy=pol,
+                )
+            )
 
-    if (
-        intel
-        and intel.status == "ok"
-        and delivery
-        and delivery.status == "ok"
-        and opp
-        and opp.terminal_status in {"success", "success_zero", "reused_fresh"}
-    ):
-        counts = (intel.detail or {}).get("counts") or {}
-        if counts.get("opportunities", 0) == 0 and opp.terminal_status not in {
-            "success_zero",
-            "reused_fresh",
-        }:
-            return EXIT_UNRELIABLE
-        return EXIT_OK
-    return EXIT_UNRELIABLE
+        # Pre-collect freshness never/unknown/stale on a required source that did
+        # not successfully collect this cycle is already covered via reused_fresh
+        # path. Also flag standalone freshness when present and invalid AND the
+        # source run is not a successful live collect this cycle.
+        for src in sorted(pol.required_sources):
+            row = fr_map.get(src)
+            run = run_by_source.get(src)
+            if not row:
+                continue
+            level = str(row.get("level") or "unknown")
+            # age_hours=None must remain unknown, never coerced to 0
+            if row.get("age_hours", "missing") is None and level not in {
+                "never",
+                "unknown",
+            }:
+                # never/unknown already invalid; other levels with None age are bad
+                if level in pol.required_freshness_levels:
+                    blockers.append(f"freshness_age_unknown:{src}")
+            if run and run.terminal_status == "success":
+                continue  # live collect supersedes pre-collect freshness
+            if level in pol.invalid_freshness_levels:
+                if "freshness_not_valid" not in blockers:
+                    blockers.append("freshness_not_valid")
+                tag = f"freshness_not_valid:{src}:{level}"
+                if tag not in blockers:
+                    blockers.append(tag)
+
+        if delivery is None or delivery.status != "ok":
+            blockers.append("delivery_not_ok")
+        else:
+            d = delivery.detail or {}
+            if "excel_ok" in pol.require_delivery_artifacts and not d.get("excel_ok"):
+                blockers.append("delivery_missing_excel")
+            if "checksums" in pol.require_delivery_artifacts and not (
+                d.get("checksums_file") or d.get("product_checksums")
+            ):
+                blockers.append("delivery_missing_checksums")
+
+        if intel is None or intel.status not in {"ok", "warn"}:
+            blockers.append("intelligence_not_ready")
+        elif intel.status == "ok":
+            counts = (intel.detail or {}).get("counts") or {}
+            if counts.get("opportunities", 0) == 0 and (
+                not opp or opp.terminal_status not in {"success_zero", "reused_fresh"}
+            ):
+                blockers.append("opportunities_empty_without_success_zero")
+
+    # Non-strict: keep historical partial/failure guards for opportunities
+    if not strict:
+        if opp and opp.terminal_status in {"failure", "partial"}:
+            blockers.append("required_source_failed:pncp_opportunities")
+
+    # Deduplicate blockers preserving order
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for b in blockers:
+        if b not in seen:
+            seen.add(b)
+            uniq.append(b)
+
+    execution_completed = True
+    consultive_ready = strict and not uniq and delivery_completed
+
+    if consultive_ready:
+        exit_code = EXIT_OK
+    elif any(b.startswith("required_source_blocked") for b in uniq):
+        exit_code = EXIT_BLOCKED
+    else:
+        # Degraded runs may complete delivery but must not claim consultive OK
+        exit_code = EXIT_UNRELIABLE
+
+    # Outside strict, allow EXIT_OK only on the classic narrow path (legacy)
+    if not strict and not uniq:
+        if (
+            intel
+            and intel.status == "ok"
+            and delivery
+            and delivery.status == "ok"
+            and opp
+            and opp.terminal_status in OK_SOURCE_TERMINAL
+        ):
+            counts = (intel.detail or {}).get("counts") or {}
+            if counts.get("opportunities", 0) == 0 and opp.terminal_status not in {
+                "success_zero",
+                "reused_fresh",
+            }:
+                exit_code = EXIT_UNRELIABLE
+            else:
+                exit_code = EXIT_OK
+        else:
+            exit_code = EXIT_UNRELIABLE
+
+    return ReadinessEvaluation(
+        exit_code=exit_code,
+        execution_completed=execution_completed,
+        delivery_completed=delivery_completed,
+        consultive_ready=consultive_ready and exit_code == EXIT_OK,
+        execution_scope=execution_scope,
+        blockers=tuple(uniq),
+        policy=pol.to_dict(),
+    )
+
+
+def compute_exit_code(
+    stages: list[StageResult],
+    runs: list[CollectionRun],
+    *,
+    strict: bool = True,
+    freshness: list[dict[str, Any]] | None = None,
+    execution_scope: str = "full",
+    policy: StrictReadinessPolicy | None = None,
+) -> int:
+    """Exit code policy (wrapper over evaluate_readiness).
+
+    EXIT_OK only when strict consultive contract is fully satisfied:
+    expected universe, required sources OK, freshness valid for reuse,
+    non-sample execution, and delivery artifacts present.
+
+    ``partial`` / ``failure`` on required sources never yields EXIT_OK.
+    Delivery alone never compensates for failed collection.
+    """
+    return evaluate_readiness(
+        stages,
+        runs,
+        strict=strict,
+        freshness=freshness,
+        execution_scope=execution_scope,
+        policy=policy,
+    ).exit_code
 
 
 def run_weekly_cycle(
@@ -1488,15 +1902,23 @@ def run_weekly_cycle(
             conn, collection_id=collection_id, freshness_rows=freshness_rows
         )
         runs.append(r_ct)
+        # Collect status considers ALL required sources, not only opportunities.
         collect_status = "ok"
-        if r_opp.terminal_status == "blocked":
-            collect_status = "blocked"
-        elif r_opp.terminal_status in {"failure"}:
-            collect_status = "fail"
-        elif r_opp.terminal_status == "partial":
-            collect_status = "warn"
-        elif r_opp.terminal_status not in {"success", "success_zero", "reused_fresh"}:
-            collect_status = "fail"
+        for r in runs:
+            if r.source not in DEFAULT_STRICT_POLICY.required_sources:
+                continue
+            if r.terminal_status == "blocked":
+                collect_status = "blocked"
+                break
+            if r.terminal_status in {"failure"}:
+                collect_status = "fail"
+            elif r.terminal_status == "partial" and collect_status == "ok":
+                collect_status = "warn"
+            elif (
+                r.terminal_status not in OK_SOURCE_TERMINAL
+                and collect_status == "ok"
+            ):
+                collect_status = "fail"
         stages.append(
             StageResult(
                 name="collect",
@@ -1543,7 +1965,39 @@ def run_weekly_cycle(
         report.products = sd.detail or {}
         report.runs = [r.to_dict() for r in runs]
         report.stages = [asdict(s) for s in stages]
-        report.exit_code = compute_exit_code(stages, runs, strict=strict)
+
+        # Universe observed from validate_db
+        universe_n, expected_n = _universe_from_stages(stages)
+        report.universe_200km = universe_n
+        report.expected_universe = expected_n
+        report.universe_version = UNIVERSE_VERSION
+
+        exec_scope = classify_execution_scope(
+            offline=offline,
+            limit=limit,
+            policy=DEFAULT_STRICT_POLICY,
+        )
+        readiness = evaluate_readiness(
+            stages,
+            runs,
+            strict=strict,
+            freshness=freshness_rows,
+            execution_scope=exec_scope,
+            policy=DEFAULT_STRICT_POLICY,
+        )
+        report.exit_code = readiness.exit_code
+        report.execution_scope = readiness.execution_scope
+        report.execution_completed = readiness.execution_completed
+        report.delivery_completed = readiness.delivery_completed
+        report.consultive_ready = readiness.consultive_ready
+        report.blockers = list(readiness.blockers)
+        report.readiness_policy = readiness.policy
+        # Human accept must never claim ready when consultive_ready is false
+        if report.consultive_ready and report.exit_code == EXIT_OK:
+            report.human_accept["status"] = "ready_for_human_review"
+        else:
+            report.human_accept["status"] = "not_consultive_ready"
+            report.human_accept["blockers"] = list(readiness.blockers)
 
         # Write manifest ONCE — no self-hash. Integrity of products is in checksums.json.
         report.finished_at = _iso()
@@ -1625,6 +2079,12 @@ def main(argv: list[str] | None = None) -> int:
                 "cycle_id": report.cycle_id,
                 "collection_id": report.collection_id,
                 "exit_code": report.exit_code,
+                "consultive_ready": report.consultive_ready,
+                "execution_scope": report.execution_scope,
+                "execution_completed": report.execution_completed,
+                "delivery_completed": report.delivery_completed,
+                "blockers": report.blockers,
+                "universe_200km": report.universe_200km,
                 "duration_seconds": report.duration_seconds,
                 "products": {
                     k: report.products.get(k)

--- a/scripts/source_registry/bindings.py
+++ b/scripts/source_registry/bindings.py
@@ -1,0 +1,164 @@
+"""Entity source bindings with capability (ADR-028 Option A).
+
+Thin module over ``entity_source_binding`` — multi-capability per entity-source
+via UNIQUE (canonical_id, source_id, capability).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+CAPABILITIES: tuple[str, ...] = ("notices_or_bids", "contracts")
+APPLICABILITIES: tuple[str, ...] = ("applicable", "not_applicable", "unknown")
+BINDING_STATUSES: tuple[str, ...] = ("active", "blocked", "deprecated")
+
+
+@dataclass(frozen=True)
+class EntitySourceBinding:
+    canonical_id: str
+    source_id: str
+    capability: str
+    applicability: str = "unknown"
+    acquisition_method: str = "unknown"
+    portal_url: str | None = None
+    external_org_id: str | None = None
+    confidence: float = 0.0
+    status: str = "active"
+    last_attempt_at: str | None = None
+    last_success_at: str | None = None
+    last_verified_at: str | None = None
+    current_blocker: str | None = None
+    next_action: str = "review_binding"
+    evidence_ref: str | None = None
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.canonical_id:
+            errors.append("canonical_id_required")
+        if not self.source_id:
+            errors.append("source_id_required")
+        if self.capability not in CAPABILITIES:
+            errors.append(f"invalid_capability:{self.capability}")
+        if self.applicability not in APPLICABILITIES:
+            errors.append(f"invalid_applicability:{self.applicability}")
+        if self.status not in BINDING_STATUSES:
+            errors.append(f"invalid_status:{self.status}")
+        return errors
+
+
+def binding_identity_key(b: EntitySourceBinding) -> tuple[str, str, str]:
+    return (b.canonical_id, b.source_id, b.capability)
+
+
+def detect_invalid_duplicates(
+    bindings: Sequence[EntitySourceBinding],
+) -> list[tuple[str, str, str]]:
+    """Return identity keys that appear more than once."""
+    seen: set[tuple[str, str, str]] = set()
+    dups: list[tuple[str, str, str]] = []
+    for b in bindings:
+        key = binding_identity_key(b)
+        if key in seen:
+            dups.append(key)
+        else:
+            seen.add(key)
+    return dups
+
+
+def ensure_capability_pair(
+    canonical_id: str,
+    source_id: str,
+    *,
+    applicability: str = "unknown",
+) -> list[EntitySourceBinding]:
+    """Create both capability bindings for an entity-source pair (honest unknown)."""
+    return [
+        EntitySourceBinding(
+            canonical_id=canonical_id,
+            source_id=source_id,
+            capability=cap,
+            applicability=applicability,
+        )
+        for cap in CAPABILITIES
+    ]
+
+
+def filter_by_capability(
+    bindings: Iterable[EntitySourceBinding],
+    capability: str,
+) -> list[EntitySourceBinding]:
+    if capability not in CAPABILITIES:
+        raise ValueError(f"unknown capability: {capability}")
+    return [b for b in bindings if b.capability == capability]
+
+
+UPSERT_COLUMNS = (
+    "canonical_id",
+    "source_id",
+    "capability",
+    "applicability",
+    "acquisition_method",
+    "portal_url",
+    "external_org_id",
+    "confidence",
+    "status",
+    "last_attempt_at",
+    "last_success_at",
+    "last_verified_at",
+    "current_blocker",
+    "next_action",
+    "evidence_ref",
+    "notes",
+)
+
+
+def binding_to_row(binding: EntitySourceBinding) -> tuple[Any, ...]:
+    data = binding.to_dict()
+    return tuple(data[c] for c in UPSERT_COLUMNS)
+
+
+def sync_bindings_to_postgres(
+    bindings: Iterable[EntitySourceBinding],
+    *,
+    dsn: str,
+) -> dict[str, int]:
+    """Idempotent upsert into entity_source_binding (migration 058)."""
+    try:
+        import psycopg2
+        from psycopg2.extras import execute_values
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("psycopg2 is required for binding sync") from exc
+
+    rows = [binding_to_row(b) for b in bindings]
+    if detect_invalid_duplicates(
+        [EntitySourceBinding(
+            canonical_id=str(r[0]),
+            source_id=str(r[1]),
+            capability=str(r[2]),
+        ) for r in rows]
+    ):
+        raise ValueError("duplicate (canonical_id, source_id, capability) in batch")
+
+    updates = ", ".join(
+        f"{c}=EXCLUDED.{c}"
+        for c in UPSERT_COLUMNS
+        if c not in {"canonical_id", "source_id", "capability"}
+    )
+    sql = f"""
+        INSERT INTO public.entity_source_binding ({', '.join(UPSERT_COLUMNS)})
+        VALUES %s
+        ON CONFLICT (canonical_id, source_id, capability) DO UPDATE SET {updates}
+    """  # noqa: S608
+    with psycopg2.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            if rows:
+                execute_values(cur, sql, rows, page_size=250)
+            cur.execute("SELECT COUNT(*) FROM public.entity_source_binding")
+            total = int(cur.fetchone()[0])
+    return {"submitted": len(rows), "persisted_total": total}

--- a/tests/test_freshness_by_entity.py
+++ b/tests/test_freshness_by_entity.py
@@ -1,0 +1,626 @@
+"""Adversarial + identity tests for entity-level freshness by capability."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.coverage.freshness_by_entity import (
+    ALLOWED_STATUSES,
+    CAPABILITY_CONTRACTS,
+    CAPABILITY_EDITAIS,
+    EXPECTED_UNIVERSE,
+    EntityObservation,
+    FreshnessIdentityError,
+    assert_list_identity,
+    build_capability_report,
+    calculate_age_hours,
+    classify_freshness_status,
+    evaluate_entity_freshness_reports,
+    load_entity_ids_from_registry,
+    load_sla_document,
+    observations_from_registry,
+    report_content_fingerprint,
+    resolve_sla,
+    validate_capability_report_strict,
+    write_reports,
+)
+
+AS_OF = datetime(2026, 7, 20, 12, 0, 0, tzinfo=UTC)
+PROJECT = Path(__file__).resolve().parents[1]
+REGISTRY = PROJECT / "data" / "entity_source_registry.jsonl"
+
+
+def _obs(
+    eid: str,
+    *,
+    capability: str = CAPABILITY_EDITAIS,
+    last_success: datetime | None = None,
+    run_id: str | None = None,
+    content_hash: str | None = None,
+    applicability: str = "applicable",
+    status_hint: str | None = None,
+    source_id: str | None = "pncp",
+    partial: bool = False,
+) -> EntityObservation:
+    return EntityObservation(
+        entity_id=eid,
+        capability=capability,
+        source_id=source_id,
+        applicability=applicability,
+        last_success_at=last_success,
+        run_id=run_id,
+        content_hash=content_hash,
+        status_hint=status_hint,
+        last_attempt_at=last_success,
+        last_verified_at=last_success,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure classification adversarial cases
+# ---------------------------------------------------------------------------
+
+
+def test_missing_timestamp_not_zero() -> None:
+    status, age = classify_freshness_status(
+        last_success_at=None,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id="r1",
+        content_hash="abc",
+    )
+    assert status == "NEVER"
+    assert age is None
+    assert calculate_age_hours(None, as_of=AS_OF) is None
+
+
+def test_future_timestamp_incomplete() -> None:
+    future = AS_OF + timedelta(hours=5)
+    status, age = classify_freshness_status(
+        last_success_at=future,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id="r1",
+        content_hash="deadbeef",
+    )
+    assert status == "INCOMPLETE"
+    assert age is not None and age < 0
+
+
+def test_stale_within_provenance() -> None:
+    old = AS_OF - timedelta(hours=100)
+    status, age = classify_freshness_status(
+        last_success_at=old,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id="r1",
+        content_hash="deadbeef",
+    )
+    assert status == "STALE"
+    assert age is not None and age > 24
+
+
+def test_fresh_requires_provenance() -> None:
+    recent = AS_OF - timedelta(hours=1)
+    status, _ = classify_freshness_status(
+        last_success_at=recent,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id="run-1",
+        content_hash="a" * 64,
+    )
+    assert status == "FRESH"
+
+
+def test_missing_hash_not_fresh() -> None:
+    recent = AS_OF - timedelta(hours=1)
+    status, _ = classify_freshness_status(
+        last_success_at=recent,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id="run-1",
+        content_hash=None,
+    )
+    assert status == "INCOMPLETE"
+    assert status != "FRESH"
+
+
+def test_missing_run_id_not_fresh() -> None:
+    recent = AS_OF - timedelta(hours=1)
+    status, _ = classify_freshness_status(
+        last_success_at=recent,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id=None,
+        content_hash="abc",
+    )
+    assert status != "FRESH"
+    assert status == "INCOMPLETE"
+
+
+def test_partial_execution_incomplete() -> None:
+    recent = AS_OF - timedelta(hours=1)
+    status, _ = classify_freshness_status(
+        last_success_at=recent,
+        as_of=AS_OF,
+        sla_hours=24,
+        run_id="r",
+        content_hash="h",
+        partial_execution=True,
+    )
+    assert status == "INCOMPLETE"
+
+
+def test_blocked_status() -> None:
+    status, _ = classify_freshness_status(
+        last_success_at=AS_OF - timedelta(hours=1),
+        as_of=AS_OF,
+        sla_hours=24,
+        status_hint="blocked",
+        run_id="r",
+        content_hash="h",
+    )
+    assert status == "BLOCKED"
+
+
+def test_not_applicable_separate() -> None:
+    status, _ = classify_freshness_status(
+        last_success_at=None,
+        as_of=AS_OF,
+        sla_hours=24,
+        applicability="not_applicable",
+    )
+    assert status == "NOT_APPLICABLE"
+
+
+def test_adversarial_no_false_fresh() -> None:
+    """UNKNOWN/NEVER/BLOCKED/INCOMPLETE never become FRESH."""
+    cases = [
+        classify_freshness_status(
+            last_success_at=None, as_of=AS_OF, sla_hours=24
+        )[0],
+        classify_freshness_status(
+            last_success_at=AS_OF - timedelta(hours=1),
+            as_of=AS_OF,
+            sla_hours=24,
+            # no provenance
+        )[0],
+        classify_freshness_status(
+            last_success_at=AS_OF - timedelta(hours=1),
+            as_of=AS_OF,
+            sla_hours=24,
+            status_hint="blocked",
+            run_id="r",
+            content_hash="h",
+        )[0],
+        classify_freshness_status(
+            last_success_at=AS_OF + timedelta(hours=2),
+            as_of=AS_OF,
+            sla_hours=24,
+            run_id="r",
+            content_hash="h",
+        )[0],
+    ]
+    for s in cases:
+        assert s in ALLOWED_STATUSES
+        assert s != "FRESH"
+        assert s in {"NEVER", "INCOMPLETE", "BLOCKED", "UNKNOWN", "STALE"}
+
+
+def test_source_level_timestamp_does_not_promote_all() -> None:
+    """A source-level timestamp must not be applied to every entity."""
+    source_max = AS_OF - timedelta(hours=1)
+    # Honest path: only entity e1 has observation; others NEVER
+    obs = [
+        _obs(
+            "e1",
+            last_success=source_max,
+            run_id="r",
+            content_hash="h" * 64,
+        ),
+        _obs("e2"),  # no observation
+        _obs("e3"),
+    ]
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=3,
+        strict_identity=True,
+    )
+    by_id = {r.entity_id: r for r in report.entities}
+    assert by_id["e1"].freshness_status == "FRESH"
+    assert by_id["e2"].freshness_status == "NEVER"
+    assert by_id["e3"].freshness_status == "NEVER"
+    assert report.covered == 1
+    assert report.uncovered == 2
+
+
+def test_not_applicable_not_in_fresh_numerator() -> None:
+    obs = [
+        _obs("a", applicability="not_applicable"),
+        _obs(
+            "b",
+            last_success=AS_OF - timedelta(hours=1),
+            run_id="r",
+            content_hash="h" * 64,
+        ),
+        _obs("c"),
+    ]
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=3,
+    )
+    assert report.status_counts["NOT_APPLICABLE"] == 1
+    assert report.covered == 1  # only FRESH
+    assert report.covered + report.uncovered == 3
+
+
+def test_duplicate_entity_raises() -> None:
+    obs = [_obs("dup"), _obs("dup"), _obs("other")]
+    with pytest.raises(FreshnessIdentityError, match="duplicate"):
+        build_capability_report(
+            obs,
+            capability=CAPABILITY_EDITAIS,
+            as_of=AS_OF,
+            expected_universe=2,
+            strict_identity=True,
+        )
+
+
+def test_missing_capability_rejected_in_strict_report() -> None:
+    obs = [_obs("x"), _obs("y")]
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=2,
+    )
+    # force-empty capability on one row
+    bad = report.to_dict()
+    bad["entities"][0]["capability"] = ""
+    # pad to 1093 for cardinality checks? for this unit test use raw validator
+    # with small set — cardinality will fail; check capability message appears
+    blockers = validate_capability_report_strict(bad)
+    assert any("capability" in b or "cardinality" in b for b in blockers)
+
+
+def test_list_identity_rejects_wrong_cardinality() -> None:
+    # 1092
+    obs_1092 = [_obs(f"e{i}") for i in range(1092)]
+    with pytest.raises(FreshnessIdentityError):
+        build_capability_report(
+            obs_1092,
+            capability=CAPABILITY_EDITAIS,
+            as_of=AS_OF,
+            expected_universe=EXPECTED_UNIVERSE,
+        )
+    # 1094
+    obs_1094 = [_obs(f"e{i}") for i in range(1094)]
+    with pytest.raises(FreshnessIdentityError):
+        build_capability_report(
+            obs_1094,
+            capability=CAPABILITY_EDITAIS,
+            as_of=AS_OF,
+            expected_universe=EXPECTED_UNIVERSE,
+        )
+
+
+def test_assert_list_identity_ok() -> None:
+    obs = [_obs(f"e{i:04d}", capability=CAPABILITY_CONTRACTS) for i in range(10)]
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_CONTRACTS,
+        as_of=AS_OF,
+        expected_universe=10,
+    )
+    identity = assert_list_identity(report.entities, expected=10)
+    assert identity.ok
+    assert identity.covered + identity.uncovered == 10
+
+
+def test_sla_versioned_per_capability() -> None:
+    doc = load_sla_document(PROJECT / "config" / "coverage_slas.yaml")
+    editais = resolve_sla(CAPABILITY_EDITAIS, doc)
+    contracts = resolve_sla(CAPABILITY_CONTRACTS, doc)
+    assert editais.sla_version
+    assert contracts.sla_version == editais.sla_version
+    assert editais.sla_hours == 24
+    assert contracts.sla_hours == 72
+    assert editais.sla_id != contracts.sla_id
+    assert "notices" in editais.sla_id or "open" in editais.sla_id
+
+
+def test_required_fields_and_status_set() -> None:
+    obs = [
+        _obs(
+            "e1",
+            last_success=AS_OF - timedelta(hours=1),
+            run_id="r",
+            content_hash="h" * 64,
+        ),
+        _obs("e2"),
+    ]
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=2,
+    )
+    for ent in report.entities:
+        d = ent.to_dict()
+        for key in (
+            "entity_id",
+            "capability",
+            "source_id",
+            "applicability",
+            "last_attempt_at",
+            "last_success_at",
+            "last_verified_at",
+            "sla_id",
+            "sla_hours",
+            "age_hours",
+            "freshness_status",
+            "run_id",
+            "raw_uri",
+            "artifact_ref",
+            "content_hash",
+            "blocker",
+            "next_action",
+            "as_of",
+            "adapter_version",
+        ):
+            assert key in d
+        assert d["freshness_status"] in ALLOWED_STATUSES
+
+
+def test_deterministic_report() -> None:
+    obs = [_obs(f"z{i}") for i in range(5)] + [_obs(f"a{i}") for i in range(5)]
+    r1 = build_capability_report(
+        obs, capability=CAPABILITY_EDITAIS, as_of=AS_OF, expected_universe=10
+    )
+    r2 = build_capability_report(
+        obs, capability=CAPABILITY_EDITAIS, as_of=AS_OF, expected_universe=10
+    )
+    assert report_content_fingerprint(r1.to_dict()) == report_content_fingerprint(
+        r2.to_dict()
+    )
+    assert [e.entity_id for e in r1.entities] == sorted(e.entity_id for e in r1.entities)
+
+
+@pytest.mark.skipif(not REGISTRY.is_file(), reason="registry jsonl missing")
+def test_report_cardinality_1093() -> None:
+    ids = load_entity_ids_from_registry(REGISTRY)
+    assert len(ids) == EXPECTED_UNIVERSE
+    assert len(set(ids)) == EXPECTED_UNIVERSE
+
+    for capability in (CAPABILITY_EDITAIS, CAPABILITY_CONTRACTS):
+        obs = observations_from_registry(REGISTRY, capability=capability)
+        report = build_capability_report(
+            obs,
+            capability=capability,
+            as_of=AS_OF,
+            expected_universe=EXPECTED_UNIVERSE,
+            strict_identity=True,
+        )
+        assert report.unique_entity_count == EXPECTED_UNIVERSE
+        assert report.list_identity.ok
+        assert report.covered + report.uncovered == EXPECTED_UNIVERSE
+        assert report.capability == capability
+        # Default lake empty → majority NEVER, never claim 95%
+        assert report.status_counts.get("FRESH", 0) < EXPECTED_UNIVERSE * 0.95
+
+
+@pytest.mark.skipif(not REGISTRY.is_file(), reason="registry jsonl missing")
+def test_write_reports_and_strict_eval(tmp_path: Path) -> None:
+    written = write_reports(
+        tmp_path,
+        registry_path=REGISTRY,
+        as_of=AS_OF,
+        sla_path=PROJECT / "config" / "coverage_slas.yaml",
+    )
+    assert written[CAPABILITY_EDITAIS].is_file()
+    assert written[CAPABILITY_CONTRACTS].is_file()
+    import json
+
+    editais = json.loads(written[CAPABILITY_EDITAIS].read_text(encoding="utf-8"))
+    contracts = json.loads(written[CAPABILITY_CONTRACTS].read_text(encoding="utf-8"))
+    assert len({e["entity_id"] for e in editais["entities"]}) == EXPECTED_UNIVERSE
+    assert len({e["entity_id"] for e in contracts["entities"]}) == EXPECTED_UNIVERSE
+    blockers = evaluate_entity_freshness_reports(
+        editais_report=editais,
+        contracts_report=contracts,
+    )
+    assert blockers == []
+
+
+def test_strict_rejects_missing_report() -> None:
+    blockers = evaluate_entity_freshness_reports(
+        editais_report=None,
+        contracts_report=None,
+    )
+    assert "freshness_report_missing:notices_or_bids" in blockers
+    assert "freshness_report_missing:contracts" in blockers
+
+
+def test_strict_rejects_incomplete_cardinality() -> None:
+    obs = [_obs(f"e{i}") for i in range(10)]
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=10,
+    )
+    blockers = validate_capability_report_strict(report)
+    assert any("cardinality" in b or "unique" in b for b in blockers)
+
+
+def test_registry_promote_evidence_not_force_never() -> None:
+    """pipeline_evidence_promote must map run_id/hash/last_seen — not invent NEVER."""
+    from scripts.coverage.freshness_by_entity import observation_from_registry_row
+
+    row = {
+        "canonical_id": "80674252:SANTO_AMARO_DA_IMPERATRIZ_CAMARA_DE_VEREADORES",
+        "last_success_at": "2026-06-19T16:14:17+00:00",
+        "last_attempt_at": "2026-07-19T03:28:34.891882+00:00",
+        "access_status": "collected",
+        "plataformas": ["pncp", "pncp_contracts"],
+        "current_blocker": "pending_live_verification",
+        "evidences": [
+            {
+                "type": "pipeline_evidence_promote",
+                "dry_run": False,
+                "last_seen_at": "2026-06-19T16:14:17+00:00",
+                "sources": ["pncp"],
+                "stages": {
+                    "mapped": True,
+                    "accessible": True,
+                    "collected": True,
+                    "normalized": True,
+                    "reconciled": True,
+                    "verified_within_sla": False,
+                },
+                "run_id": "pncp-sc-20260717T110800Z-9d6dd91153",
+                "pipeline_run_id": "pncp-sc-20260717T110800Z-9d6dd91153",
+                "raw_uri": "/tmp/contratacoes.jsonl",
+                "raw_sha256": "2b737ff8d5a9b166be2fbe40f81c67cfcb17e67a70b94ef9d111040dfc9f46af",
+            }
+        ],
+    }
+    obs = observation_from_registry_row(row, capability=CAPABILITY_EDITAIS)
+    assert obs.last_success_at is not None
+    assert obs.run_id == "pncp-sc-20260717T110800Z-9d6dd91153"
+    assert obs.content_hash and len(obs.content_hash) == 64
+    assert obs.raw_uri
+    assert obs.source_id == "pncp"
+
+    rec = build_capability_report(
+        [obs],
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=1,
+    ).entities[0]
+    # June 19 vs July 20 as_of → STALE (not NEVER, not forced empty)
+    assert rec.freshness_status == "STALE"
+    assert rec.age_hours is not None
+    assert rec.run_id == obs.run_id
+    assert rec.content_hash == obs.content_hash
+
+
+def test_capability_observation_separation_editais_vs_contracts() -> None:
+    """Notices-only promote must not populate contracts observation timestamps."""
+    from scripts.coverage.freshness_by_entity import observation_from_registry_row
+
+    row = {
+        "canonical_id": "e-mixed",
+        "last_success_at": "2026-06-19T16:14:17+00:00",
+        "plataformas": ["pncp", "pncp_contracts"],
+        "evidences": [
+            {
+                "type": "pipeline_evidence_promote",
+                "last_seen_at": "2026-06-19T16:14:17+00:00",
+                "sources": ["pncp"],
+                "run_id": "run-notices",
+                "raw_sha256": "a" * 64,
+                "raw_uri": "s3://notices",
+                "stages": {
+                    "mapped": True,
+                    "accessible": True,
+                    "collected": True,
+                    "normalized": True,
+                    "reconciled": True,
+                },
+            },
+            {
+                "type": "pipeline_evidence_promote",
+                "last_seen_at": "2026-07-19T01:38:24+00:00",
+                "sources": ["pncp_contracts"],
+                "capability": "historical_contracts",
+                "run_id": "run-contracts",
+                "raw_sha256": "b" * 64,
+                "raw_uri": "s3://contracts",
+                "stages": {
+                    "mapped": True,
+                    "accessible": True,
+                    "collected": True,
+                    "normalized": True,
+                    "reconciled": True,
+                    "verified_within_sla": True,
+                },
+            },
+        ],
+    }
+    notices = observation_from_registry_row(row, capability=CAPABILITY_EDITAIS)
+    contracts = observation_from_registry_row(row, capability=CAPABILITY_CONTRACTS)
+    assert notices.run_id == "run-notices"
+    assert contracts.run_id == "run-contracts"
+    assert notices.source_id == "pncp"
+    assert contracts.source_id == "pncp_contracts"
+    assert notices.last_success_at != contracts.last_success_at
+
+    # Pure notices entity: contracts must stay NEVER (no contracts evidence)
+    notices_only = {
+        "canonical_id": "e-notices-only",
+        "last_success_at": "2026-06-19T16:14:17+00:00",
+        "plataformas": ["pncp"],
+        "evidences": row["evidences"][:1],
+    }
+    ct = observation_from_registry_row(notices_only, capability=CAPABILITY_CONTRACTS)
+    assert ct.last_success_at is None
+    assert ct.run_id is None
+    rec = build_capability_report(
+        [ct],
+        capability=CAPABILITY_CONTRACTS,
+        as_of=AS_OF,
+        expected_universe=1,
+    ).entities[0]
+    assert rec.freshness_status == "NEVER"
+
+
+@pytest.mark.skipif(not REGISTRY.is_file(), reason="registry jsonl missing")
+def test_live_registry_promotes_are_not_all_never() -> None:
+    """Against real JSONL: entities with promote evidence must not all be NEVER."""
+    obs = observations_from_registry(REGISTRY, capability=CAPABILITY_EDITAIS)
+    with_success = sum(1 for o in obs if o.last_success_at is not None)
+    with_hash = sum(1 for o in obs if o.content_hash)
+    with_run = sum(1 for o in obs if o.run_id)
+    assert with_success >= 200, f"expected hundreds of last_success from promote, got {with_success}"
+    assert with_hash >= 200, f"expected hundreds of content_hash, got {with_hash}"
+    assert with_run >= 200, f"expected hundreds of run_id, got {with_run}"
+
+    report = build_capability_report(
+        obs,
+        capability=CAPABILITY_EDITAIS,
+        as_of=AS_OF,
+        expected_universe=EXPECTED_UNIVERSE,
+    )
+    never = report.status_counts.get("NEVER", 0)
+    stale = report.status_counts.get("STALE", 0)
+    incomplete = report.status_counts.get("INCOMPLETE", 0)
+    # Honest: many STALE from old promote windows; must not be 1093 NEVER
+    assert never < EXPECTED_UNIVERSE, "all-NEVER means provenance was dropped"
+    assert stale + incomplete > 0
+
+
+@pytest.mark.skipif(not REGISTRY.is_file(), reason="registry jsonl missing")
+def test_live_registry_contracts_differs_from_editais() -> None:
+    """Dual reports must differ at observation level (not just SLA labels)."""
+    ed = observations_from_registry(REGISTRY, capability=CAPABILITY_EDITAIS)
+    ct = observations_from_registry(REGISTRY, capability=CAPABILITY_CONTRACTS)
+    ed_map = {o.entity_id: o for o in ed}
+    ct_map = {o.entity_id: o for o in ct}
+    differing = 0
+    for eid, o_ed in ed_map.items():
+        o_ct = ct_map[eid]
+        if (o_ed.run_id, o_ed.last_success_at, o_ed.source_id) != (
+            o_ct.run_id,
+            o_ct.last_success_at,
+            o_ct.source_id,
+        ):
+            differing += 1
+    assert differing > 50, f"expected observation-level dual split, differing={differing}"

--- a/tests/test_weekly_cycle.py
+++ b/tests/test_weekly_cycle.py
@@ -18,10 +18,12 @@ from scripts.ops.weekly_cycle import (
     EXIT_UNRELIABLE,
     EXPECTED_UNIVERSE_200KM,
     StageResult,
+    StrictReadinessPolicy,
     _build_claims_catalog,
     classify_execution_scope,
     classify_opportunity_freshness,
     compute_exit_code,
+    evaluate_entity_freshness_reports,
     evaluate_readiness,
     run_weekly_cycle,
 )
@@ -1137,3 +1139,75 @@ def test_weekly_cycle_offline_skip_collect(tmp_path: Path) -> None:
     assert report.human_accept.get("status") == "PENDING_HUMAN"
     assert "LOCAL_READY" in report.claims_forbidden
     assert report.exit_code in {0, 2, 3}
+
+
+# ---------------------------------------------------------------------------
+# Entity-level freshness reports (ADR-028 / ENTITY-FRESHNESS-01)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_rejects_incomplete_entity_freshness_reports() -> None:
+    """Strict mode must fail-closed when dual entity freshness reports are incomplete."""
+    incomplete = {
+        "capability": "notices_or_bids",
+        "entities": [{"entity_id": "only-one", "capability": "notices_or_bids"}],
+        "covered": 0,
+        "uncovered": 1,
+        "unique_entity_count": 1,
+    }
+    blockers = evaluate_entity_freshness_reports(
+        editais_report=incomplete,
+        contracts_report=None,
+    )
+    assert blockers
+    assert any("missing" in b or "cardinality" in b or "unique" in b for b in blockers)
+
+    policy = StrictReadinessPolicy(require_entity_freshness_reports=True)
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+        policy=policy,
+        entity_freshness_reports={
+            "notices_or_bids": incomplete,
+            "contracts": incomplete,
+        },
+    )
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+    assert ev.blockers
+
+
+def test_strict_rejects_missing_entity_freshness_when_required() -> None:
+    policy = StrictReadinessPolicy(require_entity_freshness_reports=True)
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+        policy=policy,
+        entity_freshness_reports=None,
+    )
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+    assert any("freshness_report_missing" in b for b in ev.blockers)
+
+
+def test_pr59_false_green_regression() -> None:
+    """Alias for AM-08: universe=0, freshness=never, contracts=failure, limit=5, Excel ok."""
+    stages = _pr59_live_stages()
+    runs = _pr59_live_runs()
+    freshness = _pr59_freshness()
+    ev = evaluate_readiness(
+        stages,
+        runs,
+        strict=True,
+        freshness=freshness,
+        execution_scope="sample",
+    )
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+    assert len(ev.blockers) > 0

--- a/tests/test_weekly_cycle.py
+++ b/tests/test_weekly_cycle.py
@@ -16,10 +16,13 @@ from scripts.ops.weekly_cycle import (
     EXIT_OK,
     EXIT_TECH,
     EXIT_UNRELIABLE,
+    EXPECTED_UNIVERSE_200KM,
     StageResult,
     _build_claims_catalog,
+    classify_execution_scope,
     classify_opportunity_freshness,
     compute_exit_code,
+    evaluate_readiness,
     run_weekly_cycle,
 )
 from scripts.quality.indicator_catalog import (
@@ -205,7 +208,37 @@ def _delivery_ok_detail() -> dict:
     }
 
 
-def test_exit_ok_with_reused_and_products() -> None:
+def _fresh_sources() -> list[dict]:
+    return [
+        {
+            "source": "pncp_opportunities",
+            "level": "fresh",
+            "age_hours": 1.0,
+            "sla_hours": 48,
+        },
+        {
+            "source": "pncp_contracts",
+            "level": "fresh",
+            "age_hours": 2.0,
+            "sla_hours": 168,
+            "row_count": 100,
+        },
+    ]
+
+
+def _universe_ok_stage() -> StageResult:
+    return StageResult(
+        name="validate_db",
+        status="ok",
+        detail={
+            "universe_200km": EXPECTED_UNIVERSE_200KM,
+            "expected_universe": EXPECTED_UNIVERSE_200KM,
+            "universe_version": "extra-sc-raio-200km-v1",
+        },
+    )
+
+
+def _ok_opp_run() -> CollectionRun:
     run = CollectionRun.start(
         source="pncp_opportunities",
         collection_id="c",
@@ -218,18 +251,59 @@ def test_exit_ok_with_reused_and_products() -> None:
         scope_complete=True,
         reused_within_sla=True,
     )
-    stages = [
-        StageResult(name="validate_db", status="ok"),
+    return run
+
+
+def _ok_contracts_run() -> CollectionRun:
+    run = CollectionRun.start(
+        source="pncp_contracts",
+        collection_id="c",
+        collector_version="t",
+        mode="reuse",
+    )
+    run.finish(
+        records_obtained=100,
+        records_persisted=100,
+        request_completed=True,
+        scope_complete=False,
+        reused_within_sla=True,
+        raw_uri="db://pncp_supplier_contracts",
+    )
+    return run
+
+
+def _consultive_ok_stages() -> list[StageResult]:
+    return [
+        StageResult(name="validate_config", status="ok"),
+        _universe_ok_stage(),
+        StageResult(name="freshness", status="ok", detail={"sources": _fresh_sources()}),
         StageResult(name="collect", status="ok"),
+        StageResult(name="process", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
             name="intelligence",
             status="ok",
-            detail={"counts": {"opportunities": 5}},
+            detail={"counts": {"opportunities": 5, "contracts": 10}},
         ),
         StageResult(name="delivery", status="ok", detail=_delivery_ok_detail()),
     ]
-    assert compute_exit_code(stages, [run], strict=True) == EXIT_OK
+
+
+def test_exit_ok_with_reused_and_products() -> None:
+    """Fully valid consultive state → EXIT_OK."""
+    stages = _consultive_ok_stages()
+    runs = [_ok_opp_run(), _ok_contracts_run()]
+    ev = evaluate_readiness(
+        stages,
+        runs,
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_OK
+    assert ev.consultive_ready is True
+    assert ev.delivery_completed is True
+    assert ev.blockers == ()
 
 
 def test_exit_unreliable_empty_without_success_zero() -> None:
@@ -247,7 +321,7 @@ def test_exit_unreliable_empty_without_success_zero() -> None:
     )
     assert run.terminal_status == "partial"
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -327,7 +401,7 @@ def test_partial_collect_never_exit_ok_even_with_products() -> None:
     )
     assert run.terminal_status == "partial"
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="warn"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -343,20 +417,8 @@ def test_partial_collect_never_exit_ok_even_with_products() -> None:
 
 
 def test_strict_missing_excel_is_nonzero() -> None:
-    run = CollectionRun.start(
-        source="pncp_opportunities",
-        collection_id="c",
-        collector_version="t",
-    )
-    run.finish(
-        records_obtained=1,
-        records_persisted=1,
-        request_completed=True,
-        scope_complete=True,
-        reused_within_sla=True,
-    )
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -371,25 +433,22 @@ def test_strict_missing_excel_is_nonzero() -> None:
             error="Excel generation failed",
         ),
     ]
-    assert compute_exit_code(stages, [run], strict=True) == EXIT_TECH
+    assert (
+        compute_exit_code(
+            stages,
+            [_ok_opp_run(), _ok_contracts_run()],
+            strict=True,
+            freshness=_fresh_sources(),
+            execution_scope="full",
+        )
+        == EXIT_TECH
+    )
 
 
 def test_strict_delivery_ok_without_excel_flag_is_unreliable() -> None:
     """Even if status text is ok, missing excel_ok fails strict."""
-    run = CollectionRun.start(
-        source="pncp_opportunities",
-        collection_id="c",
-        collector_version="t",
-    )
-    run.finish(
-        records_obtained=1,
-        records_persisted=1,
-        request_completed=True,
-        scope_complete=True,
-        reused_within_sla=True,
-    )
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -403,7 +462,452 @@ def test_strict_delivery_ok_without_excel_flag_is_unreliable() -> None:
             detail={"excel_ok": False, "checksums_file": "x"},
         ),
     ]
-    assert compute_exit_code(stages, [run], strict=True) == EXIT_UNRELIABLE
+    assert (
+        compute_exit_code(
+            stages,
+            [_ok_opp_run(), _ok_contracts_run()],
+            strict=True,
+            freshness=_fresh_sources(),
+            execution_scope="full",
+        )
+        == EXIT_UNRELIABLE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strict fail-closed readiness (ARCH-RESET-RECOVERY / PR #59 regression)
+# ---------------------------------------------------------------------------
+
+
+def _pr59_live_stages() -> list[StageResult]:
+    """Stages reconstructed from PR #59 live-weekly-collect/manifest.json."""
+    return [
+        StageResult(name="validate_config", status="ok"),
+        StageResult(
+            name="validate_db",
+            status="warn",
+            detail={
+                "universe_200km": 0,
+                "expected_universe": EXPECTED_UNIVERSE_200KM,
+            },
+            error="universe_200km=0 != 1093 (scope drift)",
+        ),
+        StageResult(
+            name="freshness",
+            status="warn",
+            detail={
+                "sources": [
+                    {
+                        "source": "pncp_opportunities",
+                        "level": "never",
+                        "sla_hours": 48,
+                        "age_hours": None,
+                        "indicator": "freshness_source",
+                    },
+                    {
+                        "source": "pncp_contracts",
+                        "level": "never",
+                        "sla_hours": 168,
+                        "indicator": "freshness_source",
+                    },
+                ]
+            },
+        ),
+        StageResult(name="collect", status="ok"),
+        StageResult(name="process", status="ok"),
+        StageResult(name="quality", status="ok"),
+        StageResult(
+            name="intelligence",
+            status="ok",
+            detail={
+                "counts": {
+                    "opportunities": 1,
+                    "contracts": 0,
+                    "competitors": 0,
+                    "orgaos": 1,
+                }
+            },
+        ),
+        StageResult(name="delivery", status="ok", detail=_delivery_ok_detail()),
+    ]
+
+
+def _pr59_live_runs() -> list[CollectionRun]:
+    opp = CollectionRun.start(
+        source="pncp_opportunities",
+        collection_id="col-pr59",
+        collector_version="weekly-cycle/1.0",
+    )
+    opp.finish(
+        records_obtained=32,
+        records_persisted=0,
+        request_completed=True,
+        scope_complete=True,
+    )
+    assert opp.terminal_status == "success"
+    ct = CollectionRun.start(
+        source="pncp_contracts",
+        collection_id="col-pr59",
+        collector_version="weekly-cycle/1.0",
+        mode="reuse",
+    )
+    ct.finish(
+        request_completed=False,
+        scope_complete=False,
+        source_available=True,
+        error="no contracts in lake",
+    )
+    assert ct.terminal_status == "failure"
+    return [opp, ct]
+
+
+def _pr59_freshness() -> list[dict]:
+    return [
+        {
+            "source": "pncp_opportunities",
+            "level": "never",
+            "sla_hours": 48,
+            "age_hours": None,
+        },
+        {"source": "pncp_contracts", "level": "never", "sla_hours": 168},
+    ]
+
+
+def test_pr59_live_manifest_must_not_exit_ok() -> None:
+    """Regression: PR #59 live proof had exit_code=0 with empty universe,
+    freshness never, contracts failure, limit=5 sample — must be non-zero.
+    """
+    stages = _pr59_live_stages()
+    runs = _pr59_live_runs()
+    freshness = _pr59_freshness()
+    # limit=5 → sample
+    assert classify_execution_scope(offline=False, limit=5) == "sample"
+
+    ev = evaluate_readiness(
+        stages,
+        runs,
+        strict=True,
+        freshness=freshness,
+        execution_scope="sample",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert ev.consultive_ready is False
+    assert ev.delivery_completed is True  # delivery alone is not enough
+    assert "universe_missing_or_drifted" in ev.blockers
+    assert "required_source_failed:pncp_contracts" in ev.blockers
+    assert "freshness_not_valid" in ev.blockers
+    assert "execution_scope_not_full:sample" in ev.blockers
+
+
+def test_universe_zero_blocks_strict() -> None:
+    stages = _consultive_ok_stages()
+    stages[1] = StageResult(
+        name="validate_db",
+        status="warn",
+        detail={"universe_200km": 0, "expected_universe": EXPECTED_UNIVERSE_200KM},
+    )
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert ev.consultive_ready is False
+    assert "universe_missing_or_drifted" in ev.blockers
+
+
+def test_universe_divergent_blocks_strict() -> None:
+    stages = _consultive_ok_stages()
+    stages[1] = StageResult(
+        name="validate_db",
+        status="warn",
+        detail={"universe_200km": 500, "expected_universe": EXPECTED_UNIVERSE_200KM},
+    )
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code != EXIT_OK
+    assert "universe_missing_or_drifted" in ev.blockers
+
+
+def test_freshness_never_blocks_when_reusing() -> None:
+    stages = _consultive_ok_stages()
+    fr = [
+        {"source": "pncp_opportunities", "level": "never", "age_hours": None},
+        {"source": "pncp_contracts", "level": "never", "age_hours": None},
+    ]
+    # Both sources reused_fresh with never freshness
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_freshness_unknown_blocks() -> None:
+    # Live success on opp supersedes pre-freshness; contracts reused needs fresh
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=1,
+        records_persisted=1,
+        request_completed=True,
+        scope_complete=True,
+    )
+    fr = [
+        {"source": "pncp_opportunities", "level": "unknown", "age_hours": None},
+        {"source": "pncp_contracts", "level": "unknown", "age_hours": None},
+    ]
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [opp, _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_freshness_stale_blocks_reuse() -> None:
+    fr = [
+        {"source": "pncp_opportunities", "level": "stale", "age_hours": 100.0},
+        {"source": "pncp_contracts", "level": "stale", "age_hours": 200.0},
+    ]
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_freshness_unreliable_blocks() -> None:
+    fr = [
+        {"source": "pncp_opportunities", "level": "unreliable", "age_hours": 1.0},
+        {"source": "pncp_contracts", "level": "fresh", "age_hours": 1.0},
+    ]
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_required_contracts_failure_blocks() -> None:
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(
+        request_completed=False,
+        scope_complete=False,
+        error="no contracts in lake",
+    )
+    assert ct.terminal_status == "failure"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), ct],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "required_source_failed:pncp_contracts" in ev.blockers
+
+
+def test_required_opportunities_partial_blocks() -> None:
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=50,
+        records_persisted=20,
+        request_completed=True,
+        scope_complete=False,
+        error="partial",
+    )
+    assert opp.terminal_status == "partial"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [opp, _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "required_source_failed:pncp_opportunities" in ev.blockers
+
+
+def test_limit_sample_not_consultive_ready() -> None:
+    assert classify_execution_scope(offline=False, limit=5) == "sample"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="sample",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert ev.consultive_ready is False
+    assert "execution_scope_not_full:sample" in ev.blockers
+
+
+def test_fixture_offline_not_consultive_ready() -> None:
+    assert classify_execution_scope(offline=True, limit=50) == "fixture"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="fixture",
+    )
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+
+
+def test_success_zero_incomplete_scope_blocks() -> None:
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    # Manually craft success_zero with incomplete scope (invalid by contract)
+    opp.finish(
+        records_obtained=0,
+        records_persisted=0,
+        request_completed=True,
+        scope_complete=True,
+    )
+    assert opp.terminal_status == "success_zero"
+    opp.scope_complete = False  # invalidate after classify
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [opp, _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert any("success_zero" in b for b in ev.blockers)
+
+
+def test_delivery_ok_with_failed_source_not_exit_ok() -> None:
+    """Delivery artifacts must not compensate for required source failure."""
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(request_completed=False, scope_complete=False, error="fail")
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), ct],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.delivery_completed is True
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+
+
+def test_quality_green_collection_incomplete_not_exit_ok() -> None:
+    """Record-level quality ok must not hide failed collection."""
+    stages = _consultive_ok_stages()
+    # quality ok but contracts failed
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(request_completed=False, scope_complete=False, error="empty")
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), ct],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+
+
+def test_timestamp_absent_age_hours_none_not_zero() -> None:
+    """age_hours=None must not be coerced to 0.0 (freshness adapter safety)."""
+    level = classify_opportunity_freshness(
+        status="completed",
+        age_hours=None,
+        sla_hours=48,
+        scope_complete=True,
+    )
+    assert level == "unknown"
+    assert level != "fresh"
+
+
+def test_complete_package_without_operational_readiness() -> None:
+    """Full delivery with operational blockers → not consultive_ready."""
+    stages = _pr59_live_stages()
+    ev = evaluate_readiness(
+        stages,
+        _pr59_live_runs(),
+        strict=True,
+        freshness=_pr59_freshness(),
+        execution_scope="full",  # even full scope can't fix empty universe
+    )
+    assert ev.delivery_completed is True
+    assert ev.execution_completed is True
+    assert ev.consultive_ready is False
+    assert ev.exit_code == EXIT_UNRELIABLE
+
+
+def test_fully_valid_execution_exit_ok() -> None:
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_OK
+    assert ev.consultive_ready is True
+    assert not ev.blockers
+
+
+def test_degraded_allowed_but_not_consultive() -> None:
+    """Degraded/diagnostic mode may complete, never consultive_ready."""
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="diagnostic",
+    )
+    assert ev.consultive_ready is False
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "execution_scope_not_full:diagnostic" in ev.blockers
+
+
+def test_hours_since_none_preserved() -> None:
+    from scripts.ops.weekly_cycle import _hours_since
+
+    assert _hours_since(None) is None
+
+
+def test_classify_execution_scope_production_limit() -> None:
+    assert classify_execution_scope(offline=False, limit=50) == "full"
+    assert classify_execution_scope(offline=False, limit=49) == "sample"
+    assert classify_execution_scope(offline=True, limit=1000) == "fixture"
 
 
 def test_contract_claim_does_not_use_source_id_as_run_id() -> None:

--- a/tests/unit/source_registry/test_entity_source_binding.py
+++ b/tests/unit/source_registry/test_entity_source_binding.py
@@ -1,0 +1,87 @@
+"""Tests for capability-aware entity_source_binding (migration 058 / Option A)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.source_registry.bindings import (
+    CAPABILITIES,
+    EntitySourceBinding,
+    binding_identity_key,
+    detect_invalid_duplicates,
+    ensure_capability_pair,
+    filter_by_capability,
+)
+
+MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "db"
+    / "migrations"
+    / "058_entity_source_binding_capability.sql"
+)
+
+
+def test_migration_file_exists_and_declares_capability_unique() -> None:
+    assert MIGRATION.is_file()
+    text = MIGRATION.read_text(encoding="utf-8")
+    assert "entity_source_binding" in text
+    assert "notices_or_bids" in text
+    assert "contracts" in text
+    assert "UNIQUE (canonical_id, source_id, capability)" in text or re.search(
+        r"UNIQUE\s*\(\s*canonical_id\s*,\s*source_id\s*,\s*capability\s*\)",
+        text,
+        re.I,
+    )
+
+
+def test_both_capabilities_on_same_entity_source() -> None:
+    pair = ensure_capability_pair("123:ENT", "pncp")
+    assert len(pair) == 2
+    caps = {b.capability for b in pair}
+    assert caps == set(CAPABILITIES)
+    assert detect_invalid_duplicates(pair) == []
+
+
+def test_duplicate_identity_detected() -> None:
+    a = EntitySourceBinding(
+        canonical_id="x", source_id="pncp", capability="notices_or_bids"
+    )
+    b = EntitySourceBinding(
+        canonical_id="x", source_id="pncp", capability="notices_or_bids"
+    )
+    dups = detect_invalid_duplicates([a, b])
+    assert dups == [("x", "pncp", "notices_or_bids")]
+
+
+def test_multi_capability_not_duplicate() -> None:
+    a = EntitySourceBinding(
+        canonical_id="x", source_id="pncp", capability="notices_or_bids"
+    )
+    b = EntitySourceBinding(
+        canonical_id="x", source_id="pncp", capability="contracts"
+    )
+    assert detect_invalid_duplicates([a, b]) == []
+    assert binding_identity_key(a) != binding_identity_key(b)
+
+
+def test_validate_rejects_bad_capability() -> None:
+    bad = EntitySourceBinding(
+        canonical_id="x", source_id="pncp", capability="pricing"
+    )
+    errs = bad.validate()
+    assert any("invalid_capability" in e for e in errs)
+
+
+def test_filter_by_capability() -> None:
+    bindings = ensure_capability_pair("y", "ciga") + ensure_capability_pair("z", "pncp")
+    only = filter_by_capability(bindings, "contracts")
+    assert len(only) == 2
+    assert all(b.capability == "contracts" for b in only)
+
+
+def test_filter_unknown_capability_raises() -> None:
+    with pytest.raises(ValueError, match="unknown capability"):
+        filter_by_capability([], "nope")


### PR DESCRIPTION
## Summary

Closes the DOD item **Freshness coverage mensurável por entidade dentro dos SLAs.** (mensurability only — **not** 95% freshness).

Also includes the strict weekly fail-closed contract from this branch:

1. **Strict weekly readiness (fail-closed)** — `universe=0` / freshness `never` / contracts `failure` / `--limit 5` + Excel → `exit≠0`, `consultive_ready=false`, blockers non-empty.
2. **Entity-level dual freshness reports** — `freshness-editais.json` + `freshness-contracts.json` (1.093 entity_ids each; operational outputs stay out of git).
3. **ESR capability Option A** — migration `058_entity_source_binding_capability` (UNIQUE on canonical_id, source_id, capability).
4. **ADR-028** — freshness by entity × capability, list identity, provenance rules.
5. **Provenance mapping** — `pipeline_evidence_promote` → run_id / raw_sha256 / last_seen_at per capability (pncp vs pncp_contracts).

### Observed (as_of 2026-07-20, not a 95% claim)

| Capability | FRESH | STALE | NEVER |
|------------|-------|-------|-------|
| notices_or_bids | 0 | 408 | 685 |
| contracts | 365 | 0 | 728 |

## Test plan

- [x] `python -m pytest tests/test_weekly_cycle.py -q --no-cov`
- [x] `python -m pytest tests/test_freshness_by_entity.py -q --no-cov`
- [x] `python -m pytest tests/ -k "freshness or source_registry or weekly_cycle" -q --no-cov` (146 passed)
- [x] ruff on touched modules
- [x] `python -m scripts.coverage.freshness_by_entity --strict`

## Claims

**Allowed:** freshness mensurável por entidade; 1093 representadas; editais≠contratos; gaps nominais; strict fail-closed

**Forbidden:** cobertura/freshness/recall ≥95%; LOCAL_READY; VPS; MAX(ingested_at) global como freshness

## Evidence

`docs/ops/campaigns/ENTITY-FRESHNESS-01/`

## Out of scope

Operational coverage 95%, recall 95%, VPS, wholesale merge of PRs #54–#64.