### PR TITLE
feat(intel): national contracts intelligence foundation (migration 060)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,3 +331,12 @@ verify-stratified-recall-isolated:
 		--out artifacts/campaigns/STRATIFIED-RECALL-SOURCE-RESILIENCE-01/verify-isolated.json \
 		$(STRATIFIED_RECALL_VERIFY_FLAGS)
 
+
+# --- national intel foundation (migration 060) ---
+.PHONY: test-national-intel verify-national-intel-foundation
+test-national-intel:
+	python -m pytest tests/national_intel/ -q --tb=short
+
+verify-national-intel-foundation:
+	@test -f db/migrations/060_national_contracts_intelligence_layers.sql
+	@test ! -f db/migrations/059_national_contracts_intelligence_layers.sql

--- a/db/migrations/060_national_contracts_intelligence_layers.sql
+++ b/db/migrations/060_national_contracts_intelligence_layers.sql
@@ -1,0 +1,84 @@
+-- 060_national_contracts_intelligence_layers.sql
+-- Additive analytical views for national contracts intelligence.
+-- Does NOT alter dual coverage, crawlers, or fact-table write path.
+-- Layer semantics: raw_national | geo_sc | intel_product (see specs/004-extra-live-consulting-pack).
+
+-- L1 stamp view: all active national contracts
+CREATE OR REPLACE VIEW public.v_intel_contracts_raw_national AS
+SELECT
+    c.*,
+    'raw_national'::text AS scope_label
+FROM public.pncp_supplier_contracts c
+WHERE c.is_active = TRUE;
+
+COMMENT ON VIEW public.v_intel_contracts_raw_national IS
+'L1 national contracts inventory stamp. NOT operational SC coverage.';
+
+-- L2 geographic SC filter (not canonical universe coverage)
+CREATE OR REPLACE VIEW public.v_intel_contracts_geo_sc AS
+SELECT
+    c.*,
+    'geo_sc'::text AS scope_label
+FROM public.pncp_supplier_contracts c
+WHERE c.is_active = TRUE
+  AND c.uf IS NOT NULL
+  AND upper(btrim(c.uf)) = 'SC';
+
+COMMENT ON VIEW public.v_intel_contracts_geo_sc IS
+'L2 geographic UF=SC filter only. MUST NOT be labeled operational coverage.';
+
+-- L3 supplier geographic footprint
+CREATE OR REPLACE VIEW public.v_intel_supplier_geo AS
+SELECT
+    COALESCE(c.fornecedor_cnpj_8, left(COALESCE(c.fornecedor_cnpj, ''), 8)) AS fornecedor_cnpj_8,
+    MAX(c.fornecedor_cnpj) AS fornecedor_cnpj,
+    MAX(c.fornecedor_nome) AS fornecedor_nome,
+    COUNT(*)::bigint AS contract_count,
+    COUNT(DISTINCT upper(btrim(c.uf))) FILTER (WHERE c.uf IS NOT NULL AND btrim(c.uf) <> '')::bigint AS uf_count,
+    array_agg(DISTINCT upper(btrim(c.uf)) ORDER BY upper(btrim(c.uf)))
+        FILTER (WHERE c.uf IS NOT NULL AND btrim(c.uf) <> '') AS ufs,
+    BOOL_OR(c.uf IS NOT NULL AND upper(btrim(c.uf)) = 'SC') AS has_sc,
+    COALESCE(SUM(c.valor_total), 0)::numeric(18, 2) AS valor_sum,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY c.valor_total)
+        FILTER (WHERE c.valor_total IS NOT NULL) AS valor_p50,
+    MIN(c.data_publicacao) AS first_publicacao,
+    MAX(c.data_publicacao) AS last_publicacao,
+    'intel_product'::text AS scope_label
+FROM public.pncp_supplier_contracts c
+WHERE c.is_active = TRUE
+  AND (
+        (c.fornecedor_cnpj IS NOT NULL AND btrim(c.fornecedor_cnpj) <> '')
+        OR (c.fornecedor_nome IS NOT NULL AND btrim(c.fornecedor_nome) <> '')
+      )
+GROUP BY COALESCE(c.fornecedor_cnpj_8, left(COALESCE(c.fornecedor_cnpj, ''), 8));
+
+COMMENT ON VIEW public.v_intel_supplier_geo IS
+'L3 supplier footprint across UFs. multi-UF is FACT of contracts, not partnership.';
+
+-- L3 agency profile aggregates
+CREATE OR REPLACE VIEW public.v_intel_agency_profile AS
+SELECT
+    COALESCE(c.orgao_cnpj_8, left(COALESCE(c.orgao_cnpj, ''), 8)) AS orgao_cnpj_8,
+    MAX(c.orgao_cnpj) AS orgao_cnpj,
+    MAX(c.orgao_nome) AS orgao_nome,
+    COUNT(*)::bigint AS contract_count,
+    COUNT(DISTINCT COALESCE(c.fornecedor_cnpj_8, c.fornecedor_cnpj))::bigint AS supplier_count,
+    COALESCE(SUM(c.valor_total), 0)::numeric(18, 2) AS valor_sum,
+    AVG(c.valor_total)::numeric(18, 2) AS valor_avg,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY c.valor_total)
+        FILTER (WHERE c.valor_total IS NOT NULL) AS valor_p50,
+    MODE() WITHIN GROUP (ORDER BY upper(btrim(c.uf)))
+        FILTER (WHERE c.uf IS NOT NULL AND btrim(c.uf) <> '') AS uf_mode,
+    MIN(c.data_publicacao) AS first_publicacao,
+    MAX(c.data_publicacao) AS last_publicacao,
+    'intel_product'::text AS scope_label
+FROM public.pncp_supplier_contracts c
+WHERE c.is_active = TRUE
+  AND (
+        (c.orgao_cnpj IS NOT NULL AND btrim(c.orgao_cnpj) <> '')
+        OR (c.orgao_nome IS NOT NULL AND btrim(c.orgao_nome) <> '')
+      )
+GROUP BY COALESCE(c.orgao_cnpj_8, left(COALESCE(c.orgao_cnpj, ''), 8));
+
+COMMENT ON VIEW public.v_intel_agency_profile IS
+'L3 contracting agency aggregates. Concentration metrics computed in app layer when needed.';

--- a/docs/architecture/national-intel-foundation.md
+++ b/docs/architecture/national-intel-foundation.md
@@ -1,0 +1,25 @@
+# National contracts intelligence foundation
+
+Migration `060_national_contracts_intelligence_layers.sql` adds additive analytical
+views for national PNCP contracts. It does **not** alter dual-capability coverage,
+crawlers, or fact-table write paths.
+
+## Layers
+
+| Layer | View / product | Meaning |
+|-------|----------------|---------|
+| L1 | `v_intel_contracts_raw_national` | National inventory stamp |
+| L2 | `v_intel_contracts_geo_sc` | Geographic UF=SC filter only — **not** operational coverage |
+| L3+ | `scripts/national_intel` products | Agencies, competitors, benchmarks with lineage |
+
+## Isolation
+
+Operational SC coverage remains on the dual spine (`compute_dual_coverage` /
+canonical universe). National-intel products must never be labeled as operational
+coverage. Adversarial tests under `tests/national_intel/` enforce this boundary.
+
+## CLI
+
+```bash
+python -m scripts.national_intel --help
+```

--- a/scripts/national_intel/__init__.py
+++ b/scripts/national_intel/__init__.py
@@ -1,0 +1,10 @@
+"""National contracts strategic intelligence products (Extra).
+
+Logical layers (see specs/003):
+  raw_national → geo_sc → intel_product → delivery CLI
+
+Does NOT compute operational SC dual coverage (see scripts.coverage.dual_capability_coverage).
+Does NOT run national backfill.
+"""
+
+__version__ = "0.1.0"

--- a/scripts/national_intel/__main__.py
+++ b/scripts/national_intel/__main__.py
@@ -1,0 +1,3 @@
+from scripts.national_intel.cli import main
+
+raise SystemExit(main())

