### PR TITLE
feat(consulting): client-ready cycle integration (post 060/061)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,3 +348,39 @@ test-linkage:
 
 verify-linkage-foundation:
 	@test -f db/migrations/061_canonical_entity_linkage.sql
+
+# --- client-ready consulting cycle (integration; no bulk artifacts in git) ---
+.PHONY: test-client-ready client-ready-consulting-cycle \
+	campaign-gate-client-ready-recurring-consulting-cycle \
+	release-candidate-client-ready-recurring-consulting-cycle \
+	verify-client-ready-recurring-consulting-cycle-isolated \
+	dod-audit-client-ready-recurring-consulting-cycle
+
+test-client-ready:
+	python -m pytest \
+		tests/test_client_ready_consulting_cycle.py \
+		tests/test_commercial_rc_v2_gates.py \
+		tests/test_live_consulting_pack.py \
+		tests/test_sector_classifier_adversarial.py \
+		-q --tb=short
+
+client-ready-consulting-cycle:
+	@echo '==> client-ready-consulting-cycle (isolated DSN required)'
+	python -m scripts.ops.client_ready_consulting_cycle --help
+
+campaign-gate-client-ready-recurring-consulting-cycle: test-client-ready
+	@echo 'campaign-gate-client-ready-recurring-consulting-cycle OK (unit gates)'
+
+release-candidate-client-ready-recurring-consulting-cycle: campaign-gate-client-ready-recurring-consulting-cycle
+	@echo 'RC technical only — human acceptance remains PENDING_HUMAN'
+
+verify-client-ready-recurring-consulting-cycle-isolated: test-client-ready
+	@test -f scripts/ops/client_ready_consulting_cycle.py
+	@test -f db/migrations/060_national_contracts_intelligence_layers.sql
+	@test -f db/migrations/061_canonical_entity_linkage.sql
+	@echo 'verify-client-ready-recurring-consulting-cycle-isolated OK'
+
+dod-audit-client-ready-recurring-consulting-cycle:
+	@echo 'dod-audit-client-ready-recurring-consulting-cycle: technical audit via unit gates'
+	$(MAKE) test-client-ready
+

--- a/config/client_profiles/extra.yaml
+++ b/config/client_profiles/extra.yaml
@@ -3,9 +3,9 @@
 
 profile_id: extra_construtora
 display_name: Extra Empreiteira e Construtora
-version: 2
-version_date: "2026-07-16"
-version_notes: "I4.1 — perfil operacional completo para janela 30d (região, modalidades, valores, restrições)"
+version: 3
+version_date: "2026-07-25"
+version_notes: "RC v2 — perfil comercial engenharia: vocabulário pos/neg/exclusão, faixas, capacidades PENDING intactas"
 
 # --- Região e universo ---
 region:
@@ -16,43 +16,282 @@ region:
   # denominador de metas: entes included no raio (baseline 1093 na planilha atual)
 
 desired_object_types:
-  - id: reforma_predial
-    label: Reforma predial
+  - id: obras_edificacoes
+    label: Obras de edificações
+    terms:
+      - construcao de edificio
+      - construcao de predio
+      - edificacao publica
+      - predio publico
+  - id: pavimentacao
+    label: Pavimentação
+    terms:
+      - pavimentacao
+      - pavimentacao asfaltica
+      - capeamento asfaltico
+      - CBU
+  - id: drenagem
+    label: Drenagem
+    terms:
+      - drenagem
+      - drenagem urbana
+      - galeria pluvial
+      - sarjeta
+  - id: terraplenagem
+    label: Terraplenagem
+    terms:
+      - terraplenagem
+      - terraplanagem
+      - muro de arrimo
+  - id: infraestrutura_urbana
+    label: Infraestrutura urbana
+    terms:
+      - infraestrutura urbana
+      - revitalizacao urbana
+      - calcada
+      - passeio publico
+  - id: saneamento
+    label: Saneamento
+    terms:
+      - saneamento
+      - rede coletora
+      - esgoto
+      - adutora
+  - id: reformas
+    label: Reformas
     terms:
       - reforma predial
       - reforma de edificio publico
-      - reforma de edificacao publica
+      - reforma de escola
+      - recuperacao estrutural
+  - id: ampliacoes
+    label: Ampliações
+    terms:
+      - ampliacao de escola
+      - ampliacao de predio
+      - ampliacao de creche
   - id: manutencao_predial
     label: Manutenção predial
     terms:
       - manutencao predial
       - manutencao de edificio publico
-      - manutencao de edificacao publica
-  - id: construcao_edificios_publicos
-    label: Construção de edifícios públicos
+      - manutencao civil das edificacoes
+  - id: projetos_engenharia
+    label: Projetos de engenharia (quando comercialmente relevantes)
     terms:
-      - construcao de edificio publico
-      - construcao de edificacao publica
-      - construcao de predio publico
-  - id: infraestrutura_urbana
-    label: Infraestrutura urbana (obras correlatas)
-    terms:
-      - pavimentacao
-      - drenagem
-      - calcada
-      - revitalizacao urbana
+      - projeto executivo
+      - projeto basico
+      - projeto de engenharia
+      - projetos complementares
+      - projeto arquitetonico
 
 positive_terms:
   - engenharia civil
   - obra de engenharia
-  - reforma
+  - reforma predial
   - manutencao predial
   - construcao de edificio
   - edificacao
-  - predial
+  - pavimentacao
+  - drenagem
+  - terraplenagem
+  - saneamento
+  - infraestrutura urbana
+  - ampliacao de escola
 
-# Sem termos negativos comerciais rígidos do cliente nesta fase.
-negative_terms: []
+# Vocabulário comercial explícito (classificador setorial auditável)
+negative_terms:
+  - manutencao de frota
+  - computador
+  - lencois e mantas
+  - exames laboratoriais
+  - combustivel
+  - cursos para professores
+  - oficina de karate
+  - arrecadacao bancaria
+  - equipamentos hospitalares
+  - castracao de animais
+  - manutencao de software
+  - construcao de conhecimento
+  - medicamentos
+  - generos alimenticios
+  - uniformes
+  - residuos da construcao civil
+
+# Exclusões setoriais (salvo override explícito no perfil)
+exclusion_categories:
+  - saude_assistencial
+  - medicamentos
+  - exames
+  - roupas_vestuario
+  - alimentos
+  - computadores_ti
+  - veiculos_frota
+  - combustiveis
+  - cursos_capacitacao
+  - eventos_culturais_esportivos
+  - servicos_bancarios
+  - oficinas_culturais_esportivas
+  - materiais_sem_obra
+  - credenciamentos_genericos
+  - objetos_puramente_administrativos
+
+# Regras: genéricos sozinhos NUNCA bastam
+generic_terms_insufficient_alone:
+  - servico
+  - servicos
+  - manutencao
+  - construcao
+  - projeto
+  - obra
+  - obras
+  - engenharia
+  - infraestrutura
+
+sector_vocabulary:
+  positive:
+    - id: pavimentacao
+      term: pavimentacao
+      pattern: "\\bpavimenta(c|ç)|\\bpavimentacao\\b|\\brecapeamento\\b"
+      subcategory: pavimentacao
+      weight: 0.45
+      sql_term: pavimentacao
+    - id: drenagem
+      term: drenagem
+      pattern: "\\bdrenagem\\s+(urbana|pluvial|de\\s+aguas|viaria)|\\bgaleria\\s+pluvial\\b"
+      subcategory: drenagem
+      weight: 0.42
+      sql_term: drenagem urbana
+    - id: terraplenagem
+      term: terraplenagem
+      pattern: "\\bterraplenagem\\b|\\bterraplanagem\\b"
+      subcategory: terraplenagem
+      weight: 0.45
+      sql_term: terrapl
+    - id: saneamento
+      term: saneamento basico
+      pattern: "\\bsaneamento\\s+(basico|ambiental|urbano)\\b|\\brede\\s+de\\s+esgoto\\b|\\besgotamento\\s+sanitario\\b"
+      subcategory: saneamento
+      weight: 0.4
+      sql_term: saneamento basico
+    - id: reforma_predial
+      term: reforma predial
+      pattern: "\\breforma\\s+(predial|de\\s+edif|de\\s+pred|de\\s+escola)"
+      subcategory: reformas
+      weight: 0.4
+      sql_term: reforma predial
+    - id: manutencao_predial
+      term: manutencao predial
+      pattern: "\\bmanuten[cç][aã]o\\s+(predial|de\\s+edif|civil\\s+das\\s+edifica)"
+      subcategory: manutencao_predial
+      weight: 0.38
+      sql_term: manutencao predial
+    - id: construcao_edificios
+      term: construcao de edificio
+      pattern: "\\bconstru[cç][aã]o\\s+de\\s+(edif|pred|escola|creche)"
+      subcategory: edificacoes
+      weight: 0.45
+      sql_term: construcao de edif
+    - id: ampliacao
+      term: ampliacao de escola
+      pattern: "\\bamplia[cç][aã]o\\s+de\\s+(escola|creche|pred|edif)"
+      subcategory: edificacoes
+      weight: 0.45
+      sql_term: ampliacao de
+    - id: obra_engenharia
+      term: obra de engenharia
+      pattern: "\\bobra[s]?\\s+de\\s+engenharia\\b|\\bexecu[cç][aã]o\\s+das\\s+obras\\s+de\\s+engenharia\\b|\\bservicos?\\s+de\\s+engenharia\\s+(civil|para)\\b"
+      subcategory: obras_civis
+      weight: 0.45
+      sql_term: obra de engenharia
+    - id: infraestrutura_urbana
+      term: infraestrutura urbana
+      pattern: "\\binfraestrutura\\s+urbana\\b|\\brevitaliza"
+      subcategory: infraestrutura_urbana
+      weight: 0.38
+      sql_term: infraestrutura urbana
+    - id: projeto_engenharia
+      term: projeto de engenharia
+      pattern: "\\bprojetos?\\s+(executivo|basico|de\\s+engenharia|arquitetonicos?|complementares?)|\\barquitetonicos?\\s+e\\s+complementares\\b"
+      subcategory: projetos
+      weight: 0.38
+      sql_term: projeto
+  negative:
+    - id: seguro
+      term: seguro de frota
+      pattern: "\\bseguro\\s+(de\\s+)?(frota|veiculo|automovel|total)|\\bseguradora\\b"
+      weight: 0.7
+    - id: frota
+      term: manutencao de frota
+      pattern: "\\bmanuten[cç][aã]o\\s+da\\s+frota\\b|\\bfrota\\s+(municipal|de\\s+veiculo)|\\bveiculos?\\s+automotores\\b"
+      weight: 0.65
+    - id: voip_telecom
+      term: telefonia voip
+      pattern: "\\bvoip\\b|\\btelefonia\\b|\\bpabx\\b|\\bcentral\\s+telefonica\\b"
+      weight: 0.65
+    - id: limpeza_jardinagem
+      term: limpeza e jardinagem
+      pattern: "\\blimpeza\\s+(predial|urbana|publica)\\b|\\bjardinagem\\b|\\bro[cç]ada\\b|\\bcapeina\\b"
+      weight: 0.6
+    - id: grama_esporte
+      term: grama sintetica
+      pattern: "\\bgrama\\s+sintetica\\b|\\bgramado\\s+sintetico\\b|\\bfifa\\b"
+      weight: 0.6
+    - id: saneamento_metafora
+      term: saneamento de inconformidades
+      pattern: "\\bsaneamento\\s+de\\s+(inconformidades|pendencias|irregularidades|processos)\\b"
+      weight: 0.7
+    - id: computador
+      term: computador
+      pattern: "\\bcomputador\\b|\\bnotebook\\b|\\ball\\s+in\\s+one\\b"
+      weight: 0.55
+    - id: lencois
+      term: lencois e mantas
+      pattern: "\\blen[cç][oó]is?\\b|\\bmantas?\\s+destinad"
+      weight: 0.55
+    - id: exames
+      term: exames laboratoriais
+      pattern: "\\bexames?\\s+(laborator|clinico)|\\blaboratoriais\\b"
+      weight: 0.55
+    - id: combustivel
+      term: combustivel
+      pattern: "\\bcombustivel\\b|\\bgasolina\\b|\\bdiesel\\b"
+      weight: 0.5
+    - id: cursos
+      term: cursos
+      pattern: "\\bcurso[s]?\\s+(para|de)\\b|\\bcapacita[cç][aã]o\\b|\\bprofessores?\\b"
+      weight: 0.45
+    - id: karate
+      term: oficina de karate
+      pattern: "\\bkarat[eé]\\b|\\boficina\\s+de\\s+karate\\b"
+      weight: 0.5
+    - id: bancario
+      term: arrecadacao bancaria
+      pattern: "\\barrecada[cç][aã]o\\s+bancaria\\b|\\bservi[cç]os?\\s+bancarios?\\b"
+      weight: 0.5
+    - id: hospitalar
+      term: equipamentos hospitalares
+      pattern: "\\bequipamento[s]?\\s+hospitalar|\\bmateriais?\\s+medico"
+      weight: 0.5
+    - id: software
+      term: manutencao de software
+      pattern: "\\bmanuten[cç][aã]o\\s+de\\s+software\\b|\\bsoftware\\b"
+      weight: 0.55
+    - id: castracao
+      term: castracao
+      pattern: "\\bcastra[cç][aã]o\\b|\\besteriliza[cç][aã]o\\s+de\\s+animais\\b"
+      weight: 0.55
+    - id: residuos_cc
+      term: residuos construcao civil
+      pattern: "\\bresiduos?\\s+da\\s+constru[cç][aã]o\\s+civil\\b|\\bentulho\\b"
+      weight: 0.4
+  exclusion:
+    - id: credenciamento_generico
+      term: credenciamento generico
+      pattern: "\\bcredenciamento\\b(?!.*\\b(obra|engenharia|paviment|edifica|reforma\\s+predial))"
+    - id: saude_assistencial
+      term: saude assistencial
+      pattern: "\\b(unidade\\s+basica\\s+de\\s+saude|atencao\\s+basica|complementar\\s+ao\\s+sus)\\b"
 
 # Modalidades priorizadas (não exclusivas) — null = todas aceitas no score base
 allowed_modalities: null
@@ -82,10 +321,48 @@ documents:
   require_attachments: false
 
 engineering_categories:
-  - reforma_predial
-  - manutencao_predial
-  - construcao_edificios_publicos
+  - obras_edificacoes
+  - pavimentacao
+  - drenagem
+  - terraplenagem
   - infraestrutura_urbana
+  - saneamento
+  - reformas
+  - ampliacoes
+  - manutencao_predial
+  - projetos_engenharia
+
+# Atuação geográfica conhecida
+geographic_footprint:
+  headquarters_uf: SC
+  headquarters_municipio: São José
+  primary_radius_km: 200
+  uf_focus:
+    - SC
+  note: "Raio 200 km da planilha canônica; expansão interestadual requer decisão humana"
+
+# Capacidades conhecidas vs PENDING (NÃO inventar)
+known_capabilities:
+  - id: construcao_edificios
+    status: KNOWN_FOCUS
+    note: "CNAE principal 4120-4/00 — construção de edifícios"
+  - id: reforma_manutencao_predial
+    status: KNOWN_FOCUS
+    note: "Foco comercial declarado no perfil"
+  - id: infraestrutura_urbana_pavimentacao
+    status: KNOWN_FOCUS
+    note: "Objetos desejados: pavimentação, drenagem, revitalização"
+pending_capabilities:
+  - capital_giro
+  - capacidade_simultanea
+  - cats_atestados
+  - equipe
+  - equipamentos
+  - certidoes
+  - margem_minima
+  - risco_aceitavel
+  - capacidade_garantia
+  - apetite_consorcios
 
 # Restrições operacionais conhecidas
 operational_constraints:
@@ -250,9 +527,16 @@ commercial_preferences:
   municipalities_of_interest: []  # se vazio, usa raio 200km
   max_distance_km: 200
   work_types_focus:
-    - reforma_predial
+    - obras_edificacoes
+    - pavimentacao
+    - drenagem
+    - terraplenagem
+    - infraestrutura_urbana
+    - saneamento
+    - reformas
+    - ampliacoes
     - manutencao_predial
-    - construcao_edificios_publicos
+    - projetos_engenharia
 
 elicitation_queue:
   - field: capacity.simultaneous_works

--- a/docs/ops/client-ready-consulting-cycle.md
+++ b/docs/ops/client-ready-consulting-cycle.md
@@ -1,0 +1,22 @@
+# Client-ready recurring consulting cycle
+
+Technical orchestration that composes national intel (migration 060) and
+canonical linkage (migration 061) into commercial deliverables A–E.
+
+## Separation of concerns
+
+| Layer | Meaning |
+|-------|---------|
+| Technical readiness | Code + CI green; pack can be generated offline |
+| Package publication | Fail-closed publish path (`publish_commercial_rc_v2`) |
+| Human acceptance | **Only Tiago** may set `user-acceptance.json` to ACCEPTED |
+
+Agents must never forge human acceptance.
+
+## Operator entry
+
+```bash
+python -m scripts.ops.client_ready_consulting_cycle --help
+```
+
+Heavy outputs: generate locally / CI artifacts — do not commit PDF/XLSX dumps.

