### PR TITLE
feat(golden_path): execute freshness gate (strong proof)

### DIFF
--- a/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/README.md
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/README.md
@@ -1,0 +1,1 @@
+# Freshness gate execution proof

--- a/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/acceptance_criteria.md
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/acceptance_criteria.md
@@ -1,0 +1,11 @@
+# O golden path executa freshness gate
+
+Given reachable DSN
+When `python3 -m scripts.golden_path --execute-freshness-only` runs
+Then freshness_gate.py is invoked as subprocess
+And ledger records run_freshness_gate with structured details
+And status pass OR fail both count as executed
+And skip without running is not acceptance
+
+Note: contracts=never is a fail status but still proves execution.
+Pass/SLA is a separate DOD item.

--- a/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/cli-execute-freshness-only.txt
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/cli-execute-freshness-only.txt
@@ -1,0 +1,15 @@
+
+ Executando freshness gate...
+
+>>> Validando freshness gate...
+  Freshness gate: FAIL (stale sources) (225ms)
+    Sources stale: contracts
+
+Ledger salvo:  
+.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/ledger-freshness.json
+Log salvo:     
+/mnt/d/extra-consultoria-continue-02-main/output/golden-path/gp-20260721-104824.
+log
+  Freshness gate executado: status=fail failing=['contracts']
+  Ledger: 
+.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/ledger-freshness.json

--- a/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/ledger-freshness.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/ledger-freshness.json
@@ -1,0 +1,149 @@
+{
+  "version": 1,
+  "runs": [
+    {
+      "run_id": "gp-fr-20260721-104824",
+      "timestamp": "2026-07-21T13:48:24.918318+00:00",
+      "status": "success",
+      "wall_clock_ms": 253.59609999941313,
+      "steps": [
+        {
+          "step": "db_connectivity",
+          "status": "pass",
+          "duration_ms": 21.099800000229152,
+          "error": null,
+          "details": null
+        },
+        {
+          "step": "run_freshness_gate",
+          "status": "pass",
+          "duration_ms": 0.0,
+          "error": null,
+          "details": {
+            "status": "fail",
+            "has_structure": true,
+            "failing_sources": [
+              "contracts"
+            ],
+            "error": null,
+            "detail_keys": [
+              "critical_sources",
+              "generated_at",
+              "mode",
+              "overall"
+            ],
+            "gate_status": "fail",
+            "gate_details": {
+              "generated_at": "2026-07-21T13:48:25.148810+00:00",
+              "mode": "local-first",
+              "critical_sources": [
+                {
+                  "source": "pncp",
+                  "purpose": "editais_abertos",
+                  "critical": true,
+                  "run_source": "pncp",
+                  "data_table": "pncp_raw_bids",
+                  "data_source": "pncp",
+                  "freshness_sla_hours": 24,
+                  "recent_window_hours": 24,
+                  "last_success_at": "2026-07-21 13:25:41.440362+00:00",
+                  "last_ingested_at": "2026-07-21 13:25:41.458348+00:00",
+                  "latest_business_date": "2026-07-21 10:07:12+00:00",
+                  "recent_records": 468,
+                  "total_records": 468,
+                  "successful_runs": 1,
+                  "total_runs": 1,
+                  "freshness_status": "fresh",
+                  "failure_reason": null
+                },
+                {
+                  "source": "contracts",
+                  "purpose": "historical_contracts",
+                  "critical": true,
+                  "run_source": "contracts",
+                  "data_table": "pncp_supplier_contracts",
+                  "data_source": "pncp_contracts",
+                  "freshness_sla_hours": 576,
+                  "recent_window_hours": 168,
+                  "last_success_at": null,
+                  "last_ingested_at": null,
+                  "latest_business_date": null,
+                  "recent_records": 0,
+                  "total_records": 0,
+                  "successful_runs": 0,
+                  "total_runs": 0,
+                  "freshness_status": "never",
+                  "failure_reason": "No successful ingestion run found for critical source"
+                }
+              ],
+              "overall": {
+                "all_critical_sources_fresh": false,
+                "failing_sources": [
+                  "contracts"
+                ],
+                "exit_code": 2
+              }
+            }
+          }
+        }
+      ],
+      "sources": [],
+      "reports": [],
+      "freshness": {
+        "status": "fail",
+        "details": {
+          "generated_at": "2026-07-21T13:48:25.148810+00:00",
+          "mode": "local-first",
+          "critical_sources": [
+            {
+              "source": "pncp",
+              "purpose": "editais_abertos",
+              "critical": true,
+              "run_source": "pncp",
+              "data_table": "pncp_raw_bids",
+              "data_source": "pncp",
+              "freshness_sla_hours": 24,
+              "recent_window_hours": 24,
+              "last_success_at": "2026-07-21 13:25:41.440362+00:00",
+              "last_ingested_at": "2026-07-21 13:25:41.458348+00:00",
+              "latest_business_date": "2026-07-21 10:07:12+00:00",
+              "recent_records": 468,
+              "total_records": 468,
+              "successful_runs": 1,
+              "total_runs": 1,
+              "freshness_status": "fresh",
+              "failure_reason": null
+            },
+            {
+              "source": "contracts",
+              "purpose": "historical_contracts",
+              "critical": true,
+              "run_source": "contracts",
+              "data_table": "pncp_supplier_contracts",
+              "data_source": "pncp_contracts",
+              "freshness_sla_hours": 576,
+              "recent_window_hours": 168,
+              "last_success_at": null,
+              "last_ingested_at": null,
+              "latest_business_date": null,
+              "recent_records": 0,
+              "total_records": 0,
+              "successful_runs": 0,
+              "total_runs": 0,
+              "freshness_status": "never",
+              "failure_reason": "No successful ingestion run found for critical source"
+            }
+          ],
+          "overall": {
+            "all_critical_sources_fresh": false,
+            "failing_sources": [
+              "contracts"
+            ],
+            "exit_code": 2
+          }
+        },
+        "error": null
+      }
+    }
+  ]
+}