--- a/scripts/national_intel/agencies.py
+++ b/scripts/national_intel/agencies.py
@@ -1,0 +1,116 @@
+"""Contracting agency profile product (single-query, no N+1)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.national_intel.db import fetch_all
+from scripts.national_intel.lineage import envelope
+from scripts.national_intel.sql_filters import build_contract_filters
+
+
+def run_agencies(
+    conn: Any,
+    *,
+    keyword: str | None = None,
+    uf: str | None = None,
+    limit: int = 50,
+    dsn: str | None = None,
+) -> dict[str, Any]:
+    limit = max(1, min(int(limit), 5000))
+    where, params = build_contract_filters(keyword=keyword, uf=uf)
+    # where is allowlisted-only (sql_filters); params bind all user values.
+    head = (
+        "WITH base AS ("
+        "  SELECT "
+        "    COALESCE(c.orgao_cnpj_8, left(COALESCE(c.orgao_cnpj, ''), 8)) AS orgao_cnpj_8, "
+        "    c.orgao_cnpj, c.orgao_nome, "
+        "    COALESCE(c.fornecedor_cnpj_8, c.fornecedor_cnpj) AS supplier_key, "
+        "    c.valor_total, c.uf, c.data_publicacao "
+        "  FROM public.pncp_supplier_contracts c "
+        "  WHERE "
+    )
+    tail = (
+        "    AND ("
+        "      (c.orgao_cnpj IS NOT NULL AND btrim(c.orgao_cnpj) <> '') "
+        "      OR (c.orgao_nome IS NOT NULL AND btrim(c.orgao_nome) <> '') "
+        "    )"
+        "), "
+        "supplier_counts AS ("
+        "  SELECT orgao_cnpj_8, supplier_key, COUNT(*)::numeric AS n "
+        "  FROM base GROUP BY orgao_cnpj_8, supplier_key"
+        "), "
+        "supplier_totals AS ("
+        "  SELECT orgao_cnpj_8, SUM(n) AS total_n "
+        "  FROM supplier_counts GROUP BY orgao_cnpj_8"
+        "), "
+        "top_share AS ("
+        "  SELECT sc.orgao_cnpj_8, "
+        "    MAX(sc.n / NULLIF(st.total_n, 0)) AS top_supplier_share "
+        "  FROM supplier_counts sc "
+        "  JOIN supplier_totals st ON st.orgao_cnpj_8 = sc.orgao_cnpj_8 "
+        "  GROUP BY sc.orgao_cnpj_8"
+        "), "
+        "ranked AS ("
+        "  SELECT "
+        "    b.orgao_cnpj_8, "
+        "    MAX(b.orgao_cnpj) AS orgao_cnpj, "
+        "    MAX(b.orgao_nome) AS orgao_nome, "
+        "    COUNT(*)::bigint AS contract_count, "
+        "    COUNT(DISTINCT b.supplier_key)::bigint AS supplier_count, "
+        "    COALESCE(SUM(b.valor_total), 0)::numeric AS valor_sum, "
+        "    AVG(b.valor_total)::numeric AS valor_avg, "
+        "    percentile_cont(0.5) WITHIN GROUP (ORDER BY b.valor_total) "
+        "      FILTER (WHERE b.valor_total IS NOT NULL) AS valor_p50, "
+        "    MODE() WITHIN GROUP (ORDER BY upper(btrim(b.uf))) "
+        "      FILTER (WHERE b.uf IS NOT NULL AND btrim(b.uf) <> '') AS uf_mode, "
+        "    MIN(b.data_publicacao) AS first_publicacao, "
+        "    MAX(b.data_publicacao) AS last_publicacao "
+        "  FROM base b "
+        "  GROUP BY b.orgao_cnpj_8"
+        ") "
+        "SELECT r.*, COALESCE(t.top_supplier_share, 0) AS top_supplier_share "
+        "FROM ranked r "
+        "LEFT JOIN top_share t ON t.orgao_cnpj_8 = r.orgao_cnpj_8 "
+        "ORDER BY r.contract_count DESC, r.valor_sum DESC NULLS LAST "
+        "LIMIT %s"
+    )
+    sql = head + where + tail  # noqa: S608
+    params.append(limit)
+    raw = fetch_all(conn, sql, tuple(params))
+
+    rows: list[dict[str, Any]] = []
+    for r in raw:
+        rows.append(
+            {
+                "orgao_cnpj_8": r.get("orgao_cnpj_8"),
+                "orgao_cnpj": r.get("orgao_cnpj"),
+                "orgao_nome": r.get("orgao_nome"),
+                "contract_count": int(r.get("contract_count") or 0),
+                "supplier_count": int(r.get("supplier_count") or 0),
+                "valor_sum": float(r.get("valor_sum") or 0),
+                "valor_avg": float(r["valor_avg"]) if r.get("valor_avg") is not None else None,
+                "valor_p50": float(r["valor_p50"]) if r.get("valor_p50") is not None else None,
+                "uf_mode": r.get("uf_mode"),
+                "first_publicacao": r.get("first_publicacao"),
+                "last_publicacao": r.get("last_publicacao"),
+                "top_supplier_share": float(r.get("top_supplier_share") or 0),
+                "top_supplier_share_claim_class": "indicator",
+                "claim_class": "fact",
+            }
+        )
+
+    limitations = [
+        "Agency profiles reflect inventory present in pncp_supplier_contracts for the filter only.",
+        "top_supplier_share is an INDICATOR of concentration, not proof of collusion or exclusive partnership.",
+        "uf_mode is MODE of contracts, not legal jurisdiction of the agency.",
+        "Empty result means no matching rows in filter — not a claim of zero public demand nationally.",
+    ]
+    return envelope(
+        product_id="agencies_profile",
+        scope_label="intel_product",
+        filters={"keyword": keyword, "uf": uf, "limit": limit},
+        rows=rows,
+        limitations=limitations,
+        dsn=dsn,
+    )

--- a/scripts/national_intel/benchmarks.py
+++ b/scripts/national_intel/benchmarks.py
@@ -1,0 +1,80 @@
+"""Value benchmark product with sample-size gate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.national_intel.db import fetch_all
+from scripts.national_intel.lineage import envelope
+from scripts.national_intel.sql_filters import build_contract_filters
+
+DEFAULT_MIN_SAMPLE = 20
+
+
+def run_benchmarks(
+    conn: Any,
+    *,
+    keyword: str | None = None,
+    uf: str | None = None,
+    min_sample: int = DEFAULT_MIN_SAMPLE,
+    dsn: str | None = None,
+) -> dict[str, Any]:
+    min_sample = max(1, int(min_sample))
+    where, params = build_contract_filters(keyword=keyword, uf=uf, require_valor=True)
+    sql = (
+        "SELECT "
+        "COUNT(*)::bigint AS n, "
+        "MIN(c.valor_total)::numeric AS valor_min, "
+        "MAX(c.valor_total)::numeric AS valor_max, "
+        "AVG(c.valor_total)::numeric AS valor_avg, "
+        "percentile_cont(0.5) WITHIN GROUP (ORDER BY c.valor_total) AS valor_p50, "
+        "percentile_cont(0.9) WITHIN GROUP (ORDER BY c.valor_total) AS valor_p90 "
+        "FROM public.pncp_supplier_contracts c "
+        "WHERE " + where
+    )
+    stats = fetch_all(conn, sql, tuple(params))
+    s = stats[0] if stats else {}
+    n = int(s.get("n") or 0)
+    status = "ok" if n >= min_sample else "insufficient_sample"
+    rows: list[dict[str, Any]] = []
+    if status == "ok":
+        rows.append(
+            {
+                "status": status,
+                "sample_size": n,
+                "valor_min": float(s["valor_min"]) if s.get("valor_min") is not None else None,
+                "valor_max": float(s["valor_max"]) if s.get("valor_max") is not None else None,
+                "valor_avg": float(s["valor_avg"]) if s.get("valor_avg") is not None else None,
+                "valor_p50": float(s["valor_p50"]) if s.get("valor_p50") is not None else None,
+                "valor_p90": float(s["valor_p90"]) if s.get("valor_p90") is not None else None,
+                "unit_price": None,
+                "unit_price_claim_class": "not_applicable",
+                "claim_class": "indicator",
+            }
+        )
+    else:
+        rows.append(
+            {
+                "status": status,
+                "sample_size": n,
+                "min_sample_required": min_sample,
+                "claim_class": "indicator",
+            }
+        )
+
+    limitations = [
+        f"Minimum sample size for percentiles: {min_sample}.",
+        "Objects matched by keyword are not guaranteed technically comparable.",
+        "valor_total is global contract value — unit price omitted without valid quantity denominator.",
+        "Do not treat benchmark as Extra bid price recommendation without human review.",
+        "Filter may mix different modalities and scopes of work.",
+    ]
+    return envelope(
+        product_id="benchmarks_value",
+        scope_label="intel_product",
+        filters={"keyword": keyword, "uf": uf, "min_sample": min_sample},
+        rows=rows,
+        limitations=limitations,
+        dsn=dsn,
+        extra={"status": status, "sample_size": n},
+    )

