### PR TITLE
refactor(architecture): consolidate validated ARCH-RESET changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,14 @@ lint-fix:
 	ruff check --fix $(SCRIPTS_DIR)/
 	ruff format $(SCRIPTS_DIR)/
 
+# ENGINEERING narrow gate for weekly cycle — NOT full product suite.
+# Must never use `|| true` on ruff/pytest. Prefer `make test-all` for full suite.
+.PHONY: verify-weekly
+verify-weekly:
+	@echo '==> [$(ENV)] ENGINEERING: weekly cycle lint + unit tests (narrow)'
+	ruff check $(SCRIPTS_DIR)/ops/weekly_cycle.py tests/test_weekly_cycle.py tests/architecture/
+	python3 -m pytest tests/test_weekly_cycle.py tests/architecture/ -q --tb=line --no-cov
+
 # ── Ambiente ────────────────────────────────────────────────────────────────
 
 .PHONY: clean

--- a/docs/canonical-entry-points.yaml
+++ b/docs/canonical-entry-points.yaml
@@ -1,14 +1,51 @@
 # Canonical entry-point contract (DoD §32.1)
 # All tool adapters (CLAUDE.md, AGENTS.md, Cursor rules) MUST reference
 # docs/DEVELOPMENT.md and MUST NOT invent parallel product requirements.
-version: "1.0"
-updated_at: "2026-07-18"
+#
+# ARCH-RESET-RECOVERY-2026-07-20: explicit classification — one product weekly cycle.
+# engineering_verify_command is NARROW (verify-weekly), not a false full-suite green.
+version: "1.2"
+updated_at: "2026-07-20"
 canonical_guide: docs/DEVELOPMENT.md
+product_canonical_command: extra-weekly
+product_canonical_module: scripts.ops.weekly_cycle
+engineering_verify_command: verify-weekly
 precedence:
   - DOD.md
   - ADR vigente
   - codigo testado
   - evidencia reproduzivel
+
+# Classes: product_canonical | engineering | diagnostic | legacy_composite | component | campaign_governance
+entrypoint_classification:
+  product_canonical:
+    - make: extra-weekly
+      module: scripts.ops.weekly_cycle
+      note: Only product ops entry for Extra weekly consultive pack
+  engineering:
+    - make: verify-weekly
+      note: Narrow lint + weekly/architecture unit tests; NOT full suite
+    - make: lint
+    - make: test
+    - make: test-all
+      note: Full pytest suite — use this for integrated green, not verify-weekly
+  diagnostic:
+    - make: golden-path
+      module: scripts.golden_path
+    - make: golden-path-quick
+    - make: resilient-local-cycle
+    - make: resilient-smoke
+    - make: resilience-gate
+  legacy_composite:
+    - make: run-pipeline
+      note: Prefer extra-weekly for Extra product pack
+  component:
+    - make: run-crawl
+    - make: run-report
+    - make: report-executivo
+  campaign_governance:
+    - command: python3 squads/extra-dod-roi/scripts/cli.py force-next
+      note: DoD ROI campaign; not product weekly
 
 commands:
   setup: |
@@ -16,16 +53,21 @@ commands:
     pip install -r requirements.txt
     python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
   validate: |
-    python3 -m pytest tests/ -q --tb=no -x
-    ruff check scripts/
+    # Engineering path — prefer narrow weekly verify, then full suite when needed
+    make verify-weekly
     python3 -m scripts.ops.source_contract_tests --json
+  verify: |
+    # ENGINEERING narrow (not product, not full suite)
+    make verify-weekly
   golden_path: |
+    # DIAGNOSTIC (not product weekly)
     python3 -m scripts.golden_path --dsn "$LOCAL_DATALAKE_DSN"
   weekly: |
-    # CANONICAL weekly operational cycle for Extra Construtora
+    # CANONICAL weekly operational cycle for Extra Construtora (product)
     make extra-weekly
     # equivalent: python3 -m scripts.ops.weekly_cycle --strict
   campaign: |
+    # Campaign governance — not product weekly
     python3 squads/extra-dod-roi/scripts/cli.py force-next
 
 # Substrings that every entry-point adapter must mention (or point to DEVELOPMENT.md)
@@ -35,6 +77,7 @@ required_command_tokens:
   - scripts.ops.apply_migrations
   - force-next
   - LOCAL_DATALAKE_DSN
+  - extra-weekly
 
 required_doc_tokens:
   - DOD.md

--- a/scripts/ops/weekly_cycle.py
+++ b/scripts/ops/weekly_cycle.py
@@ -57,6 +57,34 @@ EXIT_TECH = 1
 EXIT_UNRELIABLE = 2
 EXIT_BLOCKED = 3
 
+# Canonical Extra universe (raio_200km active entities). Not a free-form magic
+# repeated ad hoc — single constant used by validate_db + readiness policy.
+EXPECTED_UNIVERSE_200KM = 1093
+UNIVERSE_VERSION = "extra-sc-raio-200km-v1"
+
+# Pack size at/above this is treated as production full pack; smaller is sample.
+PRODUCTION_PACK_LIMIT = 50
+
+# Freshness levels that never qualify a source as operationally ready.
+INVALID_FRESHNESS_LEVELS = frozenset(
+    {"never", "unknown", "stale", "unreliable", "incomplete"}
+)
+VALID_FRESHNESS_LEVELS = frozenset({"fresh"})
+
+# Terminal statuses acceptable for a required source in consultive mode.
+OK_SOURCE_TERMINAL = frozenset({"success", "success_zero", "reused_fresh"})
+BAD_SOURCE_TERMINAL = frozenset(
+    {
+        "failure",
+        "blocked",
+        "partial",
+        "interrupted",
+        "running",
+        "unknown",
+        "",
+    }
+)
+
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
@@ -152,6 +180,72 @@ class StageResult:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class StrictReadinessPolicy:
+    """Centralized, deterministic strict consultive readiness contract.
+
+    Registered in the cycle manifest so exit semantics are inspectable.
+    """
+
+    require_expected_universe: bool = True
+    expected_universe_size: int = EXPECTED_UNIVERSE_200KM
+    universe_version: str = UNIVERSE_VERSION
+    universe_tolerance: int = 0
+    required_sources: frozenset[str] = frozenset(
+        {"pncp_opportunities", "pncp_contracts"}
+    )
+    required_freshness_levels: frozenset[str] = VALID_FRESHNESS_LEVELS
+    invalid_freshness_levels: frozenset[str] = INVALID_FRESHNESS_LEVELS
+    require_complete_scope: bool = True
+    require_non_sample_run: bool = True
+    require_delivery_artifacts: frozenset[str] = frozenset(
+        {"excel_ok", "checksums"}
+    )
+    production_pack_limit: int = PRODUCTION_PACK_LIMIT
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "require_expected_universe": self.require_expected_universe,
+            "expected_universe_size": self.expected_universe_size,
+            "universe_version": self.universe_version,
+            "universe_tolerance": self.universe_tolerance,
+            "required_sources": sorted(self.required_sources),
+            "required_freshness_levels": sorted(self.required_freshness_levels),
+            "invalid_freshness_levels": sorted(self.invalid_freshness_levels),
+            "require_complete_scope": self.require_complete_scope,
+            "require_non_sample_run": self.require_non_sample_run,
+            "require_delivery_artifacts": sorted(self.require_delivery_artifacts),
+            "production_pack_limit": self.production_pack_limit,
+        }
+
+
+DEFAULT_STRICT_POLICY = StrictReadinessPolicy()
+
+
+@dataclass(frozen=True)
+class ReadinessEvaluation:
+    """Separated readiness outcome — never a single ambiguous boolean."""
+
+    exit_code: int
+    execution_completed: bool
+    delivery_completed: bool
+    consultive_ready: bool
+    execution_scope: str
+    blockers: tuple[str, ...]
+    policy: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "exit_code": self.exit_code,
+            "execution_completed": self.execution_completed,
+            "delivery_completed": self.delivery_completed,
+            "consultive_ready": self.consultive_ready,
+            "execution_scope": self.execution_scope,
+            "blockers": list(self.blockers),
+            "policy": self.policy,
+        }
+
+
 @dataclass
 class WeeklyCycleReport:
     cycle_id: str