--- a/scripts/ops/client_ready_consulting_cycle.py
+++ b/scripts/ops/client_ready_consulting_cycle.py
@@ -1,0 +1,1960 @@
+#!/usr/bin/env python3
+"""CLIENT-READY-RECURRING-CONSULTING-CYCLE-01 — integrated consulting cycle.
+
+Canonical operator entry:
+  make client-ready-consulting-cycle
+  python -m scripts.ops.client_ready_consulting_cycle run --dsn ... --out ...
+
+Sequences (isolated PostgreSQL only):
+  isolation → migrations → profile → snapshot validate → opportunities
+  → linkage → dossiers → A–E pack → weekly → monthly+delta → reconcile → evidence
+
+Global terminal status is exactly one of: PASS | BLOCKED | FAIL.
+Human RC acceptance is required for PASS; otherwise BLOCKED when technical path is green.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+CAMPAIGN_ID = "CLIENT-READY-RECURRING-CONSULTING-CYCLE-01"
+DEFAULT_DSN = os.getenv(
+    "CLIENT_READY_DSN",
+    os.getenv(
+        "CAMPAIGN_TEST_DSN",
+        "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc",
+    ),
+)
+DEFAULT_OUT = _PROJECT_ROOT / "artifacts" / "campaigns" / CAMPAIGN_ID
+
+# Identity files that must exist on both sides of acceptance binding (fail-closed).
+REQUIRED_IDENTITY_FILES: tuple[str, ...] = (
+    "pack-manifest.json",
+    "executive-summary.md",
+    "consulting-pack.xlsx",
+    "executive-report.pdf",
+)
+
+# Frozen release candidate for human product review (PR #131).
+# v1 (CHANGES_REQUESTED): commercial irrelevance — kept historical only.
+# v2: sector-filtered engineering pack — PENDING_HUMAN (never auto-ACCEPTED).
+FROZEN_RC_V1_RUN_ID = "live-pack-20260724-220350-da3bee0b"
+FROZEN_RC_V1_PRODUCT_SHA = "be96c8bc8eb2b017e491bfafe8cf99f81e321267"
+FROZEN_RC_V1_ARTIFACT_NAME = "client-ready-frozen-rc"
+FROZEN_RC_V1_STATUS = "CHANGES_REQUESTED"
+
+# Active freeze identity — commercial RC v2 (sector-filtered engineering pack).
+FROZEN_RC_RUN_ID = "live-pack-20260725-034511-57554b1d"
+FROZEN_RC_PRODUCT_SHA = "db62911a3dc5f3fe1e632efa26d100a01780201c036659bf2707624fe1c320f0"
+FROZEN_RC_SNAPSHOT_COMMIT = "HEAD"
+FROZEN_RC_ARTIFACT_NAME = "client-ready-frozen-rc-v2"
+BLOCKED_MISSING_FROZEN_RC = "BLOCKED_MISSING_FROZEN_RC_OUTPUTS"
+
+# Dump package may live outside the worktree (large ADR-020 artifact). Search order:
+_DUMP_CANDIDATES = (
+    _PROJECT_ROOT / "artifacts/migration/backfill-vps/pkg-20260723T195047Z",
+    Path("/mnt/d/extra consultoria/artifacts/migration/backfill-vps/pkg-20260723T195047Z"),
+    Path.home() / "extra-consultoria/artifacts/migration/backfill-vps/pkg-20260723T195047Z",
+)
+
+
+def _resolve_dump_package() -> Path | None:
+    for p in _DUMP_CANDIDATES:
+        if (p / "db/pncp_supplier_contracts.dump").exists() or (p / "meta/SHA256SUMS").exists():
+            return p
+    return None
+
+
+DUMP_PACKAGE = _resolve_dump_package() or _DUMP_CANDIDATES[0]
+E_EVIDENCE_DEFAULT = (
+    _PROJECT_ROOT
+    / "artifacts/campaigns/OPEN-TENDERS-OPERATIONAL-DECISION-CYCLE-01"
+    / "weekly-offline-rc/deliverable_e.json"
+)
+
+FORBIDDEN_HOST_MARKERS = (
+    "ec-prod",
+    "extra_prod",
+    "/opt/extra-consultoria",
+    "netcup",
+    "prod.extra",
+)
+ALLOWED_HOSTS = ("127.0.0.1", "localhost", "::1")
+ALLOWED_PORTS = (5433, 5435, 5436, 5437, 5438, 5439)  # local campaign ports only
+# 5432 is reserved for shared/prod-like stacks (e.g. n8n/recuperador) — reject.
+FORBIDDEN_PORTS = (5432,)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def git_sha(root: Path | None = None) -> str:
+    r = root or _PROJECT_ROOT
+    try:
+        out = subprocess.check_output(  # noqa: S603
+            ["/usr/bin/git", "rev-parse", "HEAD"],
+            cwd=str(r),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def mask_dsn(dsn: str) -> str:
+    return re.sub(r"://([^:/@]+):([^@]+)@", r"://\1:***@", dsn or "")
+
+
+def parse_dsn(dsn: str) -> tuple[str | None, int | None, str | None]:
+    raw = (dsn or "").strip()
+    if not raw:
+        return None, None, None
+    if "://" not in raw:
+        raw = "postgresql://" + raw
+    u = urlparse(raw)
+    return u.hostname, u.port, (u.path or "").lstrip("/") or None
+
+
+def isolation_guard(dsn: str, out_dir: Path | None = None) -> dict[str, Any]:
+    """Fail-closed isolation. Null/unknown production_touched is not success."""
+    host, port, db = parse_dsn(dsn)
+    hits: list[str] = []
+    hay = f"{dsn} {host or ''} {db or ''} {out_dir or ''}".lower()
+    for m in FORBIDDEN_HOST_MARKERS:
+        if m.lower() in hay:
+            hits.append(f"forbidden:{m}")
+    if host and host not in ALLOWED_HOSTS:
+        hits.append(f"host_not_local:{host}")
+    if port in FORBIDDEN_PORTS:
+        hits.append(f"forbidden_port:{port}")
+    if port is not None and port not in ALLOWED_PORTS:
+        hits.append(f"port_not_campaign_isolated:{port}")
+    if not dsn:
+        hits.append("missing_dsn")
+    if not host:
+        hits.append("host_unconfirmed")
+    if not db:
+        hits.append("database_identity_unconfirmed")
+
+    production_touched = any(
+        h.startswith("forbidden:") or h.startswith("host_not_local:") for h in hits
+    )
+    # Explicit false only when confirmed isolated; never null.
+    ok = len(hits) == 0 and not production_touched
+    result = {
+        "ok": ok,
+        "production_touched": False if ok else production_touched,
+        "soak_touched": False if ok else None,  # unknown if isolation failed
+        "dsn_masked": mask_dsn(dsn),
+        "host": host,
+        "port": port,
+        "database": db,
+        "hits": hits,
+        "checked_at": utc_now(),
+        "campaign_id": CAMPAIGN_ID,
+    }
+    if not ok:
+        # fail-closed: unknown soak is treated as blocker
+        result["soak_touched"] = result["soak_touched"] is True  # force bool false only if known
+        if result["soak_touched"] is None:
+            result["soak_touched"] = False  # not claimed; isolation already failed
+        raise SystemExit(
+            json.dumps(
+                {
+                    "status": "FAIL",
+                    "error": "ISOLATION_GUARD_BLOCK",
+                    "isolation": result,
+                },
+                ensure_ascii=False,
+            )
+        )
+    # Confirmed isolated path
+    result["production_touched"] = False
+    result["soak_touched"] = False
+    return result
+
+
+def connect(dsn: str) -> Any:
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    return psycopg2.connect(dsn, cursor_factory=RealDictCursor)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def apply_migrations(dsn: str) -> dict[str, Any]:
+    t0 = time.perf_counter()
+    r1 = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "scripts.ops.apply_migrations", "--dsn", dsn],
+        cwd=str(_PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    r2 = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "scripts.ops.apply_migrations", "--dsn", dsn],
+        cwd=str(_PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "first_exit": r1.returncode,
+        "second_exit": r2.returncode,
+        "idempotent": r1.returncode == 0 and r2.returncode == 0,
+        "duration_s": round(time.perf_counter() - t0, 3),
+        "stderr_tail": (r1.stderr or r2.stderr or "")[-500:],
+    }
+
+
+def validate_profile() -> dict[str, Any]:
+    from scripts.ops.diagnostic_profile import profile_stamp
+
+    stamp = profile_stamp()
+    path = _PROJECT_ROOT / "config/client_profiles/extra.yaml"
+    body = path.read_bytes() if path.exists() else b""
+    return {
+        **stamp,
+        "profile_path": str(path.relative_to(_PROJECT_ROOT)) if path.exists() else None,
+        "profile_sha256": hashlib.sha256(body).hexdigest() if body else None,
+        "exists": path.exists(),
+    }
+
+
+def validate_snapshot(conn: Any, dsn: str) -> dict[str, Any]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) AS n FROM pncp_supplier_contracts")
+        n = int(cur.fetchone()["n"])
+        # Prefer SC filter if column uf exists
+        try:
+            cur.execute(
+                """
+                SELECT count(*) AS n FROM pncp_supplier_contracts
+                WHERE COALESCE(is_active, TRUE) IS TRUE AND uf = 'SC'
+                """
+            )
+            n_sc = int(cur.fetchone()["n"])
+        except Exception:  # noqa: BLE001
+            conn.rollback()
+            n_sc = None
+        cur.execute(
+            "SELECT version FROM _migrations ORDER BY version DESC LIMIT 5"
+        )
+        migrations = [r["version"] for r in cur.fetchall()]
+        cur.execute("SELECT current_database() AS db, inet_server_addr() AS addr")
+        ident = dict(cur.fetchone() or {})
+
+    dump_pkg = _resolve_dump_package()
+    dump_path = (dump_pkg / "db/pncp_supplier_contracts.dump") if dump_pkg else None
+    meta_path = (dump_pkg / "meta/export-result.json") if dump_pkg else None
+    expected = None
+    dump_sha = None
+    dump_sha_source = None
+    if meta_path and meta_path.exists():
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        expected = meta.get("contracts_count")
+    sums = (dump_pkg / "meta/SHA256SUMS") if dump_pkg else None
+    listed_sha = None
+    if sums and sums.exists():
+        for line in sums.read_text(encoding="utf-8").splitlines():
+            if "pncp_supplier_contracts.dump" in line:
+                listed_sha = line.split()[0]
+                break
+    if dump_path and dump_path.exists():
+        # Prefer listed authenticated checksum (ADR-020) to avoid multi-minute rehash
+        if listed_sha and len(listed_sha) == 64:
+            dump_sha = listed_sha
+            dump_sha_source = "SHA256SUMS"
+        else:
+            dump_sha = sha256_file(dump_path)
+            dump_sha_source = "computed"
+            if listed_sha and listed_sha != dump_sha:
+                return {
+                    "ok": False,
+                    "error": "dump_sha256_mismatch",
+                    "listed": listed_sha,
+                    "computed": dump_sha,
+                }
+    elif listed_sha:
+        dump_sha = listed_sha
+        dump_sha_source = "SHA256SUMS_only"
+
+    row_ok = expected is None or int(expected) == n
+    dump_pkg_s = None
+    if dump_pkg:
+        try:
+            dump_pkg_s = str(dump_pkg.relative_to(_PROJECT_ROOT))
+        except ValueError:
+            dump_pkg_s = str(dump_pkg)
+    return {
+        "ok": n > 0 and row_ok,
+        "snapshot_row_count": n,
+        "expected_row_count": expected,
+        "row_count_reconciled": row_ok,
+        "sc_active_count": n_sc,
+        "snapshot_sha256": dump_sha,
+        "snapshot_sha256_source": dump_sha_source,
+        "dump_package": dump_pkg_s,
+        "migrations_recent": migrations,
+        "database_identity": {
+            "database": ident.get("db"),
+            "dsn_masked": mask_dsn(dsn),
+            "server_addr": str(ident.get("addr")),
+        },
+        "eligible_population_note": "computed at pack time; not hard-coded",
+    }
+
+
+def seed_opportunities_from_e(conn: Any, e_path: Path) -> dict[str, Any]:
+    """Upsert open opportunities from captured Deliverable E into opportunity_intel."""
+    if not e_path.exists():
+        return {"seeded": 0, "error": f"missing_e_evidence:{e_path}"}
+    data = json.loads(e_path.read_text(encoding="utf-8"))
+    recs = list(data.get("recommendations") or [])
+    ids: list[int] = []
+    with conn.cursor() as cur:
+        for rec in recs:
+            edital_id = str(rec.get("edital_id") or "").strip()
+            if not edital_id:
+                continue
+            # PNCP control often starts with CNPJ14
+            digits = re.sub(r"\D", "", edital_id.split("/")[0].split("-")[0])
+            cnpj = digits[:14] if len(digits) >= 14 else (digits or None)
+            objeto = (rec.get("titulo") or rec.get("objeto") or "edital aberto")[:2000]
+            source_id = f"e-evidence:{edital_id}"
+            content = hashlib.sha256(f"{source_id}|{objeto}".encode()).hexdigest()
+            url = None
+            open_ = rec.get("openness") or {}
+            url = open_.get("official_url")
+            ranking = rec.get("ranking") or rec.get("client_label") or "REVIEW"
+            # Unique authority: content_hash (uq_oi_content_hash). No (source,source_id) unique.
+            cur.execute(
+                "SELECT id FROM opportunity_intel WHERE content_hash = %s",
+                (content,),
+            )
+            existing = cur.fetchone()
+            if existing:
+                cur.execute(
+                    """
+                    UPDATE opportunity_intel SET
+                        objeto = %s,
+                        orgao_cnpj = COALESCE(%s, orgao_cnpj),
+                        orgao_nome = COALESCE(%s, orgao_nome),
+                        ranking = %s,
+                        status_canonico = 'open',
+                        is_active = TRUE,
+                        last_seen_at = now(),
+                        updated_at = now()
+                    WHERE id = %s
+                    RETURNING id
+                    """,
+                    (objeto, cnpj, rec.get("orgao"), ranking, int(existing["id"])),
+                )
+            else:
+                cur.execute(
+                    """
+                    INSERT INTO opportunity_intel (
+                        source, source_id, content_hash, numero_controle_pncp,
+                        source_url, orgao_cnpj, orgao_nome, uf, municipio, objeto,
+                        status_canonico, is_active, ranking
+                    ) VALUES (
+                        'pncp', %s, %s, %s,
+                        %s, %s, %s, 'SC', NULL, %s,
+                        'open', TRUE, %s
+                    )
+                    RETURNING id
+                    """,
+                    (
+                        source_id,
+                        content,
+                        edital_id,
+                        url,
+                        cnpj,
+                        rec.get("orgao"),
+                        objeto,
+                        ranking,
+                    ),
+                )
+            row = cur.fetchone()
+            if row:
+                ids.append(int(row["id"]))
+        # Also seed organs with historical contracts for denser linkage (labeled)
+        from scripts.linkage.seed_isolated import seed_opportunities_from_top_organs
+
+        extra = seed_opportunities_from_top_organs(conn, n_organs=8, per_organ=1)
+        ids.extend(extra)
+        conn.commit()
+        cur.execute(
+            "SELECT count(*) AS n FROM opportunity_intel WHERE COALESCE(is_active, TRUE)"
+        )
+        total = int(cur.fetchone()["n"])
+    return {
+        "seeded_from_e": len(recs),
+        "opportunity_ids": ids,
+        "opportunities_total": total,
+        "e_evidence": str(e_path),
+        "claim": "opportunities include SNAPSHOT-SEED and captured open-tender evidence; not a live PNCP crawl in this run",
+    }
+
+
+def run_linkage(dsn: str, out: Path, *, contract_limit: int = 50) -> dict[str, Any]:
+    from scripts.linkage.pipeline import run_linkage as _run
+
+    run_id = f"crc-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
+    res = _run(
+        dsn,
+        run_id=run_id,
+        snapshot_id="authenticated-dump-pkg-20260723T195047Z",
+        snapshot_hash=None,
+        contract_limit_per_opp=contract_limit,
+        max_opportunities=None,
+    )
+    payload = res.as_dict()
+    (out / "linkage-run.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    return payload
+
+
+def write_dossiers(dsn: str, linkage: dict[str, Any], out_dir: Path) -> dict[str, Any]:
+    from scripts.linkage.dossier import build_dossier, write_dossier
+    from scripts.linkage.pipeline import connect as lconnect
+    from scripts.linkage.pipeline import investigate_opportunity
+
+    run_id = linkage.get("run_id")
+    if not run_id:
+        return {"written": 0, "error": "missing_run_id"}
+    ddir = out_dir / "dossiers"
+    ddir.mkdir(parents=True, exist_ok=True)
+    conn = lconnect(dsn)
+    written: list[str] = []
+    opp_ids: list[int] = []
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT DISTINCT opportunity_id
+                FROM opportunity_organ_links
+                WHERE run_id = %s
+                ORDER BY opportunity_id
+                """,
+                (run_id,),
+            )
+            opp_ids = [int(r["opportunity_id"]) for r in cur.fetchall()]
+            if not opp_ids:
+                cur.execute(
+                    "SELECT id FROM opportunity_intel WHERE COALESCE(is_active, TRUE) ORDER BY id"
+                )
+                opp_ids = [int(r["id"]) for r in cur.fetchall()]
+        for oid in opp_ids:
+            inv = investigate_opportunity(conn, run_id, oid)
+            dos = build_dossier(inv)
+            paths = write_dossier(dos, ddir, stem=f"dossier-opp-{oid}")
+            written.append(str(paths))
+    finally:
+        conn.close()
+    return {"written": len(written), "run_id": run_id, "opportunity_ids": opp_ids}
+
+
+def run_pack(dsn: str, pack_dir: Path, e_path: Path) -> dict[str, Any]:
+    from scripts.ops.live_consulting_pack import run_pack as _run_pack
+
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    return _run_pack(
+        dsn=dsn,
+        out_dir=pack_dir,
+        uf="SC",
+        export_limit=200,
+        target_competitors=15,
+        e_evidence=e_path,
+    )
+
+
+def run_weekly(dsn: str, out_dir: Path) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    r = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "scripts.ops.weekly_cycle",
+            "--dsn",
+            dsn,
+            "--skip-collect",
+            "--no-contracts-incremental",
+            "--no-strict",
+            "--limit",
+            "30",
+            "--output-dir",
+            str(out_dir),
+        ],
+        cwd=str(_PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
+    )
+    manifest = out_dir / "manifest.json"
+    return {
+        "exit_code": r.returncode,
+        "ok": r.returncode in (0, 2),  # 2 = partial OK in weekly_cycle
+        "manifest_exists": manifest.exists(),
+        "stdout_tail": (r.stdout or "")[-800:],
+        "stderr_tail": (r.stderr or "")[-400:],
+    }
+
+
+def run_monthly(dsn: str, out_dir: Path) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # --live-isolated proves mechanics on the same snapshot (+ optional labeled inject).
+    # It is NOT dual temporal live snapshots (see strategic_monthly_monitor.run_live_two_cycle).
+    r = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "scripts.ops.strategic_monthly_monitor",
+            "--live-isolated",
+            "--dsn",
+            dsn,
+            "--out-dir",
+            str(out_dir),
+            "--audit",
+        ],
+        cwd=str(_PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    live_path = out_dir / "monthly-monitor-live.json"
+    if r.returncode == 0 and live_path.exists():
+        try:
+            payload = json.loads(live_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            payload = {}
+        # Authority: file mode after fix is LABELED_DETERMINISTIC_REPLAY
+        mode = str(payload.get("mode") or "LABELED_DETERMINISTIC_REPLAY")
+        live_dual = payload.get("live_dual_snapshot")
+        if live_dual is None:
+            live_dual = False
+        # Never upgrade inject path to live dual
+        if payload.get("synthetic_inject_used") or "LABELED" in mode.upper():
+            live_dual = False
+            mode = "LABELED_DETERMINISTIC_REPLAY"
+        return {
+            "ok": True,
+            "mode": mode,
+            "live_recurrence": False,
+            "live_dual_snapshot": bool(live_dual),
+            "synthetic_inject_used": bool(payload.get("synthetic_inject_used")),
+            "exit_code": r.returncode,
+            "path": str(live_path),
+            "stdout_tail": (r.stdout or "")[-500:],
+        }
+
+    # Fallback: pure labeled replay via run_cycle API
+    from scripts.ops.strategic_monthly_monitor import run_cycle
+
+    as_of = date.today()
+    state_path = out_dir / "cycle-state.json"
+
+    def _ser(x: Any) -> Any:
+        if hasattr(x, "__dataclass_fields__"):
+            from dataclasses import asdict
+
+            return asdict(x)
+        if isinstance(x, dict):
+            return {k: _ser(v) for k, v in x.items()}
+        if isinstance(x, list):
+            return [_ser(i) for i in x]
+        return x
+
+    c1_rep, s1 = run_cycle(
+        editais=[
+            {
+                "id": "seed-1",
+                "status": "open",
+                "deadline": (as_of + timedelta(days=20)).isoformat(),
+            },
+            {
+                "id": "seed-2",
+                "status": "open",
+                "deadline": (as_of + timedelta(days=40)).isoformat(),
+            },
+        ],
+        contracts=[],
+        state=None,
+        as_of=as_of - timedelta(days=7),
+        cycle_id="crc-replay-1",
+    )
+    from scripts.ops.strategic_monthly_monitor import save_state
+
+    save_state(s1, state_path)
+    c2_rep, _s2 = run_cycle(
+        editais=[
+            {
+                "id": "seed-1",
+                "status": "suspended",
+                "deadline": (as_of + timedelta(days=25)).isoformat(),
+            },
+            {
+                "id": "seed-2",
+                "status": "open",
+                "deadline": (as_of + timedelta(days=40)).isoformat(),
+            },
+            {
+                "id": "seed-3",
+                "status": "open",
+                "deadline": (as_of + timedelta(days=15)).isoformat(),
+            },
+        ],
+        contracts=[],
+        state=s1,
+        as_of=as_of,
+        cycle_id="crc-replay-2",
+    )
+    payload = {
+        "mode": "LABELED_DETERMINISTIC_REPLAY",
+        "live_dual_snapshot": False,
+        "live_isolated_exit": r.returncode,
+        "live_isolated_stderr": (r.stderr or "")[-500:],
+        "cycle_1": _ser(c1_rep),
+        "cycle_2": _ser(c2_rep),
+        "claim": "replay proves delta detectors; not dual live snapshot PASS",
+        "non_claims": ["live_dual_snapshot_recurrence"],
+    }
+    (out_dir / "monthly-replay.json").write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    return {
+        "ok": True,
+        "mode": "LABELED_DETERMINISTIC_REPLAY",
+        "live_recurrence": False,
+        "live_dual_snapshot": False,
+        "path": str(out_dir / "monthly-replay.json"),
+    }
+
+
+def _cat_entry(items: list[Any] | None, *, note_empty: str) -> dict[str, Any]:
+    items = list(items or [])
+    if not items:
+        return {"count": 0, "success_zero": True, "note": note_empty, "items": []}
+    return {
+        "count": len(items),
+        "success_zero": False,
+        "items": items[:50],  # cap evidence size
+    }
+
+
+def build_recurrence_delta(monthly: dict[str, Any], out_dir: Path) -> dict[str, Any]:
+    """Normalize delta categories required by the campaign from real cycle artifacts."""
+    categories: dict[str, Any] = {
+        "new_opportunities": [],
+        "status_changes": [],
+        "deadline_changes": [],
+        "new_expiring_contracts": [],
+        "org_ranking_changes": [],
+        "supplier_ranking_changes": [],
+        "coverage_changes": [],
+        "freshness_changes": [],
+        "degraded_sources": [],
+        "resolved_blockers": [],
+        "new_blockers": [],
+    }
+    mode = monthly.get("mode")
+    mon_path = out_dir / "monthly"
+    live_path = mon_path / "monthly-monitor-live.json"
+    replay_path = mon_path / "monthly-replay.json"
+
+    c2: dict[str, Any] = {}
+    c1: dict[str, Any] = {}
+    source_file = None
+    raw: dict[str, Any] = {}
+    if live_path.exists():
+        raw = json.loads(live_path.read_text(encoding="utf-8"))
+        c1 = raw.get("cycle_1") or {}
+        c2 = raw.get("cycle_2") or {}
+        source_file = str(live_path)
+        # Prefer honest mode from artifact (LABELED_DETERMINISTIC_REPLAY after fix)
+        mode = str(raw.get("mode") or mode or "LABELED_DETERMINISTIC_REPLAY")
+    elif replay_path.exists():
+        raw = json.loads(replay_path.read_text(encoding="utf-8"))
+        c1 = raw.get("cycle_1") or {}
+        c2 = raw.get("cycle_2") or {}
+        source_file = str(replay_path)
+        mode = str(raw.get("mode") or mode or "LABELED_DETERMINISTIC_REPLAY")
+
+    if c2:
+        categories["new_opportunities"] = list(c2.get("new_editais") or [])
+        categories["status_changes"] = list(c2.get("status_deltas") or [])
+        exp = c2.get("expiring_contracts") or []
+        if isinstance(exp, list):
+            categories["new_expiring_contracts"] = exp[:20]
+        elif isinstance(exp, dict) and exp.get("count"):
+            categories["new_expiring_contracts"] = [
+                {"count": exp.get("count"), "window": "90-180"}
+            ]
+        # deadline changes from status_deltas with prazo
+        categories["deadline_changes"] = [
+            d
+            for d in (c2.get("status_deltas") or [])
+            if isinstance(d, dict)
+            and (
+                d.get("prazo_novo")
+                or d.get("event_type") in {"PRAZO", "deadline_change", "ALTERACAO_PRAZO"}
+            )
+        ]
+        # ranking deltas from variation.fields
+        var = c2.get("variation") or {}
+        fields = var.get("fields") or {}
+        if fields.get("organs_count", {}).get("delta"):
+            categories["org_ranking_changes"] = [fields["organs_count"]]
+        if fields.get("winners_count", {}).get("delta"):
+            categories["supplier_ranking_changes"] = [fields["winners_count"]]
+        if fields.get("editais_total", {}).get("delta"):
+            # coverage-ish signal
+            categories["coverage_changes"] = [fields["editais_total"]]
+
+    # first cycle has no previous — all-new is not "delta"; cycle_2 is the comparison
+    note_empty = (
+        "measurable empty after complete cycle comparison"
+        if c2
+        else "cycle_2 artifact missing — cannot claim success_zero of deltas"
+    )
+    normalized: dict[str, Any] = {}
+    for k, v in categories.items():
+        if not c2 and k in {
+            "new_opportunities",
+            "status_changes",
+            "deadline_changes",
+            "new_expiring_contracts",
+        }:
+            normalized[k] = {
+                "count": None,
+                "success_zero": False,
+                "note": "NOT_MEASURED — missing cycle_2",
+            }
+        else:
+            normalized[k] = _cat_entry(v if isinstance(v, list) else [], note_empty=note_empty)
+
+    # Live dual-snapshot only if artifact explicitly says so AND no synthetic inject
+    live_dual = False
+    if isinstance(raw, dict) and raw.get("live_dual_snapshot") is True:
+        if not raw.get("synthetic_inject_used") and not raw.get(
+            "population", {}
+        ).get("same_snapshot_both_cycles"):
+            live_dual = True
+    if monthly and monthly.get("live_dual_snapshot") is True and not monthly.get(
+        "synthetic_inject_used"
+    ):
+        # Still refuse if mode is labeled
+        if str(monthly.get("mode") or "").upper().find("LABELED") < 0:
+            live_dual = bool(monthly.get("live_dual_snapshot"))
+    if "LABELED" in str(mode or "").upper() or (
+        isinstance(raw, dict) and raw.get("synthetic_inject_used")
+    ):
+        live_dual = False
+        mode = "LABELED_DETERMINISTIC_REPLAY"
+
+    result = {
+        "mode": mode or "UNKNOWN",
+        "live_dual_snapshot": live_dual,
+        "source_file": source_file,
+        "cycle_1_id": (c1.get("cycle") or {}).get("cycle_id") if isinstance(c1, dict) else None,
+        "cycle_2_id": (c2.get("cycle") or {}).get("cycle_id") if isinstance(c2, dict) else None,
+        "proofs": raw.get("proofs") if isinstance(raw, dict) else None,
+        "categories": normalized,
+        "claims": (raw.get("claims") if isinstance(raw, dict) else None)
+        or ["recurrence_mechanics_proven"],
+        "non_claims": (raw.get("non_claims") if isinstance(raw, dict) else None)
+        or ["live_dual_snapshot_recurrence"],
+    }
+    if not live_dual:
+        result["claim"] = (
+            "LABELED_DETERMINISTIC_REPLAY / same-snapshot mechanics proven; "
+            "live dual temporal snapshot NOT claimed"
+        )
+        result["live_dual_snapshot"] = False
+
+    (out_dir / "recurrence.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    return result
+
+
+def compute_pack_checksums(pack_dir: Path) -> dict[str, str]:
+    """SHA-256 of every file under pack/ except pack-full.json (ADR-020 large)."""
+    out: dict[str, str] = {}
+    if not pack_dir.is_dir():
+        return out
+    for p in sorted(pack_dir.rglob("*")):
+        if p.is_file() and p.name != "pack-full.json":
+            out[str(p.relative_to(pack_dir))] = sha256_file(p)
+    return out
+
+
+def identity_checksum_mismatches(
+    accepted_ck: dict[str, str],
+    pack_checksums: dict[str, str],
+    *,
+    required: tuple[str, ...] = REQUIRED_IDENTITY_FILES,
+) -> list[str]:
+    """Fail-closed identity compare. Missing either side is a mismatch (not skipped)."""
+    mismatches: list[str] = []
+    for key in required:
+        if key not in accepted_ck:
+            mismatches.append(f"missing_expected_checksum:{key}")
+            continue
+        if key not in pack_checksums:
+            mismatches.append(f"missing_actual_artifact:{key}")
+            continue
+        if accepted_ck[key] != pack_checksums[key]:
+            mismatches.append(f"checksum_mismatch:{key}")
+    return mismatches
+
+
+def missing_required_frozen_binaries(pack_dir: Path) -> list[str]:
+    """Return relative names of required identity files absent under pack_dir."""
+    missing: list[str] = []
+    for key in REQUIRED_IDENTITY_FILES:
+        if not (pack_dir / key).is_file():
+            missing.append(key)
+    return missing
+
+
+def human_acceptance_status(campaign_dir: Path) -> dict[str, Any]:
+    path = campaign_dir / "user-acceptance.json"
+    if not path.exists():
+        payload = {
+            "status": "PENDING_HUMAN",
+            "rc_sha": git_sha(),
+            "run_id": None,
+            "package_checksums": {},
+            "accepted_by": None,
+            "accepted_at": None,
+            "notes": None,
+        }
+        path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return payload
+    data = json.loads(path.read_text(encoding="utf-8"))
+    # Never treat agent-filled ACCEPT as real without explicit accepted_by human
+    if data.get("status") == "ACCEPTED":
+        who = data.get("accepted_by")
+        if not who or str(who).lower() in {"agent", "auto", "system", "null"}:
+            data["status"] = "PENDING_HUMAN"
+            data["notes"] = "auto-accept rejected; requires Tiago explicit acceptance"
+    return data
+
+
+def validate_acceptance_binding(
+    acceptance: dict[str, Any],
+    *,
+    pack_run_id: str | None,
+    rc_sha: str,
+    pack_checksums: dict[str, str],
+) -> dict[str, Any]:
+    """Ensure ACCEPTED records bind to this exact RC identity — never rebind.
+
+    Fail-closed for identity files: each of REQUIRED_IDENTITY_FILES must exist
+    in both accepted package_checksums and pack_checksums with equal digests.
+    binding.valid=True only when run_id, product_rc_sha (rc_sha), and all
+    identity checksums match.
+
+    Returns acceptance dict possibly demoted to PENDING_HUMAN if stale vs pack.
+    """
+    out = dict(acceptance)
+    out["binding"] = {
+        "pack_run_id": pack_run_id,
+        "rc_sha": rc_sha,
+        "product_rc_sha": rc_sha,
+        "checked_at": utc_now(),
+    }
+    if out.get("status") != "ACCEPTED":
+        # For pending forms: preserve freeze identity; never silently replace
+        # frozen package_checksums with an incomplete on-disk pack.
+        if out.get("status") in {None, "PENDING_HUMAN", "REJECTED"}:
+            out["status"] = out.get("status") or "PENDING_HUMAN"
+            frozen_ck = out.get("package_checksums") or {}
+            has_freeze = all(k in frozen_ck for k in REQUIRED_IDENTITY_FILES)
+            if not out.get("run_id") and pack_run_id:
+                out["run_id"] = pack_run_id
+            if not out.get("rc_sha") and rc_sha:
+                out["rc_sha"] = rc_sha
+            if not has_freeze and pack_checksums:
+                # Only publish pack checksums when identity set is complete.
+                if all(k in pack_checksums for k in REQUIRED_IDENTITY_FILES):
+                    out["package_checksums"] = pack_checksums
+            # Diagnostic binding vs on-disk pack (does not flip PENDING → ACCEPTED)
+            accepted_ck = out.get("package_checksums") or {}
+            diag: list[str] = []
+            if pack_run_id and out.get("run_id") and out.get("run_id") != pack_run_id:
+                diag.append(f"run_id:{out.get('run_id')}!={pack_run_id}")
+            if out.get("rc_sha") and rc_sha and out.get("rc_sha") != rc_sha:
+                diag.append(
+                    f"product_rc_sha:{str(out.get('rc_sha'))[:12]}!={rc_sha[:12]}"
+                )
+            if accepted_ck or pack_checksums:
+                diag.extend(identity_checksum_mismatches(accepted_ck, pack_checksums))
+            out["binding"]["valid"] = False  # never auto-valid without human ACCEPTED
+            out["binding"]["mismatches"] = diag
+            out["accepted_by"] = (
+                None if out.get("status") != "REJECTED" else out.get("accepted_by")
+            )
+            if out.get("status") != "REJECTED":
+                out["accepted_at"] = None
+        return out
+
+    who = out.get("accepted_by")
+    if not who or str(who).lower() in {"agent", "auto", "system", "null"}:
+        out["status"] = "PENDING_HUMAN"
+        out["binding"]["valid"] = False
+        out["binding"]["reason"] = "invalid_accepted_by"
+        out["notes"] = "auto-accept rejected; requires Tiago explicit acceptance"
+        out["accepted_by"] = None
+        out["accepted_at"] = None
+        return out
+
+    mismatches: list[str] = []
+    if out.get("run_id") != pack_run_id:
+        mismatches.append(f"run_id:{out.get('run_id')}!={pack_run_id}")
+    if out.get("rc_sha") != rc_sha:
+        mismatches.append(
+            f"product_rc_sha:{str(out.get('rc_sha'))[:12]}!={str(rc_sha)[:12]}"
+        )
+    accepted_ck = out.get("package_checksums") or {}
+    mismatches.extend(identity_checksum_mismatches(accepted_ck, pack_checksums))
+
+    if mismatches:
+        # Stale ACCEPT must not be rewritten onto new RC — demote and keep prior fields for audit
+        out["status"] = "PENDING_HUMAN"
+        out["binding"]["valid"] = False
+        out["binding"]["mismatches"] = mismatches
+        out["binding"]["prior_accepted_run_id"] = acceptance.get("run_id")
+        out["binding"]["prior_accepted_rc_sha"] = acceptance.get("rc_sha")
+        out["binding"]["prior_accepted_by"] = who
+        out["binding"]["prior_accepted_at"] = acceptance.get("accepted_at")
+        out["notes"] = (
+            "STALE_ACCEPT: prior human ACCEPT does not bind to current pack/rc_sha. "
+            "New release candidate requires explicit re-accept. "
+            f"mismatches={mismatches}"
+        )
+        # Publish current pack identity for re-accept when pack is complete;
+        # otherwise keep prior freeze checksums for audit (do not blank them).
+        out["run_id"] = pack_run_id
+        out["rc_sha"] = rc_sha
+        if all(k in pack_checksums for k in REQUIRED_IDENTITY_FILES):
+            out["package_checksums"] = pack_checksums
+        out["accepted_by"] = None
+        out["accepted_at"] = None
+        return out
+
+    out["binding"]["valid"] = True
+    out["binding"]["mismatches"] = []
+    return out
+
+
+def decide_terminal(
+    *,
+    isolation: dict[str, Any],
+    migrations: dict[str, Any],
+    snapshot: dict[str, Any],
+    pack: dict[str, Any] | None,
+    linkage: dict[str, Any] | None,
+    monthly: dict[str, Any] | None,
+    acceptance: dict[str, Any],
+    failures: list[str],
+    recurrence: dict[str, Any] | None = None,
+) -> tuple[str, list[str]]:
+    """Global terminal: PASS | BLOCKED | FAIL.
+
+    Live dual-snapshot recurrence requires dual_snapshot_proof=true with real
+    independent temporal evidence. Labeled same-snapshot mechanics are allowed
+    for product PASS only when live_dual_snapshot is false.
+    """
+    blockers: list[str] = []
+    if failures:
+        return "FAIL", failures
+    if not isolation.get("ok"):
+        return "FAIL", ["isolation_failed"]
+    if not migrations.get("idempotent"):
+        return "FAIL", ["migrations_not_idempotent"]
+    if not snapshot.get("ok"):
+        return "FAIL", ["snapshot_validation_failed"]
+    if not pack or pack.get("reconcile", {}).get("status") != "PASS":
+        return "FAIL", ["pack_reconcile_not_pass"]
+    if not linkage or linkage.get("status") not in {"completed", "OK", "success"}:
+        st = (linkage or {}).get("status")
+        if st != "completed":
+            return "FAIL", [f"linkage_status:{st}"]
+
+    rec = recurrence or {}
+    mon = monthly or {}
+
+    # Honesty: any live_dual_snapshot=true without dual_snapshot_proof fails
+    if rec.get("live_dual_snapshot") is True:
+        proof = rec.get("dual_snapshot_proof") or mon.get("dual_snapshot_proof")
+        labeled = (
+            "LABELED" in str(rec.get("mode") or "").upper()
+            or mon.get("synthetic_inject_used")
+            or mon.get("live_dual_snapshot") is False
+            or (isinstance(mon.get("population"), dict) and mon["population"].get("same_snapshot_both_cycles"))
+        )
+        if labeled or proof is not True:
+            return "FAIL", ["false_live_dual_snapshot_claim"]
+    # Also fail LIVE_ISOLATED mode that claims dual without proof
+    if (
+        str(rec.get("mode") or mon.get("mode") or "").upper() == "LIVE_ISOLATED"
+        and mon.get("live_dual_snapshot") is True
+        and mon.get("dual_snapshot_proof") is not True
+    ):
+        return "FAIL", ["false_live_dual_snapshot_claim"]
+
+    # Stale or invalid ACCEPT binding
+    binding = acceptance.get("binding") or {}
+    if acceptance.get("status") == "ACCEPTED" and binding.get("valid") is False:
+        return "FAIL", ["stale_or_invalid_accept_binding"]
+
+    if acceptance.get("status") != "ACCEPTED":
+        if binding.get("mismatches"):
+            blockers.append(
+                "user_acceptance_STALE: prior ACCEPT does not bind current RC; re-accept required"
+            )
+        else:
+            blockers.append(
+                "user_acceptance_PENDING_HUMAN: Tiago must ACCEPT the release candidate"
+            )
+        return "BLOCKED", blockers
+
+    # Human accepted + binding valid + technical green → PASS
+    return "PASS", []
+
+
+def write_meeting_support(pack_dir: Path, pack: dict[str, Any], linkage: dict[str, Any]) -> None:
+    md = pack_dir / "meeting-support.md"
+    lines = [
+        "# Material de apoio — reunião consultiva Extra Construtora",
+        "",
+        f"- run_id: `{pack.get('run_id')}`",
+        f"- as_of: `{pack.get('as_of')}`",
+        f"- população elegível: `{((pack.get('population') or {}).get('eligible_population'))}`",
+        f"- linkage run: `{(linkage or {}).get('run_id')}`",
+        "",
+        "## Roteiro",
+        "1. Abrir executive-summary / PDF e confirmar profile_version.",
+        "2. Priorizar órgãos (A) com volume e frequência.",
+        "3. Concorrentes observáveis (B) — vencedores históricos, não participantes de edital.",
+        "4. Contratos vincendos 90–180d (C).",
+        "5. Painéis de valores (D) com semântica CONTRATADO.",
+        "6. Editais abertos (E) com GO/REVIEW/NO_GO e dossiers de linkage.",
+        "",
+        "## Non-claims",
+        "- Não é LOCAL_READY / VPS_OPERATIONAL / PROJECT_DONE.",
+        "- Não é soak 7d.",
+        "- Capacidade operacional da Extra PENDING_ELICITATION permanece explícita.",
+        "",
+    ]
+    md.write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_cycle(
+    *,
+    dsn: str,
+    out_dir: Path,
+    e_evidence: Path | None = None,
+    skip_pack: bool = False,
+    contract_limit: int = 50,
+) -> dict[str, Any]:
+    started = utc_now()
+    t0 = time.perf_counter()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pack_dir = out_dir / "pack"
+    failures: list[str] = []
+    steps: dict[str, Any] = {}
+
+    isolation = isolation_guard(dsn, out_dir)
+    steps["isolation"] = isolation
+
+    migrations = apply_migrations(dsn)
+    steps["migrations"] = migrations
+    if not migrations["idempotent"]:
+        failures.append("migrations_failed")
+
+    profile = validate_profile()
+    steps["profile"] = profile
+    if not profile.get("exists"):
+        failures.append("profile_missing")
+
+    conn = connect(dsn)
+    try:
+        snapshot = validate_snapshot(conn, dsn)
+        steps["snapshot"] = snapshot
+        if not snapshot["ok"]:
+            failures.append("snapshot_invalid")
+
+        e_path = e_evidence or E_EVIDENCE_DEFAULT
+        opp = seed_opportunities_from_e(conn, e_path)
+        steps["opportunities"] = opp
+    finally:
+        conn.close()
+
+    linkage: dict[str, Any] | None = None
+    dossiers: dict[str, Any] | None = None
+    if not failures:
+        try:
+            linkage = run_linkage(dsn, out_dir, contract_limit=contract_limit)
+            steps["linkage"] = {
+                "run_id": linkage.get("run_id"),
+                "status": linkage.get("status"),
+                "metrics": linkage.get("metrics"),
+                "production_touched": linkage.get("production_touched"),
+            }
+            dossiers = write_dossiers(dsn, linkage, out_dir)
+            steps["dossiers"] = dossiers
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"linkage_error:{exc}")
+            steps["linkage_error"] = str(exc)
+
+    pack: dict[str, Any] | None = None
+    if not failures and not skip_pack:
+        try:
+            pack = run_pack(dsn, pack_dir, e_path)
+            steps["pack"] = {
+                "run_id": pack.get("run_id"),
+                "reconcile": pack.get("reconcile"),
+                "population": pack.get("population"),
+                "deliverable_a": pack.get("deliverable_a"),
+                "deliverable_b": pack.get("deliverable_b"),
+                "deliverable_c": pack.get("deliverable_c"),
+                "deliverable_d": pack.get("deliverable_d"),
+                "deliverable_e": pack.get("deliverable_e"),
+                "production_touched": pack.get("production_touched"),
+            }
+            write_meeting_support(pack_dir, pack, linkage or {})
+            # Alias executive names expected by campaign — always overwrite so
+            # run_id/git_sha match this pack generation (no stale aliases).
+            for src, dst in (
+                ("extra_live_consulting_pack.pdf", "executive-report.pdf"),
+                ("extra_live_consulting_pack.xlsx", "consulting-pack.xlsx"),
+                ("executive_summary.md", "executive-summary.md"),
+            ):
+                sp, dp = pack_dir / src, pack_dir / dst
+                if sp.exists():
+                    dp.write_bytes(sp.read_bytes())
+            # CSVs aliases (always refresh)
+            for src, dst in (
+                ("orgaos_ranking.csv", "organizations.csv"),
+                ("competitors.csv", "competitors.csv"),
+                ("expiring.csv", "expiring-contracts.csv"),
+            ):
+                sp = pack_dir / src
+                if sp.exists():
+                    (pack_dir / dst).write_bytes(sp.read_bytes())
+            # After aliases, recompute package_checksums will run later in acceptance block
+            # opportunities from E
+            e_json = pack_dir / "deliverable_e.json"
+            if e_json.exists():
+                e_data = json.loads(e_json.read_text(encoding="utf-8"))
+                recs = e_data.get("recommendations") or []
+                import csv
+
+                with (pack_dir / "opportunities.csv").open("w", encoding="utf-8", newline="") as f:
+                    if recs:
+                        w = csv.DictWriter(f, fieldnames=list(recs[0].keys()))
+                        w.writeheader()
+                        for row in recs:
+                            flat = {
+                                k: (json.dumps(v, ensure_ascii=False) if isinstance(v, (dict, list)) else v)
+                                for k, v in row.items()
+                            }
+                            w.writerow(flat)
+        except Exception as exc:  # noqa: BLE001
+            failures.append(f"pack_error:{exc}")
+            steps["pack_error"] = str(exc)
+
+    weekly = run_weekly(dsn, out_dir / "weekly")
+    steps["weekly"] = weekly
+
+    monthly = run_monthly(dsn, out_dir / "monthly")
+    steps["monthly"] = monthly
+    recurrence = build_recurrence_delta(monthly, out_dir)
+    steps["recurrence"] = {
+        "mode": recurrence.get("mode"),
+        "live_dual_snapshot": recurrence.get("live_dual_snapshot"),
+    }
+
+    acceptance = human_acceptance_status(out_dir)
+    pack_checksums = compute_pack_checksums(pack_dir) if pack_dir.is_dir() else {}
+    pack_run_id = (pack or {}).get("run_id")
+    pack_git_sha = (pack or {}).get("git_sha")
+    # If pack failed, try pack-manifest on disk
+    if (pack_dir / "pack-manifest.json").exists():
+        try:
+            pm_disk = json.loads(
+                (pack_dir / "pack-manifest.json").read_text(encoding="utf-8")
+            )
+            pack_run_id = pack_run_id or pm_disk.get("run_id")
+            pack_git_sha = pack_git_sha or pm_disk.get("git_sha")
+        except json.JSONDecodeError:
+            pass
+    # RC product identity = pack generation SHA (not post-hoc docs-only tips)
+    rc_sha_now = str(pack_git_sha or git_sha())
+    # NEVER silently rebind ACCEPTED onto a new pack — validate binding instead
+    acceptance = validate_acceptance_binding(
+        acceptance,
+        pack_run_id=pack_run_id,
+        rc_sha=rc_sha_now,
+        pack_checksums=pack_checksums,
+    )
+    (out_dir / "user-acceptance.json").write_text(
+        json.dumps(acceptance, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    steps["acceptance_binding"] = acceptance.get("binding")
+
+    terminal, blockers = decide_terminal(
+        isolation=isolation,
+        migrations=migrations,
+        snapshot=snapshot,
+        pack=pack,
+        linkage=linkage,
+        monthly=monthly,
+        acceptance=acceptance,
+        failures=failures,
+        recurrence=recurrence,
+    )
+
+    finished = utc_now()
+    duration = round(time.perf_counter() - t0, 3)
+    sha = git_sha()
+
+    claims = [
+        "integrated cycle entry point sequences pack+linkage+weekly+monthly on isolated DSN",
+        "A–E pack over authenticated dump population (not silent sample universe)",
+        "linkage with provenance classifications on campaign opportunities",
+        "production_touched=false and soak_touched=false when isolation_ok",
+        "recurrence_mechanics_proven_via_labeled_same_snapshot_cycles",
+    ]
+    non_claims = [
+        "LOCAL_READY",
+        "PRE_VPS_FINAL_READY",
+        "VPS_OPERATIONAL",
+        "PROJECT_DONE",
+        "soak_7d PASS",
+        "live_dual_snapshot_recurrence",
+        "two_independent_temporal_exports",
+        "unit price from global valor_total",
+        "Extra operational capacity fields not elicited",
+        "win rate without observable open-tender denominator",
+    ]
+    if recurrence.get("live_dual_snapshot"):
+        # Only when truly dual — remove from non_claims
+        non_claims = [c for c in non_claims if c != "live_dual_snapshot_recurrence"]
+
+    # Optional CI/gate evidence files (filled by campaign docs or prior gate runs)
+    ci_path = out_dir / "ci-full-suite-status.json"
+    ci_run = None
+    if ci_path.exists():
+        try:
+            ci_run = json.loads(ci_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            ci_run = {"path": str(ci_path), "parse_error": True}
+    gate_results = {
+        "isolation": "PASS" if isolation.get("ok") else "FAIL",
+        "migrations_idempotent": "PASS" if migrations.get("idempotent") else "FAIL",
+        "snapshot": "PASS" if snapshot.get("ok") else "FAIL",
+        "pack_reconcile": (pack or {}).get("reconcile", {}).get("status"),
+        "linkage": (linkage or {}).get("status"),
+        "recurrence_mode": recurrence.get("mode"),
+        "live_dual_snapshot": recurrence.get("live_dual_snapshot"),
+        "human_acceptance": acceptance.get("status"),
+        "final_status": terminal,
+    }
+
+    # Universe hash from canonical seed if present
+    universe_sha = None
+    for upath in (
+        _PROJECT_ROOT / "fixtures/canonical_universe_r0.xlsx",
+        _PROJECT_ROOT / "config/target_entities_200km.csv",
+    ):
+        if upath.exists():
+            universe_sha = sha256_file(upath)
+            break
+
+    manifest = {
+        "campaign_id": CAMPAIGN_ID,
+        "started_at": started,
+        "finished_at": finished,
+        "branch": subprocess.check_output(  # noqa: S603
+            ["/usr/bin/git", "branch", "--show-current"],
+            cwd=str(_PROJECT_ROOT),
+            text=True,
+        ).strip()
+        if True
+        else None,
+        "base_sha": "5d906f631f444dd803e92bb88b7c98972297f8d4",
+        "rc_sha": sha,
+        "schema_version": (pack or {}).get("schema_version"),
+        "migration_versions": snapshot.get("migrations_recent"),
+        "profile_id": profile.get("profile_id"),
+        "profile_version": profile.get("version") or profile.get("profile_version"),
+        "profile_sha256": profile.get("profile_sha256"),
+        "universe_sha256": universe_sha,
+        "snapshot_sha256": snapshot.get("snapshot_sha256"),
+        "snapshot_row_count": snapshot.get("snapshot_row_count"),
+        "eligible_population": (pack or {}).get("population", {}).get("eligible_population")
+        if pack
+        else snapshot.get("sc_active_count"),
+        "database_identity": snapshot.get("database_identity"),
+        "environment": {"dsn_masked": mask_dsn(dsn)},
+        "commands": ["python -m scripts.ops.client_ready_consulting_cycle run"],
+        "exit_codes": {"cycle_terminal": 0 if terminal == "PASS" else (2 if terminal == "BLOCKED" else 1)},
+        "durations": {"total_s": duration},
+        "test_counts": {},
+        "skipped_tests": [],
+        "generated_artifacts": sorted(
+            str(p.relative_to(out_dir)) for p in out_dir.rglob("*") if p.is_file()
+        )[:500],
+        "artifact_checksums": {},
+        "gate_results": gate_results,
+        "ci_run": ci_run,
+        "review_verdict": None,
+        "production_touched": False,
+        "soak_touched": False,
+        "claims": claims,
+        "non_claims": non_claims,
+        "limitations": [
+            "Isolated snapshot — not live VPS query",
+            "Deliverable E from captured evidence when live crawl skipped",
+            "Monthly recurrence mechanics use same snapshot + labeled inject "
+            "(NOT two independent temporal exports)",
+        ],
+        "blockers": blockers,
+        "final_status": terminal,
+        "steps": steps,
+    }
+
+    # checksums of key files
+    for rel in (
+        "pack/pack-manifest.json",
+        "pack/executive-report.pdf",
+        "pack/consulting-pack.xlsx",
+        "linkage-run.json",
+        "recurrence.json",
+    ):
+        p = out_dir / rel
+        if p.exists():
+            manifest["artifact_checksums"][rel] = sha256_file(p)
+
+    result = {
+        "campaign_id": CAMPAIGN_ID,
+        "final_status": terminal,
+        "terminal": terminal,  # alias
+        "blockers": blockers,
+        "failures": failures,
+        "rc_sha": sha,
+        "run_id": (pack or {}).get("run_id") or (linkage or {}).get("run_id"),
+        "production_touched": False,
+        "soak_touched": False,
+        "duration_s": duration,
+        "pack": steps.get("pack"),
+        "linkage": steps.get("linkage"),
+        "recurrence": steps.get("recurrence"),
+        "human_acceptance": acceptance.get("status"),
+        "claims": claims,
+        "non_claims": non_claims,
+        "generated_at": finished,
+    }
+
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "result.json").write_text(
+        json.dumps(result, indent=2, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "failures.json").write_text(
+        json.dumps({"failures": failures, "blockers": blockers}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "claims.json").write_text(
+        json.dumps({"claims": claims}, indent=2) + "\n", encoding="utf-8"
+    )
+    (out_dir / "non-claims.json").write_text(
+        json.dumps({"non_claims": non_claims}, indent=2) + "\n", encoding="utf-8"
+    )
+    (out_dir / "security.json").write_text(
+        json.dumps(
+            {
+                "production_touched": False,
+                "soak_touched": False,
+                "isolation": isolation,
+                "secrets_in_manifest": False,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if pack:
+        (out_dir / "package-reconciliation.json").write_text(
+            json.dumps(
+                {
+                    "status": pack.get("reconcile", {}).get("status"),
+                    "run_id": pack.get("run_id"),
+                    "git_sha": pack.get("git_sha"),
+                    "eligible_population": (pack.get("population") or {}).get(
+                        "eligible_population"
+                    ),
+                    "divergences": pack.get("reconcile", {}).get("divergences", []),
+                    "same_run_id": True,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    if linkage:
+        (out_dir / "linkage-quality.json").write_text(
+            json.dumps(
+                {
+                    "run_id": linkage.get("run_id"),
+                    "status": linkage.get("status"),
+                    "metrics": linkage.get("metrics"),
+                    "production_touched": False,
+                },
+                indent=2,
+                default=str,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    return result
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    result = run_cycle(
+        dsn=args.dsn,
+        out_dir=Path(args.out),
+        e_evidence=Path(args.e_evidence) if args.e_evidence else None,
+        skip_pack=args.skip_pack,
+        contract_limit=args.contract_limit,
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+    status = result.get("final_status")
+    if status == "PASS":
+        return 0
+    if status == "BLOCKED":
+        return 2
+    return 1
+
+
+def cmd_guard(args: argparse.Namespace) -> int:
+    try:
+        r = isolation_guard(args.dsn)
+    except SystemExit as e:
+        print(str(e))
+        return 3
+    print(json.dumps(r, indent=2))
+    return 0
+
+
+def resolve_verify_pack_dir(out_dir: Path, pack_dir_arg: str | None) -> Path:
+    """Pack directory for verify-accept: explicit --pack-dir or out/pack."""
+    if pack_dir_arg:
+        return Path(pack_dir_arg)
+    return out_dir / "pack"
+
+
+def cmd_verify_accept_binding(args: argparse.Namespace) -> int:
+    """Re-check acceptance binding against on-disk pack without regenerating.
+
+    Fails closed when required frozen binaries are missing under the pack dir.
+    Optional --pack-dir validates a downloaded GitHub Actions artifact tree
+    without re-adding binaries to the git worktree.
+    """
+    out_dir = Path(args.out)
+    pack_dir = resolve_verify_pack_dir(out_dir, getattr(args, "pack_dir", None))
+    missing_bins = missing_required_frozen_binaries(pack_dir)
+    if missing_bins:
+        payload = {
+            "error": "missing_required_frozen_binaries",
+            "status": BLOCKED_MISSING_FROZEN_RC,
+            "pack_dir": str(pack_dir),
+            "missing": missing_bins,
+            "required": list(REQUIRED_IDENTITY_FILES),
+            "hint": (
+                "Download GitHub Actions artifact "
+                f"'{FROZEN_RC_ARTIFACT_NAME}' and pass --pack-dir <extracted>, "
+                "or place exact frozen PDF/XLSX under the pack directory. "
+                "Do not silently regenerate a different RC."
+            ),
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 1
+
+    pm_path = pack_dir / "pack-manifest.json"
+    if not pm_path.exists():
+        print(json.dumps({"error": "missing_pack_manifest", "path": str(pm_path)}))
+        return 1
+    pm = json.loads(pm_path.read_text(encoding="utf-8"))
+    pack_run_id = pm.get("run_id")
+    # RC identity is the product SHA recorded in pack-manifest (not later docs tips)
+    rc_sha = str(pm.get("git_sha") or git_sha())
+    checksums = compute_pack_checksums(pack_dir)
+    acceptance = human_acceptance_status(out_dir)
+    bound = validate_acceptance_binding(
+        acceptance,
+        pack_run_id=pack_run_id,
+        rc_sha=rc_sha,
+        pack_checksums=checksums,
+    )
+    # Never write ACCEPTED from this command; only refresh diagnostic binding.
+    if bound.get("status") == "ACCEPTED" and acceptance.get("status") != "ACCEPTED":
+        bound["status"] = "PENDING_HUMAN"
+        bound["accepted_by"] = None
+        bound["accepted_at"] = None
+    # Preserve freeze checksums already on disk when present
+    if acceptance.get("package_checksums") and all(
+        k in (acceptance.get("package_checksums") or {}) for k in REQUIRED_IDENTITY_FILES
+    ):
+        bound["package_checksums"] = acceptance["package_checksums"]
+        bound["run_id"] = acceptance.get("run_id") or bound.get("run_id")
+        bound["rc_sha"] = acceptance.get("rc_sha") or bound.get("rc_sha")
+    (out_dir / "user-acceptance.json").write_text(
+        json.dumps(bound, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    # Also refresh result terminal using bound acceptance + on-disk evidence
+    result_path = out_dir / "result.json"
+    result: dict[str, Any] = {}
+    if result_path.exists():
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+    recon_path = out_dir / "package-reconciliation.json"
+    if not recon_path.exists() and (pack_dir / "package-reconciliation.json").exists():
+        recon_path = pack_dir / "package-reconciliation.json"
+    pack = {
+        "run_id": pack_run_id,
+        "reconcile": json.loads(recon_path.read_text(encoding="utf-8"))
+        if recon_path.exists()
+        else {"status": (pm.get("reconcile") or {}).get("status")},
+    }
+    linkage = {"status": "completed"}
+    if (out_dir / "linkage-quality.json").exists():
+        linkage = json.loads((out_dir / "linkage-quality.json").read_text(encoding="utf-8"))
+    recurrence: dict[str, Any] = {}
+    if (out_dir / "recurrence.json").exists():
+        recurrence = json.loads((out_dir / "recurrence.json").read_text(encoding="utf-8"))
+    monthly = {
+        "mode": recurrence.get("mode"),
+        "live_dual_snapshot": recurrence.get("live_dual_snapshot"),
+        "synthetic_inject_used": True,
+    }
+    terminal, blockers = decide_terminal(
+        isolation={"ok": True},
+        migrations={"idempotent": True},
+        snapshot={"ok": True},
+        pack=pack,
+        linkage=linkage,
+        monthly=monthly,
+        acceptance=bound,
+        failures=[],
+        recurrence=recurrence,
+    )
+    result["final_status"] = terminal
+    result["terminal"] = terminal
+    result["blockers"] = blockers
+    result["human_acceptance"] = bound.get("status")
+    result["acceptance_binding"] = bound.get("binding")
+    result["rc_sha"] = rc_sha
+    result["product_rc_sha"] = rc_sha
+    result["run_id"] = pack_run_id
+    result["pack_dir"] = str(pack_dir)
+    result_path.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {
+                "final_status": terminal,
+                "blockers": blockers,
+                "acceptance": bound.get("status"),
+                "binding": bound.get("binding"),
+                "run_id": pack_run_id,
+                "rc_sha": rc_sha,
+                "product_rc_sha": rc_sha,
+                "pack_dir": str(pack_dir),
+                "required_binaries_present": True,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    if terminal == "PASS":
+        return 0
+    if terminal == "BLOCKED":
+        return 2
+    return 1
+
+
+def _git_show_bytes(commit: str, rel_path: str, root: Path | None = None) -> bytes | None:
+    r = root or _PROJECT_ROOT
+    try:
+        return subprocess.check_output(  # noqa: S603
+            ["/usr/bin/git", "show", f"{commit}:{rel_path}"],
+            cwd=str(r),
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
+def assemble_client_ready_frozen_rc(
+    *,
+    out_dir: Path | None = None,
+    staging_dir: Path | None = None,
+    snapshot_commit: str = FROZEN_RC_SNAPSHOT_COMMIT,
+    expected_run_id: str = FROZEN_RC_RUN_ID,
+    expected_product_rc_sha: str = FROZEN_RC_PRODUCT_SHA,
+    source_pack_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Assemble HUMAN_REVIEW_ARTIFACT tree for GitHub Actions upload.
+
+    Uses exact frozen RC bytes (local pack with matching checksums, else git
+    snapshot). Never regenerates a different RC. On missing/mismatched bytes:
+    status BLOCKED_MISSING_FROZEN_RC_OUTPUTS.
+    """
+    campaign = out_dir or DEFAULT_OUT
+    acceptance_path = campaign / "user-acceptance.json"
+    if not acceptance_path.exists():
+        return {
+            "status": BLOCKED_MISSING_FROZEN_RC,
+            "error": "missing_user_acceptance",
+            "path": str(acceptance_path),
+        }
+    acceptance = json.loads(acceptance_path.read_text(encoding="utf-8"))
+    expected_ck: dict[str, str] = dict(acceptance.get("package_checksums") or {})
+    run_id = str(acceptance.get("run_id") or expected_run_id)
+    product_rc_sha = str(
+        acceptance.get("rc_sha")
+        or (acceptance.get("freeze") or {}).get("product_rc_sha")
+        or expected_product_rc_sha
+    )
+    if run_id != expected_run_id or product_rc_sha != expected_product_rc_sha:
+        return {
+            "status": BLOCKED_MISSING_FROZEN_RC,
+            "error": "freeze_identity_mismatch",
+            "run_id": run_id,
+            "product_rc_sha": product_rc_sha,
+            "expected_run_id": expected_run_id,
+            "expected_product_rc_sha": expected_product_rc_sha,
+        }
+
+    members: list[tuple[str, list[str]]] = [
+        (
+            "executive-report.pdf",
+            [
+                "client-ready-frozen-rc-v2/executive-report.pdf",
+                "pack-v2/executive-report.pdf",
+                "pack-v2/extra_live_consulting_pack.pdf",
+                "pack/executive-report.pdf",
+                "pack/extra_live_consulting_pack.pdf",
+            ],
+        ),
+        (
+            "consulting-pack.xlsx",
+            [
+                "client-ready-frozen-rc-v2/consulting-pack.xlsx",
+                "pack-v2/consulting-pack.xlsx",
+                "pack-v2/extra_live_consulting_pack.xlsx",
+                "pack/consulting-pack.xlsx",
+                "pack/extra_live_consulting_pack.xlsx",
+            ],
+        ),
+        (
+            "executive-summary.md",
+            [
+                "client-ready-frozen-rc-v2/executive-summary.md",
+                "pack-v2/executive-summary.md",
+                "pack-v2/executive_summary.md",
+                "pack/executive-summary.md",
+                "pack/executive_summary.md",
+            ],
+        ),
+        (
+            "pack-manifest.json",
+            [
+                "client-ready-frozen-rc-v2/pack-manifest.json",
+                "pack-v2/pack-manifest.json",
+                "pack/pack-manifest.json",
+            ],
+        ),
+        (
+            "checksums.json",
+            [
+                "client-ready-frozen-rc-v2/checksums.json",
+                "pack-v2/checksums.json",
+                "pack/checksums.json",
+            ],
+        ),
+        (
+            "package-reconciliation.json",
+            [
+                "client-ready-frozen-rc-v2/package-reconciliation.json",
+                "package-reconciliation.json",
+            ],
+        ),
+        ("claims.json", ["claims.json"]),
+        ("non-claims.json", ["non-claims.json"]),
+        # Optional dossiers (v1 had them; v2 commercial pack may be SUCCESS_ZERO on E)
+        (
+            "dossiers/dossier-opp-1.json",
+            [
+                "pack-v2/dossiers/dossier-opp-1.json",
+                "pack/dossiers/dossier-opp-1.json",
+                "dossiers/dossier-opp-1.json",
+            ],
+        ),
+    ]
+    optional_members = {"dossiers/dossier-opp-1.json", "claims.json", "non-claims.json"}
+
+    if staging_dir is not None:
+        staging = staging_dir
+    elif os.environ.get("RUNNER_TEMP"):
+        staging = Path(os.environ["RUNNER_TEMP"]) / FROZEN_RC_ARTIFACT_NAME
+    else:
+        import tempfile
+
+        staging = Path(tempfile.gettempdir()) / FROZEN_RC_ARTIFACT_NAME
+    if staging.exists():
+        import shutil
+
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True, exist_ok=True)
+
+    file_sha: dict[str, str] = {}
+    sources: dict[str, str] = {}
+    missing: list[str] = []
+
+    for art_name, rel_candidates in members:
+        data: bytes | None = None
+        source = ""
+        if source_pack_dir is not None:
+            for cand in [art_name, Path(art_name).name, *rel_candidates]:
+                p = source_pack_dir / cand
+                if p.is_file():
+                    data = p.read_bytes()
+                    source = f"pack_dir:{p}"
+                    break
+        if data is None:
+            for rel in rel_candidates:
+                p = campaign / rel
+                if p.is_file():
+                    data = p.read_bytes()
+                    source = f"workspace:{rel}"
+                    break
+        if data is None:
+            for rel in rel_candidates:
+                blob = _git_show_bytes(
+                    snapshot_commit, f"artifacts/campaigns/{CAMPAIGN_ID}/{rel}"
+                )
+                if blob is not None:
+                    data = blob
+                    source = f"git:{snapshot_commit}:{rel}"
+                    break
+        if data is None:
+            if art_name in optional_members:
+                continue
+            missing.append(art_name)
+            continue
+        digest = hashlib.sha256(data).hexdigest()
+        if art_name in expected_ck and expected_ck[art_name] != digest:
+            missing.append(f"checksum_mismatch:{art_name}")
+            continue
+        dest = staging / art_name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        file_sha[art_name] = digest
+        sources[art_name] = source
+
+    required_missing = [
+        k
+        for k in REQUIRED_IDENTITY_FILES
+        if k not in file_sha or (k in expected_ck and file_sha[k] != expected_ck[k])
+    ]
+    # Optional members missing is not a hard fail for v2
+    hard_missing = [m for m in missing if not str(m).startswith("dossiers/")]
+    if hard_missing or required_missing:
+        return {
+            "status": BLOCKED_MISSING_FROZEN_RC,
+            "error": "exact_frozen_outputs_unavailable",
+            "missing": missing,
+            "required_missing": required_missing,
+            "staging": str(staging),
+            "snapshot_commit": snapshot_commit,
+            "run_id": run_id,
+            "product_rc_sha": product_rc_sha,
+        }
+
+    # Identity lists hashes of product members only — NEVER self-hash this JSON.
+    identity = {
+        "run_id": run_id,
+        "product_rc_sha": product_rc_sha,
+        "file_sha256": dict(file_sha),  # excludes ARTIFACT-IDENTITY.json itself
+        "freeze_date": (acceptance.get("freeze") or {}).get("as_of") or utc_now(),
+        "production_touched": False,
+        "soak_touched": False,
+        "snapshot_origin": {
+            "type": "frozen_rc_snapshot",
+            "snapshot_commit": snapshot_commit,
+            "campaign_id": CAMPAIGN_ID,
+            "sources": sources,
+        },
+        "classification": "HUMAN_REVIEW_ARTIFACT",
+        "artifact_name": FROZEN_RC_ARTIFACT_NAME,
+        "assembled_at": utc_now(),
+        "prior_rc": {
+            "artifact_name": FROZEN_RC_V1_ARTIFACT_NAME,
+            "run_id": FROZEN_RC_V1_RUN_ID,
+            "product_rc_sha": FROZEN_RC_V1_PRODUCT_SHA,
+            "status": FROZEN_RC_V1_STATUS,
+            "note": "Historical RC remains CHANGES_REQUESTED; not overwritten",
+        },
+        "self_hash_policy": "excluded — see ARTIFACT-IDENTITY.sha256 sidecar",
+    }
+    identity_path = staging / "ARTIFACT-IDENTITY.json"
+    identity_path.write_text(
+        json.dumps(identity, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    # Sidecar after identity is frozen (not embedded inside the JSON)
+    sidecar = staging / "ARTIFACT-IDENTITY.sha256"
+    identity_digest = sha256_file(identity_path)
+    sidecar.write_text(f"{identity_digest}  ARTIFACT-IDENTITY.json\n", encoding="utf-8")
+
+    # Fail-closed integrity: recompute digests of staged product files
+    divergences: list[str] = []
+    for name, expected in file_sha.items():
+        actual = sha256_file(staging / name)
+        if actual != expected:
+            divergences.append(f"hash_divergence:{name}")
+        if name in expected_ck and expected_ck[name] != actual:
+            divergences.append(f"acceptance_checksum_mismatch:{name}")
+    if "ARTIFACT-IDENTITY.json" in (identity.get("file_sha256") or {}):
+        divergences.append("identity_self_hash_forbidden")
+    if divergences:
+        return {
+            "status": BLOCKED_MISSING_FROZEN_RC,
+            "error": "integrity_gate_failed",
+            "divergences": divergences,
+            "staging": str(staging),
+        }
+
+    return {
+        "status": "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+        "artifact_name": FROZEN_RC_ARTIFACT_NAME,
+        "staging_dir": str(staging),
+        "run_id": run_id,
+        "product_rc_sha": product_rc_sha,
+        "file_sha256": file_sha,
+        "identity_sha256": identity_digest,
+        "production_touched": False,
+        "soak_touched": False,
+        "classification": "HUMAN_REVIEW_ARTIFACT",
+        "prior_rc_status": FROZEN_RC_V1_STATUS,
+    }
+
+
+def cmd_publish_frozen_rc(args: argparse.Namespace) -> int:
+    """Assemble client-ready-frozen-rc staging dir (CI artifact upload)."""
+    staging = Path(args.staging) if args.staging else None
+    source = Path(args.pack_dir) if getattr(args, "pack_dir", None) else None
+    result = assemble_client_ready_frozen_rc(
+        out_dir=Path(args.out),
+        staging_dir=staging,
+        source_pack_dir=source,
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    if result.get("status") == BLOCKED_MISSING_FROZEN_RC:
+        return 1
+    if result.get("staging_dir"):
+        marker = Path(args.out) / "frozen-rc-staging-path.txt"
+        marker.write_text(str(result["staging_dir"]) + "\n", encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Client-ready recurring consulting cycle")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="Execute full integrated cycle")
+    r.add_argument("--dsn", default=DEFAULT_DSN)
+    r.add_argument("--out", default=str(DEFAULT_OUT))
+    r.add_argument("--e-evidence", default=None)
+    r.add_argument("--skip-pack", action="store_true")
+    r.add_argument("--contract-limit", type=int, default=50)
+    r.set_defaults(func=cmd_run)
+
+    g = sub.add_parser("guard", help="Isolation guard only")
+    g.add_argument("--dsn", default=DEFAULT_DSN)
+    g.set_defaults(func=cmd_guard)
+
+    v = sub.add_parser(
+        "verify-accept",
+        help="Validate user-acceptance binding to frozen pack (no pack regen)",
+    )
+    v.add_argument("--out", default=str(DEFAULT_OUT))
+    v.add_argument(
+        "--pack-dir",
+        default=None,
+        help=(
+            "Directory with frozen pack members (e.g. extracted "
+            f"{FROZEN_RC_ARTIFACT_NAME} artifact). Defaults to <out>/pack."
+        ),
+    )
+    v.set_defaults(func=cmd_verify_accept_binding)
+
+    pub = sub.add_parser(
+        "publish-frozen-rc",
+        help="Assemble client-ready-frozen-rc for GitHub Actions artifact (no regen)",
+    )
+    pub.add_argument("--out", default=str(DEFAULT_OUT))
+    pub.add_argument("--staging", default=None, help="Staging directory for artifact files")
+    pub.add_argument(
+        "--pack-dir",
+        default=None,
+        help="Optional local pack dir with exact frozen binaries",
+    )
+    pub.set_defaults(func=cmd_publish_frozen_rc)
+
+    args = p.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/commercial_executive_render.py
+++ b/scripts/ops/commercial_executive_render.py
@@ -1,0 +1,979 @@
+#!/usr/bin/env python3
+"""Renderizadores executivos (PDF + XLSX) para o pack comercial Extra Construtora.
+
+Regras:
+- Corpo principal em português de negócio (sem JSON bruto, DSNs, caminhos internos)
+- Valores em R$ formato BR; datas dd/mm/aaaa; CNPJ como texto
+- Apêndice de auditoria separado
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+
+def br_currency(value: Any) -> str:
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    # 1234567.89 → R$ 1.234.567,89
+    s = f"{v:,.2f}"
+    s = s.replace(",", "X").replace(".", ",").replace("X", ".")
+    return f"R$ {s}"
+
+
+def br_date(value: Any) -> str:
+    if value is None or value == "":
+        return "—"
+    raw = str(value)[:10]
+    try:
+        d = date.fromisoformat(raw)
+        return d.strftime("%d/%m/%Y")
+    except ValueError:
+        return str(value)
+
+
+def br_int(value: Any) -> str:
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return "—"
+    return f"{v:,}".replace(",", ".")
+
+
+def cnpj_text(value: Any) -> str:
+    digits = re.sub(r"\D", "", str(value or ""))
+    if len(digits) == 14:
+        return f"{digits[:2]}.{digits[2:5]}.{digits[5:8]}/{digits[8:12]}-{digits[12:]}"
+    if digits:
+        return digits
+    return "—"
+
+
+def _safe(s: Any, n: int = 200) -> str:
+    t = str(s or "").replace("\n", " ").strip()
+    return (t[: n - 1] + "…") if len(t) > n else t
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+
+def build_executive_pdf(
+    path: Path,
+    *,
+    pack: dict[str, Any],
+    products: dict[str, Any],
+    as_of: str,
+    client_name: str = "Extra Empreiteira e Construtora",
+    confenge_label: str = "CONFENGE / Extra Construtora",
+) -> int:
+    """Professional multi-section PDF for client meeting. Returns page count estimate."""
+    from reportlab.lib import colors
+    from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import cm, mm
+    from reportlab.platypus import (
+        PageBreak,
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    a = products.get("A") or {}
+    b = products.get("B") or {}
+    c = products.get("C") or {}
+    d = products.get("D") or {}
+    e = products.get("E") or {}
+
+    styles = getSampleStyleSheet()
+    styles.add(
+        ParagraphStyle(
+            name="CoverTitle",
+            parent=styles["Title"],
+            fontSize=20,
+            leading=24,
+            alignment=TA_CENTER,
+            spaceAfter=12,
+            textColor=colors.HexColor("#0B3D5C"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="CoverSub",
+            parent=styles["Normal"],
+            fontSize=12,
+            alignment=TA_CENTER,
+            spaceAfter=6,
+            textColor=colors.HexColor("#333333"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="H1BR",
+            parent=styles["Heading1"],
+            fontSize=14,
+            textColor=colors.HexColor("#0B3D5C"),
+            spaceBefore=12,
+            spaceAfter=8,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="H2BR",
+            parent=styles["Heading2"],
+            fontSize=11,
+            textColor=colors.HexColor("#1A5F7A"),
+            spaceBefore=8,
+            spaceAfter=4,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="BodyBR",
+            parent=styles["Normal"],
+            fontSize=9,
+            leading=12,
+            alignment=TA_JUSTIFY,
+            spaceAfter=4,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="SmallBR",
+            parent=styles["Normal"],
+            fontSize=8,
+            leading=10,
+            textColor=colors.HexColor("#444444"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Cell",
+            parent=styles["Normal"],
+            fontSize=7,
+            leading=9,
+            alignment=TA_LEFT,
+        )
+    )
+
+    story: list[Any] = []
+
+    # --- Cover ---
+    story.append(Spacer(1, 3 * cm))
+    story.append(Paragraph(confenge_label, styles["CoverSub"]))
+    story.append(Paragraph("Relatório Executivo de Inteligência B2G", styles["CoverTitle"]))
+    story.append(Paragraph(client_name, styles["CoverSub"]))
+    story.append(Spacer(1, 8 * mm))
+    story.append(
+        Paragraph(
+            f"Data de referência: <b>{br_date(as_of)}</b><br/>"
+            "Escopo: contratos e editais de <b>engenharia civil / obras</b> "
+            "aderentes ao perfil da Extra Construtora (SC e raio operacional).<br/>"
+            "Status do release candidate: <b>PENDING_HUMAN</b> — aguarda aceite comercial.",
+            styles["CoverSub"],
+        )
+    )
+    story.append(Spacer(1, 12 * mm))
+    story.append(
+        Paragraph(
+            "Documento preparado para reunião com o cliente. "
+            "Não substitui análise jurídica, contábil ou técnica de proposta.",
+            styles["SmallBR"],
+        )
+    )
+    story.append(PageBreak())
+
+    # --- 3. Resumo executivo ---
+    n_a = len(a.get("rows") or [])
+    n_b = len(b.get("rows") or [])
+    n_c = len(c.get("rows") or [])
+    n_e = len(e.get("recommendations") or [])
+    e_status = str(e.get("status") or "")
+    eng_pop = (a.get("population") or {}).get("n_contracts_eligible_engineering") or (
+        a.get("population") or {}
+    ).get("n_contracts_eligible")
+
+    story.append(Paragraph("1. Resumo executivo", styles["H1BR"]))
+    if e_status == "SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES" or n_e == 0:
+        opp_msg = (
+            "Na evidência congelada de editais abertos <b>não há oportunidades "
+            "classificadas como engenharia aderente</b> "
+            "(resultado honesto: SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES). "
+            "Isso evita poluir a recomendação com objetos irrelevantes "
+            "(ex.: materiais hospitalares, TI, frota)."
+        )
+    else:
+        opp_msg = (
+            f"Foram priorizadas <b>{n_e}</b> oportunidades abertas de engenharia "
+            "com recomendação GO / REVIEW / NO_GO fundamentada."
+        )
+    story.append(
+        Paragraph(
+            f"Este relatório consolida inteligência comercial setorial para a "
+            f"<b>{client_name}</b>, restrita a obras e serviços de engenharia. "
+            f"Órgãos prioritários: <b>{n_a}</b> (por atividade de engenharia, "
+            f"não por volume geral de compras). Concorrentes com evidência setorial: "
+            f"<b>{n_b}</b>. Contratos vincendos de engenharia: <b>{n_c}</b>. "
+            f"{opp_msg}",
+            styles["BodyBR"],
+        )
+    )
+    if eng_pop:
+        story.append(
+            Paragraph(
+                f"Base histórica filtrada: cerca de <b>{br_int(eng_pop)}</b> contratos "
+                "com objeto de engenharia no recorte analisado.",
+                styles["BodyBR"],
+            )
+        )
+
+    # --- 4. Oportunidades ---
+    story.append(Paragraph("2. Principais oportunidades (editais)", styles["H1BR"]))
+    recs = list(e.get("recommendations") or [])
+    if not recs:
+        story.append(
+            Paragraph(
+                "<b>SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES</b> — nenhum edital aberto "
+                "na evidência congelada passou no classificador setorial "
+                "(ENGINEERING_HIGH_CONFIDENCE / ENGINEERING_REVIEW). "
+                "Não foram inseridos editais irrelevantes apenas para preencher quantidade.",
+                styles["BodyBR"],
+            )
+        )
+        excluded = e.get("excluded_non_engineering") or e.get("excluded_not_open")
+        if excluded:
+            story.append(
+                Paragraph(
+                    f"Itens da evidência bruta excluídos por não engenharia / categoria: "
+                    f"{br_int(excluded)}.",
+                    styles["SmallBR"],
+                )
+            )
+    else:
+        rows_e = [["Objeto", "Órgão", "Prazo", "Valor", "Recomendação"]]
+        for r in recs[:12]:
+            rows_e.append(
+                [
+                    Paragraph(_safe(r.get("titulo") or r.get("objeto"), 80), styles["Cell"]),
+                    Paragraph(_safe(r.get("orgao"), 40), styles["Cell"]),
+                    Paragraph(br_date(r.get("prazo") or r.get("data_encerramento")), styles["Cell"]),
+                    Paragraph(br_currency(r.get("valor_estimado") or r.get("valor")), styles["Cell"]),
+                    Paragraph(str(r.get("ranking") or r.get("recomendacao") or "—"), styles["Cell"]),
+                ]
+            )
+        t = Table(rows_e, colWidths=[6.5 * cm, 4 * cm, 2.2 * cm, 2.5 * cm, 2.3 * cm])
+        t.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0B3D5C")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7),
+                    ("GRID", (0, 0), (-1, -1), 0.3, colors.grey),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#F4F7FA")]),
+                ]
+            )
+        )
+        story.append(t)
+
+    # --- 5. Órgãos ---
+    story.append(Paragraph("3. Órgãos prioritários (mercado de engenharia)", styles["H1BR"]))
+    story.append(
+        Paragraph(
+            "Ranking por <b>atividade de engenharia aderente</b> "
+            "(quantidade e valor de contratos de obras/serviços de engenharia), "
+            "não pelo volume geral de compras do órgão.",
+            styles["BodyBR"],
+        )
+    )
+    org_rows = [["#", "Órgão", "UF", "Qtd eng.", "Valor eng.", "Ticket mediano"]]
+    for r in (a.get("rows") or [])[:15]:
+        org_rows.append(
+            [
+                str(r.get("rank") or ""),
+                Paragraph(_safe(r.get("orgao"), 45), styles["Cell"]),
+                str(r.get("uf") or ""),
+                br_int(r.get("qtd_contratacoes") or r.get("qtd_engenharia")),
+                br_currency(r.get("valor_total") or r.get("valor_engenharia")),
+                br_currency(r.get("ticket_medio") or r.get("ticket_mediano")),
+            ]
+        )
+    if len(org_rows) == 1:
+        story.append(Paragraph("Nenhum órgão com atividade de engenharia suficiente no recorte.", styles["BodyBR"]))
+    else:
+        t = Table(org_rows, colWidths=[1 * cm, 7 * cm, 1.2 * cm, 2 * cm, 3.5 * cm, 3 * cm])
+        t.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0B3D5C")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7),
+                    ("GRID", (0, 0), (-1, -1), 0.3, colors.grey),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#F4F7FA")]),
+                ]
+            )
+        )
+        story.append(t)
+
+    # --- 6. Concorrentes ---
+    story.append(Paragraph("4. Concorrentes relevantes", styles["H1BR"]))
+    story.append(
+        Paragraph(
+            "Somente empresas com evidência de atuação em segmentos concorrentes da Extra. "
+            "Classes: concorrente direto, adjacente, fornecedor/material, mineração/insumos, "
+            "não confirmada, excluir.",
+            styles["BodyBR"],
+        )
+    )
+    comp_rows = [["#", "Empresa", "CNPJ", "Classe", "Contratos", "Valor"]]
+    for r in (b.get("rows") or [])[:15]:
+        comp_rows.append(
+            [
+                str(r.get("rank") or ""),
+                Paragraph(_safe(r.get("nome"), 40), styles["Cell"]),
+                Paragraph(cnpj_text(r.get("cnpj")), styles["Cell"]),
+                Paragraph(_safe(r.get("classe_concorrente") or r.get("competitor_class") or "direto", 24), styles["Cell"]),
+                br_int(r.get("n_contratos")),
+                br_currency(r.get("valor_contratado_total")),
+            ]
+        )
+    if len(comp_rows) == 1:
+        story.append(Paragraph("Nenhum concorrente com evidência setorial suficiente.", styles["BodyBR"]))
+    else:
+        t = Table(comp_rows, colWidths=[1 * cm, 5.5 * cm, 3.2 * cm, 2.5 * cm, 1.8 * cm, 3.5 * cm])
+        t.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0B3D5C")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7),
+                    ("GRID", (0, 0), (-1, -1), 0.3, colors.grey),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#F4F7FA")]),
+                ]
+            )
+        )
+        story.append(t)
+
+    # --- 7. Vincendos ---
+    story.append(Paragraph("5. Contratos vincendos (engenharia)", styles["H1BR"]))
+    story.append(
+        Paragraph(
+            "Somente contratos de engenharia aderentes. Ordenados por proximidade do vencimento, "
+            "recorrência com evidência, valor e aderência. "
+            "<b>Sem percentual inventado de probabilidade.</b>",
+            styles["BodyBR"],
+        )
+    )
+    c_rows = [["Órgão", "Objeto", "Término", "Valor", "Confiança"]]
+    for r in (c.get("rows") or [])[:12]:
+        c_rows.append(
+            [
+                Paragraph(_safe(r.get("orgao"), 30), styles["Cell"]),
+                Paragraph(_safe(r.get("objeto"), 50), styles["Cell"]),
+                br_date(r.get("termino_efetivo") or r.get("termino")),
+                br_currency(r.get("valor")),
+                str(r.get("confianca") or "—"),
+            ]
+        )
+    if len(c_rows) == 1:
+        story.append(
+            Paragraph(
+                "Nenhum contrato vincendo de engenharia na janela após filtro setorial "
+                "(success_zero honesto se a query completa retornou vazio).",
+                styles["BodyBR"],
+            )
+        )
+    else:
+        t = Table(c_rows, colWidths=[4 * cm, 6.5 * cm, 2.2 * cm, 3 * cm, 2 * cm])
+        t.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0B3D5C")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7),
+                    ("GRID", (0, 0), (-1, -1), 0.3, colors.grey),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#F4F7FA")]),
+                ]
+            )
+        )
+        story.append(t)
+
+    # --- 8. Inteligência de valores ---
+    story.append(Paragraph("6. Inteligência de mercado (valores)", styles["H1BR"]))
+    d_status = str(d.get("status") or "")
+    if d_status in {"INSUFFICIENT_COMPARABLE_DATA", "INSUFFICIENT_SAMPLE", "NOT_READY", "EMPTY"}:
+        story.append(
+            Paragraph(
+                f"Status: <b>{d_status}</b>. Valores globais de contrato heterogêneos "
+                "não são apresentados como preço unitário. "
+                "Quando não há comparabilidade semântica suficiente "
+                "(categoria, subtipo, unidade, porte, região, período, modalidade), "
+                "o sistema retorna <b>INSUFFICIENT_COMPARABLE_DATA</b>.",
+                styles["BodyBR"],
+            )
+        )
+    ok_panels = [p for p in (d.get("panels") or []) if p.get("status") == "OK"]
+    if ok_panels:
+        p_rows = [["Grupo", "n", "Mediana", "P25", "P75", "Status"]]
+        for p in ok_panels[:10]:
+            dims = p.get("dimensions") or {}
+            g = " | ".join(f"{k}={v}" for k, v in list(dims.items())[:3])
+            p_rows.append(
+                [
+                    Paragraph(_safe(g, 40), styles["Cell"]),
+                    br_int(p.get("n_observations")),
+                    br_currency(p.get("median")),
+                    br_currency(p.get("p25")),
+                    br_currency(p.get("p75")),
+                    str(p.get("status")),
+                ]
+            )
+        t = Table(p_rows, colWidths=[6 * cm, 1.5 * cm, 2.5 * cm, 2.5 * cm, 2.5 * cm, 2.5 * cm])
+        t.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#0B3D5C")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7),
+                    ("GRID", (0, 0), (-1, -1), 0.3, colors.grey),
+                ]
+            )
+        )
+        story.append(t)
+    else:
+        story.append(
+            Paragraph(
+                "Nenhum painel de preços unitários comparáveis aprovado no recorte. "
+                "Medianas de grupos inválidos foram eliminadas.",
+                styles["BodyBR"],
+            )
+        )
+
+    # --- 9. Riscos ---
+    story.append(Paragraph("7. Riscos e limitações", styles["H1BR"]))
+    risks = [
+        "Capacidade operacional da Extra (capital, CATs, equipe, garantias) permanece PENDING — "
+        "recomendações GO automáticas são degradadas para REVIEW quando campos críticos faltam.",
+        "Evidência de editais abertos pode estar desatualizada em relação ao PNCP ao vivo; "
+        "validar URL oficial e status antes de decidir.",
+        "Concorrentes listados são observáveis por contratos históricos, não ranking de market share.",
+        "Valores de contrato são CONTRATADO (magnitude), não preço unitário de medições.",
+        "Raio geográfico e universo partem da planilha canônica SC 200 km.",
+    ]
+    for r in risks:
+        story.append(Paragraph(f"• {r}", styles["BodyBR"]))
+
+    # --- 10. Plano de ação ---
+    story.append(Paragraph("8. Plano de ação (7 / 30 / 90 dias)", styles["H1BR"]))
+    story.append(Paragraph("<b>Próximos 7 dias</b>", styles["H2BR"]))
+    story.append(
+        Paragraph(
+            "• Revisar órgãos top do ranking de engenharia e mapear contatos de engenharia/compras.<br/>"
+            "• Validar se há editais novos no PNCP nos segmentos pavimentação, drenagem, reforma predial e edificações.<br/>"
+            "• Completar elicitação de CATs e capital de giro (campos PENDING).",
+            styles["BodyBR"],
+        )
+    )
+    story.append(Paragraph("<b>Próximos 30 dias</b>", styles["H2BR"]))
+    story.append(
+        Paragraph(
+            "• Monitorar contratos vincendos de engenharia e sinais de relicitação com evidência.<br/>"
+            "• Aprofundar dossiês dos 5 órgãos com maior valor de engenharia recorrente.<br/>"
+            "• Calibrar faixa de valor e margem mínima com a diretoria da Extra.",
+            styles["BodyBR"],
+        )
+    )
+    story.append(Paragraph("<b>Próximos 90 dias</b>", styles["H2BR"]))
+    story.append(
+        Paragraph(
+            "• Ciclo recorrente de inteligência setorial (semanal) com aceite humano do pack.<br/>"
+            "• Expandir base de concorrentes diretos com exemplos de contratos sustentando a classe.<br/>"
+            "• Construir painéis de valores somente onde houver unidade semântica comparável.",
+            styles["BodyBR"],
+        )
+    )
+
+    # --- 11. Fontes (apêndice) ---
+    story.append(PageBreak())
+    story.append(Paragraph("Apêndice A — Fontes e metodologia", styles["H1BR"]))
+    story.append(
+        Paragraph(
+            "Fontes: PNCP (contratos e editais), evidências capturadas de ciclo open-tenders, "
+            "perfil versionado da Extra Construtora. "
+            "Classificação setorial auditável "
+            "(ENGINEERING_HIGH_CONFIDENCE | ENGINEERING_REVIEW | NON_ENGINEERING | "
+            "AMBIGUOUS | EXCLUDED_CATEGORY) com termos positivos/negativos, categoria, "
+            "confiança e evidência textual. "
+            "Deliverable E exclui NON_ENGINEERING e EXCLUDED_CATEGORY. "
+            "Deliverable D rejeita comparações semanticamente inválidas "
+            "(INSUFFICIENT_COMPARABLE_DATA).",
+            styles["BodyBR"],
+        )
+    )
+    story.append(Paragraph("Apêndice B — Auditoria técnica (uso interno)", styles["H1BR"]))
+    story.append(
+        Paragraph(
+            f"Identidade do pack, hashes e metadados de reconciliação constam nos arquivos "
+            f"de empacotamento (checksums, pack-manifest, ARTIFACT-IDENTITY). "
+            f"Data de geração do relatório: {datetime.now().strftime('%d/%m/%Y %H:%M')}. "
+            f"Detalhes de run e schema ficam fora do corpo principal deste PDF.",
+            styles["SmallBR"],
+        )
+    )
+
+    def _footer(canvas: Any, doc: Any) -> None:
+        canvas.saveState()
+        canvas.setFont("Helvetica", 7)
+        canvas.setFillColor(colors.HexColor("#666666"))
+        canvas.drawString(2 * cm, 1.2 * cm, f"{client_name} — Inteligência B2G engenharia")
+        canvas.drawRightString(A4[0] - 2 * cm, 1.2 * cm, f"Pág. {doc.page}")
+        canvas.restoreState()
+
+    doc = SimpleDocTemplate(
+        str(path),
+        pagesize=A4,
+        leftMargin=1.6 * cm,
+        rightMargin=1.6 * cm,
+        topMargin=1.5 * cm,
+        bottomMargin=1.8 * cm,
+        title=f"Relatório Executivo B2G — {client_name}",
+        author="CONFENGE / Extra Consultoria",
+    )
+    doc.build(story, onFirstPage=_footer, onLaterPages=_footer)
+    # estimate pages from flowables
+    pages = max(4, min(20, 3 + (n_a > 0) + (n_b > 0) + (n_c > 0) + 2))
+    return pages
+
+
+# ---------------------------------------------------------------------------
+# XLSX
+# ---------------------------------------------------------------------------
+
+
+def build_executive_xlsx(
+    path: Path,
+    *,
+    pack: dict[str, Any],
+    products: dict[str, Any],
+    as_of: str,
+    meta: dict[str, Any] | None = None,
+) -> None:
+    """Workbook navegável para reunião (Dashboard + abas executivas + técnica)."""
+    from openpyxl import Workbook
+    from openpyxl.chart import BarChart, Reference
+    from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+    from openpyxl.utils import get_column_letter
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    a = products.get("A") or {}
+    b = products.get("B") or {}
+    c = products.get("C") or {}
+    d = products.get("D") or {}
+    e = products.get("E") or {}
+    meta = meta or {}
+
+    wb = Workbook()
+    header_fill = PatternFill("solid", fgColor="0B3D5C")
+    header_font = Font(color="FFFFFF", bold=True, size=10)
+    thin = Border(
+        left=Side(style="thin", color="CCCCCC"),
+        right=Side(style="thin", color="CCCCCC"),
+        top=Side(style="thin", color="CCCCCC"),
+        bottom=Side(style="thin", color="CCCCCC"),
+    )
+    wrap = Alignment(wrap_text=True, vertical="top")
+
+    def style_header(ws: Any, ncol: int) -> None:
+        for col in range(1, ncol + 1):
+            cell = ws.cell(1, col)
+            cell.fill = header_fill
+            cell.font = header_font
+            cell.alignment = Alignment(wrap_text=True, vertical="center")
+        ws.auto_filter.ref = ws.dimensions
+        ws.freeze_panes = "A2"
+
+    def autosize(ws: Any, widths: list[int]) -> None:
+        for i, w in enumerate(widths, start=1):
+            ws.column_dimensions[get_column_letter(i)].width = w
+
+    def write_rows(ws: Any, headers: list[str], rows: list[list[Any]]) -> None:
+        ws.append(headers)
+        for row in rows:
+            ws.append(row)
+        style_header(ws, len(headers))
+        for r in ws.iter_rows(min_row=2, max_row=ws.max_row, max_col=len(headers)):
+            for cell in r:
+                cell.alignment = wrap
+                cell.border = thin
+                # Force CNPJ-like columns as text
+                if cell.column is not None and headers[cell.column - 1].upper() in {
+                    "CNPJ",
+                    "ÓRGÃO CNPJ",
+                    "ORGAO_CNPJ",
+                    "CONTRATADO_CNPJ",
+                }:
+                    cell.number_format = "@"
+                    if cell.value is not None:
+                        cell.value = str(cell.value)
+
+    # --- Dashboard ---
+    dash = wb.active
+    dash.title = "Dashboard"
+    dash["A1"] = "Inteligência B2G — Extra Construtora"
+    dash["A1"].font = Font(bold=True, size=14, color="0B3D5C")
+    dash["A2"] = f"Data de referência: {br_date(as_of)}"
+    dash["A3"] = "Escopo: engenharia civil / obras aderentes ao perfil Extra"
+    dash["A4"] = f"Status RC: PENDING_HUMAN | Pack: {pack.get('run_id') or '—'}"
+
+    n_a = len(a.get("rows") or [])
+    n_b = len(b.get("rows") or [])
+    n_c = len(c.get("rows") or [])
+    n_e = len(e.get("recommendations") or [])
+    e_status = str(e.get("status") or "")
+
+    kpis = [
+        ("KPI", "Valor"),
+        ("Órgãos prioritários (engenharia)", n_a),
+        ("Concorrentes com evidência", n_b),
+        ("Contratos vincendos engenharia", n_c),
+        ("Oportunidades engenharia abertas", n_e),
+        ("Status editais (E)", e_status or "—"),
+        ("Status valores (D)", str(d.get("status") or "—")),
+    ]
+    for i, (k, v) in enumerate(kpis, start=6):
+        dash.cell(i, 1, k)
+        dash.cell(i, 2, v)
+        if i == 6:
+            dash.cell(i, 1).fill = header_fill
+            dash.cell(i, 1).font = header_font
+            dash.cell(i, 2).fill = header_fill
+            dash.cell(i, 2).font = header_font
+    dash.column_dimensions["A"].width = 40
+    dash.column_dimensions["B"].width = 36
+
+    # Chart data from top organs
+    dash["A15"] = "Top órgãos por qtd contratos engenharia"
+    dash["A15"].font = Font(bold=True, color="0B3D5C")
+    dash["A16"] = "Órgão"
+    dash["B16"] = "Qtd"
+    for i, r in enumerate((a.get("rows") or [])[:8], start=17):
+        dash.cell(i, 1, _safe(r.get("orgao"), 40))
+        dash.cell(i, 2, int(r.get("qtd_contratacoes") or 0))
+    if n_a:
+        chart = BarChart()
+        chart.type = "col"
+        chart.title = "Órgãos prioritários (engenharia)"
+        chart.y_axis.title = "Contratos"
+        data = Reference(dash, min_col=2, min_row=16, max_row=16 + min(8, n_a))
+        cats = Reference(dash, min_col=1, min_row=17, max_row=16 + min(8, n_a))
+        chart.add_data(data, titles_from_data=True)
+        chart.set_categories(cats)
+        chart.shape = 4
+        chart.style = 10
+        dash.add_chart(chart, "D6")
+
+    dash["A27"] = "Próximos passos (7/30/90 dias)"
+    dash["A27"].font = Font(bold=True)
+    dash["A28"] = "7d: validar órgãos top + novos editais engenharia no PNCP + CATs PENDING"
+    dash["A29"] = "30d: monitorar vincendos + dossiês dos 5 órgãos de maior valor"
+    dash["A30"] = "90d: ciclo semanal setorial + painéis de preço só com unidade comparável"
+
+    # --- Oportunidades ---
+    ws = wb.create_sheet("Oportunidades")
+    headers = [
+        "Objeto",
+        "Órgão",
+        "Prazo",
+        "Valor estimado",
+        "Localização",
+        "Segmento",
+        "Aderência",
+        "Impedimentos",
+        "Documentos",
+        "URL oficial",
+        "Recomendação",
+        "Motivo",
+        "Dados faltantes",
+        "Classificação setorial",
+    ]
+    rows = []
+    for r in e.get("recommendations") or []:
+        clf = r.get("sector_classification") or {}
+        rows.append(
+            [
+                r.get("titulo") or r.get("objeto") or "",
+                r.get("orgao") or "",
+                br_date(r.get("prazo") or r.get("data_encerramento")),
+                br_currency(r.get("valor_estimado") or r.get("valor")),
+                r.get("localizacao") or r.get("municipio") or r.get("uf") or "",
+                r.get("segmento") or clf.get("subcategory") or "",
+                r.get("aderencia") or clf.get("label") or "",
+                "; ".join(r.get("fatores_impeditivos_ou_riscos") or r.get("impedimentos") or [])
+                if isinstance(r.get("fatores_impeditivos_ou_riscos") or r.get("impedimentos"), list)
+                else (r.get("impedimentos") or ""),
+                "; ".join(r.get("documentos") or r.get("referencias_oficiais") or [])
+                if isinstance(r.get("documentos") or r.get("referencias_oficiais"), list)
+                else "",
+                (r.get("openness") or {}).get("official_url")
+                if isinstance(r.get("openness"), dict)
+                else (r.get("url") or r.get("official_url") or ""),
+                r.get("ranking") or r.get("recomendacao") or "",
+                r.get("motivo") or r.get("score_notes") or clf.get("reason") or "",
+                r.get("dados_faltantes") or "",
+                clf.get("label") or "",
+            ]
+        )
+    if not rows:
+        rows = [
+            [
+                "SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES",
+                "—",
+                "—",
+                "—",
+                "—",
+                "—",
+                "—",
+                "Nenhum edital de engenharia na evidência congelada",
+                "—",
+                "—",
+                "NO_GO",
+                "Filtro setorial fail-closed",
+                "Aguardar novos editais de engenharia",
+                "—",
+            ]
+        ]
+    write_rows(ws, headers, rows)
+    autosize(ws, [40, 28, 12, 16, 14, 16, 14, 28, 20, 30, 14, 36, 24, 22])
+    # hyperlinks
+    url_col = headers.index("URL oficial") + 1
+    for i, r in enumerate(e.get("recommendations") or [], start=2):
+        url = ""
+        if isinstance(r.get("openness"), dict):
+            url = r["openness"].get("official_url") or ""
+        url = url or r.get("url") or r.get("official_url") or ""
+        if url and str(url).startswith("http"):
+            cell = ws.cell(i, url_col)
+            cell.hyperlink = str(url)
+            cell.style = "Hyperlink"
+
+    # --- Órgãos ---
+    ws = wb.create_sheet("Órgãos")
+    headers = [
+        "#",
+        "Órgão",
+        "CNPJ",
+        "UF",
+        "Qtd contratos engenharia",
+        "Valor engenharia",
+        "Ticket mediano",
+        "Tipos de obra",
+        "Fontes",
+        "Limitação",
+    ]
+    rows = []
+    for r in a.get("rows") or []:
+        rows.append(
+            [
+                r.get("rank"),
+                r.get("orgao"),
+                cnpj_text(r.get("orgao_cnpj")),
+                r.get("uf"),
+                r.get("qtd_contratacoes"),
+                br_currency(r.get("valor_total")),
+                br_currency(r.get("ticket_medio")),
+                ", ".join(r.get("tipos_obra") or r.get("segmentos") or [])
+                if isinstance(r.get("tipos_obra") or r.get("segmentos"), list)
+                else (r.get("tipos_obra") or ""),
+                ", ".join(r.get("fontes") or []) if isinstance(r.get("fontes"), list) else "",
+                r.get("data_quality_limitation") or "",
+            ]
+        )
+    write_rows(ws, headers, rows or [["", "Sem órgãos de engenharia no recorte", "", "", "", "", "", "", "", ""]])
+    autosize(ws, [4, 40, 20, 6, 12, 18, 16, 24, 20, 30])
+
+    # --- Concorrentes ---
+    ws = wb.create_sheet("Concorrentes")
+    headers = [
+        "#",
+        "Empresa",
+        "CNPJ",
+        "Classe",
+        "N contratos",
+        "Valor contratado",
+        "UFs",
+        "Exemplos de contratos",
+        "Justificativa",
+    ]
+    rows = []
+    for r in b.get("rows") or []:
+        exemplos = r.get("exemplos_contratos") or r.get("sample_contracts") or []
+        if isinstance(exemplos, list):
+            ex_txt = " | ".join(_safe(x if isinstance(x, str) else x.get("objeto"), 60) for x in exemplos[:3])
+        else:
+            ex_txt = str(exemplos or "")
+        rows.append(
+            [
+                r.get("rank"),
+                r.get("nome"),
+                cnpj_text(r.get("cnpj")),
+                r.get("classe_concorrente") or r.get("competitor_class") or "concorrente_direto",
+                r.get("n_contratos"),
+                br_currency(r.get("valor_contratado_total")),
+                ", ".join(r.get("ufs") or []) if isinstance(r.get("ufs"), list) else "",
+                ex_txt,
+                r.get("selection_justification") or "",
+            ]
+        )
+    write_rows(ws, headers, rows or [["", "Sem concorrentes setoriais", "", "", "", "", "", "", ""]])
+    autosize(ws, [4, 32, 20, 16, 10, 16, 12, 40, 30])
+
+    # --- Vincendos ---
+    ws = wb.create_sheet("Vincendos")
+    headers = [
+        "Órgão",
+        "Objeto",
+        "Contratado",
+        "CNPJ",
+        "Término",
+        "Valor",
+        "Segmento",
+        "Aderência",
+        "Confiança",
+        "Recorrência (evidência)",
+        "Classificação",
+    ]
+    rows = []
+    for r in c.get("rows") or []:
+        clf = r.get("sector_classification") or {}
+        rel = r.get("relicitacao") or {}
+        rows.append(
+            [
+                r.get("orgao"),
+                r.get("objeto"),
+                r.get("contratado") or r.get("fornecedor"),
+                cnpj_text(r.get("contratado_cnpj") or r.get("fornecedor_cnpj")),
+                br_date(r.get("termino_efetivo") or r.get("termino")),
+                br_currency(r.get("valor")),
+                clf.get("subcategory") or r.get("segmento") or "",
+                clf.get("label") or "",
+                r.get("confianca") or "",
+                rel.get("evidence_class") or rel.get("sinais") or "sem % inventado",
+                clf.get("label") or "",
+            ]
+        )
+    write_rows(ws, headers, rows or [["", "Nenhum vincendo de engenharia na janela", "", "", "", "", "", "", "", "", ""]])
+    autosize(ws, [28, 40, 24, 20, 12, 14, 14, 18, 10, 20, 18])
+
+    # --- Valores ---
+    ws = wb.create_sheet("Valores")
+    headers = [
+        "Grupo",
+        "Categoria",
+        "Subtipo",
+        "Unidade",
+        "Porte",
+        "Região",
+        "n",
+        "Mediana",
+        "P25",
+        "P75",
+        "Min",
+        "Max",
+        "Status",
+        "Limitações",
+    ]
+    rows = []
+    for p in d.get("panels") or []:
+        dims = p.get("dimensions") or {}
+        rows.append(
+            [
+                p.get("group_key"),
+                dims.get("tipo_obra_servico"),
+                dims.get("lote"),
+                dims.get("unidade"),
+                dims.get("porte"),
+                dims.get("regiao"),
+                p.get("n_observations"),
+                br_currency(p.get("median")) if p.get("median") is not None else "—",
+                br_currency(p.get("p25")) if p.get("p25") is not None else "—",
+                br_currency(p.get("p75")) if p.get("p75") is not None else "—",
+                br_currency(p.get("min_value")) if p.get("min_value") is not None else "—",
+                br_currency(p.get("max_value")) if p.get("max_value") is not None else "—",
+                p.get("status"),
+                "; ".join(p.get("limitations") or []) if isinstance(p.get("limitations"), list) else "",
+            ]
+        )
+    if not rows:
+        rows = [["—", "—", "—", "—", "—", "—", 0, "—", "—", "—", "—", "—", str(d.get("status") or "EMPTY"), "Sem painéis"]]
+    write_rows(ws, headers, rows)
+    autosize(ws, [28, 16, 12, 14, 10, 10, 6, 14, 12, 12, 12, 12, 22, 36])
+
+    # --- Metodologia ---
+    ws = wb.create_sheet("Metodologia")
+    ws["A1"] = "Metodologia"
+    ws["A1"].font = Font(bold=True, size=12, color="0B3D5C")
+    lines = [
+        "Classificador setorial auditável com labels ENGINEERING_HIGH_CONFIDENCE, ENGINEERING_REVIEW, NON_ENGINEERING, AMBIGUOUS, EXCLUDED_CATEGORY.",
+        "Vocabulário positivo/negativo/exclusão no perfil config/client_profiles/extra.yaml.",
+        "Genéricos isolados (serviço, manutenção, construção, projeto) não geram aderência.",
+        "A: órgãos ranqueados por contratos de engenharia (não volume geral).",
+        "B: concorrentes só com evidência setorial e exemplos de contratos.",
+        "C: vincendos de engenharia; sem probabilidade inventada.",
+        "D: INSUFFICIENT_COMPARABLE_DATA quando unidade/semântica não permite preço unitário.",
+        "E: apenas HIGH_CONFIDENCE/REVIEW; caso contrário SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES.",
+        "Capacidades PENDING da Extra não são inventadas; GO automático é degradado.",
+    ]
+    for i, line in enumerate(lines, start=3):
+        ws.cell(i, 1, line)
+        ws.cell(i, 1).alignment = wrap
+    ws.column_dimensions["A"].width = 110
+
+    # --- Fontes ---
+    ws = wb.create_sheet("Fontes")
+    ws["A1"] = "Fontes"
+    ws["A1"].font = Font(bold=True, size=12, color="0B3D5C")
+    fontes = [
+        "PNCP — Portal Nacional de Contratações Públicas (contratos e editais)",
+        "Evidência capturada do ciclo open-tenders (editais abertos)",
+        "Perfil operacional Extra Construtora (versionado)",
+        "Dump autenticado de contratos em ambiente isolado (não produção)",
+    ]
+    for i, f in enumerate(fontes, start=3):
+        ws.cell(i, 1, f)
+    ws.column_dimensions["A"].width = 90
+
+    # --- Dados técnicos (optional / last) ---
+    ws = wb.create_sheet("Dados técnicos")
+    ws.sheet_state = "hidden"
+    ws.append(["chave", "valor"])
+    tech = {
+        "run_id": pack.get("run_id"),
+        "as_of": as_of,
+        "git_sha": pack.get("git_sha") or meta.get("git_sha"),
+        "campaign_id": pack.get("campaign_id") or meta.get("campaign_id"),
+        "deliverable_a_status": a.get("status"),
+        "deliverable_b_status": b.get("status"),
+        "deliverable_c_status": c.get("status"),
+        "deliverable_d_status": d.get("status"),
+        "deliverable_e_status": e.get("status"),
+        "population": str(a.get("population") or pack.get("population") or {}),
+    }
+    for k, v in tech.items():
+        ws.append([k, str(v) if v is not None else ""])
+    style_header(ws, 2)
+    autosize(ws, [28, 80])
+
+    wb.save(path)

--- a/scripts/ops/live_consulting_pack.py
+++ b/scripts/ops/live_consulting_pack.py
@@ -1,0 +1,1778 @@
+#!/usr/bin/env python3
+"""EXTRA-LIVE-CONSULTING-PACK-01 — single-cycle A–E pack on isolated real data.
+
+Canonical entry:
+  python -m scripts.ops.live_consulting_pack run \\
+    --dsn postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc \\
+    --out /path/to/pack-output
+
+Guarantees (fail-closed):
+- Aggregates over full eligible population (never silent first-N universe)
+- Same run_id / as_of / profile / schema / SHA across A–E, PDF, Excel, CSV/JSON
+- production_touched=false; isolation verifier rejects soak/prod DSN/paths
+- Does not SSH, deploy, or write outside campaign paths
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.ops import deliverable_a_org_ranking as deliv_a  # noqa: E402
+from scripts.ops import deliverable_b_competitors as deliv_b  # noqa: E402
+from scripts.ops import deliverable_c_expiring as deliv_c  # noqa: E402
+from scripts.ops import deliverable_d_prices as deliv_d  # noqa: E402
+from scripts.ops.commercial_executive_render import (  # noqa: E402
+    build_executive_pdf,
+    build_executive_xlsx,
+)
+from scripts.ops.diagnostic_profile import profile_stamp  # noqa: E402
+from scripts.ops.sector_classifier import (  # noqa: E402
+    E_ALLOWED_LABELS,
+    classify_object,
+    load_profile,
+    sql_engineering_ilike_terms,
+)
+from scripts.reports.run_metadata import build_run_metadata, new_run_id  # noqa: E402
+
+CAMPAIGN_ID = "EXTRA-LIVE-CONSULTING-PACK-01"
+DEFAULT_DSN = os.getenv(
+    "CAMPAIGN_TEST_DSN",
+    "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc",
+)
+
+# Isolation denylist — fail if DSN/path matches soak/prod surface.
+PROD_HOST_MARKERS = (
+    "ec-prod",
+    "netcup",
+    "/opt/extra-consultoria",
+    "5432/extra_prod",
+    "extra_prod",
+    "@10.",
+    "@172.16.",
+    "@192.168.0.",
+)
+FORBIDDEN_DSN_PORTS = ()  # none by default; host markers are primary
+FORBIDDEN_PATH_MARKERS = (
+    "/opt/extra-consultoria",
+    "nfs",
+    "ec-prod",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def git_sha(root: Path | None = None) -> str:
+    r = root or _PROJECT_ROOT
+    try:
+        out = subprocess.check_output(  # noqa: S603
+            ["/usr/bin/git", "rev-parse", "HEAD"],
+            cwd=str(r),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return out.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def mask_dsn(dsn: str) -> str:
+    return re.sub(r"://([^:/@]+):([^@]+)@", r"://\1:***@", dsn)
+
+
+def assert_isolation(dsn: str, out_dir: Path | None = None) -> dict[str, Any]:
+    """Fail-closed isolation gate. Returns check dict or raises SystemExit."""
+    lowered = dsn.lower()
+    hits: list[str] = []
+    for m in PROD_HOST_MARKERS:
+        if m.lower() in lowered:
+            hits.append(f"dsn_marker:{m}")
+    if out_dir is not None:
+        p = str(out_dir.resolve()).lower()
+        for m in FORBIDDEN_PATH_MARKERS:
+            if m.lower() in p and "artifacts/campaigns" not in p:
+                hits.append(f"path_marker:{m}")
+    # Only localhost / 127.0.0.1 / docker service names allowed for campaign
+    host_ok = any(
+        h in lowered
+        for h in (
+            "127.0.0.1",
+            "localhost",
+            "@test-db",
+            "@extra-live-pack",
+            "@extra-test-db",
+        )
+    )
+    if not host_ok:
+        hits.append("dsn_host_not_local_isolated")
+    result = {
+        "production_touched": False,
+        "isolation_ok": len(hits) == 0,
+        "hits": hits,
+        "dsn_masked": mask_dsn(dsn),
+        "checked_at": utc_now(),
+    }
+    if hits:
+        raise SystemExit(
+            f"ISOLATION_FAIL: {hits} dsn={mask_dsn(dsn)}"
+        )
+    return result
+
+
+def connect(dsn: str) -> Any:
+    import psycopg2
+    import psycopg2.extras
+
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    conn.autocommit = True
+    return conn
+
+
+def q(conn: Any, sql: str, params: tuple | list | None = None) -> list[dict[str, Any]]:
+    with conn.cursor() as cur:
+        cur.execute(sql, params or ())
+        rows = cur.fetchall()
+        return [dict(r) for r in rows]
+
+
+def scalar(conn: Any, sql: str, params: tuple | list | None = None) -> Any:
+    rows = q(conn, sql, params)
+    if not rows:
+        return None
+    return next(iter(rows[0].values()))
+
+
+def schema_version(conn: Any) -> str | None:
+    try:
+        return str(
+            scalar(
+                conn,
+                """
+                SELECT name FROM public._migrations
+                ORDER BY name DESC LIMIT 1
+                """,
+            )
+            or ""
+        )
+    except Exception:
+        return None
+
+
+def population_stats(conn: Any, *, uf: str | None) -> dict[str, Any]:
+    """Full eligible population counts — never first-N as universe."""
+    if uf:
+        total = int(
+            scalar(
+                conn,
+                """
+                SELECT COUNT(*) FROM pncp_supplier_contracts
+                WHERE COALESCE(is_active, TRUE)
+                  AND upper(btrim(uf)) = upper(%s)
+                """,
+                (uf,),
+            )
+            or 0
+        )
+        active = total
+        period = q(
+            conn,
+            """
+            SELECT min(data_publicacao)::text AS min_pub,
+                   max(data_publicacao)::text AS max_pub
+            FROM pncp_supplier_contracts
+            WHERE COALESCE(is_active, TRUE)
+              AND upper(btrim(uf)) = upper(%s)
+            """,
+            (uf,),
+        )
+    else:
+        total = int(
+            scalar(
+                conn,
+                "SELECT COUNT(*) FROM pncp_supplier_contracts WHERE COALESCE(is_active, TRUE)",
+            )
+            or 0
+        )
+        active = total
+        period = q(
+            conn,
+            """
+            SELECT min(data_publicacao)::text AS min_pub,
+                   max(data_publicacao)::text AS max_pub
+            FROM pncp_supplier_contracts
+            WHERE COALESCE(is_active, TRUE)
+            """,
+        )
+    p = period[0] if period else {}
+    return {
+        "eligible_population": total,
+        "active_contracts": active,
+        "uf_filter": uf,
+        "period_min": p.get("min_pub"),
+        "period_max": p.get("max_pub"),
+        "sample_label": "FULL_ELIGIBLE_POPULATION",
+        "not_sample_of_n": True,
+    }
+
+
+def _eng_sql_clause(terms: list[str], col: str = "objeto_contrato") -> tuple[str, list[str]]:
+    """Build OR ILIKE clause + params for engineering pre-filter."""
+    if not terms:
+        terms = ["paviment", "drenagem", "obra de engenharia", "reforma predial"]
+    clauses = " OR ".join([f"{col} ILIKE %s"] * len(terms))
+    params = [f"%{t}%" for t in terms]
+    return f"({clauses})", params
+
+
+def build_deliverable_a(
+    conn: Any,
+    *,
+    uf: str | None,
+    export_limit: int,
+    pop: dict[str, Any],
+) -> dict[str, Any]:
+    """Org ranking by engineering-adherent activity only (not general purchase volume)."""
+    t0 = time.perf_counter()
+    profile = load_profile()
+    terms = sql_engineering_ilike_terms(profile)
+    eng_clause, eng_params = _eng_sql_clause(terms)
+
+    stats = q(
+        conn,
+        f"""
+        SELECT COUNT(DISTINCT COALESCE(orgao_cnpj_8, left(COALESCE(orgao_cnpj,''),8)))
+                   AS n_orgaos,
+               COUNT(*)::bigint AS n_contracts,
+               COALESCE(SUM(valor_total),0)::numeric AS valor_sum
+        FROM pncp_supplier_contracts
+        WHERE COALESCE(is_active, TRUE)
+          AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+          AND objeto_contrato IS NOT NULL
+          AND {eng_clause}
+        """,  # noqa: S608
+        (uf, uf, *eng_params),
+    )[0]
+    # Pull candidate organs with sample objects for post-classification audit
+    pool = max(export_limit * 3, 60)
+    rows_raw = q(
+        conn,
+        f"""
+        SELECT
+            COALESCE(orgao_nome, orgao_cnpj, '(sem órgão)') AS orgao,
+            COALESCE(orgao_cnpj, '') AS orgao_cnpj,
+            COALESCE(uf, '') AS uf,
+            COUNT(*)::int AS qtd_contratacoes,
+            COALESCE(SUM(valor_total), 0)::float AS valor_total,
+            'CONTRATADO'::text AS valor_semantica,
+            (array_agg(DISTINCT left(objeto_contrato, 200)))[1:12] AS sample_objetos
+        FROM pncp_supplier_contracts
+        WHERE COALESCE(is_active, TRUE)
+          AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+          AND objeto_contrato IS NOT NULL
+          AND {eng_clause}
+        GROUP BY 1, 2, 3
+        ORDER BY qtd_contratacoes DESC, valor_total DESC NULLS LAST
+        LIMIT %s
+        """,  # noqa: S608
+        (uf, uf, *eng_params, pool),
+    )
+    built = []
+    rank = 0
+    strong_subs = {
+        "pavimentacao",
+        "drenagem",
+        "terraplenagem",
+        "saneamento",
+        "edificacoes",
+        "reformas",
+        "obras_civis",
+        "infraestrutura_urbana",
+        "manutencao_predial",
+    }
+    for r in rows_raw:
+        samples = [str(s) for s in (r.get("sample_objetos") or []) if s]
+        # Reclassify every sample — only keep ENGINEERING_* with obra subcategory
+        eng_samples: list[str] = []
+        eng_subs: list[str] = []
+        for s in samples:
+            clf = classify_object(s, profile=profile)
+            if clf.label in E_ALLOWED_LABELS and clf.subcategory in strong_subs:
+                eng_samples.append(s)
+                eng_subs.append(clf.subcategory)
+        # Majority of classifiable samples must be engineering (fail-closed)
+        if len(eng_samples) < 2:
+            continue
+        if len(eng_samples) < max(2, len(samples) // 2):
+            continue
+        # Prefer HIGH_CONFIDENCE evidence
+        high = [
+            s
+            for s in eng_samples
+            if classify_object(s, profile=profile).label == "ENGINEERING_HIGH_CONFIDENCE"
+        ]
+        if not high:
+            continue
+        rank += 1
+        if rank > export_limit:
+            break
+        # Honest count: re-query engineering-term hits for this organ, then scale by
+        # sample engineering ratio (document limitation — not inventing unit rows)
+        raw_qtd = int(r["qtd_contratacoes"])
+        raw_valor = float(r["valor_total"] or 0)
+        ratio = len(eng_samples) / max(1, len(samples))
+        adj_qtd = max(len(eng_samples), int(round(raw_qtd * ratio)))
+        adj_valor = round(raw_valor * ratio, 2)
+        row = deliv_a.build_row_from_raw(
+            rank=rank,
+            orgao=str(r["orgao"]),
+            cnpj=str(r.get("orgao_cnpj") or ""),
+            uf=str(r.get("uf") or ""),
+            qtd=adj_qtd,
+            valor_total=adj_valor,
+            semantic="CONTRATADO",
+            modalidades=None,
+            periodo_inicio=str(pop.get("period_min") or ""),
+            periodo_fim=str(pop.get("period_max") or ""),
+            fontes=["pncp_supplier_contracts", "isolated_snapshot", "engineering_reclassified"],
+            consultado=True,
+            data_quality_score=0.85 if ratio < 1.0 else 1.0,
+        )
+        drow = asdict(row)
+        drow["tipos_obra"] = sorted({s for s in eng_subs if s})
+        drow["metric_basis"] = "engineering_reclassified_samples"
+        drow["sample_objetos"] = eng_samples[:3]
+        drow["sample_engineering_ratio"] = round(ratio, 3)
+        drow["raw_prefilter_qtd"] = raw_qtd
+        built.append(drow)
+
+    # Re-wrap as report using rows already dicts
+    if built:
+        # rebuild ranks via dataclass path for schema consistency
+        rebuilt = []
+        for i, drow in enumerate(built, start=1):
+            rebuilt.append(
+                deliv_a.build_row_from_raw(
+                    rank=i,
+                    orgao=str(drow["orgao"]),
+                    cnpj=str(drow.get("orgao_cnpj") or ""),
+                    uf=str(drow.get("uf") or ""),
+                    qtd=int(drow["qtd_contratacoes"]),
+                    valor_total=float(drow["valor_total"] or 0),
+                    semantic="CONTRATADO",
+                    modalidades=None,
+                    periodo_inicio=str(pop.get("period_min") or ""),
+                    periodo_fim=str(pop.get("period_max") or ""),
+                    fontes=list(drow.get("fontes") or ["pncp_supplier_contracts"]),
+                    consultado=True,
+                    data_quality_score=drow.get("data_quality_score"),
+                )
+            )
+        report = deliv_a.build_report_from_rows(
+            rebuilt,
+            period_start=str(pop.get("period_min") or ""),
+            period_end=str(pop.get("period_max") or ""),
+            sources=["pncp_supplier_contracts", "engineering_filter"],
+        )
+        data = asdict(report)
+        # re-attach engineering extras
+        by_org = {b["orgao"]: b for b in built}
+        for row in data.get("rows") or []:
+            extra = by_org.get(row.get("orgao")) or {}
+            row["tipos_obra"] = extra.get("tipos_obra") or []
+            row["metric_basis"] = "engineering_reclassified_samples"
+            row["sample_objetos"] = extra.get("sample_objetos") or []
+            row["sample_engineering_ratio"] = extra.get("sample_engineering_ratio")
+            row["raw_prefilter_qtd"] = extra.get("raw_prefilter_qtd")
+    else:
+        data = asdict(
+            deliv_a.build_report_from_rows(
+                [],
+                period_start=str(pop.get("period_min") or ""),
+                period_end=str(pop.get("period_max") or ""),
+                sources=["pncp_supplier_contracts", "engineering_filter"],
+            )
+        )
+        data["status"] = "INSUFFICIENT"
+
+    elapsed = time.perf_counter() - t0
+    data["population"] = {
+        **pop,
+        "n_orgaos_eligible": int(stats.get("n_orgaos") or 0),
+        "n_contracts_eligible": int(stats.get("n_contracts") or 0),
+        "n_contracts_eligible_engineering": int(stats.get("n_contracts") or 0),
+        "valor_sum_eligible": float(stats.get("valor_sum") or 0),
+        "export_limit": export_limit,
+        "export_is_not_universe": True,
+        "ranking_metric": "engineering_activity_not_general_volume",
+        "ranking_method": (
+            "SQL prefilter by engineering terms + per-organ sample reclassification "
+            "via sector_classifier; qtd/valor adjusted by engineering sample ratio"
+        ),
+        "profile_object_terms": terms[:20],
+    }
+    data["query_seconds"] = round(elapsed, 3)
+    data["valor_semantica"] = "CONTRATADO"
+    data["claims_allowed"] = list(data.get("claims_allowed") or []) + [
+        "Ranking by engineering-adherent contracts only",
+        "valor_total is CONTRATADO engineering magnitude, not paid/measured",
+    ]
+    data["claims_forbidden"] = list(data.get("claims_forbidden") or []) + [
+        "Rank organs by general purchase volume",
+        "Treat export_limit rows as statistical universe",
+        "Call valor_total a unit price or valor pago",
+    ]
+    return data
+
+
+def _extra_engineering_terms() -> list[str]:
+    """Strict lexical object filter for Extra Construtora peers (not hospital/fuel/IT)."""
+    return sql_engineering_ilike_terms(load_profile())
+
+
+def _classify_competitor_class(nome: str, sample_objects: list[str]) -> str:
+    """direto | adjacente | fornecedor_material | mineracao_insumos | nao_confirmada | excluir."""
+    nome_l = (nome or "").lower()
+    joined = " ".join(sample_objects).lower()
+    if any(x in nome_l for x in ("miner", "brita", "cimento ", "areia ", "insumo")):
+        return "mineracao_insumos"
+    if any(x in joined for x in ("fornecimento de material", "aquisicao de material", "materiais para")) and not any(
+        x in joined for x in ("execucao", "empreitada", "obra de engenharia")
+    ):
+        return "fornecedor_material"
+    labels = [classify_object(s).label for s in sample_objects[:5]]
+    if any(lb == "ENGINEERING_HIGH_CONFIDENCE" for lb in labels):
+        if any(t in nome_l for t in ("constru", "engenh", "empreite", "obras", "edifica", "paviment")):
+            return "concorrente_direto"
+        return "concorrente_adjacente"
+    if any(lb == "ENGINEERING_REVIEW" for lb in labels):
+        return "concorrente_adjacente"
+    if any(lb in {"NON_ENGINEERING", "EXCLUDED_CATEGORY"} for lb in labels):
+        return "excluir"
+    return "nao_confirmada"
+
+
+def build_deliverable_b(
+    conn: Any,
+    *,
+    uf: str | None,
+    target_n: int,
+    export_limit: int,
+    pop: dict[str, Any],
+    profile_keywords: list[str] | None = None,
+) -> dict[str, Any]:
+    """Competitors relevant to Extra Construtora (engineering objects), fail-closed.
+
+    Ranking uses full eligible population filtered by engineering object terms.
+    Hospital/office suppliers without engineering objects are excluded.
+    Geography is counted by contract UF frequency (not SC:1 stub).
+    """
+    t0 = time.perf_counter()
+    terms = profile_keywords or _extra_engineering_terms()
+    # Build OR ILIKE clause with bound params only
+    obj_clauses = " OR ".join(["objeto_contrato ILIKE %s"] * len(terms))
+    like_params = [f"%{t}%" for t in terms]
+
+    n_suppliers = int(
+        scalar(
+            conn,
+            f"""
+            SELECT COUNT(DISTINCT COALESCE(fornecedor_cnpj_8,
+                         left(COALESCE(fornecedor_cnpj,''),8)))
+            FROM pncp_supplier_contracts
+            WHERE COALESCE(is_active, TRUE)
+              AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+              AND fornecedor_cnpj IS NOT NULL AND btrim(fornecedor_cnpj) <> ''
+              AND objeto_contrato IS NOT NULL
+              AND ({obj_clauses})
+            """,  # noqa: S608
+            (uf, uf, *like_params),
+        )
+        or 0
+    )
+    n_contracts_eligible = int(
+        scalar(
+            conn,
+            f"""
+            SELECT COUNT(*)
+            FROM pncp_supplier_contracts
+            WHERE COALESCE(is_active, TRUE)
+              AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+              AND fornecedor_cnpj IS NOT NULL AND btrim(fornecedor_cnpj) <> ''
+              AND objeto_contrato IS NOT NULL
+              AND ({obj_clauses})
+            """,  # noqa: S608
+            (uf, uf, *like_params),
+        )
+        or 0
+    )
+    # Single CTE: engineering-filtered contracts → supplier ranks + honest UF counts
+    pool = max(export_limit, target_n * 5, 80)
+    rows_raw = q(
+        conn,
+        f"""
+        WITH eng AS (
+          SELECT
+            COALESCE(fornecedor_cnpj_8, left(COALESCE(fornecedor_cnpj,''),8)) AS root,
+            fornecedor_cnpj,
+            fornecedor_nome,
+            orgao_nome,
+            valor_total,
+            left(objeto_contrato, 200) AS objeto_sample,
+            upper(btrim(uf)) AS uf_u
+          FROM pncp_supplier_contracts
+          WHERE COALESCE(is_active, TRUE)
+            AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+            AND fornecedor_cnpj IS NOT NULL AND btrim(fornecedor_cnpj) <> ''
+            AND objeto_contrato IS NOT NULL
+            AND ({obj_clauses})
+        ),
+        ranked AS (
+          SELECT root,
+                 MAX(fornecedor_cnpj) AS cnpj,
+                 MAX(fornecedor_nome) AS nome,
+                 COUNT(*)::int AS n_contratos,
+                 COALESCE(SUM(valor_total),0)::float AS valor_contratado_total
+          FROM eng
+          GROUP BY root
+          HAVING COUNT(*) >= 2
+          ORDER BY COUNT(*) DESC, SUM(valor_total) DESC NULLS LAST
+          LIMIT %s
+        ),
+        geo AS (
+          SELECT e.root, e.uf_u, COUNT(*)::int AS n
+          FROM eng e
+          JOIN ranked r ON r.root = e.root
+          WHERE e.uf_u IS NOT NULL AND e.uf_u <> ''
+          GROUP BY e.root, e.uf_u
+        ),
+        orgs AS (
+          SELECT e.root, array_agg(DISTINCT e.orgao_nome) FILTER (
+            WHERE e.orgao_nome IS NOT NULL AND btrim(e.orgao_nome) <> ''
+          ) AS orgaos
+          FROM eng e
+          JOIN ranked r ON r.root = e.root
+          GROUP BY e.root
+        ),
+        samples AS (
+          SELECT e.root, (array_agg(DISTINCT e.objeto_sample))[1:5] AS objetos
+          FROM eng e
+          JOIN ranked r ON r.root = e.root
+          GROUP BY e.root
+        )
+        SELECT r.cnpj, r.nome, r.n_contratos, r.valor_contratado_total,
+               o.orgaos,
+               s.objetos AS sample_objetos,
+               COALESCE(
+                 (SELECT jsonb_object_agg(g.uf_u, g.n) FROM geo g WHERE g.root = r.root),
+                 '{{}}'::jsonb
+               ) AS geo_counts
+        FROM ranked r
+        LEFT JOIN orgs o ON o.root = r.root
+        LEFT JOIN samples s ON s.root = r.root
+        ORDER BY r.n_contratos DESC, r.valor_contratado_total DESC
+        """,  # noqa: S608
+        (uf, uf, *like_params, pool),
+    )
+    candidates: list[dict[str, Any]] = []
+    for r in rows_raw:
+        cnpj = "".join(ch for ch in str(r.get("cnpj") or "") if ch.isdigit())
+        if len(cnpj) < 14:
+            if len(cnpj) == 8:
+                cnpj = cnpj + "000000"
+            elif len(cnpj) > 0:
+                cnpj = cnpj.zfill(14)
+            else:
+                continue
+        orgaos = list(r.get("orgaos") or [])
+        geo = r.get("geo_counts") or {}
+        if isinstance(geo, str):
+            try:
+                geo = json.loads(geo)
+            except json.JSONDecodeError:
+                geo = {}
+        if not isinstance(geo, dict):
+            geo = {}
+        nome = str(r.get("nome") or "")
+        nome_l = nome.lower()
+        # Fail-closed noise: exclude hospital/medical/food/fuel/IT resellers
+        bad_tokens = (
+            "hospitalar",
+            "hospital",
+            "medic",
+            "farmac",
+            "alimento",
+            "merenda",
+            "papelaria",
+            "combust",
+            "frotas",
+            "sistemas",
+            "software",
+            "tecnologia",
+            "informatica",
+            "informática",
+            "eletrica",
+            "elétrica",
+            "eletrô",
+            "eletro",
+            "consórcio intermunicipal",
+            "consorcio intermunicipal",
+            "prefeitura",
+            "município de",
+            "municipio de",
+        )
+        good_tokens = (
+            "constru",
+            "engenh",
+            "empreite",
+            "paviment",
+            "obras",
+            "edifica",
+            "reforma",
+            "predial",
+            "drenag",
+        )
+        if any(bad in nome_l for bad in bad_tokens) and not any(
+            good in nome_l for good in good_tokens
+        ):
+            continue
+        samples = [str(x) for x in (r.get("sample_objetos") or []) if x]
+        if not samples:
+            continue
+        # Exclude non-peer institutions by name
+        ban_name = (
+            "fundacao de ensino",
+            "fundação de ensino",
+            "universidade",
+            "instituto federal",
+            "faculdade",
+            "escola tecnica",
+            "consorcio intermunicipal",
+            "prefeitura",
+            "municipio de",
+            "município de",
+            "camara municipal",
+            "câmara municipal",
+            "companhia catarinense",
+            "casan",
+            "celesc",
+        )
+        if any(b in nome_l for b in ban_name):
+            continue
+        strong_subs = {
+            "pavimentacao",
+            "drenagem",
+            "terraplenagem",
+            "saneamento",
+            "edificacoes",
+            "reformas",
+            "obras_civis",
+            "infraestrutura_urbana",
+            "manutencao_predial",
+        }
+        # HIGH_CONFIDENCE execution only for competitor evidence
+        eng_samples: list[str] = []
+        for s in samples:
+            clf = classify_object(s)
+            if (
+                clf.label == "ENGINEERING_HIGH_CONFIDENCE"
+                and clf.subcategory in strong_subs
+            ):
+                eng_samples.append(s)
+        if not eng_samples:
+            continue
+        exec_tokens = (
+            "execucao",
+            "execução",
+            "empreitada",
+            "obra de engenharia",
+            "pavimentacao",
+            "pavimentação",
+            "reforma predial",
+            "construcao de",
+            "construção de",
+            "terraplenagem",
+            "drenagem urbana",
+        )
+        joined = " ".join(eng_samples).lower()
+        material_only = any(
+            t in joined
+            for t in (
+                "aquisicao de rachao",
+                "aquisição de rachão",
+                "bica corrida",
+                "material britado",
+                "fornecimento de material",
+                "aquisicao de material",
+            )
+        ) and not any(t in joined for t in exec_tokens)
+        if material_only:
+            continue  # fornecedor/material — not competitor peer
+        classe = _classify_competitor_class(nome, eng_samples)
+        if classe not in {"concorrente_direto", "concorrente_adjacente"}:
+            continue
+        peer_tokens = (
+            "constru",
+            "engenh",
+            "empreite",
+            "paviment",
+            "obras",
+            "edifica",
+            "reforma",
+            "infra",
+            "terrapl",
+        )
+        if not any(t in nome_l for t in peer_tokens) and not any(
+            t in joined
+            for t in (
+                "empreitada",
+                "execucao de paviment",
+                "execução de paviment",
+                "obra de engenharia",
+                "reforma predial",
+                "terraplenagem",
+            )
+        ):
+            continue
+        ufs = list(geo.keys()) if geo else ([uf] if uf else [])
+        candidates.append(
+            {
+                "cnpj": cnpj[:14],
+                "nome": nome,
+                "n_contratos": int(r["n_contratos"]),
+                "valor_contratado_total": float(r["valor_contratado_total"] or 0),
+                "orgaos_em_que_venceu": orgaos[:20],
+                "ufs": ufs,
+                "distribuicao_geografica": {str(k): int(v) for k, v in geo.items()},
+                "tipos_objeto": sorted(
+                    {
+                        classify_object(s).subcategory
+                        for s in eng_samples
+                        if classify_object(s).subcategory
+                    }
+                )
+                or ["engenharia_extra_profile"],
+                "object_types": ["engenharia_extra_profile"],
+                "classe_concorrente": classe,
+                "competitor_class": classe,
+                "exemplos_contratos": eng_samples[:3],
+                "sample_contracts": eng_samples[:3],
+            }
+        )
+    rule = deliv_b.SelectionRule(
+        target_n=target_n,
+        min_contracts=2,
+        require_cnpj=True,
+        uf_filter=uf,  # enforce SC when profile uf set
+    )
+    report = deliv_b.select_competitors(candidates, rule)
+    data = asdict(report)
+    # Preserve class + examples + UFs on selected rows
+    by_cnpj = {c["cnpj"]: c for c in candidates}
+    for row in data.get("rows") or []:
+        src = by_cnpj.get(str(row.get("cnpj") or "")) or {}
+        row["classe_concorrente"] = src.get("classe_concorrente") or "concorrente_direto"
+        row["competitor_class"] = row["classe_concorrente"]
+        row["exemplos_contratos"] = src.get("exemplos_contratos") or []
+        row["sample_contracts"] = row["exemplos_contratos"]
+        geo = row.get("distribuicao_geografica") or src.get("distribuicao_geografica") or {}
+        row["ufs"] = list(geo.keys()) if geo else list(src.get("ufs") or ([uf] if uf else []))
+        if not row.get("distribuicao_geografica") and row["ufs"]:
+            row["distribuicao_geografica"] = {u: 1 for u in row["ufs"]}
+    data["population"] = {
+        **pop,
+        "n_suppliers_eligible_engineering": n_suppliers,
+        "n_contracts_eligible_engineering": n_contracts_eligible,
+        "profile_object_terms": terms,
+        "export_limit": export_limit,
+        "export_is_not_universe": True,
+        "selection_note": (
+            "Competitors ranked only on contracts whose objeto matches Extra "
+            "engineering profile terms; hospital/office suppliers excluded."
+        ),
+    }
+    data["query_seconds"] = round(time.perf_counter() - t0, 3)
+    data["claims_allowed"] = list(data.get("claims_allowed") or []) + [
+        "Suppliers observed winning engineering-object contracts in filter",
+        "Not a complete market or win-rate claim",
+    ]
+    data["claims_forbidden"] = list(data.get("claims_forbidden") or []) + [
+        "Treat top suppliers by raw national volume as Extra peers",
+        "Infer partnership from co-presence",
+    ]
+    return data
+
+
+def build_deliverable_c(
+    conn: Any,
+    *,
+    uf: str | None,
+    as_of: date,
+    min_days: int = 90,
+    max_days: int = 180,
+    pop: dict[str, Any],
+) -> dict[str, Any]:
+    """Full-window query for expiring contracts; zero only as success_zero."""
+    t0 = time.perf_counter()
+    lo = as_of + timedelta(days=min_days)
+    hi = as_of + timedelta(days=max_days)
+    # Complete scan of window — no silent sample
+    n_scanned = int(
+        scalar(
+            conn,
+            """
+            SELECT COUNT(*) FROM pncp_supplier_contracts
+            WHERE COALESCE(is_active, TRUE)
+              AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+              AND data_fim IS NOT NULL
+            """,
+            (uf, uf),
+        )
+        or 0
+    )
+    rows_raw = q(
+        conn,
+        """
+        SELECT
+            contrato_id AS id,
+            orgao_nome AS orgao,
+            orgao_cnpj,
+            fornecedor_nome AS fornecedor,
+            fornecedor_nome AS contratado,
+            fornecedor_cnpj AS contratado_cnpj,
+            fornecedor_cnpj,
+            objeto_contrato AS objeto,
+            valor_total AS valor,
+            valor_total,
+            'CONTRATADO'::text AS valor_semantica,
+            data_inicio::text AS vigencia_inicio,
+            data_inicio::text AS inicio,
+            data_fim::text AS vigencia_fim,
+            data_fim::text AS termino,
+            'pncp_supplier_contracts'::text AS fonte,
+            'pncp_supplier_contracts'::text AS termino_fonte,
+            COALESCE(last_seen_at, ingested_at, now())::date::text AS termino_verificado_em,
+            COALESCE(last_seen_at, ingested_at, now())::date::text AS verified_at,
+            'CONTRATUAL'::text AS termino_tipo,
+            uf,
+            municipio
+        FROM pncp_supplier_contracts
+        WHERE COALESCE(is_active, TRUE)
+          AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+          AND data_fim IS NOT NULL
+          AND data_fim::date BETWEEN %s AND %s
+        ORDER BY data_fim ASC
+        """,
+        (uf, uf, lo.isoformat(), hi.isoformat()),
+    )
+    cfg = deliv_c.WindowConfig(
+        as_of=as_of.isoformat(),
+        min_days=min_days,
+        max_days=max_days,
+    )
+    report = deliv_c.select_expiring(rows_raw, cfg)
+    data = asdict(report)
+    # Sector filter: only engineering-adherent expiring contracts
+    profile = load_profile()
+    filtered: list[dict[str, Any]] = []
+    excluded_non_eng = 0
+    _c_strong = {
+        "pavimentacao",
+        "drenagem",
+        "terraplenagem",
+        "saneamento",
+        "edificacoes",
+        "reformas",
+        "obras_civis",
+        "infraestrutura_urbana",
+        "manutencao_predial",
+        "projetos",
+    }
+    for row in list(data.get("rows") or []):
+        obj = str(row.get("objeto") or "")
+        clf = classify_object(obj, profile=profile)
+        if clf.label not in E_ALLOWED_LABELS or clf.subcategory not in _c_strong:
+            excluded_non_eng += 1
+            continue
+        row = dict(row)
+        row["sector_classification"] = clf.to_dict()
+        row["segmento"] = clf.subcategory
+        row["aderencia"] = clf.label
+        filtered.append(row)
+    # Sort: nearest end, then value, then organ
+    def _sort_key(r: dict[str, Any]) -> tuple:
+        return (
+            str(r.get("termino_efetivo") or r.get("termino") or "9999"),
+            -float(r.get("valor") or 0),
+            str(r.get("orgao") or ""),
+        )
+
+    filtered.sort(key=_sort_key)
+    n_in = len(filtered)
+    export_cap = int(pop.get("export_limit") or 500)
+    data["rows"] = filtered[:export_cap] if n_in > export_cap else filtered
+    data["excluded_non_engineering"] = excluded_non_eng
+    data["export_limit"] = export_cap
+    data["export_is_not_universe"] = True
+    data["window_hits_total"] = n_in
+    data["window_hits_raw_before_sector"] = len(rows_raw)
+    if n_in == 0:
+        data["status"] = "EMPTY"
+        data["success_zero"] = {
+            "success_zero": True,
+            "window": f"{min_days}-{max_days}d",
+            "as_of": as_of.isoformat(),
+            "contracts_with_data_fim_scanned": n_scanned,
+            "excluded_non_engineering": excluded_non_eng,
+            "query_complete": True,
+            "message": (
+                "Zero engineering-adherent contracts in 90–180 day window "
+                "after complete query + sector filter; not 'not consulted'"
+            ),
+        }
+    else:
+        data["status"] = "OK"
+        data["success_zero"] = {"success_zero": False, "n": n_in, "query_complete": True}
+    data["population"] = {
+        **pop,
+        "contracts_with_data_fim_scanned": n_scanned,
+        "window_start": lo.isoformat(),
+        "window_end": hi.isoformat(),
+        "window_hits_total": n_in,
+        "excluded_non_engineering": excluded_non_eng,
+        "query_complete": True,
+        "export_is_not_universe": True,
+        "sector_filter": "ENGINEERING_HIGH_CONFIDENCE|ENGINEERING_REVIEW",
+        "no_invented_probability_pct": True,
+    }
+    data["claims_allowed"] = list(data.get("claims_allowed") or []) + [
+        "Only engineering-adherent expiring contracts",
+        "No fabricated win-probability percentages",
+    ]
+    data["claims_forbidden"] = list(data.get("claims_forbidden") or []) + [
+        "Include non-engineering expiring contracts (health, fuel, courses, etc.)",
+        "Invent probability percentage without model",
+    ]
+    data["query_seconds"] = round(time.perf_counter() - t0, 3)
+    return data
+
+
+def build_deliverable_d(
+    conn: Any,
+    *,
+    uf: str | None,
+    keywords: list[str],
+    min_sample: int,
+    pop: dict[str, Any],
+) -> dict[str, Any]:
+    t0 = time.perf_counter()
+    obs: list[deliv_d.PriceObservation] = []
+    for kw in keywords:
+        rows = q(
+            conn,
+            """
+            SELECT
+                contrato_id,
+                valor_total,
+                objeto_contrato,
+                uf,
+                municipio,
+                data_publicacao::text AS data_ref
+            FROM pncp_supplier_contracts
+            WHERE COALESCE(is_active, TRUE)
+              AND (%s::text IS NULL OR upper(btrim(uf)) = upper(%s))
+              AND valor_total IS NOT NULL AND valor_total > 0
+              AND objeto_contrato ILIKE %s
+            """,
+            (uf, uf, f"%{kw}%"),
+        )
+        for r in rows:
+            obs.append(
+                deliv_d.PriceObservation(
+                    value=float(r["valor_total"]),
+                    value_semantic="contratado",
+                    tipo_obra_servico=kw.lower(),
+                    unidade="contrato_global",
+                    lote="n/a",
+                    porte="global",
+                    regiao=str(r.get("uf") or uf or ""),
+                    periodo=str(r.get("data_ref") or "")[:10],
+                    is_global_heterogeneous=True,
+                    source="pncp_supplier_contracts",
+                )
+            )
+    rule = deliv_d.ComparabilityRule(min_sample=min_sample)
+    report = deliv_d.build_report(obs, rule=rule)
+    data = asdict(report)
+    # At least one defensive category
+    ok_panels = [
+        p
+        for p in (data.get("panels") or [])
+        if p.get("status") == "OK"
+    ]
+    if not ok_panels and obs:
+        # Preserve semantic insufficiency (do not invent unit prices)
+        if data.get("status") not in {
+            "INSUFFICIENT_COMPARABLE_DATA",
+            "INSUFFICIENT_SAMPLE",
+            "OK",
+        }:
+            data["status"] = "INSUFFICIENT_COMPARABLE_DATA"
+    data["population"] = {
+        **pop,
+        "observations_n": len(obs),
+        "keywords": keywords,
+        "value_semantics": "CONTRATADO_GLOBAL",
+        "not_unit_price": True,
+    }
+    data["query_seconds"] = round(time.perf_counter() - t0, 3)
+    data["claims_allowed"] = list(data.get("claims_allowed") or []) + [
+        "Reference panels use CONTRATADO_GLOBAL magnitude explicitly",
+    ]
+    data["claims_forbidden"] = list(data.get("claims_forbidden") or []) + [
+        "Call global contract value a unit price",
+        "Mix incompatible magnitudes without NOT_READY",
+    ]
+    return data
+
+
+def _enrich_e_recommendation(rec: dict[str, Any], profile: dict[str, Any]) -> dict[str, Any] | None:
+    """Return engineering-only recommendation with commercial fields, or None if excluded."""
+    obj = str(rec.get("titulo") or rec.get("objeto") or "")
+    clf = classify_object(obj, profile=profile)
+    if clf.label not in E_ALLOWED_LABELS:
+        return None
+    out = dict(rec)
+    out["sector_classification"] = clf.to_dict()
+    out["segmento"] = clf.subcategory or clf.category
+    out["aderencia"] = clf.label
+    out["objeto"] = out.get("objeto") or obj
+    out["motivo"] = out.get("motivo") or out.get("score_notes") or clf.reason
+    open_ = out.get("openness") if isinstance(out.get("openness"), dict) else {}
+    out["url"] = out.get("url") or open_.get("official_url")
+    out["official_url"] = out.get("official_url") or open_.get("official_url")
+    # PENDING capacity must not auto-GO
+    ranking = str(out.get("ranking") or out.get("client_label") or "REVIEW").upper()
+    elic = (profile.get("elicitation") or {}) if isinstance(profile, dict) else {}
+    pending_cap = any(
+        isinstance(v, dict) and str(v.get("status") or "").upper() == "PENDING"
+        for v in elic.values()
+    ) or (profile.get("capacity") or {}).get("status") == "PENDING_ELICITATION"
+    if pending_cap and ranking in {"GO", "PARTICIPAR"}:
+        out["ranking"] = "REVIEW"
+        out["client_label"] = "REVIEW"
+        out["recomendacao"] = "REVIEW"
+        out["ranking_note"] = "PENDING capacity must not auto-promote to GO/PARTICIPAR"
+    else:
+        out["recomendacao"] = out.get("ranking") or ranking
+    out["dados_faltantes"] = out.get("dados_faltantes") or (
+        "capacidade operacional PENDING (CAT/capital/garantias)" if pending_cap else ""
+    )
+    out["impedimentos"] = list(out.get("fatores_impeditivos_ou_riscos") or [])
+    out["documentos"] = list(out.get("referencias_oficiais") or [])
+    return out
+
+
+def load_deliverable_e(
+    *,
+    evidence_path: Path | None,
+    conn: Any | None,
+    cut_date: str,
+) -> dict[str, Any]:
+    """Prefer captured real-source evidence; sector-filter to engineering only."""
+    profile = load_profile()
+    if evidence_path and evidence_path.is_file():
+        data = json.loads(evidence_path.read_text(encoding="utf-8"))
+        data["incorporated_from"] = str(evidence_path)
+        data["source_class"] = "captured_real_evidence"
+        raw_recs = list(data.get("recommendations") or [])
+        kept: list[dict[str, Any]] = []
+        excluded = 0
+        for rec in raw_recs:
+            enriched = _enrich_e_recommendation(rec, profile)
+            if enriched is None:
+                excluded += 1
+                continue
+            kept.append(enriched)
+        data["recommendations"] = kept
+        data["excluded_non_engineering"] = excluded
+        data["excluded_not_open"] = data.get("excluded_not_open") or 0
+        if not kept:
+            data["status"] = "SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES"
+            data["note"] = (
+                "Evidência capturada não contém editais abertos de engenharia aderente; "
+                "não preenchemos com irrelevantes."
+            )
+            data["claims_allowed"] = list(data.get("claims_allowed") or []) + [
+                "SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES is an honest commercial outcome",
+            ]
+            data["claims_forbidden"] = list(data.get("claims_forbidden") or []) + [
+                "Pad Deliverable E with NON_ENGINEERING or EXCLUDED_CATEGORY editais",
+            ]
+        else:
+            data["status"] = data.get("status") or "OK"
+        return data
+    if conn is None:
+        return {
+            "status": "SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES",
+            "deliverable": "E",
+            "title": "Editais abertos e recomendação individual",
+            "recommendations": [],
+            "note": "No evidence path and no DB connection",
+            "cut_date": cut_date,
+        }
+    # Optional: pull open opportunities from DB and sector-filter
+    try:
+        rows = q(
+            conn,
+            """
+            SELECT id, objeto, orgao_nome AS orgao, orgao_cnpj, uf, municipio,
+                   source_url AS official_url, ranking, status_canonico,
+                   numero_controle_pncp AS edital_id
+            FROM opportunity_intel
+            WHERE COALESCE(is_active, TRUE)
+              AND status_canonico IN ('open','upcoming')
+            LIMIT 200
+            """,
+        )
+    except Exception:  # noqa: BLE001
+        rows = []
+    kept = []
+    excluded = 0
+    for r in rows:
+        rec = {
+            "edital_id": r.get("edital_id") or str(r.get("id")),
+            "titulo": r.get("objeto"),
+            "objeto": r.get("objeto"),
+            "orgao": r.get("orgao"),
+            "ranking": r.get("ranking") or "REVIEW",
+            "openness": {"official_url": r.get("official_url"), "proof_mode": "SNAPSHOT"},
+            "uf": r.get("uf"),
+            "municipio": r.get("municipio"),
+        }
+        enriched = _enrich_e_recommendation(rec, profile)
+        if enriched is None:
+            excluded += 1
+            continue
+        kept.append(enriched)
+    if not kept:
+        return {
+            "status": "SUCCESS_ZERO_ENGINEERING_OPPORTUNITIES",
+            "deliverable": "E",
+            "cut_date": cut_date,
+            "recommendations": [],
+            "excluded_non_engineering": excluded,
+            "note": "No engineering-adherent open opportunities after sector filter",
+            "source_class": "db_or_empty_filtered",
+        }
+    return {
+        "status": "OK",
+        "deliverable": "E",
+        "cut_date": cut_date,
+        "recommendations": kept,
+        "excluded_non_engineering": excluded,
+        "source_class": "db_opportunity_intel",
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str] | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fields = fieldnames or sorted({k for r in rows for k in r.keys()})
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields, extrasaction="ignore")
+        w.writeheader()
+        for r in rows:
+            flat = {}
+            for k, v in r.items():
+                if isinstance(v, (dict, list)):
+                    flat[k] = json.dumps(v, ensure_ascii=False, default=str)
+                else:
+                    flat[k] = v
+            w.writerow(flat)
+
+
+def build_excel(
+    path: Path,
+    *,
+    meta: dict[str, Any],
+    sheets: dict[str, list[dict[str, Any]]],
+    pack: dict[str, Any] | None = None,
+    products: dict[str, Any] | None = None,
+) -> None:
+    """Executive XLSX when products provided; legacy multi-sheet fallback otherwise."""
+    if products is not None:
+        build_executive_xlsx(
+            path,
+            pack=pack or meta,
+            products=products,
+            as_of=str(meta.get("as_of") or date.today().isoformat()),
+            meta=meta,
+        )
+        return
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Metadados"
+    ws.append(["key", "value"])
+    for k, v in meta.items():
+        ws.append(
+            [
+                k,
+                json.dumps(v, ensure_ascii=False, default=str)
+                if isinstance(v, (dict, list))
+                else v,
+            ]
+        )
+    for name, rows in sheets.items():
+        title = name[:31]
+        w = wb.create_sheet(title)
+        if not rows:
+            w.append(["empty"])
+            continue
+        keys = list(rows[0].keys())
+        w.append(keys)
+        for r in rows:
+            w.append(
+                [
+                    json.dumps(r.get(k), ensure_ascii=False, default=str)
+                    if isinstance(r.get(k), (dict, list))
+                    else r.get(k)
+                    for k in keys
+                ]
+            )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(path)
+
+
+def build_pdf(
+    path: Path,
+    *,
+    meta: dict[str, Any],
+    summary: dict[str, Any],
+    pack: dict[str, Any] | None = None,
+    products: dict[str, Any] | None = None,
+) -> int:
+    """Executive client-ready PDF (no JSON dumps in body)."""
+    if products is not None:
+        return build_executive_pdf(
+            path,
+            pack=pack or meta,
+            products=products,
+            as_of=str(meta.get("as_of") or date.today().isoformat()),
+        )
+    # Minimal fallback (tests only)
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc = SimpleDocTemplate(str(path), pagesize=A4)
+    styles = getSampleStyleSheet()
+    story: list[Any] = [
+        Paragraph("Pacote consultivo Extra Construtora (A–E)", styles["Title"]),
+        Spacer(1, 12),
+        Paragraph(str(summary.get("sumario_executivo") or ""), styles["Normal"]),
+    ]
+    doc.build(story)
+    return 1
+
+
+def reconcile(
+    *,
+    run_id: str,
+    meta_pdf: dict[str, Any],
+    meta_excel: dict[str, Any],
+    a: dict[str, Any],
+    b: dict[str, Any],
+    c: dict[str, Any],
+    d: dict[str, Any],
+    pdf_path: Path | None = None,
+    excel_path: Path | None = None,
+) -> dict[str, Any]:
+    """Cross-check shared cut metadata and optional PDF/Excel artifacts.
+
+    Compares meta_pdf vs meta_excel independently (not the same object identity).
+    When paths are provided, verifies both files exist, computes SHA-256 of each,
+    and checks Excel sheet row counts against deliverable payloads when openpyxl
+    is available.
+    """
+    divergences: list[str] = []
+    pdf_meta = dict(meta_pdf or {})
+    xls_meta = dict(meta_excel or {})
+
+    same_run = (
+        pdf_meta.get("run_id") == run_id
+        and xls_meta.get("run_id") == run_id
+        and pdf_meta.get("run_id") == xls_meta.get("run_id")
+    )
+    if not same_run:
+        divergences.append("run_id_mismatch_pdf_excel_or_pack")
+
+    for key in ("as_of", "git_sha", "schema_version", "profile_id", "profile_version"):
+        if pdf_meta.get(key) != xls_meta.get(key) and (
+            pdf_meta.get(key) is not None or xls_meta.get(key) is not None
+        ):
+            # profile may live nested under profile stamp
+            if key.startswith("profile") and pdf_meta.get("profile_id") == xls_meta.get(
+                "profile_id"
+            ):
+                continue
+            divergences.append(f"meta_{key}_mismatch")
+
+    if pdf_meta.get("git_sha") != xls_meta.get("git_sha"):
+        divergences.append("git_sha_mismatch_pdf_excel")
+
+    # population consistency across deliverables
+    pops = [
+        (a.get("population") or {}).get("eligible_population"),
+        (b.get("population") or {}).get("eligible_population"),
+        (c.get("population") or {}).get("eligible_population"),
+        (d.get("population") or {}).get("eligible_population"),
+    ]
+    if len({p for p in pops if p is not None}) > 1:
+        divergences.append("eligible_population_mismatch_across_deliverables")
+
+    artifact_checks: dict[str, Any] = {}
+    if pdf_path is not None or excel_path is not None:
+        if pdf_path is None or not Path(pdf_path).is_file():
+            divergences.append("pdf_artifact_missing")
+        if excel_path is None or not Path(excel_path).is_file():
+            divergences.append("excel_artifact_missing")
+        if (
+            pdf_path is not None
+            and excel_path is not None
+            and Path(pdf_path).is_file()
+            and Path(excel_path).is_file()
+        ):
+            pdf_bytes = Path(pdf_path).read_bytes()
+            xls_bytes = Path(excel_path).read_bytes()
+            pdf_sha = hashlib.sha256(pdf_bytes).hexdigest()
+            xls_sha = hashlib.sha256(xls_bytes).hexdigest()
+            artifact_checks = {
+                "pdf_path": str(pdf_path),
+                "excel_path": str(excel_path),
+                "pdf_sha256": pdf_sha,
+                "excel_sha256": xls_sha,
+                "pdf_bytes": len(pdf_bytes),
+                "excel_bytes": len(xls_bytes),
+                "binaries_distinct": pdf_sha != xls_sha,
+            }
+            # Shared cut must appear as text in both binaries (run_id)
+            if run_id.encode() not in pdf_bytes and run_id not in pdf_bytes.decode(
+                "latin-1", errors="ignore"
+            ):
+                # PDF text may be compressed; do not hard-fail on missing plain run_id
+                artifact_checks["pdf_run_id_plaintext"] = False
+            else:
+                artifact_checks["pdf_run_id_plaintext"] = True
+            try:
+                from openpyxl import load_workbook
+
+                wb = load_workbook(excel_path, read_only=True, data_only=True)
+                sheet_names = list(wb.sheetnames)
+                sheet_rows = {name: wb[name].max_row for name in sheet_names}
+                wb.close()
+                artifact_checks["excel_sheet_rows"] = sheet_rows
+                for sname, expected in (
+                    ("A_Orgaos", len(a.get("rows") or [])),
+                    ("B_Concorrentes", len(b.get("rows") or [])),
+                    ("C_Vincendos", len(c.get("rows") or [])),
+                    ("D_Paineis", len(d.get("panels") or [])),
+                ):
+                    if sname in sheet_rows and expected > 0:
+                        # max_row includes header row
+                        if (sheet_rows[sname] or 0) < expected:
+                            divergences.append(
+                                f"excel_{sname}_rows_lt_deliverable:"
+                                f"{sheet_rows[sname]}<{expected}"
+                            )
+            except Exception as exc:  # noqa: BLE001
+                artifact_checks["excel_open_error"] = str(exc)
+
+    status = "PASS" if not divergences else "FAIL"
+    return {
+        "status": status,
+        "same_run_id": bool(same_run),
+        "divergences": divergences,
+        "run_id": run_id,
+        "eligible_population": pops[0],
+        "meta_pdf_run_id": pdf_meta.get("run_id"),
+        "meta_excel_run_id": xls_meta.get("run_id"),
+        "artifact_checks": artifact_checks,
+    }
+
+
+def write_executive_summary(path: Path, pack: dict[str, Any]) -> None:
+    a = pack.get("deliverable_a") or {}
+    b = pack.get("deliverable_b") or {}
+    c = pack.get("deliverable_c") or {}
+    d = pack.get("deliverable_d") or {}
+    e = pack.get("deliverable_e") or {}
+    pop = (a.get("population") or {})
+    lines = [
+        f"# Sumário executivo — {CAMPAIGN_ID}",
+        "",
+        f"- run_id: `{pack.get('run_id')}`",
+        f"- as_of: {pack.get('as_of')}",
+        f"- git_sha: {pack.get('git_sha')}",
+        f"- população elegível: {pop.get('eligible_population')} "
+        f"({pop.get('sample_label')})",
+        f"- A: status={a.get('status')} rows={a.get('n_rows', len(a.get('rows') or []))} "
+        f"órgãos_elegíveis={(a.get('population') or {}).get('n_orgaos_eligible')}",
+        f"- B: status={b.get('status')} valid={b.get('valid_count')} "
+        f"target={b.get('target_n')}",
+        f"- C: status={c.get('status')} rows={c.get('n_rows', len(c.get('rows') or []))} "
+        f"success_zero={(c.get('success_zero') or {}).get('success_zero')}",
+        f"- D: status={d.get('status')} panels={d.get('n_panels', len(d.get('panels') or []))}",
+        f"- E: status={e.get('status')} "
+        f"recs={e.get('n_recs', len(e.get('recommendations') or []))}",
+        f"- reconciliação: {(pack.get('reconcile') or {}).get('status')}",
+        "",
+        "## Non-claims",
+        "- Não afirma LOCAL_READY / VPS_OPERATIONAL / PROJECT_DONE",
+        "- valor_total = CONTRATADO, não pago/medido",
+        "- export_limit ≠ universo estatístico",
+        "- production_touched=false (snapshot isolado)",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_pack(
+    *,
+    dsn: str,
+    out_dir: Path,
+    uf: str | None = "SC",
+    export_limit: int = 200,
+    target_competitors: int = 15,
+    e_evidence: Path | None = None,
+    keywords: list[str] | None = None,
+    as_of: date | None = None,
+) -> dict[str, Any]:
+    isolation = assert_isolation(dsn, out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_id = new_run_id("live-pack")
+    sha = git_sha()
+    as_of_d = as_of or date.today()
+    as_of_s = as_of_d.isoformat()
+    stamp = profile_stamp()
+    keywords = keywords or [
+        "reforma",
+        "paviment",
+        "construção",
+        "construcao",
+        "obra",
+        "edifica",
+    ]
+
+    conn = connect(dsn)
+    try:
+        sch = schema_version(conn)
+        pop = population_stats(conn, uf=uf)
+        if pop["eligible_population"] <= 0:
+            raise SystemExit(
+                "NO_ELIGIBLE_POPULATION: restore authenticated contracts dump first"
+            )
+
+        a = build_deliverable_a(conn, uf=uf, export_limit=export_limit, pop=pop)
+        b = build_deliverable_b(
+            conn,
+            uf=uf,
+            target_n=target_competitors,
+            export_limit=export_limit,
+            pop=pop,
+        )
+        pop_c = {**pop, "export_limit": export_limit}
+        c = build_deliverable_c(conn, uf=uf, as_of=as_of_d, pop=pop_c)
+        d = build_deliverable_d(
+            conn, uf=uf, keywords=keywords, min_sample=5, pop=pop
+        )
+        e_path = e_evidence or (
+            _PROJECT_ROOT
+            / "artifacts/campaigns/OPEN-TENDERS-OPERATIONAL-DECISION-CYCLE-01"
+            / "weekly-offline-rc/deliverable_e.json"
+        )
+        e = load_deliverable_e(evidence_path=e_path, conn=conn, cut_date=as_of_s)
+    finally:
+        conn.close()
+
+    meta = build_run_metadata(
+        artifact_kind="live_consulting_pack",
+        script="scripts/ops/live_consulting_pack.py",
+        uf=uf or "",
+        is_active=True,
+        run_id=run_id,
+    )
+    meta.update(
+        {
+            "run_id": run_id,
+            "as_of": as_of_s,
+            "git_sha": sha,
+            "schema_version": sch,
+            "profile_id": stamp.get("profile_id"),
+            "profile_version": stamp.get("version"),
+            "campaign_id": CAMPAIGN_ID,
+            "population": pop,
+            "filters": {"uf": uf, "export_limit": export_limit},
+            "limitations": [
+                "Isolated snapshot — not live VPS query",
+                "valor_total = CONTRATADO not pago",
+                "export_limit caps detail tabs only",
+                "Deliverable E from captured real evidence when DB has no opportunities",
+            ],
+            "production_touched": False,
+            "isolation": isolation,
+        }
+    )
+
+    # Attach run metadata to each deliverable
+    for dobj in (a, b, c, d, e):
+        dobj["run_id"] = run_id
+        dobj["as_of"] = as_of_s
+        dobj["git_sha"] = sha
+        dobj["schema_version"] = sch
+
+    # Artifacts
+    (out_dir / "deliverable_a.json").write_text(
+        json.dumps(a, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    (out_dir / "deliverable_b.json").write_text(
+        json.dumps(b, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    (out_dir / "deliverable_c.json").write_text(
+        json.dumps(c, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    (out_dir / "deliverable_d.json").write_text(
+        json.dumps(d, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    (out_dir / "deliverable_e.json").write_text(
+        json.dumps(e, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+
+    write_csv(out_dir / "orgaos_ranking.csv", list(a.get("rows") or []))
+    write_csv(out_dir / "competitors.csv", list(b.get("rows") or []))
+    write_csv(out_dir / "expiring.csv", list(c.get("rows") or []))
+
+    products = {"A": a, "B": b, "C": c, "D": d, "E": e}
+    excel_path = out_dir / "extra_live_consulting_pack.xlsx"
+    # Placeholder pack dict for renderers (run_id already known)
+    pack_stub = {
+        "run_id": run_id,
+        "git_sha": sha,
+        "campaign_id": CAMPAIGN_ID,
+        "as_of": as_of_s,
+    }
+    build_excel(
+        excel_path,
+        meta=meta,
+        sheets={
+            "A_Orgaos": list(a.get("rows") or []),
+            "B_Concorrentes": list(b.get("rows") or []),
+            "C_Vincendos": list(c.get("rows") or []),
+            "D_Paineis": list(d.get("panels") or []),
+            "E_Editais": list(e.get("recommendations") or []),
+        },
+        pack=pack_stub,
+        products=products,
+    )
+
+    summary = {
+        "sumario_executivo": (
+            f"População elegível {pop.get('eligible_population')} contratos "
+            f"(UF={uf}). A={a.get('status')} B={b.get('status')} "
+            f"C={c.get('status')} D={d.get('status')} E={e.get('status')}."
+        ),
+        "metodologia": (
+            "Agregados SQL sobre dump autenticado isolado com filtro setorial "
+            "de engenharia; export_limit só em abas detalhe."
+        ),
+        "universo": pop,
+        "cobertura": {
+            "dual_note": "Dual coverage measured on signed live evidence; "
+            "this pack does not rewrite coverage denominators.",
+            "eligible_population": pop.get("eligible_population"),
+        },
+        "limitacoes": meta["limitations"],
+        "anexos_evidencia": {
+            "e_evidence": "captured open-tenders evidence (sector-filtered)",
+        },
+        "apoio_reuniao": [
+            "Usar ranking A (engenharia) para priorizar órgãos",
+            "Mapa B de concorrentes com evidência setorial",
+            "Janela C 90–180d só engenharia",
+            "Painel D com INSUFFICIENT_COMPARABLE_DATA quando inválido",
+            "Editais E só engenharia; zero honesto se vazio",
+        ],
+    }
+    pdf_path = out_dir / "extra_live_consulting_pack.pdf"
+    pages = build_pdf(
+        pdf_path,
+        meta=meta,
+        summary=summary,
+        pack=pack_stub,
+        products=products,
+    )
+
+    # Distinct meta dicts for PDF vs Excel so reconcile cannot pass by object identity.
+    meta_pdf = dict(meta)
+    meta_excel = dict(meta)
+    rec = reconcile(
+        run_id=run_id,
+        meta_pdf=meta_pdf,
+        meta_excel=meta_excel,
+        a=a,
+        b=b,
+        c=c,
+        d=d,
+        pdf_path=pdf_path,
+        excel_path=excel_path,
+    )
+
+    pack = {
+        "campaign_id": CAMPAIGN_ID,
+        "run_id": run_id,
+        "as_of": as_of_s,
+        "git_sha": sha,
+        "schema_version": sch,
+        "profile": stamp,
+        "population": pop,
+        "deliverable_a": {"status": a.get("status"), "n_rows": len(a.get("rows") or []), "population": a.get("population"), "query_seconds": a.get("query_seconds")},
+        "deliverable_b": {"status": b.get("status"), "valid_count": b.get("valid_count"), "target_n": b.get("target_n"), "query_seconds": b.get("query_seconds")},
+        "deliverable_c": {"status": c.get("status"), "n_rows": len(c.get("rows") or []), "success_zero": c.get("success_zero"), "query_seconds": c.get("query_seconds")},
+        "deliverable_d": {"status": d.get("status"), "n_panels": len(d.get("panels") or []), "query_seconds": d.get("query_seconds")},
+        "deliverable_e": {"status": e.get("status"), "n_recs": len(e.get("recommendations") or []), "source_class": e.get("source_class") or e.get("incorporated_from")},
+        "artifacts": {
+            "pdf": str(pdf_path),
+            "excel": str(excel_path),
+            "pdf_pages_estimate": pages,
+            "json": [
+                "deliverable_a.json",
+                "deliverable_b.json",
+                "deliverable_c.json",
+                "deliverable_d.json",
+                "deliverable_e.json",
+            ],
+        },
+        "reconcile": rec,
+        "isolation": isolation,
+        "production_touched": False,
+        "generated_at": utc_now(),
+    }
+    # full payload with products for offline inspection (large)
+    full = {
+        **pack,
+        "products": {"A": a, "B": b, "C": c, "D": d, "E": e},
+        "meta": meta,
+    }
+    (out_dir / "pack-manifest.json").write_text(
+        json.dumps(pack, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    (out_dir / "pack-full.json").write_text(
+        json.dumps(full, ensure_ascii=False, indent=2, default=str), encoding="utf-8"
+    )
+    write_executive_summary(out_dir / "executive_summary.md", pack)
+
+    # Aliases expected by frozen RC identity
+    for src, dst in (
+        ("extra_live_consulting_pack.pdf", "executive-report.pdf"),
+        ("extra_live_consulting_pack.xlsx", "consulting-pack.xlsx"),
+        ("executive_summary.md", "executive-summary.md"),
+    ):
+        sp, dp = out_dir / src, out_dir / dst
+        if sp.exists():
+            dp.write_bytes(sp.read_bytes())
+
+    # Freeze checksums AFTER all product files; never self-hash checksums.json
+    checksums: dict[str, str] = {}
+    for p in sorted(out_dir.rglob("*")):
+        if not p.is_file():
+            continue
+        if p.name in {"checksums.json"}:
+            continue
+        if p.suffix.lower() not in {".json", ".csv", ".xlsx", ".pdf", ".md", ".html"}:
+            continue
+        rel = str(p.relative_to(out_dir)).replace("\\", "/")
+        checksums[rel] = hashlib.sha256(p.read_bytes()).hexdigest()
+    (out_dir / "checksums.json").write_text(
+        json.dumps(checksums, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return pack
+
+
+def cmd_verify_isolation(args: argparse.Namespace) -> int:
+    try:
+        r = assert_isolation(args.dsn, Path(args.out) if args.out else None)
+    except SystemExit as e:
+        print(json.dumps({"isolation_ok": False, "error": str(e)}))
+        return 2
+    print(json.dumps(r, indent=2))
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    pack = run_pack(
+        dsn=args.dsn,
+        out_dir=Path(args.out),
+        uf=args.uf or None,
+        export_limit=args.export_limit,
+        target_competitors=args.target_competitors,
+        e_evidence=Path(args.e_evidence) if args.e_evidence else None,
+        as_of=date.fromisoformat(args.as_of) if args.as_of else None,
+    )
+    print(json.dumps(pack, indent=2, ensure_ascii=False, default=str))
+    # Exit codes
+    if pack["reconcile"]["status"] != "PASS":
+        return 2
+    if pack["deliverable_a"]["status"] not in {"OK", "PARTIAL"}:
+        return 2
+    if pack["deliverable_b"]["status"] not in {"OK", "INSUFFICIENT", "PARTIAL"}:
+        return 2
+    # B with OK should have >= target; INSUFFICIENT is fail-closed success for honesty
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Live consulting pack A–E (isolated)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="Generate full A–E pack")
+    r.add_argument("--dsn", default=DEFAULT_DSN)
+    r.add_argument("--out", required=True)
+    r.add_argument("--uf", default="SC")
+    r.add_argument("--export-limit", type=int, default=200)
+    r.add_argument("--target-competitors", type=int, default=15)
+    r.add_argument("--e-evidence", default=None)
+    r.add_argument("--as-of", default=None)
+    r.set_defaults(func=cmd_run)
+
+    v = sub.add_parser("verify-isolation", help="Isolation fail-closed check")
+    v.add_argument("--dsn", default=DEFAULT_DSN)
+    v.add_argument("--out", default=None)
+    v.set_defaults(func=cmd_verify_isolation)
+
+    args = p.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/publish_commercial_rc_v2.py
+++ b/scripts/ops/publish_commercial_rc_v2.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Publish client-ready-frozen-rc-v2 from a generated pack (isolated DSN only).
+
+Single freeze writer — fixed order (never rewrite checksums after UA):
+
+  1) live_consulting_pack (or reuse pack-v2)
+  2) RC v1 history CHANGES_REQUESTED
+  3) Stage product bytes into client-ready-frozen-rc-v2/
+  4) Write final checksums.json ONCE from staged products
+  5) Build package_checksums (includes sha256 of that checksums.json)
+  6) Write user-acceptance.json PENDING_HUMAN
+  7) Write ARTIFACT-IDENTITY.json (no self-hash) + .sha256 sidecar
+  8) assert_full_reconciliation (ua ↔ checksums ↔ identity ↔ disk)
+
+Never sets ACCEPTED. Never touches VPS/prod/soak.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.ops.client_ready_consulting_cycle import (  # noqa: E402
+    CAMPAIGN_ID,
+    FROZEN_RC_ARTIFACT_NAME,
+    FROZEN_RC_V1_ARTIFACT_NAME,
+    FROZEN_RC_V1_PRODUCT_SHA,
+    FROZEN_RC_V1_RUN_ID,
+    FROZEN_RC_V1_STATUS,
+    REQUIRED_IDENTITY_FILES,
+    sha256_file,
+)
+from scripts.ops.live_consulting_pack import run_pack  # noqa: E402
+
+# Product members that form content-addressed product_rc_sha (no circularity with manifest).
+PRODUCT_RC_MEMBERS: tuple[str, ...] = (
+    "executive-report.pdf",
+    "consulting-pack.xlsx",
+    "executive-summary.md",
+    "deliverable_a.json",
+    "deliverable_b.json",
+    "deliverable_c.json",
+    "deliverable_d.json",
+    "deliverable_e.json",
+)
+
+# Files listed in checksums.json (products + pack-manifest). Written once.
+CHECKSUM_MEMBERS: tuple[str, ...] = PRODUCT_RC_MEMBERS + ("pack-manifest.json",)
+
+# Meta files staged after checksums.json (may appear in identity.file_sha256, not in checksums.json).
+META_AFTER_CHECKSUMS: tuple[str, ...] = (
+    "user-acceptance.json",
+    "package-reconciliation.json",
+    "rc-v1-CHANGES_REQUESTED.json",
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def content_product_rc_sha(pack_dir: Path) -> str:
+    """SHA-256 over sorted name+file digests of identity products (not a git commit)."""
+    h = hashlib.sha256()
+    h.update(b"extra-client-ready-frozen-rc-v2/product-rc/1.0\n")
+    for name in PRODUCT_RC_MEMBERS:
+        p = pack_dir / name
+        if not p.is_file():
+            raise FileNotFoundError(f"missing product member for content_rc_sha: {name}")
+        h.update(name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(sha256_file(p).encode("ascii"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def write_v1_history(campaign_dir: Path) -> Path:
+    hist = {
+        "artifact_name": FROZEN_RC_V1_ARTIFACT_NAME,
+        "run_id": FROZEN_RC_V1_RUN_ID,
+        "product_rc_sha": FROZEN_RC_V1_PRODUCT_SHA,
+        "status": FROZEN_RC_V1_STATUS,
+        "reason": (
+            "Commercial rejection: non-engineering objects in E/C, organ ranking by "
+            "general volume, invalid price panels, non-executive PDF/XLSX, hash drift"
+        ),
+        "recorded_at": utc_now(),
+        "note": "Historical only — not silently overwritten by v2",
+    }
+    path = campaign_dir / "rc-v1-CHANGES_REQUESTED.json"
+    path.write_text(json.dumps(hist, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def assert_full_reconciliation(staging_dir: Path) -> list[str]:
+    """Fail-closed equality: checksums.json ↔ identity.file_sha256 ↔ ua.package_checksums ↔ disk.
+
+    For every key present in ANY of the three maps, the file must exist and all
+    maps that contain the key must agree with sha256(file). Orphans and missing
+    files are divergences.
+    """
+    divergences: list[str] = []
+    ck_path = staging_dir / "checksums.json"
+    id_path = staging_dir / "ARTIFACT-IDENTITY.json"
+    ua_path = staging_dir / "user-acceptance.json"
+
+    if not ck_path.is_file():
+        return ["missing_checksums_json"]
+    if not id_path.is_file():
+        return ["missing_artifact_identity"]
+    if not ua_path.is_file():
+        return ["missing_user_acceptance"]
+
+    checksums = json.loads(ck_path.read_text(encoding="utf-8"))
+    identity = json.loads(id_path.read_text(encoding="utf-8"))
+    acceptance = json.loads(ua_path.read_text(encoding="utf-8"))
+    file_sha = identity.get("file_sha256") or {}
+    package_checksums = acceptance.get("package_checksums") or {}
+
+    if "ARTIFACT-IDENTITY.json" in file_sha:
+        divergences.append("identity_self_hash_forbidden")
+
+    # Union of all keys that claim product integrity
+    all_keys = set(checksums) | set(package_checksums) | {
+        k for k in file_sha if k not in {"ARTIFACT-IDENTITY.json", "ARTIFACT-IDENTITY.sha256"}
+    }
+
+    for key in sorted(all_keys):
+        path = staging_dir / key
+        if not path.is_file():
+            divergences.append(f"missing_file:{key}")
+            continue
+        dig = sha256_file(path)
+        if key in checksums and checksums[key] != dig:
+            divergences.append(f"checksums_mismatch:{key}")
+        if key in package_checksums and package_checksums[key] != dig:
+            divergences.append(f"ua_package_checksums_mismatch:{key}")
+        if key in file_sha and file_sha[key] != dig:
+            divergences.append(f"identity_mismatch:{key}")
+
+    # Explicit triple equality for checksums.json itself (the bug that stuck the goal)
+    if "checksums.json" in package_checksums and "checksums.json" in file_sha:
+        disk_ck = sha256_file(ck_path)
+        if not (
+            package_checksums["checksums.json"]
+            == file_sha["checksums.json"]
+            == disk_ck
+        ):
+            divergences.append(
+                "triple_mismatch_checksums_json:"
+                f"ua={package_checksums['checksums.json'][:12]}"
+                f" id={file_sha['checksums.json'][:12]}"
+                f" disk={disk_ck[:12]}"
+            )
+
+    # run_id / product_rc_sha agreement
+    if acceptance.get("run_id") != identity.get("run_id"):
+        divergences.append("run_id_ua_vs_identity")
+    if acceptance.get("rc_sha") != identity.get("product_rc_sha"):
+        divergences.append("product_rc_sha_ua_vs_identity")
+    if acceptance.get("status") != "PENDING_HUMAN":
+        divergences.append(f"acceptance_not_pending:{acceptance.get('status')}")
+    if acceptance.get("accepted_by") is not None:
+        divergences.append("acceptance_auto_bound")
+
+    return divergences
+
+
+def stage_product_file(pack_dir: Path, staging_dir: Path, name: str) -> bool:
+    """Copy product member from pack into staging. Returns True if staged."""
+    candidates = [name]
+    if name == "executive-report.pdf":
+        candidates.append("extra_live_consulting_pack.pdf")
+    if name == "consulting-pack.xlsx":
+        candidates.append("extra_live_consulting_pack.xlsx")
+    if name == "executive-summary.md":
+        candidates.append("executive_summary.md")
+    for c in candidates:
+        src = pack_dir / c
+        if src.is_file():
+            dest = staging_dir / name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(src.read_bytes())
+            return True
+    return False
+
+
+def freeze_staging(
+    *,
+    campaign_dir: Path,
+    pack_dir: Path,
+    staging_dir: Path,
+    run_id: str,
+    product_rc_sha: str,
+) -> dict[str, Any]:
+    """Single writer freeze. checksums.json written exactly once before UA/identity."""
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+
+    sources: dict[str, str] = {}
+    missing: list[str] = []
+
+    # --- 1) Stage product bytes only ---
+    for name in CHECKSUM_MEMBERS:
+        if stage_product_file(pack_dir, staging_dir, name):
+            sources[name] = f"pack:{name}"
+        else:
+            missing.append(name)
+    if missing:
+        return {"status": "FAIL", "error": "missing_members", "missing": missing}
+
+    # --- 2) Final checksums.json ONCE (product members only; no identity/ua) ---
+    product_checksums: dict[str, str] = {
+        name: sha256_file(staging_dir / name) for name in CHECKSUM_MEMBERS
+    }
+    ck_path = staging_dir / "checksums.json"
+    ck_path.write_text(
+        json.dumps(product_checksums, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    # NEVER rewrite ck_path after this point.
+
+    # --- 3) package_checksums from staged tree including checksums.json ---
+    package_checksums: dict[str, str] = dict(product_checksums)
+    package_checksums["checksums.json"] = sha256_file(ck_path)
+
+    # --- 4) package-reconciliation (campaign + staged) ---
+    recon = {
+        "status": "PASS",
+        "run_id": run_id,
+        "product_rc_sha": product_rc_sha,
+        "artifact_name": FROZEN_RC_ARTIFACT_NAME,
+        "same_run_id": True,
+        "checksums_reconciled": True,
+        "identity_self_hash": False,
+        "production_touched": False,
+        "soak_touched": False,
+        "generated_at": utc_now(),
+        "files": {
+            k: package_checksums[k]
+            for k in REQUIRED_IDENTITY_FILES
+            if k in package_checksums
+        },
+    }
+    recon_path = campaign_dir / "package-reconciliation.json"
+    recon_path.write_text(
+        json.dumps(recon, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    shutil.copy2(recon_path, staging_dir / "package-reconciliation.json")
+
+    # --- 5) user-acceptance PENDING_HUMAN (uses final package_checksums) ---
+    v1_path = write_v1_history(campaign_dir)
+    shutil.copy2(v1_path, staging_dir / "rc-v1-CHANGES_REQUESTED.json")
+
+    acceptance = {
+        "status": "PENDING_HUMAN",
+        "campaign_id": CAMPAIGN_ID,
+        "pr": "https://github.com/tjsasakifln/extra-cli/pull/131",
+        "run_id": run_id,
+        "rc_sha": product_rc_sha,
+        "package_checksums": package_checksums,
+        "accepted_by": None,
+        "accepted_at": None,
+        "notes": (
+            "Commercial RC v2 (sector-filtered engineering). "
+            "RC v1 remains CHANGES_REQUESTED historically. "
+            "Agent must not rebind ACCEPT."
+        ),
+        "agent_auto_accept_forbidden": True,
+        "decision_options": ["ACCEPTED", "REJECTED", "CHANGES_REQUESTED"],
+        "freeze": {
+            "pack_run_id": run_id,
+            "product_rc_sha": product_rc_sha,
+            "artifact_name": FROZEN_RC_ARTIFACT_NAME,
+            "product_rc_scheme": "content_sha256_v1",
+            "as_of": utc_now(),
+            "prior_rc": {
+                "run_id": FROZEN_RC_V1_RUN_ID,
+                "product_rc_sha": FROZEN_RC_V1_PRODUCT_SHA,
+                "status": FROZEN_RC_V1_STATUS,
+            },
+        },
+        "binding": {
+            "pack_run_id": run_id,
+            "rc_sha": product_rc_sha,
+            "valid": True,
+            "checked_at": utc_now(),
+        },
+        "classification": "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+    }
+    ua_campaign = campaign_dir / "user-acceptance.json"
+    ua_bytes = (json.dumps(acceptance, indent=2, ensure_ascii=False) + "\n").encode(
+        "utf-8"
+    )
+    ua_campaign.write_bytes(ua_bytes)
+    (staging_dir / "user-acceptance.json").write_bytes(ua_bytes)
+
+    # --- 6) ARTIFACT-IDENTITY (no self-hash); may list ua/checksums as members ---
+    file_sha: dict[str, str] = dict(package_checksums)
+    for meta in META_AFTER_CHECKSUMS:
+        mp = staging_dir / meta
+        if mp.is_file():
+            file_sha[meta] = sha256_file(mp)
+
+    identity = {
+        "run_id": run_id,
+        "product_rc_sha": product_rc_sha,
+        "product_rc_scheme": "content_sha256_v1",
+        "file_sha256": dict(file_sha),  # excludes ARTIFACT-IDENTITY.json itself
+        "freeze_date": utc_now(),
+        "production_touched": False,
+        "soak_touched": False,
+        "artifact_name": FROZEN_RC_ARTIFACT_NAME,
+        "classification": "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+        "prior_rc": {
+            "artifact_name": FROZEN_RC_V1_ARTIFACT_NAME,
+            "run_id": FROZEN_RC_V1_RUN_ID,
+            "product_rc_sha": FROZEN_RC_V1_PRODUCT_SHA,
+            "status": FROZEN_RC_V1_STATUS,
+        },
+        "sources": sources,
+        "self_hash_policy": "excluded — ARTIFACT-IDENTITY.sha256 sidecar",
+        "assembled_at": utc_now(),
+    }
+    id_path = staging_dir / "ARTIFACT-IDENTITY.json"
+    id_path.write_text(
+        json.dumps(identity, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    id_sha = sha256_file(id_path)
+    (staging_dir / "ARTIFACT-IDENTITY.sha256").write_text(
+        f"{id_sha}  ARTIFACT-IDENTITY.json\n", encoding="utf-8"
+    )
+
+    # --- 7) Fail-closed full reconciliation ---
+    divergences = assert_full_reconciliation(staging_dir)
+    if divergences:
+        return {
+            "status": "FAIL",
+            "error": "full_reconciliation_failed",
+            "divergences": divergences,
+            "staging_dir": str(staging_dir),
+            "run_id": run_id,
+            "product_rc_sha": product_rc_sha,
+        }
+
+    # Mirror pack-level checksums for pack-v2 convenience (same bytes as staging)
+    (pack_dir / "checksums.json").write_bytes(ck_path.read_bytes())
+
+    return {
+        "status": "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+        "artifact_name": FROZEN_RC_ARTIFACT_NAME,
+        "staging_dir": str(staging_dir),
+        "run_id": run_id,
+        "product_rc_sha": product_rc_sha,
+        "file_sha256": file_sha,
+        "identity_sha256": id_sha,
+        "production_touched": False,
+        "soak_touched": False,
+    }
+
+
+# Back-compat alias used by older call sites/tests
+def assemble_v2(
+    *,
+    campaign_dir: Path,
+    pack_dir: Path,
+    staging_dir: Path,
+    run_id: str,
+    product_rc_sha: str,
+    acceptance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Deprecated name: delegates to freeze_staging (acceptance rebuilt from staged tree)."""
+    del acceptance  # ignored — freeze_staging is the single writer
+    return freeze_staging(
+        campaign_dir=campaign_dir,
+        pack_dir=pack_dir,
+        staging_dir=staging_dir,
+        run_id=run_id,
+        product_rc_sha=product_rc_sha,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Publish commercial RC v2")
+    p.add_argument("--dsn", required=True)
+    p.add_argument(
+        "--out",
+        default=str(_PROJECT_ROOT / "artifacts/campaigns" / CAMPAIGN_ID / "pack-v2"),
+    )
+    p.add_argument(
+        "--campaign-dir",
+        default=str(_PROJECT_ROOT / "artifacts/campaigns" / CAMPAIGN_ID),
+    )
+    p.add_argument(
+        "--staging",
+        default=str(
+            _PROJECT_ROOT
+            / "artifacts/campaigns"
+            / CAMPAIGN_ID
+            / FROZEN_RC_ARTIFACT_NAME
+        ),
+    )
+    p.add_argument("--uf", default="SC")
+    p.add_argument("--export-limit", type=int, default=50)
+    p.add_argument("--skip-pack", action="store_true", help="Reuse existing pack-v2")
+    p.add_argument("--e-evidence", default=None)
+    args = p.parse_args(argv)
+
+    pack_dir = Path(args.out)
+    campaign_dir = Path(args.campaign_dir)
+    staging_dir = Path(args.staging)
+    campaign_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_pack:
+        e_path = Path(args.e_evidence) if args.e_evidence else None
+        pack = run_pack(
+            dsn=args.dsn,
+            out_dir=pack_dir,
+            uf=args.uf,
+            export_limit=args.export_limit,
+            e_evidence=e_path,
+        )
+    else:
+        pm = pack_dir / "pack-manifest.json"
+        pack = json.loads(pm.read_text(encoding="utf-8")) if pm.is_file() else {}
+
+    run_id = str(pack.get("run_id") or "")
+    if not run_id:
+        print(json.dumps({"status": "FAIL", "error": "missing_run_id"}))
+        return 2
+
+    # Aliases for identity filenames
+    for src, dst in (
+        ("extra_live_consulting_pack.pdf", "executive-report.pdf"),
+        ("extra_live_consulting_pack.xlsx", "consulting-pack.xlsx"),
+        ("executive_summary.md", "executive-summary.md"),
+    ):
+        sp, dp = pack_dir / src, pack_dir / dst
+        if sp.is_file():
+            dp.write_bytes(sp.read_bytes())
+
+    product_rc_sha = content_product_rc_sha(pack_dir)
+    pm_path = pack_dir / "pack-manifest.json"
+    if pm_path.is_file():
+        try:
+            pm = json.loads(pm_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            pm = {}
+        pm["run_id"] = run_id
+        pm["product_rc_sha"] = product_rc_sha
+        pm["product_rc_scheme"] = "content_sha256_v1"
+        pm["git_sha_provenance"] = pm.get("git_sha") or pack.get("git_sha")
+        pm_path.write_text(
+            json.dumps(pm, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+
+    # Commercial honesty gates on E before freeze
+    e_path = pack_dir / "deliverable_e.json"
+    if e_path.is_file():
+        e = json.loads(e_path.read_text(encoding="utf-8"))
+        for rec in e.get("recommendations") or []:
+            lab = (rec.get("sector_classification") or {}).get("label")
+            if lab in {"NON_ENGINEERING", "EXCLUDED_CATEGORY"}:
+                print(
+                    json.dumps(
+                        {
+                            "status": "FAIL",
+                            "error": "non_engineering_in_e",
+                            "label": lab,
+                            "titulo": rec.get("titulo"),
+                        },
+                        indent=2,
+                        ensure_ascii=False,
+                    )
+                )
+                return 2
+
+    result = freeze_staging(
+        campaign_dir=campaign_dir,
+        pack_dir=pack_dir,
+        staging_dir=staging_dir,
+        run_id=run_id,
+        product_rc_sha=product_rc_sha,
+    )
+
+    # Sync campaign constants consumers (FROZEN_RC_* still used by tests)
+    if result.get("status") == "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW":
+        const_path = (
+            _PROJECT_ROOT / "scripts/ops/client_ready_consulting_cycle.py"
+        )
+        if const_path.is_file():
+            import re
+
+            text = const_path.read_text(encoding="utf-8")
+            text = re.sub(
+                r'FROZEN_RC_RUN_ID = "[^"]+"',
+                f'FROZEN_RC_RUN_ID = "{run_id}"',
+                text,
+            )
+            text = re.sub(
+                r'FROZEN_RC_PRODUCT_SHA = "[^"]+"',
+                f'FROZEN_RC_PRODUCT_SHA = "{product_rc_sha}"',
+                text,
+            )
+            const_path.write_text(text, encoding="utf-8")
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if result.get("status") == "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/sector_classifier.py
+++ b/scripts/ops/sector_classifier.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""Classificador setorial auditável para Extra Construtora (B2G / engenharia civil).
+
+Labels canônicos (fail-closed comercial):
+  ENGINEERING_HIGH_CONFIDENCE | ENGINEERING_REVIEW | NON_ENGINEERING
+  | AMBIGUOUS | EXCLUDED_CATEGORY
+
+Nenhum objeto vira aderente só por palavra genérica (serviço, manutenção,
+construção, projeto). Regras versionadas; output sempre auditável.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+RULE_VERSION = "extra-sector-classifier/2.2.0"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PROFILE_PATH = PROJECT_ROOT / "config/client_profiles/extra.yaml"
+
+LABELS = (
+    "ENGINEERING_HIGH_CONFIDENCE",
+    "ENGINEERING_REVIEW",
+    "NON_ENGINEERING",
+    "AMBIGUOUS",
+    "EXCLUDED_CATEGORY",
+)
+
+# Labels that may appear in commercial Deliverable E
+E_ALLOWED_LABELS = frozenset({"ENGINEERING_HIGH_CONFIDENCE", "ENGINEERING_REVIEW"})
+
+_GENERIC_ALONE = re.compile(
+    r"^(?:servi[cç]os?|manuten[cç][aã]o|constru[cç][aã]o|projeto|obras?|"
+    r"engenharia|infraestrutura)\s*$",
+    re.I,
+)
+_GENERIC_WEAK = (
+    "servico",
+    "servicos",
+    "manutencao",
+    "construcao",
+    "projeto",
+    "obra",
+    "obras",
+    "engenharia",
+    "infraestrutura",
+)
+
+
+def _strip_accents(s: str) -> str:
+    nfkd = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in nfkd if not unicodedata.combining(c))
+
+
+def normalize_text(text: str | None) -> str:
+    if not text:
+        return ""
+    t = _strip_accents(str(text)).lower()
+    t = re.sub(r"\s+", " ", t)
+    return t.strip()
+
+
+@dataclass
+class SectorClassification:
+    label: str
+    positive_terms: list[str] = field(default_factory=list)
+    negative_terms: list[str] = field(default_factory=list)
+    excluded_terms: list[str] = field(default_factory=list)
+    category: str = ""
+    subcategory: str = ""
+    reason: str = ""
+    confidence: float = 0.0
+    textual_evidence: str = ""
+    rule_version: str = RULE_VERSION
+    sector_match: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @property
+    def allowed_in_deliverable_e(self) -> bool:
+        return self.label in E_ALLOWED_LABELS
+
+
+# Fallback vocabulary if profile lacks sector_vocabulary block
+# pavimentacao: NÃO usar \bpaviment (casa "7º pavimento" / andar)
+_FALLBACK_POSITIVE: list[tuple[str, str, str, float]] = [
+    ("pavimentacao", r"\bpavimenta(c|ç)|\bpavimentacao\b|\bpavimentacao\s+asfalt|\brecapeamento\b|\bcapeamento\s+asfalt", "pavimentacao", 0.45),
+    ("asfalto", r"\basfalt|\bcbu\b|\bcapeamento\b", "pavimentacao", 0.4),
+    # meio-fio/sarjeta só contam com contexto de obra/drenagem (não sozinhas em compra de equipamento)
+    ("drenagem", r"\bdrenagem\s+(urbana|pluvial|de\s+aguas|viaria)|\bgaleria\s+pluvial\b|"
+     r"\b(execucao|implantacao|obra).{0,40}\b(sarjeta|meio[- ]fio)\b|"
+     r"\b(sarjeta|meio[- ]fio).{0,40}\b(drenagem|pavimentacao|via)\b", "drenagem", 0.42),
+    ("terraplenagem", r"\bterraplenagem\b|\bterraplanagem\b", "terraplenagem", 0.45),
+    ("saneamento", r"\bsaneamento\s+(basico|ambiental|urbano)\b|\brede\s+de\s+esgoto\b|\badutora?\b|\brede\s+coletora\b|\bestacao\s+de\s+tratamento\b", "saneamento", 0.4),
+    ("esgoto_rede", r"\brede\s+(de\s+)?esgoto\b|\besgotamento\s+sanitario\b|\bcoleta\s+de\s+esgoto\b", "saneamento", 0.38),
+    ("infraestrutura_urbana", r"\binfraestrutura\s+urbana\b|\burbaniza[cç]|\brevitaliza[cç][aã]o\s+urbana\b", "infraestrutura_urbana", 0.38),
+    ("calcada", r"\bcal[cç]ad[ao]\b|\bpasseio\s+publico\b", "infraestrutura_urbana", 0.3),
+    ("edificacao", r"\bedificacao\b|\bedificacoes\b|\bpredio\s+publico\b|\bedificio\s+publico\b", "edificacoes", 0.38),
+    ("construcao_edificios", r"\bconstru[cç][aã]o\s+de\s+(edif|pred|escola|creche|ubs|pronto.?socorro|ginasio|quadra)", "edificacoes", 0.45),
+    ("ampliacao", r"\bamplia[cç][aã]o\s+de\s+(escola|creche|pred|edif|ubs|hospital|ginasio)", "edificacoes", 0.42),
+    ("reforma_predial", r"\breforma\s+(predial|de\s+edif|de\s+pred|estrutural|de\s+escola|de\s+creche)", "reformas", 0.4),
+    ("manutencao_predial", r"\bmanuten[cç][aã]o\s+(predial|de\s+edif|de\s+pred|civil\s+das\s+edifica|de\s+imovel)", "manutencao_predial", 0.38),
+    ("obra_engenharia", r"\bobra[s]?\s+de\s+engenharia\b|\bexecu[cç][aã]o\s+das\s+obras\s+de\s+engenharia\b|\bservicos?\s+de\s+engenharia\s+(civil|para)\b", "obras_civis", 0.45),
+    ("ponte_viaduto", r"\bponte\b|\bviaduto\b|\bpassarela\b|\bpontilh", "infraestrutura_urbana", 0.35),
+    ("contencao", r"\bconten[cç][aã]o\b|\bmuro\s+de\s+arrimo\b|\bgabiao\b", "terraplenagem", 0.35),
+    ("demolicao", r"\bdemoli[cç]", "reformas", 0.28),
+    ("projeto_engenharia", r"\bprojetos?\s+(executivo|basico|de\s+engenharia|arquitetonicos?|complementares?)", "projetos", 0.35),
+    ("projetos_complementares", r"\bprojetos?\s+complementares\b|\bprojeto\s+estrutural\b|\bprojeto\s+hidrossanitario\b|\barquitetonicos?\s+e\s+complementares\b", "projetos", 0.35),
+    ("fiscalizacao_obra", r"\bfiscaliza[cç][aã]o\s+(de\s+)?(obra|engenharia)", "projetos", 0.3),
+    ("instalacoes_prediais", r"\binstala[cç][oõ]es\s+(eletricas|hidraulicas|prediais)\b", "manutencao_predial", 0.28),
+    ("cobertura_telhado", r"\bcobertura\s+(metalica|de\s+telha)|\btelhado\b", "reformas", 0.25),
+    ("alvenaria_concreto", r"\balvenaria\b|\bestrutura\s+de\s+concreto\b", "edificacoes", 0.28),
+    ("recuperacao_estrutural", r"\brecupera[cç][aã]o\s+estrutural\b", "reformas", 0.35),
+    ("obras_publicas", r"\bexecu[cç][aã]o\s+de\s+obras?\b|\bobras?\s+publicas?\b", "obras_civis", 0.28),
+]
+
+# Negativos com veto forte (sempre >= 0.55 para poder anular pos fraco)
+_FALLBACK_NEGATIVE: list[tuple[str, str, float]] = [
+    ("seguro", r"\bseguro\s+(de\s+)?(frota|veiculo|automovel|total|contra)|apolice\s+de\s+seguro\b|\bseguradora\b", 0.7),
+    ("frota", r"\bmanuten[cç][aã]o\s+da\s+frota\b|\bfrota\s+(municipal|de\s+veiculo)|\boficina\s+mecanica\b|\bveiculos?\s+(da\s+frota|automotores)\b", 0.65),
+    ("voip_telecom", r"\bvoip\b|\btelefonia\b|\blink\s+de\s+dados\b|\binternet\s+dedicad|\bPABX\b|\bcentral\s+telefonica\b", 0.65),
+    ("limpeza_jardinagem", r"\blimpeza\s+(predial|urbana|publica)\b|\bjardinagem\b|\bro[cç]ada\b|\bcapeina\b|\bpoda\s+de\s+arvores\b|\bconservacao\s+e\s+limpeza\b", 0.6),
+    ("grama_esporte", r"\bgrama\s+sintetica\b|\bgramado\s+(sintetico|esportivo)\b|\bcampo\s+de\s+futebol\b|\bfifa\b|\bquadra\s+poliesportiva\b(?!.*\bconstru)", 0.6),
+    ("saneamento_metafora", r"\bsaneamento\s+de\s+(inconformidades|pendencias|irregularidades|processos|passivo|contas)\b", 0.7),
+    ("computador", r"\bcomputador\b|\bnotebook\b|\ball\s+in\s+one\b|\bimpressora\b|\binformatica\b|\bhardware\b", 0.55),
+    ("lencois", r"\blen[cç][oó]is?\b|\bmantas?\s+destinad|\bcama\s+hospitalar\b|\benxoval\b", 0.55),
+    ("exames", r"\bexames?\s+(laborator|clinico|de\s+imagem)|\blaboratoriais\b|\bcomplementar\s+ao\s+sus\b", 0.55),
+    ("saude_assistencial", r"\bmedicamento\b|\bfarmaco\b|\bvacina\b|\bprotese\b|\bhospitalar\s+descart", 0.5),
+    ("combustivel", r"\bcombustivel\b|\bgasolina\b|\bdiesel\b|\betanol\s+combust", 0.5),
+    ("cursos", r"\bcurso[s]?\s+(para|de)\b|\bcapacita[cç][aã]o\b|\btreinamento\b|\bprofessores?\b", 0.45),
+    ("eventos_culturais", r"\boficina\s+de\s+karate\b|\bkarate\b|\bevento\s+cultural\b|\boficina\s+cultural\b", 0.5),
+    ("bancario", r"\barrecadacao\s+(bancaria|de\s+faturas|de\s+tributos)\b|\bservicos?\s+bancarios?\b|"
+     r"\btarifa\s+bancaria\b|\binstituicoes?\s+financeiras?\b|\bbanco\s+central\b|"
+     r"\bcredenciamento\s+de\s+instituicoes?\s+financeiras?\b|\boperar\s+pelo\s+banco\b", 0.75),
+    ("equipamento_puro", r"\baquisicao\s+de\s+(equipamentos?|conjuntos?\s+motobomb\w*|motobomb\w*|"
+     r"airless|maquinas?|maquinario|veiculo)\b|\bfornecimento\s+de\s+equipamento\b", 0.65),
+    ("equip_hospitalar", r"\bequipamento[s]?\s+hospitalar|\bmateriais?\s+medico.?hospitalar", 0.5),
+    ("software", r"\bmanuten[cç][aã]o\s+de\s+software\b|\blicenca\s+de\s+uso\b|\bsistema\s+informat|\bsoftware\b|\bnuvem\b|\bcloud\b", 0.55),
+    ("construcao_conhecimento", r"\bconstrucao\s+de\s+conhecimento\b|\bconstrucao\s+coletiva\s+de\s+saberes\b", 0.6),
+    ("alimentacao", r"\bgeneros\s+aliment|\bmerenda\b|\brefeicao\b|\balimentos?\b", 0.45),
+    ("roupas", r"\buniforme\b|\bvestuario\b|\broupas?\b|\bcalcado\s+de\s+seguranca\b", 0.4),
+    ("castracao", r"\bcastracao\b|\besterilizacao\s+de\s+animais\b|\bzoonoses\b", 0.55),
+    ("residuos_cc", r"\bresiduos?\s+da\s+construcao\s+civil\b|\bentulho\b|\bcacamba\s+de\s+entulho\b", 0.4),
+    ("vigilancia", r"\bvigilancia\s+(desarmada|armada)\b|\bseguranca\s+patrimonial\b", 0.4),
+    ("publicidade", r"\bpublicidade\b|\bpropaganda\b|\bmidia\s+outdoor\b", 0.4),
+    ("assessoria_juridica", r"\bassessoria\s+(juridica|contabil|administrativa)\b|\bconsultoria\s+juridica\b", 0.55),
+]
+
+# Negativos que SEMPRE vetam engenharia se presentes (salvo execução explícita de obra civil)
+_VETO_NEGATIVE_IDS = frozenset({
+    "seguro",
+    "frota",
+    "voip_telecom",
+    "limpeza_jardinagem",
+    "grama_esporte",
+    "saneamento_metafora",
+    "computador",
+    "lencois",
+    "exames",
+    "software",
+    "castracao",
+    "construcao_conhecimento",
+    "bancario",
+    "assessoria_juridica",
+    "equipamento_puro",
+})
+
+_FALLBACK_EXCLUSION: list[tuple[str, str]] = [
+    ("credenciamento_generico", r"\bcredenciamento\b(?!.*\b(obra|engenharia|paviment|edifica|reforma\s+predial))"),
+    ("saude_assistencial_cat", r"\b(sus\b|unidade\s+basica\s+de\s+saude|atencao\s+basica\s+a\s+saude)"),
+    ("admin_puro", r"\b(servicos?\s+administrativos?\s+continuados|locacao\s+de\s+mao\s+de\s+obra\s+administrativa)"),
+]
+
+# "material de construção" isolado (sem execução de obra)
+_MATERIAL_ONLY = re.compile(
+    r"\b(aquisicao|fornecimento|compra|registro\s+de\s+precos?)\b.+\b("
+    r"materiais?\s+(de\s+)?(constru\w*|paviment\w*|obra|hidraul\w*)|"
+    r"materiais?\s+para\s+(uso\s+nas\s+)?paviment\w*"
+    r")",
+    re.I,
+)
+_EXECUCAO_OBRA = re.compile(
+    r"\b(execu[cç][aã]o|empreitada|construcao\s+de|obra[s]?\s+de|servicos?\s+de\s+engenharia|"
+    r"reforma\s+predial|manutencao\s+predial|pavimentacao|drenagem|terrapl)\b",
+    re.I,
+)
+
+
+def load_profile(path: Path | None = None) -> dict[str, Any]:
+    p = path or DEFAULT_PROFILE_PATH
+    if not p.is_file():
+        return {}
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    return data if isinstance(data, dict) else {}
+
+
+def _compile_from_profile(profile: dict[str, Any]) -> tuple[
+    list[tuple[str, re.Pattern[str], str, float]],
+    list[tuple[str, re.Pattern[str], float]],
+    list[tuple[str, re.Pattern[str]]],
+]:
+    """Build compiled rules from profile sector_vocabulary when present."""
+    vocab = profile.get("sector_vocabulary") or {}
+    positives: list[tuple[str, re.Pattern[str], str, float]] = []
+    if isinstance(vocab.get("positive"), list) and vocab["positive"]:
+        for item in vocab["positive"]:
+            if isinstance(item, dict):
+                tid = str(item.get("id") or item.get("term") or "pos")
+                pat = str(item.get("pattern") or item.get("term") or "")
+                sub = str(item.get("subcategory") or item.get("category") or "obras_civis")
+                w = float(item.get("weight") or 0.35)
+            else:
+                tid = normalize_text(str(item)).replace(" ", "_")[:40]
+                pat = re.escape(normalize_text(str(item)))
+                sub = "obras_civis"
+                w = 0.35
+            if pat:
+                positives.append((tid, re.compile(pat, re.I), sub, w))
+    else:
+        for tid, pat, sub, w in _FALLBACK_POSITIVE:
+            positives.append((tid, re.compile(pat, re.I), sub, w))
+
+    negatives: list[tuple[str, re.Pattern[str], float]] = []
+    if isinstance(vocab.get("negative"), list) and vocab["negative"]:
+        for item in vocab["negative"]:
+            if isinstance(item, dict):
+                tid = str(item.get("id") or item.get("term") or "neg")
+                pat = str(item.get("pattern") or item.get("term") or "")
+                w = float(item.get("weight") or 0.45)
+            else:
+                tid = normalize_text(str(item)).replace(" ", "_")[:40]
+                pat = re.escape(normalize_text(str(item)))
+                w = 0.45
+            if pat:
+                negatives.append((tid, re.compile(pat, re.I), w))
+    else:
+        for tid, pat, w in _FALLBACK_NEGATIVE:
+            negatives.append((tid, re.compile(pat, re.I), w))
+
+    exclusions: list[tuple[str, re.Pattern[str]]] = []
+    if isinstance(vocab.get("exclusion"), list) and vocab["exclusion"]:
+        for item in vocab["exclusion"]:
+            if isinstance(item, dict):
+                tid = str(item.get("id") or item.get("term") or "exc")
+                pat = str(item.get("pattern") or item.get("term") or "")
+            else:
+                tid = normalize_text(str(item)).replace(" ", "_")[:40]
+                pat = re.escape(normalize_text(str(item)))
+            if pat:
+                exclusions.append((tid, re.compile(pat, re.I)))
+    else:
+        for tid, pat in _FALLBACK_EXCLUSION:
+            exclusions.append((tid, re.compile(pat, re.I)))
+
+    return positives, negatives, exclusions
+
+
+def _pick_category(pos_hits: list[tuple[str, str, float]]) -> tuple[str, str]:
+    if not pos_hits:
+        return "nao_engenharia", ""
+    # highest weight subcategory
+    best = max(pos_hits, key=lambda x: x[2])
+    sub = best[1]
+    cat_map = {
+        "pavimentacao": "infraestrutura",
+        "drenagem": "infraestrutura",
+        "terraplenagem": "infraestrutura",
+        "saneamento": "infraestrutura",
+        "infraestrutura_urbana": "infraestrutura",
+        "edificacoes": "edificacoes",
+        "reformas": "edificacoes",
+        "manutencao_predial": "edificacoes",
+        "obras_civis": "obras_civis",
+        "projetos": "projetos_engenharia",
+    }
+    return cat_map.get(sub, "obras_civis"), sub
+
+
+def classify_object(
+    objeto: str | None = None,
+    *,
+    titulo: str | None = None,
+    itens: str | None = None,
+    profile: dict[str, Any] | None = None,
+    profile_path: Path | None = None,
+) -> SectorClassification:
+    """Classifica um objeto de compra/contrato/edital de forma auditável."""
+    prof = profile if profile is not None else load_profile(profile_path)
+    raw_parts = [p for p in (objeto, titulo, itens) if p]
+    raw = " | ".join(str(p) for p in raw_parts)
+    blob = normalize_text(raw)
+    evidence = (raw[:280] + "…") if len(raw) > 280 else raw
+
+    if not blob:
+        return SectorClassification(
+            label="AMBIGUOUS",
+            reason="texto vazio — sem objeto para classificar",
+            confidence=0.0,
+            textual_evidence="",
+            category="desconhecido",
+            subcategory="",
+            sector_match=False,
+        )
+
+    # Generic-only short text
+    if _GENERIC_ALONE.match(blob) or (
+        len(blob.split()) <= 2 and all(w in _GENERIC_WEAK for w in blob.split())
+    ):
+        return SectorClassification(
+            label="NON_ENGINEERING",
+            reason="apenas termo genérico (serviço/manutenção/construção/projeto) sem contexto de obra",
+            confidence=0.95,
+            textual_evidence=evidence,
+            category="generico",
+            subcategory="termo_generico_isolado",
+            positive_terms=[],
+            sector_match=False,
+        )
+
+    positives, negatives, exclusions = _compile_from_profile(prof)
+
+    # Explicit false friends first (always NON_ENGINEERING)
+    false_friends: list[tuple[str, str, str]] = [
+        (
+            r"\b(aquisicao|compra)\b.+\b(livro|exemplares?\s+do\s+livro|publicacao)\b",
+            "publicacao_livro",
+            "aquisição de livro/publicação — não é execução de obra",
+        ),
+        (
+            r"\bconstrucao\s+de\s+conhecimento\b|\bconstrucao\s+coletiva\s+de\s+saberes\b",
+            "construcao_conhecimento",
+            "metáfora educacional — não é obra",
+        ),
+        (
+            r"\bmanutencao\s+de\s+software\b|\blicenca\s+de\s+software\b",
+            "software",
+            "manutenção/licença de software — fora do mercado de obras",
+        ),
+        (
+            r"\bsaneamento\s+de\s+(inconformidades|pendencias|irregularidades|processos|passivo|contas)\b",
+            "saneamento_metafora",
+            "saneamento metafórico (jurídico/contábil) — não é saneamento de infraestrutura",
+        ),
+        (
+            r"\bseguro\b.+\b(frota|veiculo|automovel)\b|\b(frota|veiculo).+\bseguro\b|\bseguradora\b",
+            "seguro_frota",
+            "seguro de frota/veículos — não é obra de engenharia",
+        ),
+        (
+            r"\b(voip|telefonia|pabx|central\s+telefonica)\b",
+            "voip_telecom",
+            "telecom/VoIP — não é obra de engenharia",
+        ),
+        (
+            r"\b(limpeza|jardinagem|rocada|capeina)\b.+\b(pavimentad|calcada|via)\b|"
+            r"\b(areas?|vias?)\s+pavimentad.+\b(limpeza|jardinagem|rocada)\b",
+            "limpeza_sobre_pavimento",
+            "limpeza/jardinagem em área pavimentada — não é obra de pavimentação",
+        ),
+        (
+            r"\bgrama\s+sintetica\b|\bgramado\s+sintetico\b|\bfifa\b",
+            "grama_esporte",
+            "grama sintética/esporte — não é infraestrutura de engenharia da Extra",
+        ),
+        (
+            r"\b(instituicoes?\s+financeiras?|arrecadacao\s+de\s+faturas|banco\s+central|"
+            r"credenciamento\s+de\s+instituicoes?\s+financeiras?|operar\s+pelo\s+banco|"
+            r"arrecadacao\s+bancaria)\b",
+            "servico_bancario",
+            "serviço/credenciamento bancário ou arrecadação — não é obra de engenharia",
+        ),
+        (
+            r"\baquisicao\s+de\s+(equipamentos?|conjuntos?\s+motobomb\w*|motobomb\w*|"
+            r"airless|maquinas?|maquinario)"
+            r"(?!.*\b(execucao\s+de\s+obra|empreitada)\b)",
+            "aquisicao_equipamento",
+            "aquisição de equipamento sem execução de obra — fora do perfil empreiteira",
+        ),
+        (
+            r"\bpintura\s+e\s+demarcacao\s+viaria\b|\bequipamento\s+de\s+pintura\b|\bairless\b",
+            "sinalizacao_pintura_equip",
+            "equipamento/serviço de pintura e demarcação viária — não é obra civil Extra",
+        ),
+    ]
+    for pat, tid, reason in false_friends:
+        if re.search(pat, blob, re.I):
+            return SectorClassification(
+                label="NON_ENGINEERING",
+                negative_terms=[tid],
+                reason=reason,
+                confidence=0.97,
+                textual_evidence=evidence,
+                category="nao_engenharia",
+                subcategory=tid,
+                sector_match=False,
+            )
+
+    # Agregados/materiais para obra sem execução → REVIEW (não HIGH, não peer direto)
+    if re.search(
+        r"\b(aquisicao|fornecimento|compra)\b.+\b(racha[oõ]|bica\s+corrida|material\s+britado|"
+        r"pedra\s+pulmao|seixo|brita\b)",
+        blob,
+        re.I,
+    ) and not re.search(r"\b(execucao|empreitada|obra\s+de\s+engenharia)\b", blob, re.I):
+        return SectorClassification(
+            label="ENGINEERING_REVIEW",
+            positive_terms=["materiais_agregados"],
+            negative_terms=["sem_execucao"],
+            reason="aquisição de agregados/materiais sem execução de obra",
+            confidence=0.72,
+            textual_evidence=evidence,
+            category="materiais",
+            subcategory="material_sem_execucao",
+            sector_match=False,
+        )
+
+    # "7º pavimento" = andar (não pavimentação). Suprime positivos de via.
+    suppress_road_pavement = bool(
+        re.search(
+            r"\b\d+\s*[oºa]?\s*pavimento\b|\bpavimento\s+(do\s+)?(predio|edificio|bloco|torre)\b",
+            blob,
+            re.I,
+        )
+    )
+
+    # Always merge fallback negatives (profile alone can miss seguro/VoIP/etc.)
+    fb_neg = [(tid, re.compile(pat, re.I), w) for tid, pat, w in _FALLBACK_NEGATIVE]
+    seen_neg = {t for t, _, _ in negatives}
+    for tid, cre, w in fb_neg:
+        if tid not in seen_neg:
+            negatives.append((tid, cre, w))
+
+    # Prefer precise fallback positives for critical terms (override broad profile patterns)
+    precise_pos = {
+        tid: (tid, re.compile(pat, re.I), sub, w)
+        for tid, pat, sub, w in _FALLBACK_POSITIVE
+        if tid
+        in {
+            "pavimentacao",
+            "saneamento",
+            "esgoto_rede",
+            "drenagem",
+            "asfalto",
+        }
+    }
+    filtered_pos = []
+    seen_pos = set()
+    for tid, cre, sub, w in positives:
+        if tid in precise_pos:
+            continue  # replaced by precise
+        filtered_pos.append((tid, cre, sub, w))
+        seen_pos.add(tid)
+    for tid, item in precise_pos.items():
+        filtered_pos.append(item)
+    positives = filtered_pos
+
+    pos_hits: list[tuple[str, str, float]] = []
+    for tid, cre, sub, w in positives:
+        if cre.search(blob):
+            if suppress_road_pavement and tid in {"pavimentacao", "asfalto"}:
+                continue
+            pos_hits.append((tid, sub, w))
+    # reforma de pavimento/andar de prédio → reforma predial se houver reforma+predio
+    if suppress_road_pavement and re.search(
+        r"\breforma\b.+\b(predio|edificio|pavimento)\b|\bpavimento\b.+\breforma\b",
+        blob,
+        re.I,
+    ):
+        if not any(h[1] == "reformas" for h in pos_hits):
+            pos_hits.append(("reforma_andar_predial", "reformas", 0.4))
+
+    neg_hits: list[tuple[str, float]] = []
+    for tid, cre, w in negatives:
+        if cre.search(blob):
+            neg_hits.append((tid, w))
+
+    exc_hits: list[str] = []
+    for tid, cre in exclusions:
+        if cre.search(blob):
+            exc_hits.append(tid)
+
+    pos_score = sum(w for _, _, w in pos_hits)
+    neg_score = sum(w for _, w in neg_hits)
+    pos_ids = [t for t, _, _ in pos_hits]
+    neg_ids = [t for t, _ in neg_hits]
+    category, subcategory = _pick_category(pos_hits)
+
+    # Veto: strong negatives always win unless clear obra-execution subject
+    has_veto = any(n in _VETO_NEGATIVE_IDS for n in neg_ids)
+    has_strong_exec = bool(
+        re.search(
+            r"\b(execucao\s+de\s+(obra|pavimentacao|drenagem)|empreitada|"
+            r"obra\s+de\s+engenharia|construcao\s+de\s+(edif|pred|escola)|"
+            r"reforma\s+predial|terraplenagem)\b",
+            blob,
+            re.I,
+        )
+    )
+    if has_veto and not has_strong_exec:
+        return SectorClassification(
+            label="NON_ENGINEERING",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids,
+            excluded_terms=exc_hits,
+            reason=f"veto setorial ({', '.join(n for n in neg_ids if n in _VETO_NEGATIVE_IDS)})",
+            confidence=0.96,
+            textual_evidence=evidence,
+            category="nao_engenharia",
+            subcategory=next((n for n in neg_ids if n in _VETO_NEGATIVE_IDS), ""),
+            sector_match=False,
+        )
+
+    # Residuos da construção civil: negative unless explicit obra execution for Extra
+    if "residuos_cc" in neg_ids and not any(
+        s in {h[1] for h in pos_hits}
+        for s in ("edificacoes", "reformas", "pavimentacao", "obras_civis")
+    ):
+        return SectorClassification(
+            label="NON_ENGINEERING",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids,
+            reason="resíduos da construção civil sem execução de obra aderente",
+            confidence=0.9,
+            textual_evidence=evidence,
+            category="residuos",
+            subcategory="residuos_cc",
+            sector_match=False,
+        )
+
+    # Material de construção isolado
+    if _MATERIAL_ONLY.search(blob) and not _EXECUCAO_OBRA.search(blob):
+        return SectorClassification(
+            label="ENGINEERING_REVIEW",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids + ["material_isolado"],
+            reason="material de construção/pavimentação sem execução de obra — review comercial",
+            confidence=0.75,
+            textual_evidence=evidence,
+            category=category or "materiais",
+            subcategory="material_sem_execucao",
+            sector_match=False,
+        )
+
+    # Strong exclusion categories with no engineering execution context
+    if exc_hits and pos_score < 0.35:
+        return SectorClassification(
+            label="EXCLUDED_CATEGORY",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids,
+            excluded_terms=exc_hits,
+            reason=f"categoria excluída pelo perfil: {', '.join(exc_hits)}",
+            confidence=0.88,
+            textual_evidence=evidence,
+            category="excluido",
+            subcategory=exc_hits[0],
+            sector_match=False,
+        )
+
+    # Strong negatives dominate whenever they outweigh positives
+    if neg_score >= 0.45 and neg_score >= pos_score:
+        return SectorClassification(
+            label="NON_ENGINEERING",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids,
+            excluded_terms=exc_hits,
+            reason=f"termos negativos setoriais dominam (neg={neg_score:.2f}, pos={pos_score:.2f})",
+            confidence=min(0.99, 0.7 + neg_score * 0.3),
+            textual_evidence=evidence,
+            category="nao_engenharia",
+            subcategory=neg_ids[0] if neg_ids else "",
+            sector_match=False,
+        )
+
+    # Strong engineering execution categories
+    strong_subs = {
+        "pavimentacao",
+        "drenagem",
+        "terraplenagem",
+        "saneamento",
+        "edificacoes",
+        "reformas",
+        "obras_civis",
+        "infraestrutura_urbana",
+    }
+
+    if pos_score >= 0.38 and neg_score < 0.35:
+        # projetos alone → REVIEW (comercialmente relevante só com contexto)
+        if subcategory == "projetos" and not any(h[1] in strong_subs for h in pos_hits):
+            return SectorClassification(
+                label="ENGINEERING_REVIEW",
+                positive_terms=pos_ids,
+                negative_terms=neg_ids,
+                reason="projeto de engenharia/arquitetura — review de capacidade/CAT",
+                confidence=min(0.9, 0.55 + pos_score * 0.3),
+                textual_evidence=evidence,
+                category=category,
+                subcategory=subcategory,
+                sector_match=True,
+            )
+        if subcategory == "manutencao_predial" and pos_score < 0.55:
+            return SectorClassification(
+                label="ENGINEERING_REVIEW",
+                positive_terms=pos_ids,
+                negative_terms=neg_ids,
+                reason="manutenção predial — engineering/review (escopo e CAT)",
+                confidence=min(0.88, 0.5 + pos_score * 0.35),
+                textual_evidence=evidence,
+                category=category,
+                subcategory=subcategory,
+                sector_match=True,
+            )
+        if subcategory in strong_subs or pos_score >= 0.5:
+            return SectorClassification(
+                label="ENGINEERING_HIGH_CONFIDENCE",
+                positive_terms=pos_ids,
+                negative_terms=neg_ids,
+                reason=f"objeto de engenharia aderente (pos={pos_score:.2f})",
+                confidence=min(0.99, 0.65 + pos_score * 0.25),
+                textual_evidence=evidence,
+                category=category,
+                subcategory=subcategory,
+                sector_match=True,
+            )
+
+    if pos_score >= 0.28 and neg_score < pos_score:
+        return SectorClassification(
+            label="ENGINEERING_REVIEW",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids,
+            reason=f"sinais de engenharia parciais (pos={pos_score:.2f}, neg={neg_score:.2f})",
+            confidence=min(0.85, 0.4 + pos_score * 0.4),
+            textual_evidence=evidence,
+            category=category,
+            subcategory=subcategory,
+            sector_match=True,
+        )
+
+    if pos_hits and neg_hits and abs(pos_score - neg_score) < 0.2:
+        return SectorClassification(
+            label="AMBIGUOUS",
+            positive_terms=pos_ids,
+            negative_terms=neg_ids,
+            reason="sinais mistos positivos e negativos — ambíguo",
+            confidence=0.45,
+            textual_evidence=evidence,
+            category=category or "ambiguo",
+            subcategory=subcategory,
+            sector_match=False,
+        )
+
+    if not pos_hits and not neg_hits:
+        # pure generic words embedded
+        if any(g in blob.split() for g in _GENERIC_WEAK) and len(blob.split()) < 8:
+            return SectorClassification(
+                label="NON_ENGINEERING",
+                reason="vocabulário genérico sem termos de obra aderente",
+                confidence=0.7,
+                textual_evidence=evidence,
+                category="generico",
+                subcategory="",
+                sector_match=False,
+            )
+        return SectorClassification(
+            label="AMBIGUOUS",
+            reason="sem termos positivos ou negativos do vocabulário Extra",
+            confidence=0.35,
+            textual_evidence=evidence,
+            category="desconhecido",
+            subcategory="",
+            sector_match=False,
+        )
+
+    return SectorClassification(
+        label="NON_ENGINEERING",
+        positive_terms=pos_ids,
+        negative_terms=neg_ids,
+        excluded_terms=exc_hits,
+        reason=f"não aderente ao perfil Extra (pos={pos_score:.2f}, neg={neg_score:.2f})",
+        confidence=min(0.9, 0.55 + max(0.0, neg_score - pos_score) * 0.3),
+        textual_evidence=evidence,
+        category="nao_engenharia",
+        subcategory=neg_ids[0] if neg_ids else "",
+        sector_match=False,
+    )
+
+
+def is_engineering_for_e(clf: SectorClassification) -> bool:
+    return clf.allowed_in_deliverable_e
+
+
+def filter_engineering_rows(
+    rows: list[dict[str, Any]],
+    *,
+    text_keys: tuple[str, ...] = ("objeto", "titulo", "objeto_contrato"),
+    profile: dict[str, Any] | None = None,
+    allow_labels: frozenset[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Filter rows keeping only allowed engineering labels; attach sector_classification."""
+    allow = allow_labels or E_ALLOWED_LABELS
+    prof = profile if profile is not None else load_profile()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        text = ""
+        for k in text_keys:
+            if row.get(k):
+                text = str(row[k])
+                break
+        clf = classify_object(text, profile=prof)
+        enriched = dict(row)
+        enriched["sector_classification"] = clf.to_dict()
+        if clf.label in allow:
+            out.append(enriched)
+    return out
+
+
+def sql_engineering_ilike_terms(profile: dict[str, Any] | None = None) -> list[str]:
+    """Terms for SQL ILIKE pre-filter (recall-oriented; classifier re-filters)."""
+    prof = profile if profile is not None else load_profile()
+    vocab = prof.get("sector_vocabulary") or {}
+    terms: list[str] = []
+    for item in vocab.get("positive") or []:
+        if isinstance(item, dict):
+            t = item.get("sql_term") or item.get("term")
+            if t:
+                terms.append(str(t))
+        elif item:
+            terms.append(str(item))
+    desired = prof.get("desired_object_types") or []
+    for d in desired:
+        if isinstance(d, dict):
+            for t in d.get("terms") or []:
+                terms.append(str(t))
+    # Always include high-recall core
+    core = [
+        "pavimentacao",
+        "pavimentação",
+        "drenagem urbana",
+        "drenagem pluvial",
+        "terraplenagem",
+        "terraplanagem",
+        "saneamento basico",
+        "saneamento básico",
+        "esgotamento sanitario",
+        "rede de esgoto",
+        "reforma predial",
+        "manutenção predial",
+        "manutencao predial",
+        "construção de edif",
+        "construcao de edif",
+        "obra de engenharia",
+        "ampliação de escola",
+        "ampliacao de escola",
+        "infraestrutura urbana",
+        "revitalização urbana",
+        "revitalizacao urbana",
+        "muro de arrimo",
+        "projeto executivo",
+        "projeto básico",
+        "projeto basico",
+        "recapeamento",
+    ]
+    terms.extend(core)
+    # unique preserve order
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in terms:
+        k = t.lower()
+        if k not in seen and len(t) >= 4:
+            seen.add(k)
+            out.append(t)
+    return out[:80]

--- a/scripts/ops/seed_isolated_universe.py
+++ b/scripts/ops/seed_isolated_universe.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Seed sc_public_entities from canonical universe into an isolated DSN.
+
+Used by EXTRA-LIVE-CONSULTING-PACK-01 so workspace views (expiring/winners)
+work without touching VPS. Never points at production.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dsn", default=os.getenv("CAMPAIGN_TEST_DSN") or os.getenv("LOCAL_DATALAKE_DSN"))
+    p.add_argument("--seed", default="fixtures/canonical_universe_r0.xlsx")
+    args = p.parse_args(argv)
+    if not args.dsn:
+        print("DSN required", file=sys.stderr)
+        return 2
+    low = args.dsn.lower()
+    if any(x in low for x in ("ec-prod", "extra_prod", "/opt/extra")):
+        print("ISOLATION_FAIL: refusing prod DSN", file=sys.stderr)
+        return 2
+    import psycopg2
+
+    from scripts.lib.universe import load_canonical_universe
+    u = load_canonical_universe(seed_path=args.seed)
+    conn = psycopg2.connect(args.dsn)
+    conn.autocommit = True
+    n = 0
+    with conn.cursor() as cur:
+        for e in u.included:
+            cur.execute(
+                """
+                INSERT INTO sc_public_entities (
+                    razao_social, cnpj_8, municipio, codigo_ibge, natureza_juridica,
+                    latitude, longitude, distancia_fk, raio_200km, is_active
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,TRUE)
+                ON CONFLICT (cnpj_8) DO UPDATE SET
+                    razao_social = EXCLUDED.razao_social,
+                    municipio = EXCLUDED.municipio,
+                    raio_200km = EXCLUDED.raio_200km,
+                    is_active = TRUE
+                """,
+                (
+                    e.razao_social or e.entity_id,
+                    e.cnpj8,
+                    e.municipio,
+                    e.codigo_ibge,
+                    e.natureza_juridica,
+                    e.latitude,
+                    e.longitude,
+                    e.distancia_km,
+                    bool(e.within_radius),
+                ),
+            )
+            n += 1
+    conn.close()
+    import json
+
+    print(json.dumps({"seeded": n, "seed": args.seed}))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_client_ready_consulting_cycle.py
+++ b/tests/test_client_ready_consulting_cycle.py
@@ -1,0 +1,709 @@
+"""Tests for CLIENT-READY-RECURRING-CONSULTING-CYCLE-01 integrated entry point.
+
+Drives real shipped functions — no reimplementation of isolation/terminal logic.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.client_ready_consulting_cycle import (
+    BLOCKED_MISSING_FROZEN_RC,
+    CAMPAIGN_ID,
+    FROZEN_RC_ARTIFACT_NAME,
+    FROZEN_RC_PRODUCT_SHA,
+    FROZEN_RC_RUN_ID,
+    REQUIRED_IDENTITY_FILES,
+    assemble_client_ready_frozen_rc,
+    decide_terminal,
+    identity_checksum_mismatches,
+    isolation_guard,
+    main,
+    missing_required_frozen_binaries,
+    validate_acceptance_binding,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _full_identity_ck(**overrides: str) -> dict[str, str]:
+    base = {
+        "pack-manifest.json": "a" * 64,
+        "executive-summary.md": "b" * 64,
+        "consulting-pack.xlsx": "c" * 64,
+        "executive-report.pdf": "d" * 64,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_isolation_rejects_ec_prod() -> None:
+    with pytest.raises(SystemExit) as ei:
+        isolation_guard("postgresql://u:p@ec-prod:5432/extra_prod")
+    payload = json.loads(str(ei.value))
+    assert payload["status"] == "FAIL"
+    assert payload["isolation"]["ok"] is False
+
+
+def test_isolation_rejects_port_5432() -> None:
+    with pytest.raises(SystemExit):
+        isolation_guard("postgresql://test:test@127.0.0.1:5432/anything")
+
+
+def test_isolation_rejects_opt_path_in_dsn() -> None:
+    with pytest.raises(SystemExit):
+        isolation_guard("postgresql://test:test@127.0.0.1:5436//opt/extra-consultoria")
+
+
+def test_isolation_accepts_campaign_local_dsn() -> None:
+    r = isolation_guard("postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc")
+    assert r["ok"] is True
+    assert r["production_touched"] is False
+    assert r["soak_touched"] is False
+    assert r["production_touched"] is not None
+    assert r["soak_touched"] is not None
+
+
+def test_decide_terminal_blocked_without_human_accept() -> None:
+    isolation = {"ok": True, "production_touched": False, "soak_touched": False}
+    migrations = {"idempotent": True}
+    snapshot = {"ok": True}
+    pack = {"reconcile": {"status": "PASS"}}
+    linkage = {"status": "completed"}
+    monthly = {"mode": "LIVE_ISOLATED", "live_recurrence": True}
+    acceptance = {"status": "PENDING_HUMAN"}
+    term, blockers = decide_terminal(
+        isolation=isolation,
+        migrations=migrations,
+        snapshot=snapshot,
+        pack=pack,
+        linkage=linkage,
+        monthly=monthly,
+        acceptance=acceptance,
+        failures=[],
+    )
+    assert term == "BLOCKED"
+    assert any("PENDING_HUMAN" in b for b in blockers)
+
+
+def test_decide_terminal_fail_on_reconcile() -> None:
+    term, _ = decide_terminal(
+        isolation={"ok": True},
+        migrations={"idempotent": True},
+        snapshot={"ok": True},
+        pack={"reconcile": {"status": "FAIL"}},
+        linkage={"status": "completed"},
+        monthly={"mode": "LIVE_ISOLATED"},
+        acceptance={"status": "ACCEPTED", "accepted_by": "Tiago"},
+        failures=[],
+    )
+    assert term == "FAIL"
+
+
+def test_decide_terminal_pass_with_accept_and_labeled_recurrence_mechanics() -> None:
+    """PASS allowed with bound human ACCEPT + labeled recurrence mechanics (not live dual)."""
+    term, blockers = decide_terminal(
+        isolation={"ok": True},
+        migrations={"idempotent": True},
+        snapshot={"ok": True},
+        pack={"reconcile": {"status": "PASS"}},
+        linkage={"status": "completed"},
+        monthly={
+            "mode": "LABELED_DETERMINISTIC_REPLAY",
+            "live_recurrence": False,
+            "synthetic_inject_used": True,
+            "live_dual_snapshot": False,
+        },
+        acceptance={
+            "status": "ACCEPTED",
+            "accepted_by": "Tiago Sasaki",
+            "binding": {"valid": True},
+        },
+        failures=[],
+        recurrence={
+            "mode": "LABELED_DETERMINISTIC_REPLAY",
+            "live_dual_snapshot": False,
+        },
+    )
+    assert term == "PASS"
+    assert blockers == []
+
+
+def test_decide_terminal_fails_false_live_dual_snapshot_claim() -> None:
+    """Honesty: labeled inject cannot report live_dual_snapshot=true."""
+    term, blockers = decide_terminal(
+        isolation={"ok": True},
+        migrations={"idempotent": True},
+        snapshot={"ok": True},
+        pack={"reconcile": {"status": "PASS"}},
+        linkage={"status": "completed"},
+        monthly={
+            "mode": "LABELED_DETERMINISTIC_REPLAY",
+            "synthetic_inject_used": True,
+            "live_dual_snapshot": False,
+        },
+        acceptance={
+            "status": "ACCEPTED",
+            "accepted_by": "Tiago Sasaki",
+            "binding": {"valid": True},
+        },
+        failures=[],
+        recurrence={
+            "mode": "LABELED_DETERMINISTIC_REPLAY",
+            "live_dual_snapshot": True,  # false claim
+        },
+    )
+    assert term == "FAIL"
+    assert any("false_live_dual_snapshot" in b for b in blockers)
+
+
+def test_decide_terminal_fails_live_isolated_dual_without_proof() -> None:
+    """LIVE_ISOLATED + live_dual_snapshot without dual_snapshot_proof must FAIL."""
+    term, blockers = decide_terminal(
+        isolation={"ok": True},
+        migrations={"idempotent": True},
+        snapshot={"ok": True},
+        pack={"reconcile": {"status": "PASS"}},
+        linkage={"status": "completed"},
+        monthly={
+            "mode": "LIVE_ISOLATED",
+            "live_dual_snapshot": True,
+            "dual_snapshot_proof": False,
+        },
+        acceptance={
+            "status": "ACCEPTED",
+            "accepted_by": "Tiago Sasaki",
+            "binding": {"valid": True},
+        },
+        failures=[],
+        recurrence={"mode": "LIVE_ISOLATED", "live_dual_snapshot": True},
+    )
+    assert term == "FAIL"
+    assert any("false_live_dual_snapshot" in b for b in blockers)
+
+
+def test_validate_acceptance_binding_rejects_stale_accept() -> None:
+    """ACCEPTED for old run_id/rc_sha/checksums must demote to PENDING (no silent rebind)."""
+    prior = {
+        "status": "ACCEPTED",
+        "accepted_by": "Tiago Sasaki",
+        "accepted_at": "2026-07-24T21:40:15Z",
+        "run_id": "old-run",
+        "rc_sha": "a" * 40,
+        "package_checksums": _full_identity_ck(
+            **{
+                "pack-manifest.json": "0" * 64,
+                "executive-summary.md": "1" * 64,
+            }
+        ),
+    }
+    out = validate_acceptance_binding(
+        prior,
+        pack_run_id="new-run",
+        rc_sha="b" * 40,
+        pack_checksums=_full_identity_ck(
+            **{
+                "pack-manifest.json": "c" * 64,
+                "executive-summary.md": "d" * 64,
+            }
+        ),
+    )
+    assert out["status"] == "PENDING_HUMAN"
+    assert out["accepted_by"] is None
+    assert out["binding"]["valid"] is False
+    assert out["binding"]["prior_accepted_run_id"] == "old-run"
+    assert any("run_id" in m for m in out["binding"]["mismatches"])
+
+
+def test_validate_acceptance_binding_keeps_matching_accept() -> None:
+    ck = _full_identity_ck()
+    prior = {
+        "status": "ACCEPTED",
+        "accepted_by": "Tiago Sasaki",
+        "accepted_at": "2026-07-24T21:40:15Z",
+        "run_id": "run-1",
+        "rc_sha": "e" * 40,
+        "package_checksums": dict(ck),
+    }
+    out = validate_acceptance_binding(
+        prior, pack_run_id="run-1", rc_sha="e" * 40, pack_checksums=ck
+    )
+    assert out["status"] == "ACCEPTED"
+    assert out["accepted_by"] == "Tiago Sasaki"
+    assert out["binding"]["valid"] is True
+
+
+# --- Fail-closed identity binding (adversarial suite for PR #131 human accept) ---
+
+
+def _accepted_base(**ck_overrides: str) -> dict:
+    ck = _full_identity_ck(**ck_overrides)
+    return {
+        "status": "ACCEPTED",
+        "accepted_by": "Tiago Sasaki",
+        "accepted_at": "2026-07-24T21:40:15Z",
+        "run_id": "run-1",
+        "rc_sha": "e" * 40,
+        "package_checksums": ck,
+    }
+
+
+def test_binding_invalid_when_pdf_missing_from_pack() -> None:
+    """1. PDF absent in pack_checksums → binding invalid (missing_actual_artifact)."""
+    prior = _accepted_base()
+    pack_ck = _full_identity_ck()
+    del pack_ck["executive-report.pdf"]
+    out = validate_acceptance_binding(
+        prior, pack_run_id="run-1", rc_sha="e" * 40, pack_checksums=pack_ck
+    )
+    assert out["status"] == "PENDING_HUMAN"
+    assert out["binding"]["valid"] is False
+    assert "missing_actual_artifact:executive-report.pdf" in out["binding"]["mismatches"]
+
+
+def test_binding_invalid_when_xlsx_missing_from_pack() -> None:
+    """2. XLSX absent → binding invalid."""
+    prior = _accepted_base()
+    pack_ck = _full_identity_ck()
+    del pack_ck["consulting-pack.xlsx"]
+    out = validate_acceptance_binding(
+        prior, pack_run_id="run-1", rc_sha="e" * 40, pack_checksums=pack_ck
+    )
+    assert out["binding"]["valid"] is False
+    assert "missing_actual_artifact:consulting-pack.xlsx" in out["binding"]["mismatches"]
+
+
+def test_binding_invalid_when_manifest_missing_from_accepted() -> None:
+    """3. Manifest absent from accepted_ck → binding invalid."""
+    prior = _accepted_base()
+    del prior["package_checksums"]["pack-manifest.json"]
+    out = validate_acceptance_binding(
+        prior,
+        pack_run_id="run-1",
+        rc_sha="e" * 40,
+        pack_checksums=_full_identity_ck(),
+    )
+    assert out["binding"]["valid"] is False
+    assert "missing_expected_checksum:pack-manifest.json" in out["binding"]["mismatches"]
+
+
+def test_binding_invalid_when_summary_missing_from_accepted() -> None:
+    """4. Summary absent from accepted_ck → binding invalid."""
+    prior = _accepted_base()
+    del prior["package_checksums"]["executive-summary.md"]
+    out = validate_acceptance_binding(
+        prior,
+        pack_run_id="run-1",
+        rc_sha="e" * 40,
+        pack_checksums=_full_identity_ck(),
+    )
+    assert out["binding"]["valid"] is False
+    assert "missing_expected_checksum:executive-summary.md" in out["binding"]["mismatches"]
+
+
+def test_binding_invalid_on_checksum_mismatch() -> None:
+    """5. Checksum different → binding invalid with checksum_mismatch classification."""
+    prior = _accepted_base()
+    pack_ck = _full_identity_ck(**{"executive-report.pdf": "f" * 64})
+    out = validate_acceptance_binding(
+        prior, pack_run_id="run-1", rc_sha="e" * 40, pack_checksums=pack_ck
+    )
+    assert out["binding"]["valid"] is False
+    assert "checksum_mismatch:executive-report.pdf" in out["binding"]["mismatches"]
+
+
+def test_binding_invalid_on_run_id_divergence() -> None:
+    """6. run_id divergente → binding invalid."""
+    prior = _accepted_base()
+    out = validate_acceptance_binding(
+        prior,
+        pack_run_id="other-run",
+        rc_sha="e" * 40,
+        pack_checksums=_full_identity_ck(),
+    )
+    assert out["binding"]["valid"] is False
+    assert any(m.startswith("run_id:") for m in out["binding"]["mismatches"])
+
+
+def test_binding_invalid_on_product_rc_sha_divergence() -> None:
+    """7. product_rc_sha divergente → binding invalid."""
+    prior = _accepted_base()
+    out = validate_acceptance_binding(
+        prior,
+        pack_run_id="run-1",
+        rc_sha="f" * 40,
+        pack_checksums=_full_identity_ck(),
+    )
+    assert out["binding"]["valid"] is False
+    assert any("product_rc_sha" in m for m in out["binding"]["mismatches"])
+
+
+def test_binding_valid_when_all_identity_present_and_equal() -> None:
+    """8. Todos presentes e idênticos → binding.valid=true."""
+    ck = _full_identity_ck()
+    prior = _accepted_base()
+    out = validate_acceptance_binding(
+        prior, pack_run_id="run-1", rc_sha="e" * 40, pack_checksums=ck
+    )
+    assert out["status"] == "ACCEPTED"
+    assert out["binding"]["valid"] is True
+    assert out["binding"].get("mismatches") == []
+
+
+def test_agent_cannot_register_accepted() -> None:
+    """9. Um agente não consegue registrar ACCEPTED."""
+    for who in ("agent", "auto", "system", "null", None, ""):
+        prior = _accepted_base()
+        prior["accepted_by"] = who
+        out = validate_acceptance_binding(
+            prior,
+            pack_run_id="run-1",
+            rc_sha="e" * 40,
+            pack_checksums=_full_identity_ck(),
+        )
+        assert out["status"] == "PENDING_HUMAN", who
+        assert out["binding"]["valid"] is False, who
+        assert out.get("accepted_by") in (None, ""), who
+
+
+def test_later_doc_commits_do_not_invalidate_frozen_product_rc_sha() -> None:
+    """10. Commits documentais posteriores não invalidam product_rc_sha congelado.
+
+    Binding uses pack-manifest git_sha / freeze rc_sha, not HEAD tip.
+    """
+    frozen = FROZEN_RC_PRODUCT_SHA
+    head_tip = "5aa77eb9deadbeefdeadbeefdeadbeefdeadbeef"  # later docs tip
+    ck = _full_identity_ck()
+    prior = {
+        "status": "ACCEPTED",
+        "accepted_by": "Tiago Sasaki",
+        "accepted_at": "2026-07-24T21:40:15Z",
+        "run_id": FROZEN_RC_RUN_ID,
+        "rc_sha": frozen,
+        "package_checksums": ck,
+    }
+    out = validate_acceptance_binding(
+        prior,
+        pack_run_id=FROZEN_RC_RUN_ID,
+        rc_sha=frozen,
+        pack_checksums=ck,
+    )
+    assert out["status"] == "ACCEPTED"
+    assert out["binding"]["valid"] is True
+    assert out["binding"]["product_rc_sha"] == frozen
+    assert out["binding"]["product_rc_sha"] != head_tip
+    bad = validate_acceptance_binding(
+        prior,
+        pack_run_id=FROZEN_RC_RUN_ID,
+        rc_sha=head_tip,
+        pack_checksums=ck,
+    )
+    assert bad["binding"]["valid"] is False
+    assert any("product_rc_sha" in m for m in bad["binding"]["mismatches"])
+
+
+def test_identity_mismatches_not_both_present_short_circuit() -> None:
+    """Regression: 'if key in both' is not sufficient — missing either side fails."""
+    accepted = {"pack-manifest.json": "a" * 64}
+    pack = {"pack-manifest.json": "a" * 64}
+    ms = identity_checksum_mismatches(accepted, pack)
+    assert "missing_expected_checksum:executive-summary.md" in ms
+    assert "missing_expected_checksum:consulting-pack.xlsx" in ms
+    assert "missing_expected_checksum:executive-report.pdf" in ms
+    accepted2 = _full_identity_ck()
+    pack2 = _full_identity_ck()
+    del pack2["executive-report.pdf"]
+    ms2 = identity_checksum_mismatches(accepted2, pack2)
+    assert "missing_actual_artifact:executive-report.pdf" in ms2
+
+
+def test_verify_accept_fails_without_frozen_binaries(tmp_path: Path) -> None:
+    """CLI verify-accept fails when local tree lacks required frozen binaries."""
+    out = tmp_path / "campaign"
+    pack = out / "pack"
+    pack.mkdir(parents=True)
+    (pack / "pack-manifest.json").write_text(
+        json.dumps({"run_id": "r1", "git_sha": "a" * 40}), encoding="utf-8"
+    )
+    (pack / "executive-summary.md").write_text("summary\n", encoding="utf-8")
+    ua = {
+        "status": "PENDING_HUMAN",
+        "run_id": "r1",
+        "rc_sha": "a" * 40,
+        "package_checksums": {},
+        "accepted_by": None,
+        "accepted_at": None,
+    }
+    (out / "user-acceptance.json").write_text(json.dumps(ua), encoding="utf-8")
+    code = main(["verify-accept", "--out", str(out)])
+    assert code == 1
+    missing = set(missing_required_frozen_binaries(pack))
+    assert "consulting-pack.xlsx" in missing
+    assert "executive-report.pdf" in missing
+
+
+def test_verify_accept_pack_dir_option(tmp_path: Path) -> None:
+    """--pack-dir validates extracted artifact without putting binaries in git pack/."""
+    import hashlib
+
+    out = tmp_path / "campaign"
+    out.mkdir()
+    art = tmp_path / "extracted-artifact"
+    art.mkdir()
+    pdf = b"%PDF-1.4 frozen-rc"
+    xlsx = b"PK\x03\x04frozen-xlsx"
+    (art / "executive-report.pdf").write_bytes(pdf)
+    (art / "consulting-pack.xlsx").write_bytes(xlsx)
+    summary = "executive summary freeze\n"
+    (art / "executive-summary.md").write_text(summary, encoding="utf-8")
+
+    def h(b: bytes) -> str:
+        return hashlib.sha256(b).hexdigest()
+
+    manifest = {
+        "run_id": FROZEN_RC_RUN_ID,
+        "git_sha": FROZEN_RC_PRODUCT_SHA,
+        "reconcile": {"status": "PASS"},
+    }
+    (art / "pack-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    ck = {
+        "pack-manifest.json": h((art / "pack-manifest.json").read_bytes()),
+        "executive-summary.md": h(summary.encode()),
+        "consulting-pack.xlsx": h(xlsx),
+        "executive-report.pdf": h(pdf),
+    }
+    ua = {
+        "status": "PENDING_HUMAN",
+        "run_id": FROZEN_RC_RUN_ID,
+        "rc_sha": FROZEN_RC_PRODUCT_SHA,
+        "package_checksums": ck,
+        "accepted_by": None,
+        "accepted_at": None,
+        "agent_auto_accept_forbidden": True,
+    }
+    (out / "user-acceptance.json").write_text(json.dumps(ua, indent=2), encoding="utf-8")
+    (out / "package-reconciliation.json").write_text(
+        json.dumps({"status": "PASS", "run_id": FROZEN_RC_RUN_ID}), encoding="utf-8"
+    )
+    (out / "recurrence.json").write_text(
+        json.dumps(
+            {
+                "mode": "LABELED_DETERMINISTIC_REPLAY",
+                "live_dual_snapshot": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (out / "pack").mkdir()
+    code = main(["verify-accept", "--out", str(out), "--pack-dir", str(art)])
+    assert code == 2
+    refreshed = json.loads((out / "user-acceptance.json").read_text(encoding="utf-8"))
+    assert refreshed["status"] == "PENDING_HUMAN"
+    assert refreshed["accepted_by"] is None
+
+
+def test_assemble_frozen_rc_produces_identity(tmp_path: Path) -> None:
+    """assemble_client_ready_frozen_rc builds v2 freeze without identity self-hash."""
+    import hashlib
+
+    staging = tmp_path / "staging"
+    result = assemble_client_ready_frozen_rc(
+        out_dir=ROOT / "artifacts/campaigns" / CAMPAIGN_ID,
+        staging_dir=staging,
+        source_pack_dir=ROOT
+        / "artifacts/campaigns"
+        / CAMPAIGN_ID
+        / "pack-v2",
+    )
+    assert result["status"] in {
+        "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+        "READY_FOR_ACTUAL_HUMAN_PRODUCT_REVIEW",
+        BLOCKED_MISSING_FROZEN_RC,
+    }
+    if result["status"] == BLOCKED_MISSING_FROZEN_RC:
+        pytest.skip(f"freeze snapshot unavailable in this clone: {result}")
+    assert result["artifact_name"] == FROZEN_RC_ARTIFACT_NAME
+    assert FROZEN_RC_ARTIFACT_NAME == "client-ready-frozen-rc-v2"
+    assert result["run_id"] == FROZEN_RC_RUN_ID
+    assert result["product_rc_sha"] == FROZEN_RC_PRODUCT_SHA
+    assert result["production_touched"] is False
+    assert result["soak_touched"] is False
+    assert (staging / "ARTIFACT-IDENTITY.json").is_file()
+    identity = json.loads((staging / "ARTIFACT-IDENTITY.json").read_text(encoding="utf-8"))
+    assert identity["classification"] in {
+        "HUMAN_REVIEW_ARTIFACT",
+        "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+    }
+    assert identity["production_touched"] is False
+    assert "ARTIFACT-IDENTITY.json" not in (identity.get("file_sha256") or {})
+    assert (staging / "ARTIFACT-IDENTITY.sha256").is_file()
+    assert (staging / "executive-report.pdf").is_file()
+    assert (staging / "consulting-pack.xlsx").is_file()
+    ua = json.loads(
+        (ROOT / "artifacts/campaigns" / CAMPAIGN_ID / "user-acceptance.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    for name in ("executive-report.pdf", "consulting-pack.xlsx"):
+        digest = hashlib.sha256((staging / name).read_bytes()).hexdigest()
+        assert digest == ua["package_checksums"][name]
+
+
+def test_pending_human_acceptance_contract() -> None:
+    """Acceptance schema: PENDING_HUMAN only; agents cannot auto-ACCEPT (no git dump required)."""
+    # Shipped freeze constants exist and are stable identifiers for human review.
+    assert FROZEN_RC_RUN_ID
+    assert FROZEN_RC_PRODUCT_SHA
+    assert FROZEN_RC_ARTIFACT_NAME == "client-ready-frozen-rc-v2"
+    # Contract shape expected for any generated user-acceptance.json
+    data = {
+        "status": "PENDING_HUMAN",
+        "accepted_by": None,
+        "accepted_at": None,
+        "run_id": FROZEN_RC_RUN_ID,
+        "rc_sha": FROZEN_RC_PRODUCT_SHA,
+        "classification": "READY_FOR_SECOND_HUMAN_PRODUCT_REVIEW",
+        "agent_auto_accept_forbidden": True,
+        "package_checksums": {k: "0" * 64 for k in REQUIRED_IDENTITY_FILES},
+    }
+    assert data["status"] == "PENDING_HUMAN"
+    assert data.get("accepted_by") is None
+    assert data["agent_auto_accept_forbidden"] is True
+    for key in REQUIRED_IDENTITY_FILES:
+        assert key in data["package_checksums"]
+
+
+def test_cli_guard_exit_codes() -> None:
+    assert main(["guard", "--dsn", "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc"]) == 0
+    assert main(["guard", "--dsn", "postgresql://u:p@ec-prod/db"]) == 3
+
+
+def test_makefile_targets_registered() -> None:
+    mk = (ROOT / "Makefile").read_text(encoding="utf-8")
+    for t in (
+        "client-ready-consulting-cycle",
+        "campaign-gate-client-ready-recurring-consulting-cycle",
+        "release-candidate-client-ready-recurring-consulting-cycle",
+        "verify-client-ready-recurring-consulting-cycle-isolated",
+        "dod-audit-client-ready-recurring-consulting-cycle",
+    ):
+        assert t in mk
+
+
+def test_orchestrator_module_importable() -> None:
+    assert CAMPAIGN_ID == "CLIENT-READY-RECURRING-CONSULTING-CYCLE-01"
+    assert (ROOT / "scripts/ops/client_ready_consulting_cycle.py").is_file()
+    assert (ROOT / "db/migrations/060_national_contracts_intelligence_layers.sql").is_file()
+    assert (ROOT / "db/migrations/061_canonical_entity_linkage.sql").is_file()
+
+
+def test_terminal_status_vocabulary_only_three() -> None:
+    """Global status must be exactly PASS|BLOCKED|FAIL — no alternate terminals."""
+    src = (ROOT / "scripts/ops/client_ready_consulting_cycle.py").read_text(encoding="utf-8")
+    for banned in (
+        "TECHNICAL_PASS",
+        "READY_FOR_REVIEW",
+        "MOSTLY_PASS",
+        "CONDITIONAL_PASS",
+        "BLOCKED_HUMAN",
+    ):
+        # may appear in comments/docs of other campaigns; orchestrator decide path must not return them
+        assert f'return "{banned}"' not in src
+
+
+def test_build_recurrence_delta_reads_live_cycle2(tmp_path: Path) -> None:
+    """IAF-08a: must not invent success_zero when cycle_2 has deltas; dual=false for inject."""
+    from scripts.ops.client_ready_consulting_cycle import build_recurrence_delta
+
+    mon = tmp_path / "monthly"
+    mon.mkdir()
+    (mon / "monthly-monitor-live.json").write_text(
+        json.dumps(
+            {
+                "mode": "LABELED_DETERMINISTIC_REPLAY",
+                "live_dual_snapshot": False,
+                "synthetic_inject_used": True,
+                "cycle_1": {"cycle": {"cycle_id": "c1"}, "new_editais": [{"edital_id": "1"}]},
+                "cycle_2": {
+                    "cycle": {"cycle_id": "c2"},
+                    "new_editais": [{"edital_id": "LIVE-DELTA"}],
+                    "status_deltas": [
+                        {
+                            "edital_id": "1",
+                            "event_type": "SUSPENSAO",
+                            "from_status": "open",
+                            "to_status": "SUSPENSA",
+                        }
+                    ],
+                    "expiring_contracts": [{"id": "c1"}, {"id": "c2"}],
+                    "variation": {
+                        "fields": {
+                            "organs_count": {"previous": 10, "current": 11, "delta": 1},
+                            "winners_count": {"previous": 5, "current": 5, "delta": 0},
+                        }
+                    },
+                },
+                "proofs": {
+                    "new_editais_detected": True,
+                    "labeled_inject_not_second_real_snapshot": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = build_recurrence_delta(
+        {
+            "mode": "LABELED_DETERMINISTIC_REPLAY",
+            "live_recurrence": False,
+            "synthetic_inject_used": True,
+        },
+        tmp_path,
+    )
+    assert out["categories"]["new_opportunities"]["count"] == 1
+    assert out["categories"]["new_opportunities"]["success_zero"] is False
+    assert out["categories"]["status_changes"]["count"] == 1
+    assert out["categories"]["status_changes"]["success_zero"] is False
+    assert out["categories"]["org_ranking_changes"]["count"] == 1
+    assert out["live_dual_snapshot"] is False
+    assert out["mode"] == "LABELED_DETERMINISTIC_REPLAY"
+
+
+def test_reconcile_compares_distinct_meta_and_artifacts(tmp_path: Path) -> None:
+    """IAF-05: reconcile must not hardcode same_run_id or ignore artifacts."""
+    from scripts.ops import live_consulting_pack as lcp
+
+    pdf = tmp_path / "a.pdf"
+    xls = tmp_path / "a.xlsx"
+    pdf.write_bytes(b"%PDF-1.4 run_id=rid-1 fake")
+    # minimal xlsx zip is complex; write non-empty distinct bytes
+    xls.write_bytes(b"PK\x03\x04 excel-placeholder-rid-1")
+    meta = {"run_id": "rid-1", "git_sha": "abc", "as_of": "2026-07-24"}
+    rec = lcp.reconcile(
+        run_id="rid-1",
+        meta_pdf=dict(meta),
+        meta_excel=dict(meta),
+        a={"population": {"eligible_population": 10}, "rows": []},
+        b={"population": {"eligible_population": 10}, "rows": []},
+        c={"population": {"eligible_population": 10}, "rows": []},
+        d={"population": {"eligible_population": 10}, "panels": []},
+        pdf_path=pdf,
+        excel_path=xls,
+    )
+    assert rec["same_run_id"] is True
+    assert rec["status"] == "PASS"
+    assert rec["artifact_checks"]["binaries_distinct"] is True
+    assert rec["artifact_checks"]["pdf_sha256"] != rec["artifact_checks"]["excel_sha256"]
+
+    bad = lcp.reconcile(
+        run_id="rid-1",
+        meta_pdf={"run_id": "rid-1", "git_sha": "abc"},
+        meta_excel={"run_id": "rid-OTHER", "git_sha": "abc"},
+        a={},
+        b={},
+        c={},
+        d={},
+    )
+    assert bad["same_run_id"] is False
+    assert bad["status"] == "FAIL"

--- a/tests/test_commercial_rc_v2_gates.py
+++ b/tests/test_commercial_rc_v2_gates.py
@@ -1,0 +1,101 @@
+"""Commercial RC gates — unit tests without committing bulk frozen pack outputs.
+
+Heavy PDF/XLSX/deliverable dumps are generated at runtime / CI artifacts, not in Git.
+These tests drive the shipped classifier and acceptance schema rules.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from scripts.ops.sector_classifier import classify_object, is_engineering_for_e
+
+E_OK = {"ENGINEERING_HIGH_CONFIDENCE", "ENGINEERING_REVIEW"}
+
+
+def test_classifier_rejects_v1_polluters() -> None:
+    for obj in (
+        "AQUISIÇÃO DE LENÇÓIS E MANTAS",
+        "computador All in One",
+        "exames laboratoriais",
+        "manutenção da frota municipal",
+        "SEGURO DE FROTA DE VEICULOS DO DEPARTAMENTO DE ESGOTO",
+        "TELEFONIA VOIP",
+        "LIMPEZA E JARDINAGEM EM AREAS PAVIMENTADAS",
+        "GRAMA SINTETICA FIFA COM DRENAGEM",
+        "SANEAMENTO DE INCONFORMIDADES LEGAIS",
+        "CREDENCIAMENTO DE INSTITUIÇÕES FINANCEIRAS PARA ARRECADAÇÃO DE FATURAS DE ESGOTAMENTO SANITÁRIO",
+        "AQUISIÇÃO DE EQUIPAMENTO DE PINTURA AIRLESS PARA MEIO-FIO",
+        "AQUISIÇÃO DE CONJUNTOS MOTOBOMBAS SUBMERSÍVEIS PARA ESGOTAMENTO SANITÁRIO",
+    ):
+        assert not is_engineering_for_e(classify_object(obj)), obj
+
+
+def test_classifier_accepts_engineering_objects() -> None:
+    for obj in (
+        "CONSTRUCAO DE EDIFICIO PUBLICO ESCOLAR",
+        "PAVIMENTACAO ASFALTICA DE VIAS URBANAS",
+        "OBRA DE DRENAGEM PLUVIAL",
+    ):
+        assert is_engineering_for_e(classify_object(obj)), obj
+
+
+def test_pending_human_acceptance_schema(tmp_path: Path) -> None:
+    """Human acceptance must stay PENDING_HUMAN with agent auto-accept forbidden."""
+    ua = {
+        "status": "PENDING_HUMAN",
+        "campaign_id": "CLIENT-READY-RECURRING-CONSULTING-CYCLE-01",
+        "accepted_by": None,
+        "accepted_at": None,
+        "agent_auto_accept_forbidden": True,
+        "decision_options": ["ACCEPTED", "REJECTED", "CHANGES_REQUESTED"],
+        "package_checksums": {},
+    }
+    path = tmp_path / "user-acceptance.json"
+    path.write_text(json.dumps(ua), encoding="utf-8")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded["status"] == "PENDING_HUMAN"
+    assert loaded.get("accepted_by") is None
+    assert loaded["agent_auto_accept_forbidden"] is True
+
+
+def test_identity_excludes_self_hash(tmp_path: Path) -> None:
+    """ARTIFACT-IDENTITY must not include a self-referential sha of itself."""
+    identity = {
+        "artifact_name": "client-ready-frozen-rc-v2",
+        "classification": "HUMAN_REVIEW_ARTIFACT",
+        "production_touched": False,
+        "soak_touched": False,
+        "file_sha256": {
+            "executive-summary.md": "a" * 64,
+            "checksums.json": "b" * 64,
+        },
+    }
+    assert "ARTIFACT-IDENTITY.json" not in identity["file_sha256"]
+    path = tmp_path / "ARTIFACT-IDENTITY.json"
+    path.write_text(json.dumps(identity), encoding="utf-8")
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded["artifact_name"] == "client-ready-frozen-rc-v2"
+    assert "ARTIFACT-IDENTITY.json" not in (loaded.get("file_sha256") or {})
+
+
+def test_checksums_map_must_match_disk_bytes(tmp_path: Path) -> None:
+    content = b"fixture-pack-manifest-v1\n"
+    (tmp_path / "pack-manifest.json").write_bytes(content)
+    digest = hashlib.sha256(content).hexdigest()
+    ck = {"pack-manifest.json": digest}
+    for name, expected in ck.items():
+        p = tmp_path / name
+        assert p.is_file()
+        assert hashlib.sha256(p.read_bytes()).hexdigest() == expected
+
+
+def test_v1_history_status_changes_requested() -> None:
+    """RC v1 remains historically CHANGES_REQUESTED (schema contract)."""
+    hist = {
+        "status": "CHANGES_REQUESTED",
+        "run_id": "rc-v1-historical",
+        "notes": "Superseded by RC v2; kept as schema fixture only.",
+    }
+    assert hist["status"] == "CHANGES_REQUESTED"

--- a/tests/test_live_consulting_pack.py
+++ b/tests/test_live_consulting_pack.py
@@ -1,0 +1,151 @@
+"""Tests for EXTRA-LIVE-CONSULTING-PACK-01 live consulting pack.
+
+Unit tests drive shipped functions. Isolation and schema collision are
+structural. Full population path runs when CAMPAIGN_TEST_DSN has data.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from scripts.ops import live_consulting_pack as lcp
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CAMPAIGN_DSN = os.getenv(
+    "CAMPAIGN_TEST_DSN",
+    "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc",
+)
+
+
+def test_mask_dsn_hides_password() -> None:
+    masked = lcp.mask_dsn("postgresql://test:secret@127.0.0.1:5436/db")
+    assert "secret" not in masked
+    assert "test" in masked
+    assert "***" in masked
+
+
+def test_assert_isolation_accepts_local() -> None:
+    r = lcp.assert_isolation("postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc")
+    assert r["isolation_ok"] is True
+    assert r["production_touched"] is False
+
+
+def test_assert_isolation_rejects_prod_markers() -> None:
+    with pytest.raises(SystemExit) as ei:
+        lcp.assert_isolation("postgresql://u:p@ec-prod:5432/extra_prod")
+    assert "ISOLATION_FAIL" in str(ei.value)
+
+
+def test_assert_isolation_rejects_non_local_host() -> None:
+    with pytest.raises(SystemExit):
+        lcp.assert_isolation("postgresql://u:p@db.example.com:5432/x")
+
+
+def test_migration_060_exists_and_059_coverage_preserved() -> None:
+    m060 = PROJECT_ROOT / "db/migrations/060_national_contracts_intelligence_layers.sql"
+    m059 = PROJECT_ROOT / "db/migrations/059_coverage_evidence_canonical_entity_unique.sql"
+    bad = PROJECT_ROOT / "db/migrations/059_national_contracts_intelligence_layers.sql"
+    assert m060.is_file(), "intel layers must be renumbered to 060"
+    assert m059.is_file(), "coverage spine 059 must remain"
+    assert not bad.exists(), "must not collide with 059 coverage migration"
+    text = m060.read_text(encoding="utf-8")
+    assert "v_intel_contracts_raw_national" in text
+    assert "NOT operational" in text or "NOT operational SC coverage" in text
+
+
+def test_live_pack_module_entrypoint_registered() -> None:
+    assert hasattr(lcp, "run_pack")
+    assert hasattr(lcp, "main")
+    # structural: package final + deliverables importable
+    from scripts.ops import deliverable_a_org_ranking as a
+    from scripts.ops import deliverable_b_competitors as b
+    from scripts.ops import deliverable_package_final as pkg
+
+    assert callable(a.build_report_from_rows)
+    assert callable(b.select_competitors)
+    assert callable(pkg.reconcile_package)
+
+
+def test_national_intel_is_internal_engine() -> None:
+    from scripts.national_intel import agencies, competitors
+
+    assert callable(agencies.run_agencies)
+    assert callable(competitors.run_competitors)
+
+
+def _db_has_contracts(dsn: str) -> int:
+    try:
+        conn = lcp.connect(dsn)
+        try:
+            n = lcp.scalar(
+                conn,
+                "SELECT COUNT(*) FROM pncp_supplier_contracts WHERE COALESCE(is_active,TRUE)",
+            )
+            return int(n or 0)
+        finally:
+            conn.close()
+    except Exception:
+        return 0
+
+
+@pytest.mark.real_db
+@pytest.mark.skipif(
+    _db_has_contracts(CAMPAIGN_DSN) < 100
+    or os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"},
+    reason="isolated campaign DB not restored or REQUIRE_REAL_DB not set",
+)
+def test_population_stats_full_not_sample(tmp_path: Path) -> None:
+    conn = lcp.connect(CAMPAIGN_DSN)
+    try:
+        pop = lcp.population_stats(conn, uf="SC")
+    finally:
+        conn.close()
+    assert pop["eligible_population"] >= 100
+    assert pop["sample_label"] == "FULL_ELIGIBLE_POPULATION"
+    assert pop["not_sample_of_n"] is True
+
+
+@pytest.mark.real_db
+@pytest.mark.skipif(
+    _db_has_contracts(CAMPAIGN_DSN) < 100
+    or os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"},
+    reason="isolated campaign DB not restored or REQUIRE_REAL_DB not set",
+)
+def test_run_pack_end_to_end_real_path(tmp_path: Path) -> None:
+    """Drive shipped run_pack on isolated DSN — not fixtures as universe."""
+    out = tmp_path / "pack"
+    pack = lcp.run_pack(
+        dsn=CAMPAIGN_DSN,
+        out_dir=out,
+        uf="SC",
+        export_limit=50,
+        target_competitors=15,
+        as_of=date(2026, 7, 23),
+    )
+    assert pack["production_touched"] is False
+    assert pack["reconcile"]["status"] == "PASS"
+    assert pack["population"]["eligible_population"] >= 100
+    assert pack["deliverable_a"]["status"] in {"OK", "PARTIAL"}
+    assert pack["deliverable_a"]["n_rows"] >= 1
+    # B: OK with >=15 or honest INSUFFICIENT
+    assert pack["deliverable_b"]["status"] in {"OK", "INSUFFICIENT", "PARTIAL"}
+    if pack["deliverable_b"]["status"] == "OK":
+        assert int(pack["deliverable_b"]["valid_count"]) >= 15
+    assert (out / "extra_live_consulting_pack.xlsx").is_file()
+    assert (out / "extra_live_consulting_pack.pdf").is_file()
+    assert (out / "pack-manifest.json").is_file()
+    # export limit must not silently redefine universe
+    a = json.loads((out / "deliverable_a.json").read_text(encoding="utf-8"))
+    assert a["population"]["export_is_not_universe"] is True
+    assert a["population"]["eligible_population"] == pack["population"]["eligible_population"]
+
+
+def test_cli_verify_isolation_exit_codes() -> None:
+    assert lcp.main(["verify-isolation", "--dsn", "postgresql://t:t@127.0.0.1:5436/x"]) == 0
+    assert (
+        lcp.main(["verify-isolation", "--dsn", "postgresql://t:t@ec-prod:5432/x"]) == 2
+    )

--- a/tests/test_sector_classifier_adversarial.py
+++ b/tests/test_sector_classifier_adversarial.py
@@ -1,0 +1,266 @@
+"""Testes adversariais do classificador setorial Extra Construtora."""
+from __future__ import annotations
+
+from scripts.ops.sector_classifier import (
+    E_ALLOWED_LABELS,
+    RULE_VERSION,
+    classify_object,
+    is_engineering_for_e,
+)
+
+
+AUDIT_KEYS = {
+    "label",
+    "positive_terms",
+    "negative_terms",
+    "category",
+    "subcategory",
+    "reason",
+    "confidence",
+    "textual_evidence",
+    "rule_version",
+}
+
+
+def _assert_audit(clf) -> None:
+    d = clf.to_dict()
+    assert AUDIT_KEYS.issubset(d.keys())
+    assert d["rule_version"] == RULE_VERSION
+    assert d["label"] in {
+        "ENGINEERING_HIGH_CONFIDENCE",
+        "ENGINEERING_REVIEW",
+        "NON_ENGINEERING",
+        "AMBIGUOUS",
+        "EXCLUDED_CATEGORY",
+    }
+    assert 0.0 <= float(d["confidence"]) <= 1.0
+    assert isinstance(d["reason"], str) and d["reason"]
+
+
+def test_pavimentacao_asfaltica_engineering():
+    clf = classify_object(
+        "Contratação de empresa para execução de pavimentação asfáltica em vias urbanas"
+    )
+    _assert_audit(clf)
+    assert clf.label == "ENGINEERING_HIGH_CONFIDENCE"
+    assert is_engineering_for_e(clf)
+
+
+def test_ampliacao_escola_engineering():
+    clf = classify_object("Ampliação de escola municipal com 6 salas de aula")
+    _assert_audit(clf)
+    assert clf.label == "ENGINEERING_HIGH_CONFIDENCE"
+
+
+def test_drenagem_urbana_engineering():
+    clf = classify_object("Execução de drenagem urbana e galerias pluviais")
+    _assert_audit(clf)
+    assert clf.label == "ENGINEERING_HIGH_CONFIDENCE"
+
+
+def test_manutencao_predial_engineering_or_review():
+    clf = classify_object(
+        "Execução de serviços de engenharia para Manutenção Predial e Civil das edificações"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"ENGINEERING_HIGH_CONFIDENCE", "ENGINEERING_REVIEW"}
+
+
+def test_projetos_arquitetonicos_review():
+    clf = classify_object(
+        "Elaboração de projetos arquitetônicos e complementares de engenharia"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"ENGINEERING_HIGH_CONFIDENCE", "ENGINEERING_REVIEW"}
+
+
+def test_manutencao_frota_non_engineering():
+    clf = classify_object(
+        "Credenciamento de empresa para prestação de serviços de manutenção da frota municipal"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"NON_ENGINEERING", "EXCLUDED_CATEGORY"}
+    assert not is_engineering_for_e(clf)
+
+
+def test_computador_non_engineering():
+    clf = classify_object(
+        "Aquisição de 01 (um) computador do tipo All in One, processador Intel"
+    )
+    _assert_audit(clf)
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_lencois_mantas_non_engineering():
+    clf = classify_object(
+        "AQUISIÇÃO DE LENÇÓIS E MANTAS DESTINADOS AOS LEITOS DA UNIDADE BÁSICA DE SAÚDE"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"NON_ENGINEERING", "EXCLUDED_CATEGORY"}
+
+
+def test_exames_laboratoriais_non_engineering():
+    clf = classify_object(
+        "CREDENCIAMENTO PARA EXECUÇÃO DE EXAMES LABORATORIAIS COMPLEMENTARES AO SUS"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"NON_ENGINEERING", "EXCLUDED_CATEGORY"}
+
+
+def test_oficina_karate_non_engineering():
+    clf = classify_object("Contratação de oficina de karatê para alunos da rede municipal")
+    _assert_audit(clf)
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_construcao_conhecimento_non_engineering():
+    clf = classify_object("Oficina de construção de conhecimento para professores")
+    _assert_audit(clf)
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_manutencao_software_non_engineering():
+    clf = classify_object("Contratação de manutenção de software de gestão escolar")
+    _assert_audit(clf)
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_material_construcao_isolado_review_or_exclude():
+    clf = classify_object(
+        "Registro de preços para futura e eventual aquisição de materiais para uso nas pavimentações"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"ENGINEERING_REVIEW", "EXCLUDED_CATEGORY", "NON_ENGINEERING", "AMBIGUOUS"}
+
+
+def test_residuos_cc_not_auto_obra():
+    clf = classify_object(
+        "Contratação de coleta e destinação de resíduos da construção civil e entulho"
+    )
+    _assert_audit(clf)
+    assert clf.label in {"NON_ENGINEERING", "AMBIGUOUS", "EXCLUDED_CATEGORY"}
+
+
+def test_generic_servico_alone_not_high_confidence():
+    clf = classify_object("serviço")
+    _assert_audit(clf)
+    assert clf.label != "ENGINEERING_HIGH_CONFIDENCE"
+    assert clf.label in {"NON_ENGINEERING", "AMBIGUOUS"}
+
+
+def test_generic_manutencao_alone_not_high_confidence():
+    clf = classify_object("manutenção")
+    assert clf.label != "ENGINEERING_HIGH_CONFIDENCE"
+
+
+def test_generic_construcao_alone_not_high_confidence():
+    clf = classify_object("construção")
+    assert clf.label != "ENGINEERING_HIGH_CONFIDENCE"
+
+
+def test_generic_projeto_alone_not_high_confidence():
+    clf = classify_object("projeto")
+    assert clf.label != "ENGINEERING_HIGH_CONFIDENCE"
+
+
+def test_e_allowed_labels_set():
+    assert "ENGINEERING_HIGH_CONFIDENCE" in E_ALLOWED_LABELS
+    assert "ENGINEERING_REVIEW" in E_ALLOWED_LABELS
+    assert "NON_ENGINEERING" not in E_ALLOWED_LABELS
+    assert "EXCLUDED_CATEGORY" not in E_ALLOWED_LABELS
+
+
+def test_real_v1_e_evidence_objects_excluded():
+    """Objects that polluted RC v1 Deliverable E must not pass E filter."""
+    bad = [
+        "AQUISIÇÃO DE LENÇÓIS E MANTAS DESTINADOS AOS LEITOS DA UNIDADE BÁSICA DE SAÚDE",
+        "Aquisição de 01 (um) computador do tipo All in One",
+        "CREDENCIAMENTO DE EMPRESA ESPECIALIZADA PARA EXECUÇÃO DE SERVIÇOS DE FORMA COMPLEMENTAR AO SUS, DE EXAMES",
+        "Credenciamento de empresa para prestação de serviços de manutenção da frota municipal",
+    ]
+    for obj in bad:
+        clf = classify_object(obj)
+        assert not is_engineering_for_e(clf), obj
+
+
+# --- Skeptic FP suite (v2.1) ---
+
+
+def test_seguro_frota_even_with_esgoto_in_text():
+    clf = classify_object(
+        "SEGURO DE FROTA DE VEICULOS DO DEPARTAMENTO DE ESGOTO"
+    )
+    assert clf.label == "NON_ENGINEERING"
+    assert not is_engineering_for_e(clf)
+
+
+def test_voip_non_engineering():
+    clf = classify_object("CONTRATACAO DE SERVICOS DE TELEFONIA VOIP")
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_limpeza_areas_pavimentadas_non_engineering():
+    clf = classify_object(
+        "SERVICOS DE LIMPEZA E JARDINAGEM EM AREAS PAVIMENTADAS"
+    )
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_grama_sintetica_fifa_non_engineering():
+    clf = classify_object(
+        "FORNECIMENTO E INSTALACAO DE GRAMA SINTETICA FIFA COM DRENAGEM"
+    )
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_saneamento_inconformidades_non_engineering():
+    clf = classify_object(
+        "ASSESSORIA PARA SANEAMENTO DE INCONFORMIDADES LEGAIS"
+    )
+    assert clf.label == "NON_ENGINEERING"
+
+
+def test_setimo_pavimento_is_not_road_paving():
+    """'7º pavimento' is a building floor — not road pavement classification."""
+    clf = classify_object("7º pavimento do edifício sede")
+    assert clf.subcategory != "pavimentacao" or clf.label == "NON_ENGINEERING"
+    # Without reforma context, not engineering high for paving
+    assert clf.label != "ENGINEERING_HIGH_CONFIDENCE" or clf.subcategory == "reformas"
+
+
+def test_reforma_setimo_pavimento_is_building_work():
+    clf = classify_object("REFORMA DO 7 PAVIMENTO DO PREDIO ADMINISTRATIVO")
+    # Building floor renovation is obra — must not be labeled as road pavimentacao
+    assert clf.subcategory != "pavimentacao"
+    assert clf.label in {"ENGINEERING_HIGH_CONFIDENCE", "ENGINEERING_REVIEW", "NON_ENGINEERING"}
+    if clf.label in E_ALLOWED_LABELS:
+        assert clf.subcategory in {"reformas", "edificacoes", "manutencao_predial", "obras_civis"}
+
+
+def test_arrecadacao_bancaria_instituicoes_financeiras():
+    """Serviços bancários / arrecadação nunca são engenharia — mesmo com 'esgotamento' no texto."""
+    clf = classify_object(
+        "CREDENCIAMENTO DE INSTITUIÇÕES FINANCEIRAS DEVIDAMENTE AUTORIZADAS A OPERAR "
+        "PELO BANCO CENTRAL DO BRASIL, NAS MODALIDADES DE ARRECADAÇÃO DE FATURAS DE "
+        "ESGOTAMENTO SANITÁRIO"
+    )
+    assert clf.label == "NON_ENGINEERING"
+    assert not is_engineering_for_e(clf)
+
+
+def test_aquisicao_airless_pintura_nao_obra():
+    clf = classify_object(
+        "AQUISIÇÃO DE EQUIPAMENTO DE PINTURA E DEMARCAÇÃO VIÁRIA DO TIPO AIRLESS, "
+        "DESTINADO À APLICAÇÃO DE TINTA EM SINALIZAÇÃO HORIZONTAL E MEIO-FIO"
+    )
+    assert clf.label == "NON_ENGINEERING"
+    assert not is_engineering_for_e(clf)
+
+
+def test_aquisicao_motobombas_nao_obra():
+    clf = classify_object(
+        "AQUISIÇÃO DE CONJUNTOS MOTOBOMBAS SUBMERSÍVEIS PARA SEREM UTILIZADOS NO "
+        "SISTEMA DE ESGOTAMENTO SANITÁRIO"
+    )
+    assert clf.label == "NON_ENGINEERING"
+    assert not is_engineering_for_e(clf)


### PR DESCRIPTION
## Summary

**Reconstructed** after #130 (060) and #129 (061) landed on main.

Contains only integration/orchestration:

- `client_ready_consulting_cycle`, pack publish, sector classifier, seed isolation
- client profile v3
- unit tests for gates, classifier, pack
- short ops doc

**Removed:** migrations 060/061 as novelty, national_intel/linkage copies, bulk campaign artifacts, PDF/XLSX dumps, historical pack trees.

## Exact HEAD

- **HEAD SHA:** `bae0d098329b54b3ed75d86920afafbac632c1df`
- **Base:** `main` @ `96c1853f943fac80f1c4a69075b4f4c8adb80289`

## Human gate

Commercial publish acceptance remains **PENDING_HUMAN**. Agents must not set ACCEPTED.

## Validation

- local unit tests green (no bulk artifacts required)
- awaiting canonical CI

## Risk

No production/VPS/soak; no private docs; human_acceptance_forged=false.