--- a/scripts/national_intel/cli.py
+++ b/scripts/national_intel/cli.py
@@ -1,0 +1,100 @@
+"""CLI entry: python -m scripts.national_intel <command>"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from scripts.national_intel.agencies import run_agencies
+from scripts.national_intel.benchmarks import run_benchmarks
+from scripts.national_intel.competitors import run_competitors
+from scripts.national_intel.db import connect, resolve_dsn
+from scripts.national_intel.lineage import write_json
+
+
+def _print(data: dict[str, Any], output: str | None) -> int:
+    write_json(output, data)
+    if not output:
+        json.dump(data, sys.stdout, ensure_ascii=False, indent=2, default=str)
+        sys.stdout.write("\n")
+    else:
+        print(f"wrote {output} rows={data.get('row_count')} product={data.get('product_id')}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m scripts.national_intel",
+        description=(
+            "Strategic intelligence over national PNCP contracts. "
+            "Does NOT compute SC operational dual coverage. "
+            "Prefer NATIONAL_INTEL_DSN on port 5435 (isolated)."
+        ),
+    )
+    def _add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--dsn",
+            default=None,
+            help="Postgres DSN (default NATIONAL_INTEL_DSN or LOCAL_DATALAKE_DSN)",
+        )
+        p.add_argument("--output", default=None, help="Write JSON artifact path")
+
+    _add_common(parser)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_c = sub.add_parser("competitors", help="Supplier rankings + UF footprint")
+    _add_common(p_c)
+    p_c.add_argument("--keyword", default=None)
+    p_c.add_argument("--uf", default=None)
+    p_c.add_argument("--limit", type=int, default=50)
+
+    p_b = sub.add_parser("benchmarks", help="Value distribution benchmarks")
+    _add_common(p_b)
+    p_b.add_argument("--keyword", default=None)
+    p_b.add_argument("--uf", default=None)
+    p_b.add_argument("--min-sample", type=int, default=20)
+
+    p_a = sub.add_parser("agencies", help="Contracting agency profiles")
+    _add_common(p_a)
+    p_a.add_argument("--keyword", default=None)
+    p_a.add_argument("--uf", default=None)
+    p_a.add_argument("--limit", type=int, default=50)
+
+    args = parser.parse_args(argv)
+    dsn = resolve_dsn(getattr(args, "dsn", None))
+
+    with connect(dsn) as conn:
+        if args.cmd == "competitors":
+            data = run_competitors(
+                conn,
+                keyword=args.keyword,
+                uf=args.uf,
+                limit=args.limit,
+                dsn=dsn,
+            )
+            return _print(data, args.output)
+        if args.cmd == "benchmarks":
+            data = run_benchmarks(
+                conn,
+                keyword=args.keyword,
+                uf=args.uf,
+                min_sample=args.min_sample,
+                dsn=dsn,
+            )
+            return _print(data, args.output)
+        if args.cmd == "agencies":
+            data = run_agencies(
+                conn,
+                keyword=args.keyword,
+                uf=args.uf,
+                limit=args.limit,
+                dsn=dsn,
+            )
+            return _print(data, args.output)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/national_intel/competitors.py
+++ b/scripts/national_intel/competitors.py
@@ -1,0 +1,101 @@
+"""Competitor / supplier geographic intelligence product."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.national_intel.db import fetch_all
+from scripts.national_intel.lineage import envelope
+from scripts.national_intel.sql_filters import build_contract_filters
+
+
+def run_competitors(
+    conn: Any,
+    *,
+    keyword: str | None = None,
+    uf: str | None = None,
+    limit: int = 50,
+    dsn: str | None = None,
+) -> dict[str, Any]:
+    """Rank suppliers by contract count with UF footprint.
+
+    claim_class:
+      - ufs, has_sc, contract_count, valor_sum → fact
+      - ranking position → indicator
+      - "potential entrant" flags → hypothesis (caller may annotate)
+    """
+    limit = max(1, min(int(limit), 5000))
+    where, params = build_contract_filters(keyword=keyword, uf=uf)
+    # WHERE built only from allowlisted fragments + %s binds (see sql_filters).
+    sql = (
+        "SELECT "
+        "COALESCE(c.fornecedor_cnpj_8, left(COALESCE(c.fornecedor_cnpj, ''), 8)) "
+        "AS fornecedor_cnpj_8, "
+        "MAX(c.fornecedor_cnpj) AS fornecedor_cnpj, "
+        "MAX(c.fornecedor_nome) AS fornecedor_nome, "
+        "COUNT(*)::bigint AS contract_count, "
+        "COUNT(DISTINCT upper(btrim(c.uf))) "
+        "FILTER (WHERE c.uf IS NOT NULL AND btrim(c.uf) <> '')::bigint AS uf_count, "
+        "array_agg(DISTINCT upper(btrim(c.uf)) ORDER BY upper(btrim(c.uf))) "
+        "FILTER (WHERE c.uf IS NOT NULL AND btrim(c.uf) <> '') AS ufs, "
+        "BOOL_OR(c.uf IS NOT NULL AND upper(btrim(c.uf)) = 'SC') AS has_sc, "
+        "COALESCE(SUM(c.valor_total), 0)::numeric AS valor_sum "
+        "FROM public.pncp_supplier_contracts c "
+        "WHERE "
+        + where
+        + " AND ("
+        " (c.fornecedor_cnpj IS NOT NULL AND btrim(c.fornecedor_cnpj) <> '') "
+        " OR (c.fornecedor_nome IS NOT NULL AND btrim(c.fornecedor_nome) <> '') "
+        ") "
+        "GROUP BY 1 "
+        "ORDER BY contract_count DESC, valor_sum DESC NULLS LAST "
+        "LIMIT %s"
+    )
+    params.append(limit)
+    raw = fetch_all(conn, sql, tuple(params))
+    rows: list[dict[str, Any]] = []
+    for i, r in enumerate(raw, start=1):
+        ufs = r.get("ufs") or []
+        if isinstance(ufs, str):
+            ufs = [ufs]
+        has_sc = bool(r.get("has_sc"))
+        uf_count = int(r.get("uf_count") or 0)
+        entry_hypothesis = None
+        if not has_sc and uf_count >= 1 and keyword:
+            entry_hypothesis = {
+                "label": "potential_sc_entrant",
+                "claim_class": "hypothesis",
+                "reason": "Active outside SC on keyword filter; no SC contracts in filter window",
+            }
+        rows.append(
+            {
+                "rank": i,
+                "rank_claim_class": "indicator",
+                "fornecedor_cnpj_8": r.get("fornecedor_cnpj_8"),
+                "fornecedor_cnpj": r.get("fornecedor_cnpj"),
+                "fornecedor_nome": r.get("fornecedor_nome"),
+                "contract_count": int(r.get("contract_count") or 0),
+                "uf_count": uf_count,
+                "ufs": list(ufs),
+                "has_sc": has_sc,
+                "valor_sum": float(r.get("valor_sum") or 0),
+                "claim_class": "fact",
+                "entrant_signal": entry_hypothesis,
+            }
+        )
+
+    limitations = [
+        "Keyword filter is lexical on objeto_contrato — not technical object equivalence.",
+        "valor_sum is global contracted value (valor_total), not unit price or margin.",
+        "Absence of SC contracts in this filter is not proof of non-operation in SC.",
+        "No partnership/consortium is inferred from co-presence.",
+        "National inventory completeness depends on upstream crawl windows — not assumed complete.",
+    ]
+    return envelope(
+        product_id="competitors_geo",
+        scope_label="intel_product",
+        filters={"keyword": keyword, "uf": uf, "limit": limit},
+        rows=rows,
+        limitations=limitations,
+        dsn=dsn,
+    )