@@ -172,6 +266,16 @@ class WeeklyCycleReport:
     limitations: list[str] = field(default_factory=list)
     human_accept: dict[str, Any] = field(default_factory=dict)
     duration_seconds: float = 0.0
+    # Explicit readiness contract (manifest fields)
+    execution_scope: str = "diagnostic"
+    execution_completed: bool = False
+    delivery_completed: bool = False
+    consultive_ready: bool = False
+    blockers: list[str] = field(default_factory=list)
+    readiness_policy: dict[str, Any] = field(default_factory=dict)
+    universe_200km: int | None = None
+    expected_universe: int = EXPECTED_UNIVERSE_200KM
+    universe_version: str = UNIVERSE_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -223,13 +327,21 @@ def stage_validate_db(conn: Any) -> StageResult:
         """,
     )
     n = int((uni[0] or {}).get("n") or 0) if uni else 0
-    detail = {"tables": present, "universe_200km": n, "expected_universe": 1093}
-    if n != 1093:
+    detail = {
+        "tables": present,
+        "universe_200km": n,
+        "expected_universe": EXPECTED_UNIVERSE_200KM,
+        "universe_version": UNIVERSE_VERSION,
+    }
+    if n != EXPECTED_UNIVERSE_200KM:
         return StageResult(
             name="validate_db",
             status="warn",
             detail=detail,
-            error=f"universe_200km={n} != 1093 (scope drift)",
+            error=(
+                f"universe_200km={n} != {EXPECTED_UNIVERSE_200KM} "
+                f"(scope drift; universe_version={UNIVERSE_VERSION})"
+            ),
         )
     return StageResult(name="validate_db", status="ok", detail=detail)
 
@@ -635,6 +747,19 @@ def stage_quality(conn: Any, runs: list[CollectionRun]) -> StageResult:
     except Exception as exc:  # noqa: BLE001
         issues.append(f"identity check error: {exc}")
 
+    # Record-level quality is separate from collection completeness.
+    # A source failure must never yield quality status=ok (would hide run failure).
+    collection_issues: list[str] = []
+    for r in runs:
+        if r.source in DEFAULT_STRICT_POLICY.required_sources and r.terminal_status in BAD_SOURCE_TERMINAL:
+            collection_issues.append(
+                f"required_source_{r.terminal_status}:{r.source}"
+            )
+        elif r.source in DEFAULT_STRICT_POLICY.required_sources and r.terminal_status not in OK_SOURCE_TERMINAL:
+            collection_issues.append(
+                f"required_source_not_ok:{r.source}:{r.terminal_status}"
+            )
+
     opp_run = next((r for r in runs if r.source == "pncp_opportunities"), None)
     if opp_run and opp_run.terminal_status in {"failure", "blocked"}:
         issues.append(f"pncp_opportunities terminal={opp_run.terminal_status}")
@@ -655,10 +780,28 @@ def stage_quality(conn: Any, runs: list[CollectionRun]) -> StageResult:
         "catalog_size": len(catalog),
         "opportunity_counts": counts[0] if counts else {},
         "issues": issues,
-        "runs": [r.terminal_status for r in runs],
+        "collection_issues": collection_issues,
+        "record_quality_ok": not issues,
+        "collection_complete": not collection_issues,
+        "runs": [
+            {"source": r.source, "terminal_status": r.terminal_status} for r in runs
+        ],
     }
-    if any("blocked" == r.terminal_status for r in runs if r.source == "pncp_opportunities"):
-        return StageResult(name="quality", status="blocked", detail=detail, error="; ".join(issues) or "blocked")
+    if any(r.terminal_status == "blocked" for r in runs if r.source == "pncp_opportunities"):
+        return StageResult(
+            name="quality",
+            status="blocked",
+            detail=detail,
+            error="; ".join(issues + collection_issues) or "blocked",
+        )
+    # Collection incompleteness is a quality-stage warning, never ok.
+    if collection_issues:
+        return StageResult(
+            name="quality",
+            status="warn",
+            detail=detail,
+            error="; ".join(collection_issues + issues),
+        )
     if issues:
         return StageResult(name="quality", status="warn", detail=detail, error="; ".join(issues))
     return StageResult(name="quality", status="ok", detail=detail)
@@ -1295,71 +1438,342 @@ def _default_gaps(conn: Any, intel: dict[str, Any]) -> list[dict[str, Any]]:
     return gaps
 
 
-def compute_exit_code(
+def classify_execution_scope(
+    *,
+    offline: bool = False,
+    limit: int = PRODUCTION_PACK_LIMIT,
+    policy: StrictReadinessPolicy | None = None,
+) -> str:
+    """Derive execution scope from runtime flags (code, not free text).
+
+    - fixture: offline / synthetic
+    - sample: pack limit below production threshold (e.g. --limit 5)
+    - full: production pack size and online
+    """
+    pol = policy or DEFAULT_STRICT_POLICY
+    if offline:
+        return "fixture"
+    if int(limit) < int(pol.production_pack_limit):
+        return "sample"
+    return "full"
+
+
+def _freshness_by_source(freshness: list[dict[str, Any]] | None) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in freshness or []:
+        src = str(row.get("source") or "")
+        if src:
+            out[src] = row
+    return out
+
+
+def _universe_from_stages(stages: list[StageResult]) -> tuple[int | None, int]:
+    """Extract observed/expected universe from validate_db stage detail."""
+    vdb = next((s for s in stages if s.name == "validate_db"), None)
+    if vdb is None:
+        return None, EXPECTED_UNIVERSE_200KM
+    detail = vdb.detail or {}
+    expected = int(detail.get("expected_universe") or EXPECTED_UNIVERSE_200KM)
+    if "universe_200km" not in detail:
+        return None, expected
+    try:
+        return int(detail["universe_200km"]), expected
+    except (TypeError, ValueError):
+        return None, expected
+
+
+def _source_blockers(
+    run: CollectionRun | None,
+    *,
+    source: str,
+    freshness_row: dict[str, Any] | None,
+    policy: StrictReadinessPolicy,
+) -> list[str]:
+    """Evaluate one required source against terminal status + freshness rules."""
+    blockers: list[str] = []
+    if run is None:
+        blockers.append(f"required_source_missing:{source}")
+        return blockers
+
+    status = str(run.terminal_status or "")
+    if status in BAD_SOURCE_TERMINAL or status not in OK_SOURCE_TERMINAL:
+        blockers.append(f"required_source_failed:{source}")
+        return blockers
+
+    # success_zero only when request completed, scope complete, source available
+    if status == "success_zero":
+        if not run.request_completed or not run.source_available:
+            blockers.append(f"success_zero_not_valid:{source}")
+        if policy.require_complete_scope and not run.scope_complete:
+            blockers.append(f"success_zero_incomplete_scope:{source}")
+        return blockers
+
+    # success this cycle requires complete scope for opportunities
+    if status == "success":
+        if policy.require_complete_scope and not run.scope_complete:
+            # contracts never re-crawl full API in weekly — success path rare;
+            # still enforce when claimed.
+            blockers.append(f"success_incomplete_scope:{source}")
+        return blockers
+
+    # reused_fresh: must be backed by valid freshness (never/stale/unknown fail)
+    if status == "reused_fresh":
+        level = str((freshness_row or {}).get("level") or "unknown")
+        age = (freshness_row or {}).get("age_hours", "missing")
+        if level in policy.invalid_freshness_levels or level not in policy.required_freshness_levels:
+            blockers.append("freshness_not_valid")
+            blockers.append(f"freshness_not_valid:{source}:{level}")
+        # age_hours=None must never be treated as 0
+        if age is None and level == "fresh":
+            blockers.append(f"freshness_age_unknown:{source}")
+        return blockers
+
+    blockers.append(f"required_source_failed:{source}")
+    return blockers
+
+
+def evaluate_readiness(
     stages: list[StageResult],
     runs: list[CollectionRun],
     *,
     strict: bool = True,
-) -> int:
-    """Exit code policy.
+    freshness: list[dict[str, Any]] | None = None,
+    execution_scope: str = "full",
+    policy: StrictReadinessPolicy | None = None,
+) -> ReadinessEvaluation:
+    """Centralized exit + consultive readiness evaluation.
 
-    EXIT_OK only when critical collection is complete (success / success_zero /
-    reused_fresh of a complete prior run) AND delivery is ok (incl. Excel).
-
-    ``partial`` never yields EXIT_OK — even outside strict mode.
-    ``strict`` additionally fails closed on delivery/artifact defects that
-    non-strict might still surface as products with EXIT_UNRELIABLE.
+    Delivery success is necessary but never sufficient.
+    Quality of existing rows does not prove collection completeness.
     """
