### PR TITLE
fix(golden_path): clean-env tolerates dual measurement fail without gate

### DIFF
--- a/scripts/golden_path.py
+++ b/scripts/golden_path.py
@@ -635,7 +635,9 @@ def evaluate_run_outcome(
             return "failed", 3
         if report_fails:
             return "failed", 4
-        if coverage_measurement_success is False:
+        # Clean-env foundation still measures dual coverage (identity/gates in details)
+        # but only fails the pipeline on dual when --require-coverage-gate is set.
+        if require_coverage_gate and coverage_measurement_success is False:
             return "failed", 1
         if require_coverage_gate and coverage_gate_pass is False:
             return "coverage_gate_failed", 2

--- a/tests/test_dual_capability_coverage.py
+++ b/tests/test_dual_capability_coverage.py
@@ -848,3 +848,38 @@ def test_mapping_status_preserves_identity_unresolved() -> None:
     else:
         status = "ok"
     assert status == "identity_unresolved"
+
+
+def test_skip_sources_tolerates_measurement_fail() -> None:
+    """Clean-env foundation must not fail solely on dual measurement integrity."""
+    from scripts.golden_path import evaluate_run_outcome
+
+    overall, code = evaluate_run_outcome(
+        [],
+        set(),
+        None,
+        [],
+        skip_sources=True,
+        skip_freshness=True,
+        skip_reports=True,
+        coverage_measurement_success=False,
+        coverage_gate_pass=False,
+        require_coverage_gate=False,
+    )
+    assert overall == "success"
+    assert code == 0
+
+    overall2, code2 = evaluate_run_outcome(
+        [],
+        set(),
+        None,
+        [],
+        skip_sources=True,
+        skip_freshness=True,
+        skip_reports=True,
+        coverage_measurement_success=False,
+        coverage_gate_pass=False,
+        require_coverage_gate=True,
+    )
+    assert overall2 == "failed"
+    assert code2 == 1


### PR DESCRIPTION
## Summary

After PR #110 made `identity_unresolved` fail `measurement_success`, clean-env (`--skip-sources`) started failing full suite `test_clean_env_confirm_drop_runs`.

Foundation path now:
- still **measures** dual coverage (details retained)
- only fails pipeline on dual when `--require-coverage-gate`
- matches the original clean-env intent (bootstrap empty DB without 95%/identity gate)

## Test
- `test_skip_sources_tolerates_measurement_fail`
- dual suite selective green