--- a/scripts/national_intel/db.py
+++ b/scripts/national_intel/db.py
@@ -1,0 +1,69 @@
+"""Minimal DB helper for national_intel (isolated DSN preferred)."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+def resolve_dsn(explicit: str | None = None) -> str:
+    dsn = explicit or os.environ.get("NATIONAL_INTEL_DSN") or os.environ.get("LOCAL_DATALAKE_DSN")
+    if not dsn:
+        raise SystemExit(
+            "DSN required: set NATIONAL_INTEL_DSN (preferred, port 5435) "
+            "or pass --dsn. Do not point at HC writer DB during live backfill."
+        )
+    # Soft guard: warn if classic HC port appears
+    if ":5433/" in dsn or dsn.rstrip("/").endswith(":5433"):
+        # allow explicit override for read-only inventory but print warning to stderr
+        import sys
+
+        print(
+            "WARNING: DSN uses port 5433 (HC backfill DB). "
+            "national_intel is read-only SQL but prefer 5435 isolated DB.",
+            file=sys.stderr,
+        )
+    return dsn
+
+
+@contextmanager
+def connect(dsn: str) -> Iterator[Any]:
+    try:
+        import psycopg
+
+        conn = psycopg.connect(dsn)
+        try:
+            yield conn
+        finally:
+            conn.close()
+        return
+    except ImportError:
+        pass
+    import psycopg2
+
+    conn = psycopg2.connect(dsn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def fetch_all(conn: Any, sql: str, params: tuple[Any, ...] | dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        # Avoid treating bare "%" in SQL (e.g. LIKE 'v_%') as pyformat placeholders
+        # when no params are intended.
+        if params is None:
+            cur.execute(sql)
+        else:
+            cur.execute(sql, params)
+        cols = [d[0] for d in cur.description] if cur.description else []
+        rows = cur.fetchall()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        if hasattr(r, "keys"):
+            out.append(dict(r))
+        else:
+            out.append(dict(zip(cols, r, strict=False)))
+    return out

--- a/scripts/national_intel/lineage.py
+++ b/scripts/national_intel/lineage.py
@@ -1,0 +1,84 @@
+"""JSON product envelope + claim class helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+CLAIM_LEGEND = {
+    "fact": "Directly observed from contract rows (counts, UF set, sums).",
+    "indicator": "Derived statistic (percentiles, shares, modes); not a legal finding.",
+    "hypothesis": "Business inference requiring human validation; not proven relationship.",
+}
+
+
+def git_sha(root: Path | None = None) -> str | None:
+    """Best-effort short SHA without spawning a shell (bandit-safe)."""
+    try:
+        base = Path(root) if root else Path.cwd()
+        head = base / ".git" / "HEAD"
+        if not head.is_file():
+            return None
+        content = head.read_text(encoding="utf-8").strip()
+        if content.startswith("ref:"):
+            ref = content.split(" ", 1)[1].strip()
+            ref_path = base / ".git" / ref
+            if ref_path.is_file():
+                return ref_path.read_text(encoding="utf-8").strip()[:7] or None
+            return None
+        return content[:7] or None
+    except OSError:
+        return None
+
+
+def mask_dsn(dsn: str | None) -> str:
+    if not dsn:
+        return "unset"
+    # postgresql://user:pass@host:port/db → postgresql://***@host:port/db
+    if "@" in dsn and "://" in dsn:
+        scheme, rest = dsn.split("://", 1)
+        creds, hostpart = rest.split("@", 1)
+        return f"{scheme}://***@{hostpart}"
+    return "***"
+
+
+def envelope(
+    *,
+    product_id: str,
+    scope_label: str,
+    filters: dict[str, Any],
+    rows: list[dict[str, Any]],
+    limitations: list[str],
+    dsn: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "product_id": product_id,
+        "scope_label": scope_label,
+        "as_of": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "filters": filters,
+        "row_count": len(rows),
+        "limitations": limitations,
+        "claim_class_legend": CLAIM_LEGEND,
+        "lineage": {
+            "git_sha": git_sha(),
+            "dsn_host_port_masked": mask_dsn(dsn or os.environ.get("NATIONAL_INTEL_DSN")),
+            "query_id": product_id,
+            "module_version": "0.1.0",
+        },
+        "rows": rows,
+    }
+    if extra:
+        body.update(extra)
+    return body
+
+
+def write_json(path: Path | str | None, data: dict[str, Any]) -> None:
+    if not path:
+        return
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, ensure_ascii=False, indent=2, default=str) + "\n", encoding="utf-8")

--- a/scripts/national_intel/sql_filters.py
+++ b/scripts/national_intel/sql_filters.py
@@ -1,0 +1,35 @@
+"""Allowlisted SQL filter fragments for national_intel queries.
+
+All dynamic WHERE composition uses only these constant fragments plus bound
+parameters (%s). User input never becomes raw SQL text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Constant fragments only — never interpolate user strings into these.
+F_ACTIVE = "c.is_active = TRUE"
+F_KEYWORD = "c.objeto_contrato ILIKE %s"
+F_UF = "upper(btrim(c.uf)) = upper(btrim(%s))"
+F_VALOR_NOT_NULL = "c.valor_total IS NOT NULL"
+
+
+def build_contract_filters(
+    *,
+    keyword: str | None = None,
+    uf: str | None = None,
+    require_valor: bool = False,
+) -> tuple[str, list[Any]]:
+    """Return (where_sql, params) from allowlisted fragments + bind params."""
+    clauses: list[str] = [F_ACTIVE]
+    params: list[Any] = []
+    if require_valor:
+        clauses.append(F_VALOR_NOT_NULL)
+    if keyword is not None and str(keyword).strip() != "":
+        clauses.append(F_KEYWORD)
+        params.append(f"%{keyword}%")
+    if uf is not None and str(uf).strip() != "":
+        clauses.append(F_UF)
+        params.append(uf)
+    return " AND ".join(clauses), params

--- a/tests/national_intel/conftest.py
+++ b/tests/national_intel/conftest.py
@@ -1,0 +1,41 @@
+"""Fixtures for national_intel tests — isolated DSN only."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+# Prefer campaign isolated DB (5436); fall back to legacy PR121 port 5435.
+DEFAULT_ISOLATED = os.environ.get(
+    "CAMPAIGN_TEST_DSN",
+    "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc",
+)
+
+
+@pytest.fixture(scope="session")
+def national_intel_dsn() -> str:
+    dsn = os.environ.get("NATIONAL_INTEL_DSN", DEFAULT_ISOLATED)
+    # Refuse accidental HC writer if env forces it without override flag
+    if ":5433/" in dsn and os.environ.get("ALLOW_NI_ON_5433") != "1":
+        pytest.skip("Refusing tests on port 5433 without ALLOW_NI_ON_5433=1")
+    return dsn
+
+
+@pytest.fixture(scope="function")
+def pg_conn(national_intel_dsn: str) -> Iterator:
+    try:
+        from scripts.national_intel.db import connect
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"db helper unavailable: {exc}")
+    try:
+        with connect(national_intel_dsn) as conn:
+            # Autocommit-friendly: ensure clean transaction per test
+            if hasattr(conn, "rollback"):
+                conn.rollback()
+            yield conn
+            if hasattr(conn, "rollback"):
+                conn.rollback()
+    except Exception as exc:
+        pytest.skip(f"isolated Postgres unavailable: {exc}")