+    pol = policy or DEFAULT_STRICT_POLICY
+    blockers: list[str] = []
+
     if any(s.status == "fail" for s in stages if s.name in {"validate_config", "validate_db"}):
-        return EXIT_TECH
+        return ReadinessEvaluation(
+            exit_code=EXIT_TECH,
+            execution_completed=False,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("technical_validation_failed",),
+            policy=pol.to_dict(),
+        )
+
     opp = next((r for r in runs if r.source == "pncp_opportunities"), None)
     if opp and opp.terminal_status == "blocked":
-        return EXIT_BLOCKED
+        return ReadinessEvaluation(
+            exit_code=EXIT_BLOCKED,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("required_source_blocked:pncp_opportunities",),
+            policy=pol.to_dict(),
+        )
     if any(s.status == "blocked" for s in stages):
-        return EXIT_BLOCKED
-    if opp and opp.terminal_status == "failure":
-        return EXIT_UNRELIABLE
-    # Critical partial is never consultively OK
-    if opp and opp.terminal_status == "partial":
-        return EXIT_UNRELIABLE
+        return ReadinessEvaluation(
+            exit_code=EXIT_BLOCKED,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("stage_blocked",),
+            policy=pol.to_dict(),
+        )
 
     delivery = next((s for s in stages if s.name == "delivery"), None)
     quality = next((s for s in stages if s.name == "quality"), None)
     intel = next((s for s in stages if s.name == "intelligence"), None)
 
-    if delivery and delivery.status == "fail":
-        # Missing Excel / incomplete pack is technical delivery failure under strict;
-        # still non-zero outside strict (unreliable for consultive use).
-        return EXIT_TECH if strict else EXIT_UNRELIABLE
-
     if quality and quality.status == "blocked":
-        return EXIT_BLOCKED
+        return ReadinessEvaluation(
+            exit_code=EXIT_BLOCKED,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("quality_blocked",),
+            policy=pol.to_dict(),
+        )
+
+    delivery_completed = bool(
+        delivery
+        and delivery.status == "ok"
+        and (delivery.detail or {}).get("excel_ok")
+        and (
+            (delivery.detail or {}).get("checksums_file")
+            or (delivery.detail or {}).get("product_checksums")
+        )
+    )
+
+    if delivery and delivery.status == "fail":
+        return ReadinessEvaluation(
+            exit_code=EXIT_TECH if strict else EXIT_UNRELIABLE,
+            execution_completed=True,
+            delivery_completed=False,
+            consultive_ready=False,
+            execution_scope=execution_scope,
+            blockers=("delivery_failed",),
+            policy=pol.to_dict(),
+        )
+
+    # --- Operational readiness (strict consultive contract) ---
+    universe_n, expected_n = _universe_from_stages(stages)
+    if strict and pol.require_expected_universe:
+        if universe_n is None:
+            blockers.append("universe_missing_or_drifted")
+        elif universe_n == 0:
+            blockers.append("universe_missing_or_drifted")
+        elif abs(universe_n - expected_n) > pol.universe_tolerance:
+            blockers.append("universe_missing_or_drifted")
+
+    if strict and pol.require_non_sample_run and execution_scope != "full":
+        blockers.append(f"execution_scope_not_full:{execution_scope}")
+
+    fr_map = _freshness_by_source(freshness)
+    run_by_source = {r.source: r for r in runs}
 
     if strict:
-        if delivery is None or delivery.status != "ok":
-            return EXIT_UNRELIABLE
-        d = delivery.detail or {}
-        if not d.get("excel_ok"):
-            return EXIT_UNRELIABLE
-        if not d.get("checksums_file") and not d.get("product_checksums"):
-            return EXIT_UNRELIABLE
+        for src in sorted(pol.required_sources):
+            blockers.extend(
+                _source_blockers(
+                    run_by_source.get(src),
+                    source=src,
+                    freshness_row=fr_map.get(src),
+                    policy=pol,
+                )
+            )
 
