### PR TITLE
feat(golden_path): strong fail-closed planilha-alvo validation

### DIFF
--- a/scripts/golden_path.py
+++ b/scripts/golden_path.py
@@ -5,10 +5,11 @@ Executa a sequencia completa e idempotente:
   1. Verifica conectividade com PostgreSQL
   2. Aplica migrations versionadas (db/migrations via scripts.ops.apply_migrations)
   3. Aplica seeds determinísticos (db/seed/001_sc_entities + 002_entity_aliases)
-  4. Crawl das fontes prioritarias (pncp, pcp, compras_gov) com
+  4. Importa/valida a planilha-alvo canônica (Extra alvos de licitação)
+  5. Crawl das fontes prioritarias (pncp, pcp, compras_gov) com
      timeout, retry 3x e backoff exponencial + jitter
-  5. Valida freshness gate
-  6. Gera relatorios (PDF executivo + Excel rastreavel)
+  6. Valida freshness gate
+  7. Gera relatorios (PDF executivo + Excel rastreavel)
 
 Cada etapa e registrada em um ledger JSON para rastreabilidade.
 
@@ -40,6 +41,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -564,6 +566,246 @@ def apply_seeds(dsn: str) -> tuple[bool, float, dict[str, list[str]]]:
         return False, dur, summary
 
 