--- a/tests/national_intel/test_adversarial_nv_matrix.py
+++ b/tests/national_intel/test_adversarial_nv_matrix.py
@@ -1,0 +1,518 @@
+"""P0 adversarial matrix NV/UQ/DE/CI against real compute_dual_coverage.
+
+Implements design in artifacts/.../coverage-isolation/adversarial-test-matrix.md
+using the production dual spine (not a reimplementation).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.coverage.dual_capability_coverage import (
+    CAP_HISTORICAL_CONTRACTS,
+    CAP_OPEN_TENDERS,
+    EvidenceObservation,
+    compute_dual_coverage,
+    load_data_presence,
+    map_db_entities,
+    validate_success_zero,
+)
+from scripts.lib.universe import CanonicalEntity, CanonicalUniverse, load_canonical_universe
+
+
+def _entity(eid: str, name: str = "Ente X", cnpj8: str = "12345678") -> CanonicalEntity:
+    return CanonicalEntity(
+        entity_id=eid,
+        seed_row=2,
+        razao_social=name,
+        cnpj8=cnpj8,
+        municipio="FLORIANOPOLIS",
+        codigo_ibge="4205407",
+        natureza_juridica="MUNICIPIO",
+        latitude=-27.5,
+        longitude=-48.5,
+        distancia_km=10.0,
+        radius_decision="included",
+        within_radius=True,
+        decision_method="seed",
+        identity_key=f"{cnpj8}|FLORIANOPOLIS|{name}",
+    )
+
+
+def _universe(entities: list[CanonicalEntity], seed_sha: str = "a" * 64) -> CanonicalUniverse:
+    return CanonicalUniverse(
+        seed_path="fixture.xlsx",
+        seed_sha256=seed_sha,
+        radius_km=200.0,
+        entities=entities,
+    )
+
+
+def _appl(entities: list[CanonicalEntity], *caps: str) -> dict[str, dict[str, str]]:
+    return {cap: {e.entity_id: "applicable" for e in entities} for cap in caps}
+
+
+def _req(entities: list[CanonicalEntity], *caps: str) -> dict[str, dict[str, list[str]]]:
+    return {cap: {e.entity_id: ["pncp"] for e in entities} for cap in caps}
+
+
+def _obs(
+    entity_id: str,
+    *,
+    capability: str = CAP_HISTORICAL_CONTRACTS,
+    state: str = "success_with_data",
+    fresh_hours: float = 1.0,
+    records: int = 3,
+    queried_start: str | None = None,
+    queried_end: str | None = None,
+    pages_expected: int | None = 1,
+    pages_processed: int | None = 1,
+    run_id: str = "run-1",
+    error_message: str = "",
+    metadata: dict | None = None,
+) -> EvidenceObservation:
+    now = datetime.now(UTC)
+    completed = now - timedelta(hours=fresh_hours)
+    meta = dict(metadata or {})
+    meta.setdefault("provenance", "nv-matrix")
+    meta.setdefault("pagination_complete", "true")
+    return EvidenceObservation(
+        entity_id=entity_id,
+        source="pncp",
+        capability=capability,
+        state=state,
+        applicability="applicable",
+        run_id=run_id,
+        started_at=completed - timedelta(minutes=5),
+        completed_at=completed,
+        pages_expected=pages_expected,
+        pages_processed=pages_processed,
+        records_fetched=records,
+        records_persisted=records if state == "success_with_data" else 0,
+        queried_start=queried_start,
+        queried_end=queried_end,
+        error_code="",
+        error_message=error_message,
+        evidence_reference=f"nv:{entity_id}",
+        freshness_status="fresh" if fresh_hours < 24 else "stale",
+        metadata=meta,
+    )
+
+
+def _report(
+    u: CanonicalUniverse,
+    *,
+    obs: dict | None = None,
+    presence: dict | None = None,
+):
+    # CanonicalUniverse.included is property over radius — for fixture all within_radius
+    ents = [e for e in u.entities if e.within_radius]
+    return compute_dual_coverage(
+        universe=u,
+        observations_by_cap=obs
+        if obs is not None
+        else {CAP_OPEN_TENDERS: {}, CAP_HISTORICAL_CONTRACTS: {}},
+        presence_by_cap=presence
+        if presence is not None
+        else {CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: set()},
+        entity_applicability=_appl(ents, CAP_OPEN_TENDERS, CAP_HISTORICAL_CONTRACTS),  # type: ignore[arg-type]
+        entity_required_sources=_req(ents, CAP_OPEN_TENDERS, CAP_HISTORICAL_CONTRACTS),  # type: ignore[arg-type]
+        include_legacy_stamp=False,
+        use_config_matrix=False,
+        require_canonical_policy=False,
+        fail_on_unmapped_presence=False,
+    )
+
+
+# --- NV series ---
+
+
+def test_NV01_millions_non_sc_do_not_raise_coverage() -> None:
+    ents = [_entity(f"e{i}", cnpj8=f"1000000{i}") for i in range(3)]
+    u = _universe(ents)
+    # Simulate unmapped national presence noise: presence set stays empty (unmapped)
+    # while conceptually R has 2e6 non-SC rows — coverage must ignore R volume.
+    r = _report(
+        u,
+        obs={CAP_OPEN_TENDERS: {}, CAP_HISTORICAL_CONTRACTS: {}},
+        presence={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: set()},
+    )
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.applicable_denominator == 3
+    assert hc.covered_numerator == 0
+    assert hc.coverage_pct == 0.0
+    assert hc.data_presence_numerator == 0
+    assert hc.coverage_gate_pass is False
+    assert r.coverage_gate_pass is False
+
+
+def test_NV02_presence_not_labeled_as_coverage_pct() -> None:
+    ents = [_entity("e1"), _entity("e2", cnpj8="22222222"), _entity("e3", cnpj8="33333333")]
+    u = _universe(ents)
+    r = _report(
+        u,
+        presence={
+            CAP_OPEN_TENDERS: set(),
+            # presence for all entities WITHOUT evidence → descriptive only
+            CAP_HISTORICAL_CONTRACTS: {"e1", "e2", "e3"},
+        },
+    )
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.coverage_pct == 0.0
+    assert hc.covered_numerator == 0
+    assert hc.data_presence_numerator == 3
+    assert hc.data_presence_pct == 100.0
+    assert hc.method == "dual_capability_coverage"
+    summary = r.to_dict() if hasattr(r, "to_dict") else {}
+    # coverage_pct must not equal national volume fiction
+    assert hc.coverage_pct != hc.data_presence_pct or hc.covered_numerator == 0
+    blob = str(summary) + str(r.limitations)
+    assert "Presence is descriptive" in blob or any(
+        "presence" in (x or "").lower() for x in (r.limitations or [])
+    )
+
+
+def test_NV03_add_remove_national_presence_keeps_coverage() -> None:
+    ents = [_entity(f"e{i}", cnpj8=f"3000000{i}") for i in range(3)]  # e0,e1,e2
+    u = _universe(ents)
+    ids = {e.entity_id for e in ents}
+    empty_obs = {CAP_OPEN_TENDERS: {}, CAP_HISTORICAL_CONTRACTS: {}}
+    before = _report(
+        u,
+        obs=empty_obs,
+        presence={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: set()},
+    )
+    after_add = _report(
+        u,
+        obs=empty_obs,
+        presence={
+            CAP_OPEN_TENDERS: set(),
+            CAP_HISTORICAL_CONTRACTS: ids,  # "national mapped noise" for all of U
+        },
+    )
+    after_remove = _report(
+        u,
+        obs=empty_obs,
+        presence={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: set()},
+    )
+    for rep in (before, after_add, after_remove):
+        hc = rep.capabilities[CAP_HISTORICAL_CONTRACTS]
+        assert hc.covered_numerator == 0
+        assert hc.coverage_pct == 0.0
+        assert hc.applicable_denominator == 3
+    assert (
+        before.capabilities[CAP_HISTORICAL_CONTRACTS].covered_numerator
+        == after_add.capabilities[CAP_HISTORICAL_CONTRACTS].covered_numerator
+        == after_remove.capabilities[CAP_HISTORICAL_CONTRACTS].covered_numerator
+    )
+
+
+def test_NV04_contracts_without_evidence_never_checked() -> None:
+    e = _entity("e1")
+    u = _universe([e])
+    r = _report(
+        u,
+        obs={CAP_OPEN_TENDERS: {}, CAP_HISTORICAL_CONTRACTS: {}},
+        presence={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: {"e1"}},
+    )
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.covered_numerator == 0
+    assert hc.never_checked_count == 1
+    ent = next(x for x in hc.entities if x.entity_id == "e1")
+    assert ent.covered is False
+    assert ent.coverage_state == "never_checked"
+    assert ent.has_data_presence is True
+
+
+def test_NV07_legacy_is_covered_ignored() -> None:
+    """Dual must not use entity_coverage.is_covered — pure path has no legacy stamp."""
+    e = _entity("e1")
+    u = _universe([e])
+    r = _report(u)
+    assert r.legacy_metric is None
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.covered_numerator == 0
+    joined = " ".join(r.limitations).lower()
+    assert "is_covered" in joined or "any_row" in joined or "forbidden" in joined
+
+
+def test_NV08_gate_not_pass_from_volume_alone() -> None:
+    ents = [_entity(f"e{i}", cnpj8=f"8000000{i}") for i in range(5)]
+    u = _universe(ents)
+    r = _report(
+        u,
+        presence={
+            CAP_OPEN_TENDERS: {e.entity_id for e in ents},
+            CAP_HISTORICAL_CONTRACTS: {e.entity_id for e in ents},
+        },
+    )
+    assert r.coverage_gate_pass is False
+    assert r.capabilities[CAP_HISTORICAL_CONTRACTS].gate_status in {"FAIL", "NOT_READY"}
+
+
+def test_NV05_shared_cnpj8_does_not_double_cover_without_evidence() -> None:
+    """Two seed entities same CNPJ8; presence alone does not cover either."""
+    e1 = _entity("root-a", cnpj8="11223344")
+    e2 = _entity("root-b", cnpj8="11223344")
+    u = _universe([e1, e2])
+    r = _report(
+        u,
+        presence={
+            CAP_OPEN_TENDERS: set(),
+            CAP_HISTORICAL_CONTRACTS: {"root-a", "root-b"},
+        },
+    )
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.covered_numerator == 0
+    assert hc.coverage_pct == 0.0
+    assert all(not ent.covered for ent in hc.entities)
+    assert hc.never_checked_count == 2
+
+
+def test_NV06_outsider_presence_rejected_or_not_covered() -> None:
+    """Presence entity_id outside U is DualCoverageError (fail-closed), not silent cover."""
+    e = _entity("e1")
+    u = _universe([e])
+    r = _report(
+        u,
+        presence={
+            CAP_OPEN_TENDERS: set(),
+            CAP_HISTORICAL_CONTRACTS: {"outsider-not-in-u"},
+        },
+    )
+    # Engine fails closed on outsider presence ids
+    if r.error:
+        assert "entity_id_outside_canonical_universe" in r.error
+        assert r.measurement_success is False
+        assert r.coverage_gate_pass is False
+        assert CAP_HISTORICAL_CONTRACTS not in r.capabilities or (
+            r.capabilities[CAP_HISTORICAL_CONTRACTS].covered_numerator == 0
+        )
+    else:
+        hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+        assert hc.covered_numerator == 0
+        assert hc.data_presence_numerator == 0
+
+
+# --- UQ series ---
+
+
+def test_UQ01_no_observation_never_checked() -> None:
+    e = _entity("e1")
+    r = _report(_universe([e]))
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.never_checked_count == 1
+    assert hc.covered_numerator == 0
+    ent = hc.entities[0]
+    assert ent.coverage_state == "never_checked"
+    assert ent.covered is False
+
+
+def test_UQ02_presence_true_obs_empty_not_success_zero() -> None:
+    e = _entity("e1")
+    r = _report(
+        _universe([e]),
+        presence={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: {"e1"}},
+    )
+    ent = r.capabilities[CAP_HISTORICAL_CONTRACTS].entities[0]
+    assert ent.coverage_state == "never_checked"
+    assert ent.coverage_state != "success_zero"
+    assert ent.covered is False
+
+
+def test_UQ05_all_never_checked_partition() -> None:
+    ents = [_entity(f"e{i}", cnpj8=f"5000000{i}") for i in range(4)]
+    r = _report(_universe(ents))
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.never_checked_count == 4
+    assert hc.covered_numerator == 0
+    assert hc.applicable_denominator == 4
+
+
+# --- DE / load_canonical_universe ---
+
+
+def test_DE_load_canonical_universe_included_1093() -> None:
+    seed = Path("fixtures/canonical_universe_r0.xlsx")
+    assert seed.is_file()
+    u = load_canonical_universe(seed_path=seed)
+    assert len(u.included) == 1093
+    # Dual on first 3 included with empty obs: denom 3 not 1093 when micro-universe
+    micro = _universe(list(u.included)[:3], seed_sha=u.seed_sha256)
+    r = _report(micro)
+    assert r.capabilities[CAP_HISTORICAL_CONTRACTS].applicable_denominator == 3
+    assert r.capabilities[CAP_HISTORICAL_CONTRACTS].covered_numerator == 0
+
+
+def test_DE03_covered_outside_applicable_fails() -> None:
+    e1 = _entity("e1")
+    e2 = _entity("e2", cnpj8="22222222")
+    u = _universe([e1, e2])
+    now = datetime.now(UTC)
+    q_start = (now - timedelta(days=365 * 3 + 10)).date().isoformat()
+    q_end = now.date().isoformat()
+    # Force e2 covered but mark e2 not_applicable
+    obs = {
+        CAP_OPEN_TENDERS: {},
+        CAP_HISTORICAL_CONTRACTS: {
+            "e2": {
+                "pncp": _obs(
+                    "e2",
+                    queried_start=q_start,
+                    queried_end=q_end,
+                )
+            }
+        },
+    }
+    appl = {
+        CAP_OPEN_TENDERS: {"e1": "applicable", "e2": "applicable"},
+        CAP_HISTORICAL_CONTRACTS: {"e1": "applicable", "e2": "not_applicable"},
+    }
+    req = _req([e1, e2], CAP_OPEN_TENDERS, CAP_HISTORICAL_CONTRACTS)
+    # When e2 is not_applicable but has success obs, scoring should not count as covered in A_C
+    r = compute_dual_coverage(
+        universe=u,
+        observations_by_cap=obs,
+        presence_by_cap={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: set()},
+        entity_applicability=appl,  # type: ignore[arg-type]
+        entity_required_sources=req,  # type: ignore[arg-type]
+        include_legacy_stamp=False,
+        use_config_matrix=False,
+        require_canonical_policy=False,
+    )
+    hc = r.capabilities[CAP_HISTORICAL_CONTRACTS]
+    # e2 not in applicable set → cannot contribute to numerator
+    assert "e2" not in {x.entity_id for x in hc.entities if x.covered}
+    assert hc.covered_numerator == 0
+
+
+# --- CI ---
+
+
+def test_CI01_tenders_do_not_cover_contracts() -> None:
+    e = _entity("e1")
+    u = _universe([e])
+    obs = {
+        CAP_OPEN_TENDERS: {"e1": {"pncp": _obs("e1", capability=CAP_OPEN_TENDERS)}},
+        CAP_HISTORICAL_CONTRACTS: {},
+    }
+    r = _report(
+        u,
+        obs=obs,
+        presence={CAP_OPEN_TENDERS: {"e1"}, CAP_HISTORICAL_CONTRACTS: set()},
+    )
+    assert r.capabilities[CAP_OPEN_TENDERS].covered_numerator == 1
+    assert r.capabilities[CAP_HISTORICAL_CONTRACTS].covered_numerator == 0
+    assert r.capabilities[CAP_HISTORICAL_CONTRACTS].never_checked_count == 1
+
+
+def test_CI03_no_average_coverage_field() -> None:
+    ents = [_entity("e1"), _entity("e2", cnpj8="22222222")]
+    r = _report(_universe(ents))
+    d = r.to_dict() if hasattr(r, "to_dict") else {}
+    assert "average_coverage" not in d
+    assert "coverage_pct_avg" not in d
+
+
+# --- SZ smoke lock ---
+
+
+def test_SZ01_label_alone_not_valid_zero() -> None:
+    obs = _obs("e1", state="success_zero", records=0, pages_expected=None, pages_processed=None)
+    ok, reasons = validate_success_zero(obs)
+    assert ok is False
+    assert reasons
+
+
+# --- DB-level NV on isolated Postgres ---
+
+
+@pytest.fixture
+def isolated_conn():
+    import os
+
+    dsn = os.environ.get(
+        "NATIONAL_INTEL_DSN",
+        "postgresql://test:test@127.0.0.1:5435/extra_national_intelligence_test",
+    )
+    if ":5433/" in dsn and os.environ.get("ALLOW_NI_ON_5433") != "1":
+        pytest.skip("refusing HC writer port")
+    try:
+        from scripts.national_intel.db import connect
+
+        with connect(dsn) as conn:
+            yield conn, dsn
+    except Exception as exc:
+        pytest.skip(f"isolated db unavailable: {exc}")
+
+
+def test_NV01_db_insert_non_sc_rows_does_not_change_dual_pure_metrics(isolated_conn) -> None:
+    """Insert non-SC national rows on isolated DB; dual pure path with frozen empty
+    evidence keeps coverage at 0; presence load may see unmapped rows only.
+    """
+    conn, dsn = isolated_conn
+    # Real universe stamp
+    seed = Path("fixtures/canonical_universe_r0.xlsx")
+    full = load_canonical_universe(seed_path=seed)
+    assert len(full.included) == 1093
+    micro_ents = list(full.included)[:3]
+    micro = _universe(micro_ents, seed_sha=full.seed_sha256)
+
+    before = _report(micro)
+    hc_before = before.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc_before.covered_numerator == 0
+    assert hc_before.applicable_denominator == 3
+
+    # Bulk insert non-SC noise (not linked to seed CNPJs)
+    with conn.cursor() as cur:
+        for i in range(200):
+            cid = f"NV-NOISE-{i:05d}"
+            cur.execute(
+                """
+                INSERT INTO public.pncp_supplier_contracts (
+                  contrato_id, orgao_cnpj, orgao_nome, fornecedor_cnpj, fornecedor_nome,
+                  objeto_contrato, valor_total, data_publicacao, uf, source, is_active
+                ) VALUES (
+                  %s, %s, %s, %s, %s, %s, %s, %s, %s, 'pncp', true
+                )
+                ON CONFLICT (contrato_id) DO NOTHING
+                """,
+                (
+                    cid,
+                    f"9{i:013d}"[:14],
+                    f"ORGAO NOISE {i}",
+                    f"8{i:013d}"[:14],
+                    f"FORN NOISE {i}",
+                    "objeto nacional ruido",
+                    1000.0 + i,
+                    "2024-01-15",
+                    "SP" if i % 2 == 0 else "RJ",
+                ),
+            )
+        conn.commit()
+
+    after = _report(micro)
+    hc_after = after.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc_after.covered_numerator == hc_before.covered_numerator == 0
+    assert hc_after.coverage_pct == hc_before.coverage_pct == 0.0
+    assert hc_after.applicable_denominator == hc_before.applicable_denominator == 3
+    assert after.coverage_gate_pass is False
+
+    # Optional: data presence from DB for historical_contracts should not invent coverage
+    try:
+        mapping = map_db_entities(conn, full)
+        pres = load_data_presence(
+            conn,
+            CAP_HISTORICAL_CONTRACTS,
+            mapping.db_id_to_entity_id,
+            set(e.entity_id for e in micro_ents),
+            cnpj8_to_entity_id=mapping.cnpj8_to_entity_id,
+        )
+        # Presence may be empty/unmapped for noise CNPJs — never raises covered
+        assert pres is not None
+    except Exception:
+        # map_db may need sc_public_entities; pure dual path already proved isolation
+        pass

--- a/tests/national_intel/test_coverage_isolation_national_volume.py
+++ b/tests/national_intel/test_coverage_isolation_national_volume.py
@@ -1,0 +1,155 @@
+"""SC coverage isolation — real dual spine + load_canonical_universe.
+
+Supplements adversarial matrix (test_adversarial_nv_matrix.py).
+Does not depend on PR #121 campaign artifacts; uses shipped migration/spec 004.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from scripts.coverage import dual_capability_coverage as dual
+from scripts.coverage.dual_capability_coverage import (
+    CAP_HISTORICAL_CONTRACTS,
+    CAP_OPEN_TENDERS,
+    compute_dual_coverage,
+)
+from scripts.lib.universe import CanonicalEntity, CanonicalUniverse, load_canonical_universe
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_dual_module_documents_presence_not_coverage() -> None:
+    doc = dual.__doc__ or ""
+    assert "data_presence" in inspect.getsource(dual)
+    assert "never a coverage label" in doc or "descriptive only" in doc
+
+
+def _entity(eid: str, cnpj8: str = "12345678") -> CanonicalEntity:
+    return CanonicalEntity(
+        entity_id=eid,
+        seed_row=2,
+        razao_social=eid,
+        cnpj8=cnpj8,
+        municipio="FLORIANOPOLIS",
+        codigo_ibge="4205407",
+        natureza_juridica="MUNICIPIO",
+        latitude=-27.5,
+        longitude=-48.5,
+        distancia_km=10.0,
+        radius_decision="included",
+        within_radius=True,
+        decision_method="seed",
+        identity_key=f"{cnpj8}|{eid}",
+    )
+
+
+def _universe(entities: list[CanonicalEntity]) -> CanonicalUniverse:
+    return CanonicalUniverse(
+        seed_path="fixture.xlsx",
+        seed_sha256="a" * 64,
+        radius_km=200.0,
+        entities=entities,
+    )
+
+
+def _empty_dual(entities: list[CanonicalEntity], presence: set[str] | None = None):
+    appl = {
+        CAP_OPEN_TENDERS: {e.entity_id: "applicable" for e in entities},
+        CAP_HISTORICAL_CONTRACTS: {e.entity_id: "applicable" for e in entities},
+    }
+    req = {
+        CAP_OPEN_TENDERS: {e.entity_id: ["pncp"] for e in entities},
+        CAP_HISTORICAL_CONTRACTS: {e.entity_id: ["pncp"] for e in entities},
+    }
+    return compute_dual_coverage(
+        universe=_universe(entities),
+        observations_by_cap={CAP_OPEN_TENDERS: {}, CAP_HISTORICAL_CONTRACTS: {}},
+        presence_by_cap={
+            CAP_OPEN_TENDERS: set(),
+            CAP_HISTORICAL_CONTRACTS: presence or set(),
+        },
+        entity_applicability=appl,  # type: ignore[arg-type]
+        entity_required_sources=req,  # type: ignore[arg-type]
+        include_legacy_stamp=False,
+        use_config_matrix=False,
+        require_canonical_policy=False,
+    )
+
+
+def test_compute_dual_coverage_before_after_presence_volume() -> None:
+    ents = [_entity(f"e{i}", cnpj8=f"1100000{i}") for i in range(5)]
+    before = _empty_dual(ents, presence=set())
+    after = _empty_dual(ents, presence={e.entity_id for e in ents})
+    b = before.capabilities[CAP_HISTORICAL_CONTRACTS]
+    a = after.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert b.covered_numerator == a.covered_numerator == 0
+    assert b.coverage_pct == a.coverage_pct == 0.0
+    assert b.applicable_denominator == a.applicable_denominator == 5
+    assert a.data_presence_numerator == 5
+    assert b.data_presence_numerator == 0
+    assert before.coverage_gate_pass is False
+    assert after.coverage_gate_pass is False
+
+
+def test_load_canonical_universe_denominator_authority() -> None:
+    seed = ROOT / "fixtures/canonical_universe_r0.xlsx"
+    u = load_canonical_universe(seed_path=seed)
+    assert len(u.included) == 1093
+    slice_ents = list(u.included)[:5]
+    report = compute_dual_coverage(
+        universe=CanonicalUniverse(
+            seed_path=u.seed_path,
+            seed_sha256=u.seed_sha256,
+            radius_km=u.radius_km,
+            entities=slice_ents,
+        ),
+        observations_by_cap={CAP_OPEN_TENDERS: {}, CAP_HISTORICAL_CONTRACTS: {}},
+        presence_by_cap={CAP_OPEN_TENDERS: set(), CAP_HISTORICAL_CONTRACTS: set()},
+        entity_applicability={
+            CAP_OPEN_TENDERS: {e.entity_id: "applicable" for e in slice_ents},
+            CAP_HISTORICAL_CONTRACTS: {e.entity_id: "applicable" for e in slice_ents},
+        },  # type: ignore[arg-type]
+        entity_required_sources={
+            CAP_OPEN_TENDERS: {e.entity_id: ["pncp"] for e in slice_ents},
+            CAP_HISTORICAL_CONTRACTS: {e.entity_id: ["pncp"] for e in slice_ents},
+        },  # type: ignore[arg-type]
+        include_legacy_stamp=False,
+        use_config_matrix=False,
+        require_canonical_policy=False,
+    )
+    hc = report.capabilities[CAP_HISTORICAL_CONTRACTS]
+    assert hc.applicable_denominator == 5
+    assert hc.covered_numerator == 0
+    assert report.universe.seed_sha256 == u.seed_sha256 or report.universe.entity_count == 5
+
+
+def test_intel_migration_preserves_coverage_spine() -> None:
+    """060 intel layers exist; 059 coverage unique remains; no 059_national collision."""
+    m060 = ROOT / "db/migrations/060_national_contracts_intelligence_layers.sql"
+    m059 = ROOT / "db/migrations/059_coverage_evidence_canonical_entity_unique.sql"
+    bad = ROOT / "db/migrations/059_national_contracts_intelligence_layers.sql"
+    assert m060.is_file()
+    assert m059.is_file()
+    assert not bad.exists()
+    text = m060.read_text(encoding="utf-8")
+    assert "v_intel_contracts_raw_national" in text
+    assert "NOT operational" in text or "NOT operational SC coverage" in text
+    assert "success_zero" not in text or True  # isolation documented in comments/scope
+
+
+def test_scope_labels_in_migration_and_spec004() -> None:
+    """Scope labels live in migration 060 + spec 004 (not PR121 orphan paths)."""
+    m060 = (ROOT / "db/migrations/060_national_contracts_intelligence_layers.sql").read_text(
+        encoding="utf-8"
+    )
+    assert "raw_national" in m060
+    assert "geo_sc" in m060
+    assert "intel_product" in m060
+    # Must not redefine dual operational coverage as national volume
+    assert "canonical_sc_operational" not in m060 or "NOT" in m060
+    spec = ROOT / "specs/004-extra-live-consulting-pack/spec.md"
+    assert spec.is_file()
+    st = spec.read_text(encoding="utf-8")
+    assert "060" in st or "national_intel" in st or "FULL" in st or "elegível" in st.lower()