--- a/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/proof.json
@@ -1,0 +1,88 @@
+{
+  "at": "2026-07-21T13:48:44.381990+00:00",
+  "ok": true,
+  "mode": "execute-freshness-only",
+  "gate_status": "fail",
+  "steps": [
+    {
+      "step": "db_connectivity",
+      "status": "pass",
+      "duration_ms": 21.099800000229152,
+      "error": null,
+      "details": null
+    },
+    {
+      "step": "run_freshness_gate",
+      "status": "pass",
+      "duration_ms": 0.0,
+      "error": null,
+      "details": {
+        "status": "fail",
+        "has_structure": true,
+        "failing_sources": [
+          "contracts"
+        ],
+        "error": null,
+        "detail_keys": [
+          "critical_sources",
+          "generated_at",
+          "mode",
+          "overall"
+        ],
+        "gate_status": "fail",
+        "gate_details": {
+          "generated_at": "2026-07-21T13:48:25.148810+00:00",
+          "mode": "local-first",
+          "critical_sources": [
+            {
+              "source": "pncp",
+              "purpose": "editais_abertos",
+              "critical": true,
+              "run_source": "pncp",
+              "data_table": "pncp_raw_bids",
+              "data_source": "pncp",
+              "freshness_sla_hours": 24,
+              "recent_window_hours": 24,
+              "last_success_at": "2026-07-21 13:25:41.440362+00:00",
+              "last_ingested_at": "2026-07-21 13:25:41.458348+00:00",
+              "latest_business_date": "2026-07-21 10:07:12+00:00",
+              "recent_records": 468,
+              "total_records": 468,
+              "successful_runs": 1,
+              "total_runs": 1,
+              "freshness_status": "fresh",
+              "failure_reason": null
+            },
+            {
+              "source": "contracts",
+              "purpose": "historical_contracts",
+              "critical": true,
+              "run_source": "contracts",
+              "data_table": "pncp_supplier_contracts",
+              "data_source": "pncp_contracts",
+              "freshness_sla_hours": 576,
+              "recent_window_hours": 168,
+              "last_success_at": null,
+              "last_ingested_at": null,
+              "latest_business_date": null,
+              "recent_records": 0,
+              "total_records": 0,
+              "successful_runs": 0,
+              "total_runs": 0,
+              "freshness_status": "never",
+              "failure_reason": "No successful ingestion run found for critical source"
+            }
+          ],
+          "overall": {
+            "all_critical_sources_fresh": false,
+            "failing_sources": [
+              "contracts"
+            ],
+            "exit_code": 2
+          }
+        }
+      }
+    }
+  ],
+  "note": "Executed on clean test-db; fail due to contracts never \u2014 still executed"
+}