+
+# ---------------------------------------------------------------------------
+# Step 1d: Validate target spreadsheet (canonical — DoD §12.1)
+# ---------------------------------------------------------------------------
+
+# Preferred basename (never a .backup / .copy / temp variant).
+CANONICAL_SPREADSHEET_BASENAME = "Extra - alvos de licitação. R-0.xlsx"
+# Expected included (raio 200km) set size and ordered-ids hash from current DOD.
+EXPECTED_CANONICAL_INCLUDED = 1093
+EXPECTED_CANONICAL_IDS_SHA256 = (
+    "0b3f894d87ba71f2e0fa96887cb3075033488de1af1e6e55f97ccda0701fb396"
+)
+REQUIRED_SHEET_NAME = "Entes Públicos SC"
+REQUIRED_HEADER_MARKERS = ("Razão Social", "CNPJ", "Município", "Raio")
+_BACKUP_NAME_TOKENS = (".backup", ".copy", ".tmp", "~$", ".temp")
+
+
+def _is_backup_or_temp_name(name: str) -> bool:
+    lowered = name.lower()
+    return any(tok in lowered for tok in _BACKUP_NAME_TOKENS)
+
+
+def _ordered_ids_sha256(ids: list[str]) -> str:
+    payload = "\n".join(sorted(str(i) for i in ids)).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def resolve_canonical_spreadsheet(
+    project_root: Path,
+    *,
+    explicit_path: Path | None = None,
+    allow_backup: bool = False,
+) -> Path:
+    """Select exactly one canonical target spreadsheet by explicit rules.
+
+    Rules (fail-closed):
+    1. Explicit path wins when provided and exists.
+    2. Prefer exact basename CANONICAL_SPREADSHEET_BASENAME under project root.
+    3. Else non-backup candidates matching ``Extra*alvos*.xlsx`` under root
+       (and ``data/``). Zero → missing; >1 → ambiguous.
+    4. Backup/copy/temp names are never selected silently.
+    5. Backup-only is allowed only when ``allow_backup`` is True.
+    """
+    root = project_root.resolve()
+
+    if explicit_path is not None:
+        path = explicit_path.expanduser().resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"Explicit spreadsheet not found: {path}")
+        if _is_backup_or_temp_name(path.name) and not allow_backup:
+            raise FileNotFoundError(
+                f"Refusing backup/temp spreadsheet without allow_backup: {path.name}"
+            )
+        return path
+
+    preferred = root / CANONICAL_SPREADSHEET_BASENAME
+    if preferred.is_file():
+        return preferred.resolve()
+
+    def _collect(dir_path: Path) -> list[Path]:
+        if not dir_path.is_dir():
+            return []
+        return sorted(dir_path.glob("Extra*alvos*.xlsx"))
+
+    all_hits = _collect(root) + _collect(root / "data")
+    # de-dupe by resolve
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for p in all_hits:
+        rp = p.resolve()
+        if rp in seen:
+            continue
+        seen.add(rp)
+        unique.append(rp)
+
+    primary = [p for p in unique if not _is_backup_or_temp_name(p.name)]
+    backups = [p for p in unique if _is_backup_or_temp_name(p.name)]
+
+    if len(primary) == 1:
+        return primary[0]
+    if len(primary) > 1:
+        names = ", ".join(p.name for p in primary)
+        raise FileNotFoundError(
+            f"Ambiguous target spreadsheets (multiple primary candidates): {names}"
+        )
+    # no primary
+    if backups and allow_backup:
+        if len(backups) == 1:
+            return backups[0]
+        names = ", ".join(p.name for p in backups)
+        raise FileNotFoundError(
+            f"Ambiguous backup spreadsheets: {names}"
+        )
+    if backups and not allow_backup:
+        raise FileNotFoundError(
+            "Only backup/temp spreadsheet(s) found; refusing silent selection. "
+            "Provide canonical "
+            f"'{CANONICAL_SPREADSHEET_BASENAME}' or set allow_backup."
+        )
+    raise FileNotFoundError(
+        f"Canonical spreadsheet '{CANONICAL_SPREADSHEET_BASENAME}' not found "
+        "under project root or data/."
+    )
+
+
+def validate_target_spreadsheet(
+    project_root: Path | None = None,
+    *,
+    explicit_path: Path | None = None,
+    allow_backup: bool | None = None,
+    expected_included: int = EXPECTED_CANONICAL_INCLUDED,
+    expected_ids_sha256: str = EXPECTED_CANONICAL_IDS_SHA256,
+) -> tuple[bool, float, dict[str, Any]]:
+    """Locate and strongly validate the Extra target spreadsheet (planilha-alvo).
+
+    Uses ``scripts.lib.universe.load_canonical_universe`` (project authority).
+    Records path, SHA-256, sheet, physical rows vs canonical included entities
+    as separate metrics, and fail-closed on identity mismatch.
+    Does not mutate the database.
+    """
+    start = time.monotonic()
+    root = (project_root or _PROJECT_ROOT).resolve()
+    details: dict[str, Any] = {
+        "physical_rows": None,
+        "canonical_entities": None,
+        "sheet_name": REQUIRED_SHEET_NAME,
+        "path": None,
+        "sha256": None,
+        "canonical_ids_sha256": None,
+        "selection_rule": None,
+    }
+    if allow_backup is None:
+        allow_backup = os.getenv("EXTRA_GP_ALLOW_BACKUP_SPREADSHEET", "").strip() in {
+            "1",
+            "true",
+            "TRUE",
+            "yes",
+            "YES",
+        }
+    try:
+        from scripts.lib.universe import load_canonical_universe
+
+        xlsx_path = resolve_canonical_spreadsheet(
+            root,
+            explicit_path=explicit_path,
+            allow_backup=allow_backup,
+        )
+        details["path"] = str(xlsx_path)
+        details["selection_rule"] = (
+            "explicit"
+            if explicit_path is not None
+            else (
+                "exact_basename"
+                if xlsx_path.name == CANONICAL_SPREADSHEET_BASENAME
+                else ("backup_explicit_allow" if allow_backup else "single_primary_glob")
+            )
+        )
+        if _is_backup_or_temp_name(xlsx_path.name) and not allow_backup:
+            details["error"] = f"backup path selected without allow: {xlsx_path.name}"
+            dur = (time.monotonic() - start) * 1000
+            return False, dur, details
+
+        # Header / sheet preflight (fail-closed with clear errors)
+        from openpyxl import load_workbook
+
+        wb = load_workbook(xlsx_path, read_only=True, data_only=True)
+        try:
+            if REQUIRED_SHEET_NAME not in wb.sheetnames:
+                details["error"] = (
+                    f"required sheet '{REQUIRED_SHEET_NAME}' missing; "
+                    f"available={list(wb.sheetnames)}"
+                )
+                dur = (time.monotonic() - start) * 1000
+                return False, dur, details
+            ws = wb[REQUIRED_SHEET_NAME]
+            header_row = next(ws.iter_rows(min_row=1, max_row=1, values_only=True), None)
+            header_text = " ".join(str(c) for c in (header_row or []) if c is not None)
+            missing_markers = [
+                m for m in REQUIRED_HEADER_MARKERS if m.lower() not in header_text.lower()
+            ]
+            # CNPJ marker may appear as "CNPJ (8 dígitos)"
+            if missing_markers:
+                details["error"] = f"required header markers missing: {missing_markers}"
+                details["header"] = header_text[:300]
+                dur = (time.monotonic() - start) * 1000
+                return False, dur, details
+            details["header"] = header_text[:300]
+        finally:
+            wb.close()
+
+        universe = load_canonical_universe(seed_path=xlsx_path)
+        physical = len(universe.entities)
+        included = universe.included
+        included_ids = [e.entity_id for e in included]
+        ids_sha = _ordered_ids_sha256(included_ids)
+        details["physical_rows"] = physical
+        details["canonical_entities"] = len(included)
+        details["outside_radius"] = len(universe.excluded)
+        details["unresolved_rows"] = len(universe.unresolved)
+        details["sha256"] = universe.seed_sha256
+        details["canonical_ids_sha256"] = ids_sha
+        details["seed_path_resolved"] = universe.seed_path
+        details["expected_canonical_entities"] = expected_included
+        details["expected_canonical_ids_sha256"] = expected_ids_sha256
+
+        if physical <= 0:
+            details["error"] = "spreadsheet has zero physical entity rows"
+            dur = (time.monotonic() - start) * 1000
+            return False, dur, details
+        if len(included) != expected_included:
+            details["error"] = (
+                f"canonical included count mismatch: got {len(included)} "
+                f"expected {expected_included} "
+                f"(physical_rows={physical})"
+            )
+            dur = (time.monotonic() - start) * 1000
+            return False, dur, details
+        if ids_sha != expected_ids_sha256:
+            details["error"] = (
+                "canonical_ids_sha256 mismatch "
+                f"(got={ids_sha} expected={expected_ids_sha256})"
+            )
+            dur = (time.monotonic() - start) * 1000
+            return False, dur, details
+        # set equality with itself is tautological; uniqueness already enforced
+        if len(set(included_ids)) != len(included_ids):
+            details["error"] = "duplicate canonical entity ids"
+            dur = (time.monotonic() - start) * 1000
+            return False, dur, details
+
+        dur = (time.monotonic() - start) * 1000
+        return True, dur, details
+    except Exception as exc:
+        details["error"] = str(exc)[:500]
+        dur = (time.monotonic() - start) * 1000
+        _logger.error("Target spreadsheet validation failed: %s", exc)
+        return False, dur, details
+
+
+
 # ---------------------------------------------------------------------------
 # Step 2: Crawl Sources (with timeout, retry, backoff + jitter)
 # ---------------------------------------------------------------------------