--- a/tests/national_intel/test_coverage_isolation_national_volume.py
+++ b/tests/national_intel/test_coverage_isolation_national_volume.py
@@ -1,7 +1,7 @@
 """SC coverage isolation — real dual spine + load_canonical_universe.
 
 Supplements adversarial matrix (test_adversarial_nv_matrix.py).
-Does not depend on PR #121 campaign artifacts; uses shipped migration/spec 004.
+Does not depend on PR #121 campaign artifacts; uses shipped migration 060 + architecture note.
 """
 
 from __future__ import annotations
@@ -139,8 +139,8 @@ def test_intel_migration_preserves_coverage_spine() -> None:
     assert "success_zero" not in text or True  # isolation documented in comments/scope
 
 
-def test_scope_labels_in_migration_and_spec004() -> None:
-    """Scope labels live in migration 060 + spec 004 (not PR121 orphan paths)."""
+def test_scope_labels_in_migration_and_architecture_doc() -> None:
+    """Scope labels live in migration 060 + durable architecture note (not campaign packs)."""
     m060 = (ROOT / "db/migrations/060_national_contracts_intelligence_layers.sql").read_text(
         encoding="utf-8"
     )
@@ -149,7 +149,9 @@ def test_scope_labels_in_migration_and_spec004() -> None:
     assert "intel_product" in m060
     # Must not redefine dual operational coverage as national volume
     assert "canonical_sc_operational" not in m060 or "NOT" in m060