-    if (
-        intel
-        and intel.status == "ok"
-        and delivery
-        and delivery.status == "ok"
-        and opp
-        and opp.terminal_status in {"success", "success_zero", "reused_fresh"}
-    ):
-        counts = (intel.detail or {}).get("counts") or {}
-        if counts.get("opportunities", 0) == 0 and opp.terminal_status not in {
-            "success_zero",
-            "reused_fresh",
-        }:
-            return EXIT_UNRELIABLE
-        return EXIT_OK
-    return EXIT_UNRELIABLE
+        # Pre-collect freshness never/unknown/stale on a required source that did
+        # not successfully collect this cycle is already covered via reused_fresh
+        # path. Also flag standalone freshness when present and invalid AND the
+        # source run is not a successful live collect this cycle.
+        for src in sorted(pol.required_sources):
+            row = fr_map.get(src)
+            run = run_by_source.get(src)
+            if not row:
+                continue
+            level = str(row.get("level") or "unknown")
+            # age_hours=None must remain unknown, never coerced to 0
+            if row.get("age_hours", "missing") is None and level not in {
+                "never",
+                "unknown",
+            }:
+                # never/unknown already invalid; other levels with None age are bad
+                if level in pol.required_freshness_levels:
+                    blockers.append(f"freshness_age_unknown:{src}")
+            if run and run.terminal_status == "success":
+                continue  # live collect supersedes pre-collect freshness
+            if level in pol.invalid_freshness_levels:
+                if "freshness_not_valid" not in blockers:
+                    blockers.append("freshness_not_valid")
+                tag = f"freshness_not_valid:{src}:{level}"
+                if tag not in blockers:
+                    blockers.append(tag)
+
+        if delivery is None or delivery.status != "ok":
+            blockers.append("delivery_not_ok")
+        else:
+            d = delivery.detail or {}
+            if "excel_ok" in pol.require_delivery_artifacts and not d.get("excel_ok"):
+                blockers.append("delivery_missing_excel")
+            if "checksums" in pol.require_delivery_artifacts and not (
+                d.get("checksums_file") or d.get("product_checksums")
+            ):
+                blockers.append("delivery_missing_checksums")
+
+        if intel is None or intel.status not in {"ok", "warn"}:
+            blockers.append("intelligence_not_ready")
+        elif intel.status == "ok":
+            counts = (intel.detail or {}).get("counts") or {}
+            if counts.get("opportunities", 0) == 0 and (
+                not opp or opp.terminal_status not in {"success_zero", "reused_fresh"}
+            ):
+                blockers.append("opportunities_empty_without_success_zero")
+
+    # Non-strict: keep historical partial/failure guards for opportunities
+    if not strict:
+        if opp and opp.terminal_status in {"failure", "partial"}:
+            blockers.append("required_source_failed:pncp_opportunities")
+
+    # Deduplicate blockers preserving order
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for b in blockers:
+        if b not in seen:
+            seen.add(b)
+            uniq.append(b)
+
+    execution_completed = True
+    consultive_ready = strict and not uniq and delivery_completed
+
+    if consultive_ready:
+        exit_code = EXIT_OK
+    elif any(b.startswith("required_source_blocked") for b in uniq):
+        exit_code = EXIT_BLOCKED
+    else:
+        # Degraded runs may complete delivery but must not claim consultive OK
+        exit_code = EXIT_UNRELIABLE
+
+    # Outside strict, allow EXIT_OK only on the classic narrow path (legacy)
+    if not strict and not uniq:
+        if (
+            intel
+            and intel.status == "ok"
+            and delivery
+            and delivery.status == "ok"
+            and opp
+            and opp.terminal_status in OK_SOURCE_TERMINAL
+        ):
+            counts = (intel.detail or {}).get("counts") or {}
+            if counts.get("opportunities", 0) == 0 and opp.terminal_status not in {
+                "success_zero",
+                "reused_fresh",
+            }:
+                exit_code = EXIT_UNRELIABLE
+            else:
+                exit_code = EXIT_OK
+        else:
+            exit_code = EXIT_UNRELIABLE
+
+    return ReadinessEvaluation(
+        exit_code=exit_code,
+        execution_completed=execution_completed,
+        delivery_completed=delivery_completed,
+        consultive_ready=consultive_ready and exit_code == EXIT_OK,
+        execution_scope=execution_scope,
+        blockers=tuple(uniq),
+        policy=pol.to_dict(),
+    )
+
+
+def compute_exit_code(
+    stages: list[StageResult],
+    runs: list[CollectionRun],
+    *,
+    strict: bool = True,
+    freshness: list[dict[str, Any]] | None = None,
+    execution_scope: str = "full",
+    policy: StrictReadinessPolicy | None = None,
+) -> int:
+    """Exit code policy (wrapper over evaluate_readiness).
+
+    EXIT_OK only when strict consultive contract is fully satisfied:
+    expected universe, required sources OK, freshness valid for reuse,
+    non-sample execution, and delivery artifacts present.
+
+    ``partial`` / ``failure`` on required sources never yields EXIT_OK.
+    Delivery alone never compensates for failed collection.
+    """
+    return evaluate_readiness(
+        stages,
+        runs,
+        strict=strict,
+        freshness=freshness,
+        execution_scope=execution_scope,
+        policy=policy,
+    ).exit_code
 
 
 def run_weekly_cycle(
@@ -1488,15 +1902,23 @@ def run_weekly_cycle(
             conn, collection_id=collection_id, freshness_rows=freshness_rows
         )
         runs.append(r_ct)
+        # Collect status considers ALL required sources, not only opportunities.
         collect_status = "ok"
-        if r_opp.terminal_status == "blocked":
-            collect_status = "blocked"
-        elif r_opp.terminal_status in {"failure"}:
-            collect_status = "fail"
-        elif r_opp.terminal_status == "partial":
-            collect_status = "warn"
-        elif r_opp.terminal_status not in {"success", "success_zero", "reused_fresh"}:
-            collect_status = "fail"
+        for r in runs:
+            if r.source not in DEFAULT_STRICT_POLICY.required_sources:
+                continue
+            if r.terminal_status == "blocked":
+                collect_status = "blocked"
+                break
+            if r.terminal_status in {"failure"}:
+                collect_status = "fail"
+            elif r.terminal_status == "partial" and collect_status == "ok":
+                collect_status = "warn"
+            elif (
+                r.terminal_status not in OK_SOURCE_TERMINAL
+                and collect_status == "ok"
+            ):
+                collect_status = "fail"
         stages.append(
             StageResult(
                 name="collect",
@@ -1543,7 +1965,39 @@ def run_weekly_cycle(
         report.products = sd.detail or {}
         report.runs = [r.to_dict() for r in runs]
         report.stages = [asdict(s) for s in stages]
-        report.exit_code = compute_exit_code(stages, runs, strict=strict)
+
+        # Universe observed from validate_db
+        universe_n, expected_n = _universe_from_stages(stages)
+        report.universe_200km = universe_n
+        report.expected_universe = expected_n
+        report.universe_version = UNIVERSE_VERSION
+
+        exec_scope = classify_execution_scope(
+            offline=offline,
+            limit=limit,
+            policy=DEFAULT_STRICT_POLICY,
+        )
+        readiness = evaluate_readiness(
+            stages,
+            runs,
+            strict=strict,
+            freshness=freshness_rows,
+            execution_scope=exec_scope,
+            policy=DEFAULT_STRICT_POLICY,
+        )
+        report.exit_code = readiness.exit_code
+        report.execution_scope = readiness.execution_scope
+        report.execution_completed = readiness.execution_completed
+        report.delivery_completed = readiness.delivery_completed
+        report.consultive_ready = readiness.consultive_ready
+        report.blockers = list(readiness.blockers)
+        report.readiness_policy = readiness.policy
+        # Human accept must never claim ready when consultive_ready is false
+        if report.consultive_ready and report.exit_code == EXIT_OK:
+            report.human_accept["status"] = "ready_for_human_review"
+        else:
+            report.human_accept["status"] = "not_consultive_ready"
+            report.human_accept["blockers"] = list(readiness.blockers)
 
         # Write manifest ONCE — no self-hash. Integrity of products is in checksums.json.
         report.finished_at = _iso()
@@ -1625,6 +2079,12 @@ def main(argv: list[str] | None = None) -> int:
                 "cycle_id": report.cycle_id,
                 "collection_id": report.collection_id,
                 "exit_code": report.exit_code,
+                "consultive_ready": report.consultive_ready,
+                "execution_scope": report.execution_scope,
+                "execution_completed": report.execution_completed,
+                "delivery_completed": report.delivery_completed,
+                "blockers": report.blockers,
+                "universe_200km": report.universe_200km,
                 "duration_seconds": report.duration_seconds,
                 "products": {
                     k: report.products.get(k)

--- a/tests/architecture/__init__.py
+++ b/tests/architecture/__init__.py
@@ -1,0 +1,1 @@
+"""Architecture fitness and characterization tests (ARCH-RESET recovery)."""

--- a/tests/architecture/test_fitness_functions.py
+++ b/tests/architecture/test_fitness_functions.py
@@ -1,0 +1,185 @@
+"""Structural fitness functions for ARCH-RESET recovery.
+
+These are real structural checks — not scanners that only prove a string exists.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.collect.run_contract import CollectionRun
+from scripts.ops.weekly_cycle import (
+    EXIT_OK,
+    StageResult,
+    evaluate_readiness,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_single_product_canonical_weekly_entrypoint() -> None:
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    product = data["entrypoint_classification"]["product_canonical"]
+    assert len(product) == 1
+    assert product[0]["make"] == "extra-weekly"
+    assert product[0]["module"] == "scripts.ops.weekly_cycle"
+    assert data["product_canonical_module"] == "scripts.ops.weekly_cycle"
+
+
+def test_engineering_verify_is_narrow_not_product() -> None:
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    eng = {r.get("make") for r in data["entrypoint_classification"]["engineering"]}
+    prod = {r.get("make") for r in data["entrypoint_classification"]["product_canonical"]}
+    assert data["engineering_verify_command"] == "verify-weekly"
+    assert "verify-weekly" in eng
+    assert "verify-weekly" not in prod
+    assert "extra-weekly" not in eng
+
+
+def test_makefile_mandatory_gates_no_or_true() -> None:
+    """ruff/pytest recipes must not swallow failures with || true."""
+    mk = (ROOT / "Makefile").read_text(encoding="utf-8")
+    for target in ("lint", "verify-weekly", "test", "test-all", "extra-weekly"):
+        m = re.search(rf"^{re.escape(target)}:.*?(?=^\S|\Z)", mk, flags=re.M | re.S)
+        assert m, f"missing make target {target}"
+        block = m.group(0)
+        # Allow || true only in clean's find (not in these gates)
+        if target == "clean":
+            continue
+        assert "|| true" not in block, f"{target} must not use || true"
+
+
+def test_no_llm_in_freshness_or_coverage_modules() -> None:
+    """Freshness/coverage classification must stay deterministic (no LLM imports)."""
+    banned = re.compile(
+        r"\b(openai|anthropic|litellm|langchain|chat_completion|ChatCompletion)\b",
+        re.I,
+    )
+    paths = [
+        ROOT / "scripts/ops/weekly_cycle.py",
+        ROOT / "scripts/quality/indicator_catalog.py",
+    ]
+    for path in paths:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        assert not banned.search(text), f"LLM dependency found in {path}"
+
+
+def test_impossible_exit_ok_with_mandatory_blockers() -> None:
+    stages = [
+        StageResult(
+            name="validate_db",
+            status="warn",
+            detail={"universe_200km": 0, "expected_universe": 1093},
+        ),
+        StageResult(
+            name="intelligence",
+            status="ok",
+            detail={"counts": {"opportunities": 1}},
+        ),
+        StageResult(
+            name="delivery",
+            status="ok",
+            detail={
+                "excel_ok": True,
+                "checksums_file": "x",
+                "product_checksums": {"a": {"sha256": "b"}},
+            },
+        ),
+    ]
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=1,
+        records_persisted=1,
+        request_completed=True,
+        scope_complete=True,
+    )
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(request_completed=False, scope_complete=False, error="no contracts")
+    ev = evaluate_readiness(
+        stages,
+        [opp, ct],
+        strict=True,
+        freshness=[
+            {"source": "pncp_opportunities", "level": "never", "age_hours": None},
+            {"source": "pncp_contracts", "level": "never"},
+        ],
+        execution_scope="sample",
+    )
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+    assert ev.blockers
+
+
+def test_sample_execution_cannot_be_consultive_ready() -> None:
+    stages = [
+        StageResult(
+            name="validate_db",
+            status="ok",
+            detail={"universe_200km": 1093, "expected_universe": 1093},
+        ),
+        StageResult(
+            name="intelligence",
+            status="ok",
+            detail={"counts": {"opportunities": 5}},
+        ),
+        StageResult(
+            name="delivery",
+            status="ok",
+            detail={
+                "excel_ok": True,
+                "checksums_file": "x",
+                "product_checksums": {"a": {"sha256": "b"}},
+            },
+        ),
+    ]
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=10,
+        records_persisted=10,
+        request_completed=True,
+        scope_complete=True,
+        reused_within_sla=True,
+    )
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(
+        records_obtained=10,
+        records_persisted=10,
+        request_completed=True,
+        scope_complete=False,
+        reused_within_sla=True,
+    )
+    fr = [
+        {"source": "pncp_opportunities", "level": "fresh", "age_hours": 1.0},
+        {"source": "pncp_contracts", "level": "fresh", "age_hours": 1.0},
+    ]
+    ev = evaluate_readiness(
+        stages, [opp, ct], strict=True, freshness=fr, execution_scope="sample"
+    )
+    assert ev.consultive_ready is False
+    assert ev.exit_code != EXIT_OK
+
+
+def test_weekly_cycle_is_registered_canonical_module() -> None:
+    """Only one module registered as product weekly contract."""
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    modules = [
+        row.get("module")
+        for row in data["entrypoint_classification"]["product_canonical"]
+        if row.get("module")
+    ]
+    assert modules == ["scripts.ops.weekly_cycle"]
+    # Module file must exist
+    assert (ROOT / "scripts/ops/weekly_cycle.py").is_file()

--- a/tests/architecture/test_weekly_characterization.py
+++ b/tests/architecture/test_weekly_characterization.py
@@ -1,0 +1,250 @@
+"""Characterization tests for the canonical Extra weekly pipeline.
+
+Selectively reused from ARCH-RESET PR #55, strengthened for fail-closed readiness
+(PR #63 / ARCH-RESET-RECOVERY). Behavior locks, not string theater.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.collect.run_contract import CollectionRun
+from scripts.ops.weekly_cycle import (
+    EXIT_OK,
+    EXIT_TECH,
+    EXIT_UNRELIABLE,
+    StageResult,
+    build_parser,
+    classify_execution_scope,
+    classify_opportunity_freshness,
+    compute_exit_code,
+    evaluate_readiness,
+    run_weekly_cycle,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_makefile_extra_weekly_points_to_weekly_cycle_module() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    assert re.search(r"^extra-weekly:", makefile, flags=re.M)
+    assert "scripts.ops.weekly_cycle" in makefile
+    assert "--strict" in makefile
+
+
+def test_makefile_verify_weekly_has_no_true_swallow() -> None:
+    """Mandatory weekly gate must not ignore ruff/pytest failures."""
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    assert re.search(r"^verify-weekly:", makefile, flags=re.M)
+    # Extract verify-weekly recipe block until next target
+    m = re.search(
+        r"^verify-weekly:.*?(?=^\S|\Z)",
+        makefile,
+        flags=re.M | re.S,
+    )
+    assert m, "verify-weekly target missing"
+    block = m.group(0)
+    assert "|| true" not in block
+    assert "ruff check" in block
+    assert "pytest" in block or "python3 -m pytest" in block
+
+
+def test_canonical_entry_points_yaml_marks_weekly_product() -> None:
+    path = ROOT / "docs" / "canonical-entry-points.yaml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data.get("product_canonical_command") == "extra-weekly"
+    assert data.get("product_canonical_module") == "scripts.ops.weekly_cycle"
+    cmds = data.get("commands") or {}
+    assert "weekly" in cmds
+    weekly_blob = cmds["weekly"]
+    text = weekly_blob if isinstance(weekly_blob, str) else yaml.safe_dump(weekly_blob)
+    assert "extra-weekly" in text or "weekly_cycle" in text
+
+
+def test_competing_make_targets_still_exist_but_are_not_extra_weekly() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    targets = set(re.findall(r"^([a-zA-Z0-9_.-]+):", makefile, flags=re.M))
+    assert "extra-weekly" in targets
+    for t in ("golden-path", "run-pipeline", "report-executivo", "resilient-local-cycle"):
+        assert t in targets, f"expected make target {t} present at baseline"
+
+
+def test_cli_parser_exposes_strict_and_offline_seams() -> None:
+    p = build_parser()
+    help_text = p.format_help()
+    assert "--strict" in help_text
+    assert "--offline" in help_text
+
+
+def test_stage_boundary_names_stable_for_strangler() -> None:
+    critical_stage_names = {
+        "validate_config",
+        "validate_db",
+        "delivery",
+        "quality",
+        "intelligence",
+        "collect",
+    }
+    src = (ROOT / "scripts" / "ops" / "weekly_cycle.py").read_text(encoding="utf-8")
+    for name in critical_stage_names:
+        assert f'"{name}"' in src or f"'{name}'" in src
+    # Central policy must exist (not scattered ifs only)
+    assert "StrictReadinessPolicy" in src
+    assert "evaluate_readiness" in src
+
+
+def test_partial_collect_never_exit_ok_strict() -> None:
+    run = CollectionRun.start(
+        source="pncp_opportunities",
+        collection_id="char-c",
+        collector_version="t",
+    )
+    run.finish(
+        records_obtained=5,
+        records_persisted=5,
+        request_completed=True,
+        scope_complete=False,
+        error="partial",
+    )
+    stages = [
+        StageResult(name="validate_db", status="ok", detail={"universe_200km": 1093, "expected_universe": 1093}),
+        StageResult(name="collect", status="ok"),
+        StageResult(name="quality", status="ok"),
+        StageResult(
+            name="intelligence",
+            status="ok",
+            detail={"counts": {"opportunities": 3}},
+        ),
+        StageResult(
+            name="delivery",
+            status="ok",
+            detail={
+                "excel_ok": True,
+                "checksums_file": "x",
+                "product_checksums": {"a": {"sha256": "b"}},
+            },
+        ),
+    ]
+    assert compute_exit_code(stages, [run], strict=True) == EXIT_UNRELIABLE
+    assert compute_exit_code(stages, [run], strict=True) != EXIT_OK
+
+
+def test_freshness_fail_closed_for_partial() -> None:
+    assert (
+        classify_opportunity_freshness(
+            status="partial",
+            age_hours=0.1,
+            sla_hours=48,
+            scope_complete=False,
+        )
+        == "incomplete"
+    )
+
+
+def test_run_weekly_without_db_is_tech_fail_and_has_ids(tmp_path: Path) -> None:
+    report = run_weekly_cycle(
+        dsn="postgresql://invalid:invalid@127.0.0.1:1/no_db",
+        output_dir=tmp_path / "out",
+        strict=True,
+        offline=True,
+        skip_collect=True,
+        limit=5,
+    )
+    assert report.cycle_id
+    assert report.collection_id
+    assert report.exit_code == EXIT_TECH
+    assert "LOCAL_READY" in report.claims_forbidden
+
+
+def test_two_offline_cycles_get_distinct_cycle_ids(tmp_path: Path) -> None:
+    r1 = run_weekly_cycle(
+        dsn="postgresql://invalid:invalid@127.0.0.1:1/no_db",
+        output_dir=tmp_path / "a",
+        offline=True,
+        skip_collect=True,
+    )
+    r2 = run_weekly_cycle(
+        dsn="postgresql://invalid:invalid@127.0.0.1:1/no_db",
+        output_dir=tmp_path / "b",
+        offline=True,
+        skip_collect=True,
+    )
+    assert r1.cycle_id != r2.cycle_id
+    assert r1.collection_id != r2.collection_id
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    [
+        "LOCAL_READY",
+        "VPS_OPERATIONAL",
+        "PROJECT_DONE",
+        "cobertura operacional 95%",
+    ],
+)
+def test_forbidden_claims_always_listed(forbidden: str, tmp_path: Path) -> None:
+    report = run_weekly_cycle(
+        dsn="postgresql://invalid:invalid@127.0.0.1:1/no_db",
+        output_dir=tmp_path / "c",
+        offline=True,
+        skip_collect=True,
+    )
+    assert forbidden in report.claims_forbidden
+
+
+def test_sample_scope_never_consultive_ready() -> None:
+    assert classify_execution_scope(offline=False, limit=5) == "sample"
+    stages = [
+        StageResult(
+            name="validate_db",
+            status="ok",
+            detail={"universe_200km": 1093, "expected_universe": 1093},
+        ),
+        StageResult(
+            name="delivery",
+            status="ok",
+            detail={
+                "excel_ok": True,
+                "checksums_file": "x",
+                "product_checksums": {"a": {"sha256": "b"}},
+            },
+        ),
+        StageResult(
+            name="intelligence",
+            status="ok",
+            detail={"counts": {"opportunities": 1}},
+        ),
+    ]
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=1,
+        records_persisted=1,
+        request_completed=True,
+        scope_complete=True,
+        reused_within_sla=True,
+    )
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(
+        records_obtained=1,
+        records_persisted=1,
+        request_completed=True,
+        scope_complete=False,
+        reused_within_sla=True,
+    )
+    fr = [
+        {"source": "pncp_opportunities", "level": "fresh", "age_hours": 1.0},
+        {"source": "pncp_contracts", "level": "fresh", "age_hours": 1.0},
+    ]
+    ev = evaluate_readiness(
+        stages, [opp, ct], strict=True, freshness=fr, execution_scope="sample"
+    )
+    assert ev.consultive_ready is False
+    assert ev.exit_code != EXIT_OK

--- a/tests/test_entrypoint_classification.py
+++ b/tests/test_entrypoint_classification.py
@@ -1,0 +1,38 @@
+"""ARCH-RESET recovery — entrypoint classification contract (from PR #56, adapted)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_product_canonical_is_extra_weekly_only() -> None:
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    assert data["product_canonical_command"] == "extra-weekly"
+    assert data["product_canonical_module"] == "scripts.ops.weekly_cycle"
+    classes = data["entrypoint_classification"]
+    product = classes["product_canonical"]
+    assert len(product) == 1
+    assert product[0]["make"] == "extra-weekly"
+    for row in classes.get("legacy_composite", []) + classes.get("diagnostic", []):
+        assert row.get("make") != "extra-weekly"
+
+
+def test_makefile_has_verify_weekly_and_extra_weekly() -> None:
+    mk = (ROOT / "Makefile").read_text(encoding="utf-8")
+    assert re.search(r"^extra-weekly:", mk, flags=re.M)
+    assert re.search(r"^verify-weekly:", mk, flags=re.M)
+    assert "scripts.ops.weekly_cycle" in mk
+
+
+def test_engineering_verify_not_listed_as_product() -> None:
+    data = yaml.safe_load((ROOT / "docs/canonical-entry-points.yaml").read_text(encoding="utf-8"))
+    eng = {r.get("make") for r in data["entrypoint_classification"]["engineering"]}
+    assert "verify-weekly" in eng
+    prod = {r.get("make") for r in data["entrypoint_classification"]["product_canonical"]}
+    assert "verify-weekly" not in prod
+    assert data["engineering_verify_command"] == "verify-weekly"

--- a/tests/test_weekly_cycle.py
+++ b/tests/test_weekly_cycle.py
@@ -16,10 +16,13 @@ from scripts.ops.weekly_cycle import (
     EXIT_OK,
     EXIT_TECH,
     EXIT_UNRELIABLE,
+    EXPECTED_UNIVERSE_200KM,
     StageResult,
     _build_claims_catalog,
+    classify_execution_scope,
     classify_opportunity_freshness,
     compute_exit_code,
+    evaluate_readiness,
     run_weekly_cycle,
 )
 from scripts.quality.indicator_catalog import (
@@ -205,7 +208,37 @@ def _delivery_ok_detail() -> dict:
     }
 
 
-def test_exit_ok_with_reused_and_products() -> None:
+def _fresh_sources() -> list[dict]:
+    return [
+        {
+            "source": "pncp_opportunities",
+            "level": "fresh",
+            "age_hours": 1.0,
+            "sla_hours": 48,
+        },
+        {
+            "source": "pncp_contracts",
+            "level": "fresh",
+            "age_hours": 2.0,
+            "sla_hours": 168,
+            "row_count": 100,
+        },
+    ]
+
+
+def _universe_ok_stage() -> StageResult:
+    return StageResult(
+        name="validate_db",
+        status="ok",
+        detail={
+            "universe_200km": EXPECTED_UNIVERSE_200KM,
+            "expected_universe": EXPECTED_UNIVERSE_200KM,
+            "universe_version": "extra-sc-raio-200km-v1",
+        },
+    )
+
+
+def _ok_opp_run() -> CollectionRun:
     run = CollectionRun.start(
         source="pncp_opportunities",
         collection_id="c",
@@ -218,18 +251,59 @@ def test_exit_ok_with_reused_and_products() -> None:
         scope_complete=True,
         reused_within_sla=True,
     )
-    stages = [
-        StageResult(name="validate_db", status="ok"),
+    return run
+
+
+def _ok_contracts_run() -> CollectionRun:
+    run = CollectionRun.start(
+        source="pncp_contracts",
+        collection_id="c",
+        collector_version="t",
+        mode="reuse",
+    )
+    run.finish(
+        records_obtained=100,
+        records_persisted=100,
+        request_completed=True,
+        scope_complete=False,
+        reused_within_sla=True,
+        raw_uri="db://pncp_supplier_contracts",
+    )
+    return run
+
+
+def _consultive_ok_stages() -> list[StageResult]:
+    return [
+        StageResult(name="validate_config", status="ok"),
+        _universe_ok_stage(),
+        StageResult(name="freshness", status="ok", detail={"sources": _fresh_sources()}),
         StageResult(name="collect", status="ok"),
+        StageResult(name="process", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
             name="intelligence",
             status="ok",
-            detail={"counts": {"opportunities": 5}},
+            detail={"counts": {"opportunities": 5, "contracts": 10}},
         ),
         StageResult(name="delivery", status="ok", detail=_delivery_ok_detail()),
     ]
-    assert compute_exit_code(stages, [run], strict=True) == EXIT_OK
+
+
+def test_exit_ok_with_reused_and_products() -> None:
+    """Fully valid consultive state → EXIT_OK."""
+    stages = _consultive_ok_stages()
+    runs = [_ok_opp_run(), _ok_contracts_run()]
+    ev = evaluate_readiness(
+        stages,
+        runs,
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_OK
+    assert ev.consultive_ready is True
+    assert ev.delivery_completed is True
+    assert ev.blockers == ()
 
 
 def test_exit_unreliable_empty_without_success_zero() -> None:
@@ -247,7 +321,7 @@ def test_exit_unreliable_empty_without_success_zero() -> None:
     )
     assert run.terminal_status == "partial"
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -327,7 +401,7 @@ def test_partial_collect_never_exit_ok_even_with_products() -> None:
     )
     assert run.terminal_status == "partial"
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="warn"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -343,20 +417,8 @@ def test_partial_collect_never_exit_ok_even_with_products() -> None:
 
 
 def test_strict_missing_excel_is_nonzero() -> None:
-    run = CollectionRun.start(
-        source="pncp_opportunities",
-        collection_id="c",
-        collector_version="t",
-    )
-    run.finish(
-        records_obtained=1,
-        records_persisted=1,
-        request_completed=True,
-        scope_complete=True,
-        reused_within_sla=True,
-    )
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -371,25 +433,22 @@ def test_strict_missing_excel_is_nonzero() -> None:
             error="Excel generation failed",
         ),
     ]
-    assert compute_exit_code(stages, [run], strict=True) == EXIT_TECH
+    assert (
+        compute_exit_code(
+            stages,
+            [_ok_opp_run(), _ok_contracts_run()],
+            strict=True,
+            freshness=_fresh_sources(),
+            execution_scope="full",
+        )
+        == EXIT_TECH
+    )
 
 
 def test_strict_delivery_ok_without_excel_flag_is_unreliable() -> None:
     """Even if status text is ok, missing excel_ok fails strict."""
-    run = CollectionRun.start(
-        source="pncp_opportunities",
-        collection_id="c",
-        collector_version="t",
-    )
-    run.finish(
-        records_obtained=1,
-        records_persisted=1,
-        request_completed=True,
-        scope_complete=True,
-        reused_within_sla=True,
-    )
     stages = [
-        StageResult(name="validate_db", status="ok"),
+        _universe_ok_stage(),
         StageResult(name="collect", status="ok"),
         StageResult(name="quality", status="ok"),
         StageResult(
@@ -403,7 +462,452 @@ def test_strict_delivery_ok_without_excel_flag_is_unreliable() -> None:
             detail={"excel_ok": False, "checksums_file": "x"},
         ),
     ]
-    assert compute_exit_code(stages, [run], strict=True) == EXIT_UNRELIABLE
+    assert (
+        compute_exit_code(
+            stages,
+            [_ok_opp_run(), _ok_contracts_run()],
+            strict=True,
+            freshness=_fresh_sources(),
+            execution_scope="full",
+        )
+        == EXIT_UNRELIABLE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strict fail-closed readiness (ARCH-RESET-RECOVERY / PR #59 regression)
+# ---------------------------------------------------------------------------
+
+
+def _pr59_live_stages() -> list[StageResult]:
+    """Stages reconstructed from PR #59 live-weekly-collect/manifest.json."""
+    return [
+        StageResult(name="validate_config", status="ok"),
+        StageResult(
+            name="validate_db",
+            status="warn",
+            detail={
+                "universe_200km": 0,
+                "expected_universe": EXPECTED_UNIVERSE_200KM,
+            },
+            error="universe_200km=0 != 1093 (scope drift)",
+        ),
+        StageResult(
+            name="freshness",
+            status="warn",
+            detail={
+                "sources": [
+                    {
+                        "source": "pncp_opportunities",
+                        "level": "never",
+                        "sla_hours": 48,
+                        "age_hours": None,
+                        "indicator": "freshness_source",
+                    },
+                    {
+                        "source": "pncp_contracts",
+                        "level": "never",
+                        "sla_hours": 168,
+                        "indicator": "freshness_source",
+                    },
+                ]
+            },
+        ),
+        StageResult(name="collect", status="ok"),
+        StageResult(name="process", status="ok"),
+        StageResult(name="quality", status="ok"),
+        StageResult(
+            name="intelligence",
+            status="ok",
+            detail={
+                "counts": {
+                    "opportunities": 1,
+                    "contracts": 0,
+                    "competitors": 0,
+                    "orgaos": 1,
+                }
+            },
+        ),
+        StageResult(name="delivery", status="ok", detail=_delivery_ok_detail()),
+    ]
+
+
+def _pr59_live_runs() -> list[CollectionRun]:
+    opp = CollectionRun.start(
+        source="pncp_opportunities",
+        collection_id="col-pr59",
+        collector_version="weekly-cycle/1.0",
+    )
+    opp.finish(
+        records_obtained=32,
+        records_persisted=0,
+        request_completed=True,
+        scope_complete=True,
+    )
+    assert opp.terminal_status == "success"
+    ct = CollectionRun.start(
+        source="pncp_contracts",
+        collection_id="col-pr59",
+        collector_version="weekly-cycle/1.0",
+        mode="reuse",
+    )
+    ct.finish(
+        request_completed=False,
+        scope_complete=False,
+        source_available=True,
+        error="no contracts in lake",
+    )
+    assert ct.terminal_status == "failure"
+    return [opp, ct]
+
+
+def _pr59_freshness() -> list[dict]:
+    return [
+        {
+            "source": "pncp_opportunities",
+            "level": "never",
+            "sla_hours": 48,
+            "age_hours": None,
+        },
+        {"source": "pncp_contracts", "level": "never", "sla_hours": 168},
+    ]
+
+
+def test_pr59_live_manifest_must_not_exit_ok() -> None:
+    """Regression: PR #59 live proof had exit_code=0 with empty universe,
+    freshness never, contracts failure, limit=5 sample — must be non-zero.
+    """
+    stages = _pr59_live_stages()
+    runs = _pr59_live_runs()
+    freshness = _pr59_freshness()
+    # limit=5 → sample
+    assert classify_execution_scope(offline=False, limit=5) == "sample"
+
+    ev = evaluate_readiness(
+        stages,
+        runs,
+        strict=True,
+        freshness=freshness,
+        execution_scope="sample",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert ev.consultive_ready is False
+    assert ev.delivery_completed is True  # delivery alone is not enough
+    assert "universe_missing_or_drifted" in ev.blockers
+    assert "required_source_failed:pncp_contracts" in ev.blockers
+    assert "freshness_not_valid" in ev.blockers
+    assert "execution_scope_not_full:sample" in ev.blockers
+
+
+def test_universe_zero_blocks_strict() -> None:
+    stages = _consultive_ok_stages()
+    stages[1] = StageResult(
+        name="validate_db",
+        status="warn",
+        detail={"universe_200km": 0, "expected_universe": EXPECTED_UNIVERSE_200KM},
+    )
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert ev.consultive_ready is False
+    assert "universe_missing_or_drifted" in ev.blockers
+
+
+def test_universe_divergent_blocks_strict() -> None:
+    stages = _consultive_ok_stages()
+    stages[1] = StageResult(
+        name="validate_db",
+        status="warn",
+        detail={"universe_200km": 500, "expected_universe": EXPECTED_UNIVERSE_200KM},
+    )
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code != EXIT_OK
+    assert "universe_missing_or_drifted" in ev.blockers
+
+
+def test_freshness_never_blocks_when_reusing() -> None:
+    stages = _consultive_ok_stages()
+    fr = [
+        {"source": "pncp_opportunities", "level": "never", "age_hours": None},
+        {"source": "pncp_contracts", "level": "never", "age_hours": None},
+    ]
+    # Both sources reused_fresh with never freshness
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_freshness_unknown_blocks() -> None:
+    # Live success on opp supersedes pre-freshness; contracts reused needs fresh
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=1,
+        records_persisted=1,
+        request_completed=True,
+        scope_complete=True,
+    )
+    fr = [
+        {"source": "pncp_opportunities", "level": "unknown", "age_hours": None},
+        {"source": "pncp_contracts", "level": "unknown", "age_hours": None},
+    ]
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [opp, _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_freshness_stale_blocks_reuse() -> None:
+    fr = [
+        {"source": "pncp_opportunities", "level": "stale", "age_hours": 100.0},
+        {"source": "pncp_contracts", "level": "stale", "age_hours": 200.0},
+    ]
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_freshness_unreliable_blocks() -> None:
+    fr = [
+        {"source": "pncp_opportunities", "level": "unreliable", "age_hours": 1.0},
+        {"source": "pncp_contracts", "level": "fresh", "age_hours": 1.0},
+    ]
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=fr,
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "freshness_not_valid" in ev.blockers
+
+
+def test_required_contracts_failure_blocks() -> None:
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(
+        request_completed=False,
+        scope_complete=False,
+        error="no contracts in lake",
+    )
+    assert ct.terminal_status == "failure"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), ct],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "required_source_failed:pncp_contracts" in ev.blockers
+
+
+def test_required_opportunities_partial_blocks() -> None:
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    opp.finish(
+        records_obtained=50,
+        records_persisted=20,
+        request_completed=True,
+        scope_complete=False,
+        error="partial",
+    )
+    assert opp.terminal_status == "partial"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [opp, _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "required_source_failed:pncp_opportunities" in ev.blockers
+
+
+def test_limit_sample_not_consultive_ready() -> None:
+    assert classify_execution_scope(offline=False, limit=5) == "sample"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="sample",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert ev.consultive_ready is False
+    assert "execution_scope_not_full:sample" in ev.blockers
+
+
+def test_fixture_offline_not_consultive_ready() -> None:
+    assert classify_execution_scope(offline=True, limit=50) == "fixture"
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="fixture",
+    )
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+
+
+def test_success_zero_incomplete_scope_blocks() -> None:
+    opp = CollectionRun.start(
+        source="pncp_opportunities", collection_id="c", collector_version="t"
+    )
+    # Manually craft success_zero with incomplete scope (invalid by contract)
+    opp.finish(
+        records_obtained=0,
+        records_persisted=0,
+        request_completed=True,
+        scope_complete=True,
+    )
+    assert opp.terminal_status == "success_zero"
+    opp.scope_complete = False  # invalidate after classify
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [opp, _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert any("success_zero" in b for b in ev.blockers)
+
+
+def test_delivery_ok_with_failed_source_not_exit_ok() -> None:
+    """Delivery artifacts must not compensate for required source failure."""
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(request_completed=False, scope_complete=False, error="fail")
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), ct],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.delivery_completed is True
+    assert ev.exit_code != EXIT_OK
+    assert ev.consultive_ready is False
+
+
+def test_quality_green_collection_incomplete_not_exit_ok() -> None:
+    """Record-level quality ok must not hide failed collection."""
+    stages = _consultive_ok_stages()
+    # quality ok but contracts failed
+    ct = CollectionRun.start(
+        source="pncp_contracts", collection_id="c", collector_version="t"
+    )
+    ct.finish(request_completed=False, scope_complete=False, error="empty")
+    ev = evaluate_readiness(
+        stages,
+        [_ok_opp_run(), ct],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_UNRELIABLE
+
+
+def test_timestamp_absent_age_hours_none_not_zero() -> None:
+    """age_hours=None must not be coerced to 0.0 (freshness adapter safety)."""
+    level = classify_opportunity_freshness(
+        status="completed",
+        age_hours=None,
+        sla_hours=48,
+        scope_complete=True,
+    )
+    assert level == "unknown"
+    assert level != "fresh"
+
+
+def test_complete_package_without_operational_readiness() -> None:
+    """Full delivery with operational blockers → not consultive_ready."""
+    stages = _pr59_live_stages()
+    ev = evaluate_readiness(
+        stages,
+        _pr59_live_runs(),
+        strict=True,
+        freshness=_pr59_freshness(),
+        execution_scope="full",  # even full scope can't fix empty universe
+    )
+    assert ev.delivery_completed is True
+    assert ev.execution_completed is True
+    assert ev.consultive_ready is False
+    assert ev.exit_code == EXIT_UNRELIABLE
+
+
+def test_fully_valid_execution_exit_ok() -> None:
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="full",
+    )
+    assert ev.exit_code == EXIT_OK
+    assert ev.consultive_ready is True
+    assert not ev.blockers
+
+
+def test_degraded_allowed_but_not_consultive() -> None:
+    """Degraded/diagnostic mode may complete, never consultive_ready."""
+    ev = evaluate_readiness(
+        _consultive_ok_stages(),
+        [_ok_opp_run(), _ok_contracts_run()],
+        strict=True,
+        freshness=_fresh_sources(),
+        execution_scope="diagnostic",
+    )
+    assert ev.consultive_ready is False
+    assert ev.exit_code == EXIT_UNRELIABLE
+    assert "execution_scope_not_full:diagnostic" in ev.blockers
+
+
+def test_hours_since_none_preserved() -> None:
+    from scripts.ops.weekly_cycle import _hours_since
+
+    assert _hours_since(None) is None
+
+
+def test_classify_execution_scope_production_limit() -> None:
+    assert classify_execution_scope(offline=False, limit=50) == "full"
+    assert classify_execution_scope(offline=False, limit=49) == "sample"
+    assert classify_execution_scope(offline=True, limit=1000) == "fixture"
 
 
 def test_contract_claim_does_not_use_source_id_as_run_id() -> None:


### PR DESCRIPTION
## Outcome

Selective consolidation of validated ARCH-RESET fragments **on top of** fail-closed weekly readiness (#63):

- Product vs engineering vs diagnostic entrypoint classification
- Honest narrow gate: `make verify-weekly` (no `|| true`, not a fake full suite)
- Characterization tests (from #55, strengthened)
- Structural fitness functions (exit blockers, sample scope, single canonical module)

## Critical defect addressed

Architecture campaign left many parallel PRs with premature docs, false verify semantics, and weak characterization. This PR extracts only proven contracts and tests — no wholesale spike merge.

## Baseline

- Depends on / includes: #63 (`fix/weekly-strict-fail-closed`)
- Base intended: `main` after #63, or merge this stack after reviewing #63 first
- Tip: `refactor/arch-reset-consolidation`

## Scope

### Included
- `docs/canonical-entry-points.yaml` v1.2 classification
- `Makefile` target `verify-weekly`
- `tests/architecture/test_weekly_characterization.py` (from #55 + readiness)
- `tests/architecture/test_fitness_functions.py`
- `tests/test_entrypoint_classification.py` (from #56, adapted)

### Excluded
- ADR ACCEPTED without human decision (#54)
- Decision loop wholesale (#52)
- Ledger wholesale (#53)
- OCDS pseudo-conformidade (#57) — reference-only deferred
- Premature docs rebaseline (#61) — reserved for PR 3
- Spike binaries / multi-spike junk (#60)
- Skeptic remediation bulk (#62) — only fitness intent reused

## Behavioral contract

1. Only `extra-weekly` / `scripts.ops.weekly_cycle` is product_canonical
2. `verify-weekly` is engineering narrow; never product; never claims full suite
3. No `|| true` on lint/test/verify-weekly/extra-weekly recipes
4. Sample execution cannot be consultive_ready
5. EXIT_OK impossible with mandatory blockers

## Before / After

| Item | Before | After |
|---|---|---|
| Entry classification | ad hoc | explicit YAML classes |
| Engineering gate name | absent / misleading verify in spikes | `verify-weekly` honest narrow |
| Characterization | only in open #55 | on consolidation branch, readiness-aware |
| Fitness | text scanners in spikes | structural pytest |

## Tests

```text
make verify-weekly
# 66 passed, 1 skipped (weekly + architecture)
python3 -m pytest tests/test_entrypoint_classification.py -q --no-cov
# 3 passed
```

## Live validation

N/A (engineering contracts + unit tests).

## DOD impact

None flipped. No 95% claims.

## Existing PRs superseded or reused

| PR | Decision | Reused | Rejected |
|---|---|---|---|
| #55 | SUPERSEDE (content folded) | characterization tests | fragile string-only locks |
| #56 | SUPERSEDE partial | classification idea | `make verify` false full-suite name |
| #54 | DEFER docs | inventory idea only | ADR ACCEPTED, duplicate baseline.json |
| #57 | DEFER | OCDS as reference concept | pseudo-conformidade code |
| #58 | DEFER | check IDs concept | parallel quality layer |
| #59 | REGRESSION in #63 | live evidence | positive exit 0 interpretation |
| #60 | DEFER | honest REJECTED/DEFERRED decisions | binaries/tmp multi-spike |
| #61 | SUPERSEDE by PR 3 later | pointers intent | premature final docs |
| #62 | SUPERSEDE partial | fitness intent | bulk remediation noise |
| #52/#53 | OUT OF CORE | — | giant decision/ledger PRs |
| #48–#51 | OUT OF CORE | agent safety | agent theater |

## Dependencies and security

No new runtime dependencies. Same as #63 for weekly module.

## Migration

1. Merge #63 first (or this stack if reviewing together)
2. Use `make verify-weekly` for weekly engineering gate
3. Use `make test-all` for full suite — do not rename narrow gate to `verify` meaning full

## Rollback

```bash
git revert 24c8131
# or close PR; does not affect product weekly if #63 kept
```

## Allowed claims

- Entrypoints classified with one product weekly
- Narrow engineering gate exists without false green
- Fitness checks are structural pytest

## Forbidden claims

- Full suite green via verify-weekly
- Architecture campaign DONE
- 95% coverage / LOCAL_READY / VPS
- Human acceptance of ADRs

## Human decisions required

1. Merge order: prefer **#63 then this PR**, or this stack alone
2. Close/supersede #55, #56 after merge (human action)
3. Whether contracts remain required (already in #63 policy)
4. PR 3 docs only after human green on #63+#64

## Review recommendation

**READY_FOR_HUMAN_REVIEW** (draft)