@@ -947,6 +1189,29 @@ def parse_args() -> argparse.Namespace:
         help="Skip db/seed scripts (not canonical; use only when seed already loaded)",
     )
     p.add_argument(
+        "--skip-spreadsheet",
+        action="store_true",
+        help="Skip target spreadsheet validation (not canonical)",
+    )
+    p.add_argument(
+        "--validate-spreadsheet-only",
+        action="store_true",
+        help=(
+            "Run only canonical planilha-alvo validation and write ledger "
+            "(skips DB/migrations/seeds/crawl/reports)"
+        ),
+    )
+    p.add_argument(
+        "--spreadsheet",
+        default=None,
+        help="Explicit path to target spreadsheet (must not be .backup unless allowed)",
+    )
+    p.add_argument(
+        "--allow-backup-spreadsheet",
+        action="store_true",
+        help="Allow selecting a .backup/.copy spreadsheet (off by default; fail-closed)",
+    )
+    p.add_argument(
         "--strict",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -982,6 +1247,58 @@ def main() -> int:
 
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
+
+    # Early path: spreadsheet-only validation (CLI proof for DoD planilha item)
+    if args.validate_spreadsheet_only:
+        run_id = f"gp-ss-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        timestamp = datetime.now(UTC).isoformat()
+        steps: list[StepRecord] = []
+        source_records: list[SourceRecord] = []
+        report_records: list[ReportRecord] = []
+        freshness_record: FreshnessRecord | None = None
+        explicit = Path(args.spreadsheet) if args.spreadsheet else None
+        _echo("\n[validate-spreadsheet-only] Validando planilha-alvo canônica...", "header")
+        ss_ok, ss_dur, ss_details = validate_target_spreadsheet(
+            _PROJECT_ROOT,
+            explicit_path=explicit,
+            allow_backup=args.allow_backup_spreadsheet or None,
+        )
+        steps.append(
+            StepRecord(
+                step="validate_target_spreadsheet",
+                status="pass" if ss_ok else "fail",
+                duration_ms=ss_dur,
+                details=ss_details,
+            )
+        )
+        overall = "success" if ss_ok else "failed"
+        _save_final_ledger(
+            run_id,
+            timestamp,
+            overall,
+            steps,
+            source_records,
+            report_records,
+            freshness_record,
+            wall_start,
+            args.ledger_output,
+        )
+        if not ss_ok:
+            _echo(
+                f"  Planilha-alvo INVALIDA: {ss_details.get('error', 'unknown')}",
+                "error",
+            )
+            return 1
+        _echo(
+            "  Planilha-alvo OK "
+            f"(physical={ss_details.get('physical_rows')} "
+            f"canonical={ss_details.get('canonical_entities')} "
+            f"sha256={str(ss_details.get('sha256', ''))[:12]}… "
+            f"{ss_dur:.0f}ms)",
+            "ok",
+        )
+        _echo(f"  Ledger: {args.ledger_output}", "ok")
+        return 0
 
     # ── Resolve DSN ──
     dsn = args.dsn or os.getenv("LOCAL_DATALAKE_DSN")
@@ -1156,9 +1473,64 @@ def main() -> int:
         )
 
     # =========================================================================