--- a/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/pytest.txt
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-94ff481872/pytest.txt
@@ -1,0 +1,12 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
+benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /mnt/d/extra-consultoria-continue-02-main
+configfile: pytest.ini
+plugins: benchmark-5.2.3, html-4.2.0, hypothesis-6.152.7, repeat-0.9.4, Faker-37.4.2, timeout-2.4.0, asyncio-1.1.0, mock-3.15.1, metadata-3.1.1, cov-4.1.0, anyio-4.2.0
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 3 items
+
+tests/test_golden_path_freshness.py ...                                  [100%]
+
+============================== 3 passed in 1.49s ===============================

--- a/scripts/golden_path.py
+++ b/scripts/golden_path.py
@@ -204,6 +204,33 @@ def assert_sources_persisted(
     }
 
 
+def assert_freshness_gate_executed(
+    freshness: FreshnessRecord | None,
+) -> tuple[bool, dict[str, Any]]:
+    """Prove the freshness gate was executed (pass or fail), not skipped/absent.
+
+    Execution proof requires status in {pass, fail} and structured details
+    (JSON gate output). "fail" still proves the gate ran — a separate DOD item
+    covers pass/SLA.
+    """
+    if freshness is None:
+        return False, {"error": "no freshness record", "status": None}
+    status = str(freshness.status or "")
+    details = freshness.details if isinstance(freshness.details, dict) else {}
+    has_structure = bool(details.get("overall") or details.get("critical_sources"))
+    ok = status in {"pass", "fail"} and has_structure
+    failing = []
+    if isinstance(details.get("overall"), dict):
+        failing = list(details["overall"].get("failing_sources") or [])
+    return ok, {
+        "status": status,
+        "has_structure": has_structure,
+        "failing_sources": failing,
+        "error": freshness.error,
+        "detail_keys": sorted(details.keys()) if details else [],
+    }
+
+
 def _backoff_delay(attempt: int, base: float = 4.0, max_delay: float = 60.0) -> float:
     """Exponential backoff with jitter."""
     delay = min(base * (2**attempt), max_delay)
@@ -1305,6 +1332,11 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     p.add_argument(
+        "--execute-freshness-only",
+        action="store_true",
+        help=("Run only freshness gate + ledger (requires DB; skips crawl/reports/migrations/seeds)"),
+    )
+    p.add_argument(
         "--spreadsheet",
         default=None,
         help="Explicit path to target spreadsheet (must not be .backup unless allowed)",
@@ -1500,6 +1532,84 @@ def main() -> int:
             "ok",
         )
         _echo(f"  Ledger: {args.ledger_output}", "ok")
+        return 0
+
+    # Early path: freshness gate only (DoD executa freshness gate)
+    if args.execute_freshness_only:
+        run_id = f"gp-fr-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+        timestamp = datetime.now(UTC).isoformat()
+        steps: list[StepRecord] = []
+        source_records: list[SourceRecord] = []
+        report_records: list[ReportRecord] = []
+
+        dsn = args.dsn or os.getenv("LOCAL_DATALAKE_DSN")
+        if not dsn:
+            try:
+                import config.settings as _cfg
+
+                dsn = _cfg.LOCAL_DATALAKE_DSN
+            except ImportError:
+                dsn = "postgresql://postgres:@127.0.0.1:54399/postgres"
+
+        ok_db, dur_db = check_db(dsn)
+        steps.append(
+            StepRecord(
+                step="db_connectivity",
+                status="pass" if ok_db else "fail",
+                duration_ms=dur_db,
+            )
+        )
+        if not ok_db:
+            _save_final_ledger(
+                run_id,
+                timestamp,
+                "failed",
+                steps,
+                source_records,
+                report_records,
+                None,
+                wall_start,
+                args.ledger_output,
+            )
+            return 1
+
+        _echo("\n[execute-freshness-only] Executando freshness gate...", "header")
+        freshness_record = run_freshness_gate(dsn)
+        exec_ok, exec_details = assert_freshness_gate_executed(freshness_record)
+        steps.append(
+            StepRecord(
+                step="run_freshness_gate",
+                status="pass" if exec_ok else "fail",
+                duration_ms=0.0,
+                details={
+                    **exec_details,
+                    "gate_status": freshness_record.status,
+                    "gate_details": freshness_record.details,
+                },
+            )
+        )
+        overall = "success" if exec_ok else "failed"
+        _save_final_ledger(
+            run_id,
+            timestamp,
+            overall,
+            steps,
+            source_records,
+            report_records,
+            freshness_record,
+            wall_start,
+            args.ledger_output,
+        )
+        if not exec_ok:
+            _echo(f"  Freshness gate NÃO executado: {exec_details}", "error")
+            return 1
+        _echo(
+            f"  Freshness gate executado: status={freshness_record.status} "
+            f"failing={exec_details.get('failing_sources')}",
+            "ok" if freshness_record.status == "pass" else "warn",
+        )
+        _echo(f"  Ledger: {args.ledger_output}", "ok")
+        # Exit 0 when gate ran (even if status=fail); non-zero only if not executed.
         return 0
 
     # ── Resolve DSN ──
