### PR TITLE
fix(golden_path): ledger records git_sha and schema_version

### DIFF
--- a/scripts/golden_path.py
+++ b/scripts/golden_path.py
@@ -287,6 +287,8 @@ class RunRecord:
     sources: list[SourceRecord] = field(default_factory=list)
     reports: list[ReportRecord] = field(default_factory=list)
     freshness: FreshnessRecord | None = None
+    # DoD §12.1 — always populated by _save_final_ledger
+    meta: dict[str, Any] | None = None
 
 
 def collect_run_metadata(*, dsn: str | None = None) -> dict[str, Any]:
@@ -1466,8 +1468,20 @@ def _save_final_ledger(
     freshness: FreshnessRecord | None,
     wall_start: float,
     ledger_path_str: str | None,
+    *,
+    dsn: str | None = None,
 ) -> None:
     wall_dur = (time.monotonic() - wall_start) * 1000
+    meta = collect_run_metadata(dsn=dsn)
+    for step in steps:
+        if step.step == "validate_target_spreadsheet" and isinstance(step.details, dict):
+            sha = step.details.get("sha256")
+            if sha:
+                meta["spreadsheet_sha256"] = sha
+            cids = step.details.get("canonical_ids_sha256")
+            if cids:
+                meta["canonical_ids_sha256"] = cids
+            break
     record = RunRecord(
         run_id=run_id,
         timestamp=timestamp,
@@ -1477,6 +1491,7 @@ def _save_final_ledger(
         sources=sources,
         reports=reports,
         freshness=freshness,
+        meta=meta,
     )
     data = _load_ledger()
     run_list = _normalize_ledger_runs(data.get("runs", []))
@@ -1485,6 +1500,7 @@ def _save_final_ledger(
     _save_ledger(run_list, path)
     _echo(f"\nLedger salvo:  {path}")
     _echo(f"Log salvo:     {_log_file}")
+    _echo(f"  meta.git_sha={meta.get('git_sha')} schema={meta.get('schema_version')}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_golden_path_ledger_meta.py
+++ b/tests/test_golden_path_ledger_meta.py
@@ -42,9 +42,14 @@ def test_cli_writes_ledger_and_log(tmp_path: Path) -> None:
     last = runs[-1]
     assert last.get("steps"), "ledger must contain steps"
     assert last.get("wall_clock_ms", 0) > 0
+    meta = last.get("meta") or {}
+    assert meta.get("git_sha"), "ledger meta must record code version (git_sha)"
+    assert meta.get("schema_version"), "ledger meta must record schema_version"
+    assert meta.get("canonical_command") == "python3 -m scripts.golden_path"
     # log file mentioned in stdout
     out = r.stdout + r.stderr
     assert "Log salvo" in out or "log" in out.lower()
+    assert "meta.git_sha=" in out or meta.get("git_sha")
 
 
 def test_metadata_includes_code_and_schema_version() -> None:


### PR DESCRIPTION
## Summary

Wires `collect_run_metadata()` into every `_save_final_ledger` write so CLI ledger runs include:

- `meta.git_sha` (code version)
- `meta.schema_version` (`migrations_count=N`)
- optional `spreadsheet_sha256` / `canonical_ids_sha256` from planilha step

Closes the honest QA FAIL from CONTINUE-03 that rejected acceptance of those DOD items when metadata was never written to the ledger.

## Test plan
- [x] `pytest tests/test_golden_path_ledger_meta.py` (4 passed)
- [ ] CI green