+    # Step 1d: Validate target spreadsheet (canonical — DoD §12.1)
+    # =========================================================================
+    if args.skip_spreadsheet:
+        _echo("\n[1d/7] Planilha-alvo SKIPPED (--skip-spreadsheet)", "warn")
+        steps.append(
+            StepRecord(
+                step="validate_target_spreadsheet",
+                status="skipped",
+                duration_ms=0.0,
+                details={"reason": "skip-spreadsheet"},
+            )
+        )
+    else:
+        _echo("\n[1d/7] Validando planilha-alvo canônica...", "header")
+        explicit = Path(args.spreadsheet) if args.spreadsheet else None
+        ss_ok, ss_dur, ss_details = validate_target_spreadsheet(
+            _PROJECT_ROOT,
+            explicit_path=explicit,
+            allow_backup=args.allow_backup_spreadsheet or None,
+        )
+        steps.append(
+            StepRecord(
+                step="validate_target_spreadsheet",
+                status="pass" if ss_ok else "fail",
+                duration_ms=ss_dur,
+                details=ss_details,
+            )
+        )
+        if not ss_ok:
+            _echo(
+                f"  Planilha-alvo INVALIDA: {ss_details.get('error', 'unknown')}",
+                "error",
+            )
+            _save_final_ledger(
+                run_id,
+                timestamp,
+                "failed",
+                steps,
+                source_records,
+                report_records,
+                freshness_record,
+                wall_start,
+                args.ledger_output,
+            )
+            return 1
+        _echo(
+            "  Planilha-alvo OK "
+            f"(physical={ss_details.get('physical_rows')} "
+            f"canonical={ss_details.get('canonical_entities')} "
+            f"ids={str(ss_details.get('canonical_ids_sha256', ''))[:12]}… "
+            f"{ss_dur:.0f}ms)",
+            "ok",
+        )
+
+    # =========================================================================
     # Step 2: Crawl Sources
     # =========================================================================
-    _echo("\n[2/6] Crawl das fontes de dados...", "header")
+    _echo("\n[2/7] Crawl das fontes de dados...", "header")
     _echo(f"  Fontes: {', '.join(s.name for s in selected_sources)}")
     _echo("  Timeout: 120s por fonte  |  Retries: 3x com backoff+jitter")
 

--- a/scripts/golden_path.py
+++ b/scripts/golden_path.py
@@ -218,9 +218,7 @@ def run_coverage_calculation(dsn: str) -> StepRecord:
         conn = psycopg2.connect(dsn, connect_timeout=5)
         try:
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'"
-                )
+                cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")
                 n = int(cur.fetchone()[0])
         finally:
             conn.close()