@@ -1810,8 +1920,28 @@ def main() -> int:
     if args.skip_freshness:
         _echo("  SKIP (--skip-freshness)", "warn")
         freshness_record = FreshnessRecord(status="skipped")
+        steps.append(
+            StepRecord(
+                step="run_freshness_gate",
+                status="skipped",
+                duration_ms=0.0,
+                details={"reason": "skip-freshness"},
+            )
+        )
     else:
         freshness_record = run_freshness_gate(dsn)
+        fr_ok, fr_details = assert_freshness_gate_executed(freshness_record)
+        steps.append(
+            StepRecord(
+                step="run_freshness_gate",
+                status="pass" if fr_ok else "fail",
+                duration_ms=0.0,
+                details={
+                    **fr_details,
+                    "gate_status": freshness_record.status,
+                },
+            )
+        )
 
     # =========================================================================
     # Step 4: Reports

--- a/tests/test_golden_path_freshness.py
+++ b/tests/test_golden_path_freshness.py
@@ -1,0 +1,90 @@
+"""DoD §12.1 — golden path executes freshness gate (not mere function presence)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.golden_path import (
+    FreshnessRecord,
+    assert_freshness_gate_executed,
+    run_freshness_gate,
+)
+
+
+def test_help_documents_execute_freshness_only() -> None:
+    r = subprocess.run(
+        [sys.executable, "-m", "scripts.golden_path", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert r.returncode == 0
+    assert "execute-freshness-only" in (r.stdout + r.stderr)
+
+
+def test_assert_freshness_requires_structure() -> None:
+    ok, d = assert_freshness_gate_executed(None)
+    assert ok is False
+
+    ok, d = assert_freshness_gate_executed(FreshnessRecord(status="skipped"))
+    assert ok is False
+
+    ok, d = assert_freshness_gate_executed(
+        FreshnessRecord(status="fail", details={"overall": {"failing_sources": ["contracts"]}})
+    )
+    assert ok is True
+    assert d["status"] == "fail"
+    assert "contracts" in d["failing_sources"]
+
+    ok, d = assert_freshness_gate_executed(
+        FreshnessRecord(
+            status="pass",
+            details={"critical_sources": [{"source": "pncp"}], "overall": {"failing_sources": []}},
+        )
+    )
+    assert ok is True
+
+
+def test_run_freshness_gate_invokes_script(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Prove subprocess to freshness_gate.py, not just import of helper."""
+    import scripts.golden_path as gp
+
+    calls: list[list[str]] = []
+    out_dir = tmp_path / "readiness"
+    out_dir.mkdir()
+    gate_json = out_dir / "freshness-gate.json"
+    gate_json.write_text(
+        json.dumps(
+            {
+                "overall": {"all_critical_sources_fresh": False, "failing_sources": ["contracts"]},
+                "critical_sources": [{"source": "pncp", "freshness_status": "fresh"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+
+        class R:
+            returncode = 2
+            stdout = ""
+            stderr = "stale"
+
+        return R()
+
+    monkeypatch.setattr(gp.subprocess, "run", fake_run)
+    monkeypatch.setattr(gp, "_OUTPUT_DIR", tmp_path)
+    rec = run_freshness_gate("postgresql://test@localhost/db")
+    assert calls, "freshness_gate.py must be invoked"
+    assert any("freshness_gate.py" in str(c) for c in calls[0])
+    assert rec.status == "fail"
+    ok, details = assert_freshness_gate_executed(rec)
+    assert ok is True
+    assert "contracts" in details["failing_sources"]


### PR DESCRIPTION
## Summary
DoD: **O golden path executa freshness gate.**

- Invokes `scripts/freshness_gate.py` via subprocess
- Ledger step `run_freshness_gate` + CLI `--execute-freshness-only`
- `pass` and `fail` both count as executed (SLA pass is separate)
- Live clean-db: `status=fail`, `failing=['contracts']` — gate ran

## Test plan
- [x] pytest tests/test_golden_path_freshness.py
- [x] live --execute-freshness-only
- [ ] CI green