### PR TITLE
docs(ops): dual campaign stamp consistency on main tip 3ab3a3a

### DIFF
--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/NEXT-DOD-PATH.md
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/NEXT-DOD-PATH.md
@@ -1,65 +1,73 @@
-# NEXT-DOD-PATH — após verdade dual de cobertura v1.1
+# NEXT-DOD-PATH — dual capability coverage (post-closure)
 
 **Campaign:** `DUAL-CAPABILITY-COVERAGE-TRUTH-01`  
-**Implementation tip:** `campaign/dual-capability-coverage-truth` @ `2dd7c8c`  
-**PR:** #108  
-**Adapter:** `dual_capability_coverage/1.1.0`
+**Date:** 2026-07-22  
+**Main tip (source of truth):** `3ab3a3a738437791cb4a9e34b76f41bb578f47a8`  
+**Adapter:** dual fail-closed engine on main (PRs #108–#112)
 
-## Estado comprovado (reproof local af045a9 / tip 2dd7c8c)
+## Estado comprovado (reproof live em main)
 
 | Campo | Valor |
 |-------|-------|
 | Method | `dual_capability_coverage` |
-| Universe | 1093 (seed stamps + ordered ids) |
-| open_tenders | den=1093 num=0 never_checked=1093 gate FAIL 0% |
-| historical_contracts | den=1093 num=0 never_checked=1093 gate FAIL 0% |
-| measurement_success | true |
-| coverage_gate_pass | false |
-| schema_compatibility_mode | modern |
-| identity_unresolved_count | 4 (ambiguous cnpj8 `00394494`, no first-wins) |
-| mapping | partial 1089/2085 db entities mapped |
-| legacy 19.5791% | SUPERSEDED |
+| artifact git_sha | `3ab3a3a738437791cb4a9e34b76f41bb578f47a8` (= origin/main) |
+| measurement_success | **false** |
+| coverage_gate_pass | **false** |
+| pipeline_success | **false** |
+| scope_complete | **true** |
+| dual_gate_status | **NOT_READY** |
+| mapping_status | **identity_unresolved** |
+| identity_unresolved_count | **4** |
+| ambiguous_cnpj8 | `['00394494']` |
+| universe entity_count | 1093 |
+| seed_sha256 | `d65f272812cf8dc9…` |
+| canonical_ids_sha256 | `0b3f894d87ba71f2…` |
+| open_tenders | den=1093 num=0 never=1093 cap_meas=False gate=FAIL presence=0.0% |
+| historical_contracts | den=1093 num=0 never=1093 cap_meas=False gate=FAIL presence=0.0915% |
+| legacy 19.5791% | SUPERSEDED (ERRATA-19-5791.md) |
 | 95% live claim | **NÃO** |
+| LOCAL_READY | **NÃO** |
 
-### Comandos de reproof
+### Comandos de reproof (main)
 
 ```bash
 export LOCAL_DATALAKE_DSN="${LOCAL_DATALAKE_DSN:-postgresql://test:test@127.0.0.1:5433/extra_test}"
 export REQUIRE_REAL_DB=1
+git checkout 3ab3a3a  # or origin/main
 python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
 python3 -m scripts.coverage.dual_capability_coverage --capability both --output-dir output/coverage
 python3 -m scripts.golden_path --execute-dual-coverage-only --capability both
 python3 -m pytest tests/test_dual_capability_coverage.py tests/test_golden_path_coverage.py -q -o addopts=
 ```
 
-## Próximos passos priorizados
+## Process stack — DONE (not next work)
 
-| # | Ação | Owner | Deps | Evidência |
-|---|------|-------|------|-----------|
-| 1 | CI full suite verde no tip final | @devops | push 2dd7c8c | Actions run SUCCESS |
-| 2 | Revisão independente PASS_FOR_MERGE (não implementador) | @qa | CI green | review file + verdict |
-| 3 | Merge PR #108 → main | @devops | review PASS | merge SHA |
-| 4 | Reproof dual em main | @dev/@qa | merge | summary JSON + git_sha main |
-| 5 | Acceptance pack + register_acceptance / controller | @qa/@po | main reproof | pack path |
-| 6 | DOD §12.1 calcula cobertura → ACCEPTED (só método dual) | @po | controller | DOD checkbox + evidence |
-| 7 | Resolver identity_unresolved (cnpj8 ambíguo) | @data-engineer | main | zero ambiguous roots or explicit blocked |
-| 8 | Backfill coverage_evidence PNCP open_tenders frescos ≤24h | ops | engine | never_checked ↓ |
-| 9 | Backfill historical_contracts ≥3y + incremental ≤7d | ops | engine | dual % real |
-| 10 | Candidatar gates 95% só com prova live dual | @po/@qa | 8+9 | gate PASS dual |
+| # | Step | Status | Evidence |
+|---|------|--------|----------|
+| 1 | Implement dual fail-closed engine | **DONE** | PR #108 merge `edd7618` |
+| 2 | CI green on implementation | **DONE** | Actions on #108 / main post-merge |
+| 3 | Independent review PASS_FOR_MERGE | **DONE** | `independent-review-v1.3-final.md` (reviewed_commit `ed7be1c`) |
+| 4 | Merge implementation to main | **DONE** | PR #108 |
+| 5 | Main dual reproof | **DONE** | live summary above on `3ab3a3a` |
+| 6 | Acceptance pack + controller + DOD accept | **DONE** | pack `.dod/evidence/DOD-rol-1-definition-of-done-4efe05fc94/` · PR #109 |
+| 7 | Skeptic: identity/scope/view | **DONE** | PR #110 |
+| 8 | Clean-env measurement tolerance | **DONE** | PR #111 full suite green |
+| 9 | Cap-level measurement honesty + docs stamp | **DONE** | PR #112 · tip `3ab3a3a` |
+
+## Próximos passos (somente operacional)
+
+| # | Ação | Owner | Deps | Evidência / comando |
+|---|------|-------|------|---------------------|
+| A | Resolver CNPJ raiz ambíguo `00394494` (identity_unresolved→0) | @data-engineer | main engine DONE | dual summary mapping_status=ok, identity_unresolved_count=0 |
+| B | Backfill `coverage_evidence` PNCP open_tenders frescos ≤24h | ops | A opcional | never_checked↓; dual CLI |
+| C | Backfill historical_contracts ≥3y + incremental ≤7d | ops | A opcional | dual CLI contracts gate path |
+| D | Re-medir dual em main após backfill | @dev/@qa | B+C | summary measurement_success=true (se identity ok) + % reais |
+| E | Candidatar gates 95% só com prova live dual | @po/@qa | D | gate PASS both caps + acceptance pack 95% |
+| F | Rebasar PR #107 (valores) se ainda aberta | @devops | main tip | avoid golden_path conflict |
 
 ## Non-claims
 
-* Não há cobertura 95%.
+* Não há cobertura operacional 95%.
 * Não há LOCAL_READY / PROJECT_DONE.
-* Não declarar GOAL DONE até itens 1–6.
-* PR #107 (valores report) é concorrente em golden_path — rebasar após merge dual se necessário.
-
-## Post-merge acceptance (2026-07-22)
-
-| Item | Status |
-|------|--------|
-| PR #108 merge | `edd7618` |
-| Main CI | `29887826689` SUCCESS |
-| Dual calculation acceptance pack | `.dod/evidence/DOD-rol-1-definition-of-done-4efe05fc94/` |
-| DOD §12.1 calcula cobertura | ACCEPTED dual method (not 95%) |
-| 95% gates | OPEN |
+* measurement_success=false em main é **correto** enquanto identity_unresolved>0.
+* Process steps 1–9 acima estão **DONE**; não reabrir como “next” sem regressão.

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/STATUS.md
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/STATUS.md
@@ -1,18 +1,34 @@
 # STATUS — DUAL-CAPABILITY-COVERAGE-TRUTH-01
 
-**Status:** COMPLETE on main (measurement dual fail-closed + normative accept + skeptic gaps closed)  
+**Status:** COMPLETE on main (dual measurement fail-closed + normative accept + skeptic stack)  
 **Date:** 2026-07-22  
-**Final main tip (pre this PR):** `ac81c51` — will advance after this PR merges
+**Final main tip:** `3ab3a3a738437791cb4a9e34b76f41bb578f47a8`
 
 ## Merged stack
 
-| PR | Role | Merge SHA |
-|----|------|-----------|
+| PR | Role | Merge / tip |
+|----|------|-------------|
 | #108 | dual engine implementation | `edd7618` |
 | #109 | DOD accept calcula cobertura (dual method) | `30f5548` |
 | #110 | skeptic: identity/scope/view | `3a17805` |
 | #111 | clean-env skip_sources measurement tolerance | `ac81c51` |
-| this | cap-level measurement_success honesty + docs/review re-stamp | ed7be1c + review v1.3 |
+| #112 | cap-level measurement honesty + review v1.3 | `3ab3a3a` (= current tip) |
+
+## Live dual snapshot (must match dual summary on tip)
+
+| Field | Value |
+|-------|-------|
+| measurement_success | false |
+| mapping_status | identity_unresolved |
+| identity_unresolved_count | 4 |
+| dual_gate_status | NOT_READY |
+| open_tenders cap_meas | False / never=1093 |
+| historical_contracts cap_meas | False / never=1093 |
+
+## Independent review
+
+* `independent-review-v1.3-final.md` — reviewed_commit `ed7be1c` (cap-level honesty fix), PASS_FOR_MERGE, 20+ executed attacks
+* Historical reviews (v1.1/v1.2) remain audit trail only; tip truth is v1.3 + main tip above
 
 ## Non-claims
 

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/completion-baseline.md
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/completion-baseline.md
@@ -84,3 +84,13 @@ git rev-parse origin/main origin/campaign/dual-capability-coverage-truth
 git merge-base origin/main origin/campaign/dual-capability-coverage-truth
 git log --oneline origin/main..origin/campaign/dual-capability-coverage-truth
 ```
+
+## Docs stamp closure
+
+**Date:** 2026-07-22  
+**Main tip:** `3ab3a3a738437791cb4a9e34b76f41bb578f47a8`  
+**Live dual:** measurement_success=false · mapping_status=identity_unresolved · identity_unresolved_count=4 · dual_gate_status=NOT_READY  
+**Gate:** `docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py` → exit 0  
+**Evidence:** `evidence/dual-reproof-summary.json` (git_sha = tip)  
+
+Process stack #108–#112 DONE on main. Remaining work is operational (identity CNPJ + backfill), not engine implementable.

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/evidence/README-REPROOF.md
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/evidence/README-REPROOF.md
@@ -1,0 +1,33 @@
+# Dual reproof evidence pointer
+
+`dual-reproof-summary.json` is the **canonical live dual snapshot** for campaign
+stamp consistency. It must match `origin/main` tip and the honest identity state.
+
+**Refresh command:**
+
+```bash
+git rev-parse origin/main   # expect 3ab3a3a738437791cb4a9e34b76f41bb578f47a8
+export LOCAL_DATALAKE_DSN="${LOCAL_DATALAKE_DSN:-postgresql://test:test@127.0.0.1:5433/extra_test}"
+export REQUIRE_REAL_DB=1
+python3 -m scripts.coverage.dual_capability_coverage --capability both --output-dir output/coverage
+cp output/coverage/dual-capability-coverage-summary.json \
+  docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/evidence/dual-reproof-summary.json
+python3 docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
+```
+
+Current closure snapshot (2026-07-22, tip `3ab3a3a738437791cb4a9e34b76f41bb578f47a8`):
+
+| Field | Value |
+|-------|-------|
+| main / artifact git_sha | `3ab3a3a738437791cb4a9e34b76f41bb578f47a8` |
+| measurement_success | false |
+| coverage_gate_pass | false |
+| pipeline_success | false |
+| dual_gate_status | NOT_READY |
+| mapping_status | identity_unresolved |
+| identity_unresolved_count | 4 |
+| ambiguous_cnpj8 | 00394494 |
+| open_tenders | den=1093 num=0 never=1093 cap_meas=false |
+| historical_contracts | den=1093 num=0 never=1093 presence=0.0915% cap_meas=false |
+
+Gate script: `scripts/check_campaign_stamp_consistency.py` (exit 0 required for docs closure).

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/evidence/dual-reproof-summary.json
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/evidence/dual-reproof-summary.json
@@ -1,17 +1,18 @@
 {
-  "adapter_version": "dual_capability_coverage/1.0.0",
-  "as_of": "2026-07-22T01:20:49.054527Z",
+  "adapter_version": "dual_capability_coverage/1.1.0",
+  "as_of": "2026-07-22T04:12:43.425790Z",
   "universe": {
     "entity_count": 1093,
-    "seed_path": "/mnt/d/extra consultoria/Extra - alvos de licita\u00e7\u00e3o. R-0.xlsx",
+    "seed_path": "/tmp/extra-dual-docs-closure-10731/fixtures/canonical_universe_r0.xlsx",
     "seed_sha256": "d65f272812cf8dc95f3ca78c5db9a2fb2a39a759e5633eb3fb91891ad10a5486",
     "canonical_ids_sha256": "0b3f894d87ba71f2e0fa96887cb3075033488de1af1e6e55f97ccda0701fb396",
     "radius_km": 200.0,
     "radius_rule": "seed column 'Raio 200km?': SIM = included, NAO = excluded; missing/unknown remains unresolved and is not in included set",
-    "as_of": "2026-07-22T01:20:49.054527Z",
-    "git_sha": "5a19df7dcd938af255ab5f44dc8d4d2137da40b2",
+    "as_of": "2026-07-22T04:12:43.425790Z",
+    "git_sha": "3ab3a3a738437791cb4a9e34b76f41bb578f47a8",
     "schema_version": "migrations_count=63",
-    "code_version": "dual_capability_coverage/1.0.0",
+    "code_version": "dual_capability_coverage/1.1.0",
+    "universe_version": "d65f272812cf:0b3f894d87ba:1093",
     "entity_ids_sample": [
       "extra-0081e4515ae9da5512ec",
       "extra-0097599f1fcd438155f0",
@@ -24,21 +25,30 @@
     "open_tenders": {
       "capability": "open_tenders",
       "universe_version": "d65f272812cf:0b3f894d87ba:1093",
+      "universe_count": 1093,
       "applicable_denominator": 1093,
       "covered_numerator": 0,
       "coverage_pct": 0.0,
       "threshold": 0.95,
       "gate_status": "FAIL",
-      "as_of": "2026-07-22T01:20:49.054527Z",
+      "as_of": "2026-07-22T04:12:43.425790Z",
       "freshness_sla": 24,
       "fresh_count": 0,
       "stale_count": 0,
       "unknown_count": 0,
+      "applicability_unknown_count": 0,
+      "applicability_blocked_count": 0,
       "blocked_count": 0,
       "partial_count": 0,
       "success_zero_count": 0,
       "success_with_data_count": 0,
       "not_applicable_count": 0,
+      "pending_count": 0,
+      "never_checked_count": 1093,
+      "error_count": 0,
+      "source_blocked_count": 0,
+      "identity_unresolved_count": 4,
+      "unmapped_evidence_count": 0,
       "data_presence_numerator": 0,
       "data_presence_pct": 0.0,
       "source_combinations": [
@@ -48,34 +58,46 @@
         "Presence is descriptive and is never coverage.",
         "Complementary sources do not replace required source combinations.",
         "entity_coverage.is_covered / any_row are forbidden as coverage methods.",
-        "Gate PASS requires coverage>=95% and zero unknown applicability rows in results."
+        "Applicability without proven rule is unknown (never silent applicable).",
+        "Gate PASS requires coverage>=95%, zero applicability unknown/blocked, zero unmapped evidence."
       ],
-      "git_sha": "5a19df7dcd938af255ab5f44dc8d4d2137da40b2",
+      "git_sha": "3ab3a3a738437791cb4a9e34b76f41bb578f47a8",
       "schema_version": "migrations_count=63",
-      "measurement_success": true,
+      "measurement_success": false,
       "coverage_gate_pass": false,
-      "method": "dual_capability_coverage"
+      "method": "dual_capability_coverage",
+      "reconciliation_ok": true,
+      "reconciliation_errors": []
     },
     "historical_contracts": {
       "capability": "historical_contracts",
       "universe_version": "d65f272812cf:0b3f894d87ba:1093",
+      "universe_count": 1093,
       "applicable_denominator": 1093,
       "covered_numerator": 0,
       "coverage_pct": 0.0,
       "threshold": 0.95,
       "gate_status": "FAIL",
-      "as_of": "2026-07-22T01:20:49.054527Z",
+      "as_of": "2026-07-22T04:12:43.425790Z",
       "freshness_sla": 168,
       "fresh_count": 0,
       "stale_count": 0,
       "unknown_count": 0,
+      "applicability_unknown_count": 0,
+      "applicability_blocked_count": 0,
       "blocked_count": 0,
       "partial_count": 0,
       "success_zero_count": 0,
       "success_with_data_count": 0,
       "not_applicable_count": 0,
-      "data_presence_numerator": 0,
-      "data_presence_pct": 0.0,
+      "pending_count": 0,
+      "never_checked_count": 1093,
+      "error_count": 0,
+      "source_blocked_count": 0,
+      "identity_unresolved_count": 4,
+      "unmapped_evidence_count": 0,
+      "data_presence_numerator": 1,
+      "data_presence_pct": 0.0915,
       "source_combinations": [
         "pncp"
       ],
@@ -83,23 +105,33 @@
         "Presence is descriptive and is never coverage.",
         "Complementary sources do not replace required source combinations.",
         "entity_coverage.is_covered / any_row are forbidden as coverage methods.",
-        "Gate PASS requires coverage>=95% and zero unknown applicability rows in results."
+        "Applicability without proven rule is unknown (never silent applicable).",
+        "Gate PASS requires coverage>=95%, zero applicability unknown/blocked, zero unmapped evidence."
       ],
-      "git_sha": "5a19df7dcd938af255ab5f44dc8d4d2137da40b2",
+      "git_sha": "3ab3a3a738437791cb4a9e34b76f41bb578f47a8",
       "schema_version": "migrations_count=63",
-      "measurement_success": true,
+      "measurement_success": false,
       "coverage_gate_pass": false,
-      "method": "dual_capability_coverage"
+      "method": "dual_capability_coverage",
+      "reconciliation_ok": true,
+      "reconciliation_errors": []
     }
   },
-  "measurement_success": true,
+  "measurement_success": false,
   "coverage_gate_pass": false,
   "pipeline_success": false,
+  "scope_complete": true,
+  "dual_gate_status": "NOT_READY",
+  "capabilities_evaluated": [
+    "historical_contracts",
+    "open_tenders"
+  ],
   "limitations": [
     "Presence is descriptive and is never coverage.",
     "Complementary sources do not replace required source combinations.",
     "entity_coverage.is_covered / any_row are forbidden as coverage methods.",
-    "Gate PASS requires coverage>=95% and zero unknown applicability rows in results."
+    "Applicability without proven rule is unknown (never silent applicable).",
+    "Gate PASS requires coverage>=95%, zero applicability unknown/blocked, zero unmapped evidence."
   ],
   "legacy_metric": {
     "status": "legacy_non_canonical",
@@ -109,7 +141,61 @@
     "note": "Superseded by dual_capability_coverage. Historical claim 214/1093=19.5791% used is_covered without set equality and without capability split. See ERRATA-19-5791.md.",
     "forbidden_as_coverage": true
   },
-  "error": null,
+  "error": "identity_unresolved: count=4 ambiguous_cnpj8=['00394494']",
+  "mapping_metrics": {
+    "db_entities_seen": 2085,
+    "db_entities_mapped": 1089,
+    "db_entities_unmapped": 996,
+    "unmapped_entity_ids_sample": [
+      "1620",
+      "1621",
+      "1622",
+      "1623",
+      "1461",
+      "1506",
+      "1616",
+      "906",
+      "1617",
+      "1618",
+      "1091",
+      "1092",
+      "1093",
+      "1094",
+      "1095",
+      "1096",
+      "1097",
+      "1098",
+      "1099",
+      "1100"
+    ],
+    "mapping_coverage_pct": 52.2302,
+    "mapping_status": "identity_unresolved",
+    "ambiguous_cnpj8": [
+      "00394494"
+    ],
+    "identity_unresolved_count": 4
+  },
+  "presence_status": {
+    "open_tenders": {
+      "status": "no_rows",
+      "entity_count": 0,
+      "unmapped_count": 0,
+      "unmapped_sample": [],
+      "error": null,
+      "table_name": "pncp_raw_bids"
+    },
+    "historical_contracts": {
+      "status": "rows_present",
+      "entity_count": 1,
+      "unmapped_count": 0,
+      "unmapped_sample": [],
+      "error": null,
+      "table_name": "pncp_supplier_contracts"
+    }
+  },
+  "schema_compatibility_mode": "modern",
+  "unmapped_evidence_count": 0,
+  "outsider_evidence_count": 0,
   "forbidden_methods": [
     "any_row",
     "entity_coverage.any_row",
@@ -122,6 +208,8 @@
     "average of open_tenders and historical_contracts",
     "data_presence labeled as coverage",
     "legacy 214/1093=19.5791% as canonical dual coverage",
-    "live 95% without dual-definition proof"
+    "live 95% without dual-definition proof",
+    "silent unmapped evidence as zero coverage",
+    "fail-open schema/query errors as empty sets"
   ]
 }

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Fail closed if campaign docs stamps drift from origin/main + live dual evidence.
+
+Canonical stamps checked in:
+  - NEXT-DOD-PATH.md
+  - STATUS.md
+  - evidence/README-REPROOF.md
+  - evidence/dual-reproof-summary.json
+  - specs/001-dual-capability-coverage-truth/converge-report.md (if present)
+
+Exit 0 only when all of the following hold:
+  * expected main tip SHA appears in the stamp docs
+  * dual-reproof-summary.json git_sha == expected tip
+  * dual-reproof-summary measurement_success is false (current honest state)
+  * mapping_status == identity_unresolved with identity_unresolved_count == 4
+  * no stale "measurement_success=true" claim without identity resolution in stamp docs
+
+Usage:
+  python3 docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
+  python3 .../check_campaign_stamp_consistency.py --expected-main-sha 3ab3a3a...
+  python3 .../check_campaign_stamp_consistency.py --repo-root /path/to/repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CAMPAIGN = Path("docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01")
+STAMP_DOCS = [
+    CAMPAIGN / "NEXT-DOD-PATH.md",
+    CAMPAIGN / "STATUS.md",
+    CAMPAIGN / "evidence" / "README-REPROOF.md",
+]
+OPTIONAL_DOCS = [
+    Path("specs/001-dual-capability-coverage-truth/converge-report.md"),
+]
+EVIDENCE_JSON = CAMPAIGN / "evidence" / "dual-reproof-summary.json"
+
+# Honest live state on main tip at campaign closure (identity not resolved yet).
+EXPECTED_MEASUREMENT_SUCCESS = False
+EXPECTED_MAPPING_STATUS = "identity_unresolved"
+EXPECTED_IDENTITY_UNRESOLVED_COUNT = 4
+EXPECTED_DUAL_GATE = "NOT_READY"
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    out = subprocess.check_output(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        stderr=subprocess.STDOUT,
+    )
+    return out.strip()
+
+
+def _resolve_expected_sha(repo: Path, explicit: str | None) -> str:
+    if explicit:
+        return explicit.strip().lower()
+    try:
+        return _run_git(repo, "rev-parse", "origin/main").lower()
+    except subprocess.CalledProcessError:
+        return _run_git(repo, "rev-parse", "HEAD").lower()
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: discover from script location or cwd)",
+    )
+    parser.add_argument(
+        "--expected-main-sha",
+        default=None,
+        help="Full or prefix SHA expected in stamp docs (default: origin/main)",
+    )
+    parser.add_argument(
+        "--allow-measurement-true",
+        action="store_true",
+        help="Relax gate if identity has been fixed and measurement_success is true",
+    )
+    args = parser.parse_args()
+
+    script_path = Path(__file__).resolve()
+    repo = args.repo_root
+    if repo is None:
+        # .../docs/ops/campaigns/DUAL-.../scripts/this.py → repo root is parents[5]
+        candidates = [
+            script_path.parents[5],
+            Path.cwd(),
+        ]
+        repo = next((c for c in candidates if (c / ".git").exists() or (c / "docs").exists()), Path.cwd())
+    repo = repo.resolve()
+
+    errors: list[str] = []
+    notes: list[str] = []
+
+    expected = _resolve_expected_sha(repo, args.expected_main_sha)
+    short = expected[:12]
+    notes.append(f"expected_main_sha={expected}")
+    notes.append(f"repo_root={repo}")
+
+    # --- stamp docs must contain tip SHA ---
+    for rel in STAMP_DOCS + OPTIONAL_DOCS:
+        path = repo / rel
+        if not path.is_file():
+            if rel in OPTIONAL_DOCS:
+                notes.append(f"optional_missing={rel}")
+                continue
+            errors.append(f"missing_stamp_doc:{rel}")
+            continue
+        text = _read(path)
+        if short not in text and expected not in text:
+            errors.append(f"sha_missing_in_doc:{rel}:expected_prefix={short}")
+        # Forbid optimistic stale claims in active stamp docs
+        if rel.name in {"NEXT-DOD-PATH.md", "STATUS.md", "README-REPROOF.md"}:
+            # measurement_success | true (markdown table or prose) as current state
+            if re.search(
+                r"measurement_success\s*\|\s*\*?\*?true\*?\*?",
+                text,
+                flags=re.IGNORECASE,
+            ):
+                if not args.allow_measurement_true:
+                    errors.append(f"stale_measurement_true_claim:{rel}")
+            if re.search(r"mapping_status\s*\|\s*\*?\*?ok\*?\*?", text, flags=re.IGNORECASE):
+                if not args.allow_measurement_true:
+                    errors.append(f"stale_mapping_ok_claim:{rel}")
+
+    # --- evidence JSON must match tip + honest identity state ---
+    ev_path = repo / EVIDENCE_JSON
+    if not ev_path.is_file():
+        errors.append(f"missing_evidence_json:{EVIDENCE_JSON}")
+    else:
+        try:
+            data = json.loads(ev_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"evidence_json_invalid:{exc}")
+            data = None
+        if data is not None:
+            u = data.get("universe") or {}
+            git_sha = str(u.get("git_sha") or data.get("git_sha") or "").lower()
+            if not git_sha:
+                errors.append("evidence_missing_git_sha")
+            elif not (git_sha == expected or expected.startswith(git_sha) or git_sha.startswith(short)):
+                errors.append(
+                    f"evidence_git_sha_mismatch:actual={git_sha}:expected={expected}"
+                )
+            ms = data.get("measurement_success")
+            mm = data.get("mapping_metrics") or {}
+            map_status = mm.get("mapping_status")
+            iuc = mm.get("identity_unresolved_count")
+            dgs = data.get("dual_gate_status")
+
+            notes.append(f"evidence.measurement_success={ms}")
+            notes.append(f"evidence.mapping_status={map_status}")
+            notes.append(f"evidence.identity_unresolved_count={iuc}")
+            notes.append(f"evidence.dual_gate_status={dgs}")
+
+            if not args.allow_measurement_true:
+                if ms is not EXPECTED_MEASUREMENT_SUCCESS:
+                    errors.append(
+                        f"evidence_measurement_success:actual={ms}:expected={EXPECTED_MEASUREMENT_SUCCESS}"
+                    )
+                if map_status != EXPECTED_MAPPING_STATUS:
+                    errors.append(
+                        f"evidence_mapping_status:actual={map_status}:expected={EXPECTED_MAPPING_STATUS}"
+                    )
+                if iuc != EXPECTED_IDENTITY_UNRESOLVED_COUNT:
+                    errors.append(
+                        f"evidence_identity_unresolved_count:actual={iuc}:expected={EXPECTED_IDENTITY_UNRESOLVED_COUNT}"
+                    )
+                if dgs != EXPECTED_DUAL_GATE:
+                    errors.append(
+                        f"evidence_dual_gate_status:actual={dgs}:expected={EXPECTED_DUAL_GATE}"
+                    )
+            else:
+                # When identity is fixed, require measurement honesty still be self-consistent
+                if ms is True and map_status == "identity_unresolved":
+                    errors.append("evidence_incoherent:measurement_true_with_identity_unresolved")
+
+            # Caps must not claim measurement_success true while report is false
+            for cap_name, cap in (data.get("capabilities") or {}).items():
+                cap_ms = cap.get("measurement_success")
+                if ms is False and cap_ms is True:
+                    errors.append(f"cap_measurement_incoherent:{cap_name}:cap_true_report_false")
+
+    # --- optional: origin/main equals expected ---
+    try:
+        tip = _run_git(repo, "rev-parse", "origin/main").lower()
+        notes.append(f"origin/main={tip}")
+        if tip != expected and not args.expected_main_sha:
+            errors.append(f"origin_main_drift:origin={tip}:resolved={expected}")
+    except subprocess.CalledProcessError as exc:
+        notes.append(f"git_origin_main_unavailable:{exc}")
+
+    print("=== campaign stamp consistency ===")
+    for n in notes:
+        print(f"NOTE  {n}")
+    if errors:
+        for e in errors:
+            print(f"FAIL  {e}")
+        print(f"RESULT FAIL count={len(errors)}")
+        return 1
+    print("RESULT PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/001-dual-capability-coverage-truth/converge-report.md
+++ b/specs/001-dual-capability-coverage-truth/converge-report.md
@@ -1,31 +1,32 @@
 # Speckit converge — dual-capability-coverage-truth
 
 **Date:** 2026-07-22  
-**Base main:** ac81c51 (+ this remediation)
+**Main tip:** `3ab3a3a738437791cb4a9e34b76f41bb578f47a8`
 
 ## Codebase vs tasks
 
 | Task | Status | Evidence |
 |------|--------|----------|
 | T001–T019 engine/spec | Done | dual engine + tests + checklist |
-| T020 PR/CI | Done | PR #108 CI green + merge edd7618 |
-| T021–T031 fail-closed/matrix/hashes | Done | dual_capability_coverage v1.1+ |
-| T032 independent review | Done | v1.1 H1 + v1.2 skeptic + v1.3 re-stamp |
-| T033 merge | Done | #108 |
-| T034 main reproof | Done | main dual CLI after merges |
-| T035 acceptance pack/controller | Done | dod_controller accept + pack 4efe05fc94 |
+| T020 PR/CI | Done | PR #108 CI + merge |
+| T021–T031 fail-closed/matrix/hashes | Done | dual engine on main |
+| T032 independent review | Done | v1.3-final reviewed_commit ed7be1c |
+| T033 merge | Done | #108–#112 on main tip `3ab3a3a` |
+| T034 main reproof | Done | live dual summary measurement=false map=identity_unresolved |
+| T035 acceptance pack/controller | Done | pack 4efe05fc94 + dod_controller |
 | T036 DOD ACCEPTED | Done | PR #109 |
-| T040–T044 skeptic remediation | Done | #110/#111 + this PR |
+| T040–T044 skeptic remediation | Done | #110–#112 |
 
 ## Remaining unbuilt work
 
 Only **operational** (not measurement-engine implementable):
 
-1. Resolve ambiguous CNPJ roots (identity_unresolved → 0)
-2. Backfill coverage_evidence for dual 95% gates
-3. Optional: activate applicability config beyond draft
+1. Resolve ambiguous CNPJ roots (`00394494`) → identity_unresolved=0
+2. Backfill coverage_evidence → dual 95% candidacy
+3. Optional: promote applicability config beyond draft
 
 ## Converge verdict
 
-**CONVERGED** for measurement dual fail-closed + normative "calcula cobertura".  
-**NOT** claiming dual 95% operational gates.
+**CONVERGED** for dual fail-closed measurement + normative “calcula cobertura”.  
+**NOT** claiming dual 95% operational gates.  
+Process steps merge/accept/review are **DONE** on main `3ab3a3a`.


### PR DESCRIPTION
## Summary

Atomic docs closure for **DUAL-CAPABILITY-COVERAGE-TRUTH-01** after process stack #108–#112 landed on main.

- Rewrite `NEXT-DOD-PATH.md` / `STATUS.md` / `converge-report.md` to live dual state on tip `3ab3a3a`
- Live dual: `measurement_success=false`, `mapping_status=identity_unresolved`, `identity_unresolved_count=4`
- Refresh `evidence/dual-reproof-summary.json` from live dual CLI on tip
- Add `scripts/check_campaign_stamp_consistency.py` (fail-closed stamp gate)
- Process steps 1–9 marked DONE; next path is operational (CNPJ `00394494` + backfill), not engine rework

## Non-claims

- No dual 95% operational coverage
- No LOCAL_READY / PROJECT_DONE

## Test plan

- [x] `python3 docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py` → exit 0
- [x] Live dual CLI on tip confirms measurement_success=false / identity_unresolved
- [ ] CI green on PR
- [ ] Re-run consistency gate on post-merge `origin/main`