@@ -303,12 +301,10 @@ def evaluate_run_outcome(
     essential_ok = [r for r in successes if r.name in essential_names]
     non_essential_fail = [r for r in fails if r.name not in essential_names]
 
-    freshness_status = (freshness.status if freshness else "skipped")
+    freshness_status = freshness.status if freshness else "skipped"
     if skip_freshness:
         freshness_status = "skipped"
-    report_fails = [
-        r for r in reports if r.status == "fail" and not skip_reports
-    ]
+    report_fails = [r for r in reports if r.status == "fail" and not skip_reports]
 
     # --- non-strict legacy path (explicit opt-out only) ---
     if not strict:
@@ -566,7 +562,6 @@ def apply_seeds(dsn: str) -> tuple[bool, float, dict[str, list[str]]]:
         return False, dur, summary
 
 
-
 # ---------------------------------------------------------------------------
 # Step 1d: Validate target spreadsheet (canonical — DoD §12.1)
 # ---------------------------------------------------------------------------
@@ -575,9 +570,7 @@ def apply_seeds(dsn: str) -> tuple[bool, float, dict[str, list[str]]]:
 CANONICAL_SPREADSHEET_BASENAME = "Extra - alvos de licitação. R-0.xlsx"
 # Expected included (raio 200km) set size and ordered-ids hash from current DOD.
 EXPECTED_CANONICAL_INCLUDED = 1093
-EXPECTED_CANONICAL_IDS_SHA256 = (
-    "0b3f894d87ba71f2e0fa96887cb3075033488de1af1e6e55f97ccda0701fb396"
-)
+EXPECTED_CANONICAL_IDS_SHA256 = "0b3f894d87ba71f2e0fa96887cb3075033488de1af1e6e55f97ccda0701fb396"
 REQUIRED_SHEET_NAME = "Entes Públicos SC"
 REQUIRED_HEADER_MARKERS = ("Razão Social", "CNPJ", "Município", "Raio")
 _BACKUP_NAME_TOKENS = (".backup", ".copy", ".tmp", "~$", ".temp")
@@ -616,9 +609,7 @@ def resolve_canonical_spreadsheet(
         if not path.is_file():
             raise FileNotFoundError(f"Explicit spreadsheet not found: {path}")
         if _is_backup_or_temp_name(path.name) and not allow_backup:
-            raise FileNotFoundError(
-                f"Refusing backup/temp spreadsheet without allow_backup: {path.name}"
-            )
+            raise FileNotFoundError(f"Refusing backup/temp spreadsheet without allow_backup: {path.name}")
         return path
 
     preferred = root / CANONICAL_SPREADSHEET_BASENAME
@@ -648,17 +639,13 @@ def resolve_canonical_spreadsheet(
         return primary[0]
     if len(primary) > 1:
         names = ", ".join(p.name for p in primary)
-        raise FileNotFoundError(
-            f"Ambiguous target spreadsheets (multiple primary candidates): {names}"
-        )
+        raise FileNotFoundError(f"Ambiguous target spreadsheets (multiple primary candidates): {names}")
     # no primary
     if backups and allow_backup:
         if len(backups) == 1:
             return backups[0]
         names = ", ".join(p.name for p in backups)
-        raise FileNotFoundError(
-            f"Ambiguous backup spreadsheets: {names}"
-        )
+        raise FileNotFoundError(f"Ambiguous backup spreadsheets: {names}")
     if backups and not allow_backup:
         raise FileNotFoundError(
             "Only backup/temp spreadsheet(s) found; refusing silent selection. "
@@ -666,8 +653,7 @@ def resolve_canonical_spreadsheet(
             f"'{CANONICAL_SPREADSHEET_BASENAME}' or set allow_backup."
         )
     raise FileNotFoundError(
-        f"Canonical spreadsheet '{CANONICAL_SPREADSHEET_BASENAME}' not found "
-        "under project root or data/."
+        f"Canonical spreadsheet '{CANONICAL_SPREADSHEET_BASENAME}' not found under project root or data/."
     )
 
 
@@ -734,18 +720,13 @@ def validate_target_spreadsheet(
         wb = load_workbook(xlsx_path, read_only=True, data_only=True)
         try:
             if REQUIRED_SHEET_NAME not in wb.sheetnames:
-                details["error"] = (
-                    f"required sheet '{REQUIRED_SHEET_NAME}' missing; "
-                    f"available={list(wb.sheetnames)}"
-                )
+                details["error"] = f"required sheet '{REQUIRED_SHEET_NAME}' missing; available={list(wb.sheetnames)}"
                 dur = (time.monotonic() - start) * 1000
                 return False, dur, details
             ws = wb[REQUIRED_SHEET_NAME]
             header_row = next(ws.iter_rows(min_row=1, max_row=1, values_only=True), None)
             header_text = " ".join(str(c) for c in (header_row or []) if c is not None)
-            missing_markers = [
-                m for m in REQUIRED_HEADER_MARKERS if m.lower() not in header_text.lower()
-            ]
+            missing_markers = [m for m in REQUIRED_HEADER_MARKERS if m.lower() not in header_text.lower()]
             # CNPJ marker may appear as "CNPJ (8 dígitos)"
             if missing_markers:
                 details["error"] = f"required header markers missing: {missing_markers}"
@@ -784,10 +765,7 @@ def validate_target_spreadsheet(
             dur = (time.monotonic() - start) * 1000
             return False, dur, details
         if ids_sha != expected_ids_sha256:
-            details["error"] = (
-                "canonical_ids_sha256 mismatch "
-                f"(got={ids_sha} expected={expected_ids_sha256})"
-            )
+            details["error"] = f"canonical_ids_sha256 mismatch (got={ids_sha} expected={expected_ids_sha256})"
             dur = (time.monotonic() - start) * 1000
             return False, dur, details
         # set equality with itself is tautological; uniqueness already enforced
@@ -803,7 +781,6 @@ def validate_target_spreadsheet(
         dur = (time.monotonic() - start) * 1000
         _logger.error("Target spreadsheet validation failed: %s", exc)
         return False, dur, details
-
 
 
 # ---------------------------------------------------------------------------
@@ -928,8 +905,7 @@ def crawl_source(
                     f"  {label} {source.name}: "
                     f"fetched={fetched}, "
                     f"inserted={metrics.get('inserted', 0)}, "
-                    f"persisted={metrics.get('persisted', 0)}"
-                    + (" [watermark-resume]" if resumed_live else ""),
+                    f"persisted={metrics.get('persisted', 0)}" + (" [watermark-resume]" if resumed_live else ""),
                     "ok" if src_status == "success" else "warn",
                 )
                 return SourceRecord(
@@ -1196,10 +1172,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--validate-spreadsheet-only",
         action="store_true",
-        help=(
-            "Run only canonical planilha-alvo validation and write ledger "
-            "(skips DB/migrations/seeds/crawl/reports)"
-        ),
+        help=("Run only canonical planilha-alvo validation and write ledger (skips DB/migrations/seeds/crawl/reports)"),
     )
     p.add_argument(
         "--spreadsheet",
@@ -1466,9 +1439,7 @@ def main() -> int:
             )
             return 1
         _echo(
-            "  Seeds OK "
-            f"(ran={len(seed_summary.get('ran') or [])} "
-            f"{seed_dur:.0f}ms)",
+            f"  Seeds OK (ran={len(seed_summary.get('ran') or [])} {seed_dur:.0f}ms)",
             "ok",
         )
 
@@ -1574,8 +1545,7 @@ def main() -> int:
 
     if sources_fail or sources_zero:
         _echo(
-            f"\n  {len(sources_success)} com dados, "
-            f"{len(sources_zero)} zero, {len(sources_fail)} falha(s)",
+            f"\n  {len(sources_success)} com dados, {len(sources_zero)} zero, {len(sources_fail)} falha(s)",
             "warn",
         )
         for r in sources_fail:

--- a/tests/test_golden_path_canonical.py
+++ b/tests/test_golden_path_canonical.py
@@ -149,3 +149,152 @@ def test_apply_seeds_runs_seed_scripts(monkeypatch: pytest.MonkeyPatch) -> None:
     assert any("001_sc_entities" in p for p in summary["ran"])
     assert any("002_entity_aliases" in p for p in summary["ran"])
     assert len(ran) == 2
+
+
+# ---------------------------------------------------------------------------
+# DoD §12.1 — planilha-alvo strong validation
+# ---------------------------------------------------------------------------
+
+EXPECTED_IDS_SHA = "0b3f894d87ba71f2e0fa96887cb3075033488de1af1e6e55f97ccda0701fb396"
+CANONICAL_XLSX = "Extra - alvos de licitação. R-0.xlsx"
+
+
+def test_help_documents_spreadsheet_flags() -> None:
+    r = subprocess.run(
+        [sys.executable, "-m", "scripts.golden_path", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert r.returncode == 0
+    out = r.stdout + r.stderr
+    assert "skip-spreadsheet" in out
+    assert "validate-spreadsheet-only" in out
+
+
+def test_resolve_prefers_canonical_not_backup(tmp_path: Path) -> None:
+    from scripts.golden_path import resolve_canonical_spreadsheet
+
+    root = Path(__file__).resolve().parents[1]
+    src = root / CANONICAL_XLSX
+    assert src.is_file()
+    # Copy both canonical and backup into temp root; canonical must win.
+    import shutil
+
+    dest = tmp_path / CANONICAL_XLSX
+    backup = tmp_path / "Extra - alvos de licitação. R-0.backup.xlsx"
+    shutil.copy2(src, dest)
+    shutil.copy2(src, backup)
+    chosen = resolve_canonical_spreadsheet(tmp_path)
+    assert chosen.name == CANONICAL_XLSX
+    assert ".backup" not in chosen.name
+
+
+def test_resolve_backup_only_fails_without_allow(tmp_path: Path) -> None:
+    from scripts.golden_path import resolve_canonical_spreadsheet
+    import shutil
+
+    root = Path(__file__).resolve().parents[1]
+    src = root / CANONICAL_XLSX
+    backup = tmp_path / "Extra - alvos de licitação. R-0.backup.xlsx"
+    shutil.copy2(src, backup)
+    with pytest.raises(FileNotFoundError, match="backup"):
+        resolve_canonical_spreadsheet(tmp_path, allow_backup=False)
+
+
+def test_resolve_missing_fails(tmp_path: Path) -> None:
+    from scripts.golden_path import resolve_canonical_spreadsheet
+
+    with pytest.raises(FileNotFoundError):
+        resolve_canonical_spreadsheet(tmp_path)
+
+
+def test_resolve_ambiguous_primary_fails(tmp_path: Path) -> None:
+    from scripts.golden_path import resolve_canonical_spreadsheet
+    import shutil
+
+    root = Path(__file__).resolve().parents[1]
+    src = root / CANONICAL_XLSX
+    # Two non-backup candidates with different names matching glob
+    a = tmp_path / "Extra - alvos A.xlsx"
+    b = tmp_path / "Extra - alvos B.xlsx"
+    shutil.copy2(src, a)
+    shutil.copy2(src, b)
+    with pytest.raises(FileNotFoundError, match="Ambiguous"):
+        resolve_canonical_spreadsheet(tmp_path)
+
+
+def test_validate_target_spreadsheet_live_strong() -> None:
+    """Strong AC: path, sha256, dual metrics, 1093 set + ids hash."""
+    from scripts.golden_path import validate_target_spreadsheet
+
+    root = Path(__file__).resolve().parents[1]
+    ok, dur, details = validate_target_spreadsheet(root)
+    assert ok is True, details
+    assert dur >= 0
+    assert details.get("path")
+    assert CANONICAL_XLSX in details["path"]
+    assert ".backup" not in Path(details["path"]).name
+    assert details.get("sha256")
+    assert len(details["sha256"]) == 64
+    assert details.get("physical_rows") == 2085
+    assert details.get("canonical_entities") == 1093
+    assert details.get("physical_rows") != details.get("canonical_entities")
+    assert details.get("canonical_ids_sha256") == EXPECTED_IDS_SHA
+    assert details.get("sheet_name") == "Entes Públicos SC"
+    assert details.get("selection_rule") in {"exact_basename", "single_primary_glob"}
+
+
+def test_validate_wrong_expected_count_fails() -> None:
+    from scripts.golden_path import validate_target_spreadsheet
+
+    root = Path(__file__).resolve().parents[1]
+    ok, _dur, details = validate_target_spreadsheet(
+        root, expected_included=9999, expected_ids_sha256=EXPECTED_IDS_SHA
+    )
+    assert ok is False
+    assert "mismatch" in str(details.get("error", "")).lower()
+
+
+def test_validate_cli_spreadsheet_only_writes_ledger(tmp_path: Path) -> None:
+    """Proof via canonical CLI entrypoint, not only isolated function call."""
+    root = Path(__file__).resolve().parents[1]
+    ledger = tmp_path / "ledger-ss.json"
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.golden_path",
+            "--validate-spreadsheet-only",
+            "--ledger-output",
+            str(ledger),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        cwd=str(root),
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert ledger.is_file()
+    import json
+
+    data = json.loads(ledger.read_text(encoding="utf-8"))
+    steps = data.get("steps") or data.get("ledger", {}).get("steps") or []
+    # ledger shape may nest under keys — search flexibly
+    if not steps and isinstance(data, dict):
+        for v in data.values():
+            if isinstance(v, list) and v and isinstance(v[0], dict) and "step" in v[0]:
+                steps = v
+                break
+        if not steps:
+            # try common shapes
+            steps = data.get("execution", {}).get("steps") or []
+    names = [s.get("step") for s in steps] if steps else []
+    assert "validate_target_spreadsheet" in names or any(
+        "validate_target_spreadsheet" in json.dumps(data) for _ in [0]
+    ), data
+    blob = json.dumps(data)
+    assert "canonical_entities" in blob or "1093" in blob
+    assert "physical_rows" in blob or "2085" in blob

--- a/tests/test_golden_path_canonical.py
+++ b/tests/test_golden_path_canonical.py
@@ -1,4 +1,5 @@
 """DoD §12.1 — canonical golden path command + metadata + fail-closed."""
+
 from __future__ import annotations
 
 import subprocess
@@ -192,8 +193,9 @@ def test_resolve_prefers_canonical_not_backup(tmp_path: Path) -> None:
 
 
 def test_resolve_backup_only_fails_without_allow(tmp_path: Path) -> None:
-    from scripts.golden_path import resolve_canonical_spreadsheet
     import shutil
+
+    from scripts.golden_path import resolve_canonical_spreadsheet
 
     root = Path(__file__).resolve().parents[1]
     src = root / CANONICAL_XLSX
@@ -211,8 +213,9 @@ def test_resolve_missing_fails(tmp_path: Path) -> None:
 
 
 def test_resolve_ambiguous_primary_fails(tmp_path: Path) -> None:
-    from scripts.golden_path import resolve_canonical_spreadsheet
     import shutil
+
+    from scripts.golden_path import resolve_canonical_spreadsheet
 
     root = Path(__file__).resolve().parents[1]
     src = root / CANONICAL_XLSX
@@ -250,9 +253,7 @@ def test_validate_wrong_expected_count_fails() -> None:
     from scripts.golden_path import validate_target_spreadsheet
 
     root = Path(__file__).resolve().parents[1]
-    ok, _dur, details = validate_target_spreadsheet(
-        root, expected_included=9999, expected_ids_sha256=EXPECTED_IDS_SHA
-    )
+    ok, _dur, details = validate_target_spreadsheet(root, expected_included=9999, expected_ids_sha256=EXPECTED_IDS_SHA)
     assert ok is False
     assert "mismatch" in str(details.get("error", "")).lower()
 


### PR DESCRIPTION
## Summary

Replaces contaminated PR #74 with a **thin, single-item** change for:

> O golden path importa ou valida a planilha-alvo.

### What this does
- Selects **exactly one** canonical spreadsheet by explicit rules (preferred basename `Extra - alvos de licitação. R-0.xlsx`)
- **Never** silently selects `.backup` / `.copy` / temp
- Loads universe via **`scripts.lib.universe.load_canonical_universe`**
- Records **path**, **SHA-256**, sheet, header markers
- Separates **physical_rows (2085)** vs **canonical_entities (1093)**
- Enforces **canonical_ids_sha256** set equality (`0b3f894d…`)
- Fail-closed: missing, backup-only, ambiguous, count/hash mismatch
- Ledger step `validate_target_spreadsheet`
- CLI: `python3 -m scripts.golden_path --validate-spreadsheet-only`

### What this does NOT do
- No premature VERIFIED stack for fontes/PDF/Excel/etc.
- No mass `.dod/manifest.yaml` rewrite
- No billing blocker churn
- No `entity_rows >= 100` weak gate

### Relation to PR #74
PR #74 mixed product skeleton with ~12 premature VERIFIED characterizations and accepted a `.backup.xlsx` path. Adversarial review: **REPLACE_WITH_CLEAN_PR**. This PR is the replacement.

## Test plan
- [x] `python3 -m pytest tests/test_golden_path_canonical.py -q` (16 passed)
- [x] `python3 -m scripts.golden_path --validate-spreadsheet-only` → ledger pass, 2085/1093
- [x] ruff clean on touched files
- [ ] CI full suite green on this head
- [ ] Independent adversarial QA note

## Campaign
`DOD-CONVERGENCE-EXTRA-CONTINUE-02`