-    spec = ROOT / "specs/004-extra-live-consulting-pack/spec.md"
-    assert spec.is_file()
-    st = spec.read_text(encoding="utf-8")
-    assert "060" in st or "national_intel" in st or "FULL" in st or "elegível" in st.lower()
+    arch = ROOT / "docs/architecture/national-intel-foundation.md"
+    assert arch.is_file()
+    st = arch.read_text(encoding="utf-8")
+    assert "060" in st
+    assert "national" in st.lower()
+    assert "operational" in st.lower()

--- a/tests/national_intel/test_products_fixture.py
+++ b/tests/national_intel/test_products_fixture.py
@@ -1,0 +1,116 @@
+"""Product tests for national_intel engines.
+
+When REQUIRE_REAL_DB=1 and an isolated DB with migration 060 + contracts is
+available, exercises real SQL. Otherwise skips cleanly (never fail on MagicMock).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.national_intel.agencies import run_agencies
+from scripts.national_intel.benchmarks import run_benchmarks
+from scripts.national_intel.competitors import run_competitors
+
+
+def _is_real_conn(conn) -> bool:
+    if conn is None or isinstance(conn, MagicMock):
+        return False
+    # Real psycopg2 connection has closed attribute / info
+    return hasattr(conn, "cursor") and not isinstance(getattr(conn, "cursor", None), MagicMock)
+
+
+def _require_real_db() -> bool:
+    return os.getenv("REQUIRE_REAL_DB", "").lower() in {"1", "true", "yes"}
+
+
+pytestmark = [
+    pytest.mark.real_db,
+]
+
+
+@pytest.fixture
+def real_pg(pg_conn):
+    if not _require_real_db():
+        pytest.skip("REQUIRE_REAL_DB not set")
+    if not _is_real_conn(pg_conn):
+        pytest.skip("psycopg2 mocked or unavailable")
+    return pg_conn
+
+
+def test_competitors_envelope(real_pg, national_intel_dsn: str) -> None:
+    data = run_competitors(real_pg, keyword="paviment", limit=20, dsn=national_intel_dsn)
+    assert data["product_id"] == "competitors_geo"
+    assert data["scope_label"] == "intel_product"
+    assert "limitations" in data
+    # Empty result is valid when no matching rows (not a mock assert-0 trap)
+    assert data["row_count"] >= 0
+    if data["row_count"] >= 1:
+        entrants = [r for r in data["rows"] if r.get("entrant_signal")]
+        for e in entrants:
+            assert e["entrant_signal"]["claim_class"] == "hypothesis"
+            assert e["has_sc"] is False
+
+
+def test_benchmarks_sample_gate(real_pg, national_intel_dsn: str) -> None:
+    ok = run_benchmarks(real_pg, keyword="paviment", min_sample=3, dsn=national_intel_dsn)
+    assert ok["status"] in {"ok", "insufficient_sample"}
+    if ok.get("sample_size", 0) >= 3:
+        assert ok["status"] == "ok"
+        assert ok["rows"][0]["valor_p50"] is not None
+        assert ok["rows"][0]["unit_price"] is None
+
+    bad = run_benchmarks(
+        real_pg, keyword="zzzz-no-match-xyz", min_sample=20, dsn=national_intel_dsn
+    )
+    assert bad["status"] == "insufficient_sample"
+
+
+def test_agencies_profiles(real_pg, national_intel_dsn: str) -> None:
+    data = run_agencies(real_pg, limit=20, dsn=national_intel_dsn)
+    assert data["product_id"] == "agencies_profile"
+    assert data["scope_label"] == "intel_product"
+    assert data["row_count"] >= 0
+    if data["row_count"] >= 1:
+        row = data["rows"][0]
+        assert "contract_count" in row
+        assert "top_supplier_share" in row
+        assert row["top_supplier_share_claim_class"] == "indicator"
+
+
+def test_views_exist(real_pg) -> None:
+    from scripts.national_intel.db import fetch_all
+
+    rows = fetch_all(
+        real_pg,
+        """
+        SELECT table_name FROM information_schema.views
+        WHERE table_schema='public' AND table_name LIKE %s
+        ORDER BY 1
+        """,
+        ("v_intel_%",),
+    )
+    names = {r["table_name"] for r in rows}
+    if not names:
+        pytest.skip("intel views not applied on this DSN (migration 060 pending)")
+    assert "v_intel_contracts_raw_national" in names
+    assert "v_intel_contracts_geo_sc" in names
+    assert "v_intel_supplier_geo" in names
+    assert "v_intel_agency_profile" in names
+
+
+def test_geo_sc_view_only_sc(real_pg) -> None:
+    from scripts.national_intel.db import fetch_all
+
+    try:
+        rows = fetch_all(
+            real_pg,
+            "SELECT DISTINCT uf FROM v_intel_contracts_geo_sc LIMIT 100",
+        )
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"view unavailable: {exc}")
+    for r in rows:
+        assert str(r["uf"]).upper() == "SC"


### PR DESCRIPTION
## Summary

**Reconstructed** from the former commercial mega-pack into a narrow foundation PR:

- migration `060_national_contracts_intelligence_layers.sql` (additive views only)
- `scripts/national_intel` module + CLI
- isolation / adversarial unit tests
- short architecture note

**Removed:** commercial A–E pack, PDFs/XLSX, campaign dumps, client-ready cycle, live pack orchestration.

## Exact HEAD under test

- **HEAD SHA:** `a94bb0822954505376b584022e6accf15e38e1a7`
- **Base:** `main` @ `d4ddd208026fe1446a22c074463a3aa83fdeacf5`

## Validation

- ruff clean
- generated-artifacts + reviewability policy PASS
- Canonical CI on this HEAD (awaiting Actions)

## Risk

No production / VPS / soak; no private client documents.