### PR TITLE
fix(ci): hypothesis, skip policy, Markdown HEAD SHA reviewability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov
+          pip install pytest pytest-asyncio pytest-cov hypothesis
 
       - name: Run critical readiness tests with coverage
         run: >-
@@ -196,7 +196,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov
+          pip install pytest pytest-asyncio pytest-cov hypothesis
 
       - name: Operational expanded unit suite
         run: >-
@@ -266,7 +266,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-asyncio pytest-cov psycopg2-binary openpyxl prometheus_client
+          pip install pytest pytest-asyncio pytest-cov hypothesis psycopg2-binary openpyxl prometheus_client
 
       - name: Canonical full suite (migrations + seeds + pytest no marker exclusion)
         run: python -m scripts.ops.run_full_suite
@@ -311,7 +311,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy pytest pytest-asyncio pytest-cov psycopg2-binary prometheus_client
+          pip install ruff mypy pytest pytest-asyncio pytest-cov hypothesis psycopg2-binary prometheus_client
 
       - name: Ruff resilience modules
         run: >
@@ -501,6 +501,26 @@ jobs:
   # ============================================================================
   # SECURITY — bandit (fail-closed, sem continue-on-error)
   # ============================================================================
+  # ==========================================================================
+  # PYTEST SKIP POLICY — no module-level importorskip hiding adversarial suites
+  # ==========================================================================
+  pytest-skip-policy:
+    name: Pytest Skip Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Run pytest skip policy gate
+        run: |
+          set -euo pipefail
+          python -m scripts.ops.check_pytest_skip_policy --root tests
+
   security:
     name: Security (bandit)
     runs-on: ubuntu-latest

--- a/docs/ops/branch-protection-main.md
+++ b/docs/ops/branch-protection-main.md
@@ -16,6 +16,7 @@ From `.github/workflows/ci.yml` job `name:` fields:
 - `Dependency Audit (pip-audit)`
 - `Generated Artifacts Policy`
 - `PR Reviewability Policy`
+- `Pytest Skip Policy`
 
 ## Apply via GitHub API
 
@@ -39,7 +40,8 @@ gh api -X PUT "repos/${REPO}/branches/main/protection" \
       "Security (bandit)",
       "Dependency Audit (pip-audit)",
       "Generated Artifacts Policy",
-      "PR Reviewability Policy"
+      "PR Reviewability Policy",
+      "Pytest Skip Policy"
     ]
   },
   "enforce_admins": true,

--- a/docs/pytest-skip-allowlist.json
+++ b/docs/pytest-skip-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "1.0",
+  "module_level_skips": [],
+  "notes": "Empty by default. Module-level pytest.importorskip/skip must not hide security or adversarial suites. Prefer installing test deps in CI."
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ rapidfuzz>=3.0.0
 # selenium>=4.15.0  # descomentar se precisar de crawlers com Selenium
 # webdriver-manager>=4.0.0  # gerenciamento automatico de ChromeDriver
 prometheus_client>=0.20.0
+
+# Test / property-based (budget adversarial suite)
+hypothesis>=6.100.0

--- a/scripts/ops/check_pr_reviewability.py
+++ b/scripts/ops/check_pr_reviewability.py
@@ -159,6 +159,60 @@ def is_textual(path: str) -> bool:
     return Path(path).suffix.lower() in TEXTUAL_SUFFIXES
 
 
+# Required canonical CI job names (must match .github/workflows/ci.yml `name:`)
+REQUIRED_CANONICAL_CHECKS = (
+    "Lint (ruff)",
+    "Type Check (mypy)",
+    "Test (critical readiness)",
+    "Test operational expanded (PR)",
+    "Test All (full suite)",
+    "Resilience Gate (pre-VPS)",
+    "Security (bandit)",
+    "Dependency Audit (pip-audit)",
+    "Generated Artifacts Policy",
+    "PR Reviewability Policy",
+    "Pytest Skip Policy",
+)
+
+# Match HEAD/CI SHA declarations including Markdown bold/backticks:
+#   **HEAD SHA:** `abc123...`
+#   HEAD SHA: abc123
+#   CI SHA: `abc`
+_CLAIMED_SHA_RES = (
+    re.compile(
+        r"(?is)(?:\*{0,2}|_{0,2})?(?:ci\s+|head\s+)?(?:sha|commit|head)"
+        r"(?:\s+sha)?(?:\*{0,2}|_{0,2})?\s*[:=]\s*"
+        r"(?:\*{0,2}|_{0,2})?\s*`?([0-9a-f]{7,40})`?",
+    ),
+    re.compile(
+        r"(?is)\*{0,2}head\s+sha\*{0,2}\s*[:=]\s*\*{0,2}\s*`?([0-9a-f]{7,40})`?",
+    ),
+)
+
+
+def extract_claimed_head_shas(body: str) -> list[str]:
+    """Return claimed HEAD/CI SHAs from PR body (Markdown-aware)."""
+    if not body:
+        return []
+    # Strip common Markdown emphasis so bold labels still match.
+    stripped = re.sub(r"[*_]{1,3}", "", body)
+    found: list[str] = []
+    for src in (body, stripped):
+        for cre in _CLAIMED_SHA_RES:
+            for m in cre.finditer(src):
+                sha = m.group(1).lower()
+                if sha not in found:
+                    found.append(sha)
+    return found
+
+
+def sha_matches_head(claimed: str, head_sha: str) -> bool:
+    head_l = head_sha.lower()
+    c = claimed.lower()
+    return head_l.startswith(c) or c.startswith(head_l[:7])
+
+
+
 def evaluate(
     *,
     base: str,
@@ -167,6 +221,7 @@ def evaluate(
     body: str | None = None,
     head_sha: str | None = None,
     required_checks_present: bool | None = None,
+    required_check_names: list[str] | None = None,
 ) -> list[dict[str, object]]:
     """Return list of violations. Draft PRs skip size/multi-cap hard fails."""
     violations: list[dict[str, object]] = []
@@ -275,34 +330,50 @@ def evaluate(
 
     # Body consistency checks (when provided by CI)
     if body:
-        sha_mentions = re.findall(r"\b([0-9a-f]{7,40})\b", body.lower())
-        if head_sha and sha_mentions:
-            head_l = head_sha.lower()
-            # if body claims a CI SHA that is not current head (explicit pattern)
-            for m in re.finditer(
-                r"(?:ci|head|sha|commit)\s*[:=]\s*`?([0-9a-f]{7,40})`?",
-                body,
-                re.I,
-            ):
-                claimed = m.group(1).lower()
-                if not (head_l.startswith(claimed) or claimed.startswith(head_l[:7])):
+        if head_sha:
+            for claimed in extract_claimed_head_shas(body):
+                if not sha_matches_head(claimed, head_sha):
                     maybe(
                         "body_ci_sha_mismatch",
                         {
                             "claimed": claimed,
                             "head": head_sha,
-                            "hint": "Update PR body to the exact HEAD SHA under test.",
+                            "hint": (
+                                "Update PR body so **HEAD SHA:** matches the exact "
+                                "tip under test (Markdown bold/backticks supported)."
+                            ),
                         },
                     )
-        if re.search(r"\b(PASS|CI_GREEN|READY_TO_MERGE)\b", body) and (
-            required_checks_present is False
-        ):
-            maybe(
-                "declared_pass_without_gates",
-                {
-                    "hint": "Do not declare PASS while required CI gates are missing.",
-                },
-            )
+        declares_pass = bool(
+            re.search(r"\b(PASS|CI_GREEN|READY_TO_MERGE)\b", body)
+        )
+        if declares_pass:
+            # Fail-closed: PASS claims require explicit confirmation that
+            # required gates ran (not unknown / not false).
+            if required_checks_present is not True:
+                maybe(
+                    "declared_pass_without_gates",
+                    {
+                        "required_checks_present": required_checks_present,
+                        "hint": (
+                            "Do not declare PASS/CI_GREEN while required gates are "
+                            "missing or unverified (pass --required-checks-present true "
+                            "only when all REQUIRED_CANONICAL_CHECKS completed)."
+                        ),
+                    },
+                )
+            if required_check_names is not None:
+                present = set(required_check_names)
+                missing = [c for c in REQUIRED_CANONICAL_CHECKS if c not in present]
+                if missing:
+                    maybe(
+                        "missing_required_checks",
+                        {
+                            "missing": missing,
+                            "hint": "All REQUIRED_CANONICAL_CHECKS must be present.",
+                        },
+                    )
+
 
     if exception is None and (REPO_ROOT / EXCEPTION_PATH).is_file():
         # incomplete exception registry is itself a violation only if non-empty bad
@@ -340,6 +411,10 @@ def main(argv: list[str] | None = None) -> int:
         choices=("true", "false", "unknown"),
         default="unknown",
     )
+    parser.add_argument(
+        "--required-check-names-file",
+        help="file with one completed check name per line (optional)",
+    )
     parser.add_argument("--paths", nargs="*", help="explicit paths (tests)")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
@@ -356,6 +431,14 @@ def main(argv: list[str] | None = None) -> int:
     else:
         rcp = None
 
+    check_names: list[str] | None = None
+    if args.required_check_names_file:
+        check_names = [
+            ln.strip()
+            for ln in Path(args.required_check_names_file).read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+
     try:
         violations = evaluate(
             base=args.base,
@@ -364,6 +447,7 @@ def main(argv: list[str] | None = None) -> int:
             body=body,
             head_sha=args.head_sha,
             required_checks_present=rcp,
+            required_check_names=check_names,
         )
     except subprocess.CalledProcessError as exc:
         print(f"error: git failed: {exc}", file=sys.stderr)

--- a/scripts/ops/check_pr_reviewability.py
+++ b/scripts/ops/check_pr_reviewability.py
@@ -344,8 +344,16 @@ def evaluate(
                             ),
                         },
                     )
+        # Only treat status-like declarations as PASS claims — not prose that
+        # merely mentions the word "PASS" (e.g. "when body declares PASS").
         declares_pass = bool(
-            re.search(r"\b(PASS|CI_GREEN|READY_TO_MERGE)\b", body)
+            re.search(
+                r"(?is)(?:status|verdict|result|ci(?:\s+status)?)\s*[:=]\s*"
+                r"`?(?:PASS|CI_GREEN|READY_TO_MERGE)`?\b"
+                r"|\bCI_GREEN\b|\bREADY_TO_MERGE\b"
+                r"|(?:^|\n)\s*PASS\s*(?:\n|$)",
+                body,
+            )
         )
         if declares_pass:
             # Fail-closed: PASS claims require explicit confirmation that

--- a/scripts/ops/check_pytest_skip_policy.py
+++ b/scripts/ops/check_pytest_skip_policy.py
@@ -1,0 +1,121 @@
+"""Fail-closed scan: unexpected module-level pytest skips / importorskip.
+
+Usage:
+  python -m scripts.ops.check_pytest_skip_policy
+  python -m scripts.ops.check_pytest_skip_policy --root tests
+
+Exit 0 = pass, 1 = violations, 2 = error.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_PATH = REPO_ROOT / "docs" / "pytest-skip-allowlist.json"
+
+
+def _load_allowlist() -> set[str]:
+    if not ALLOWLIST_PATH.is_file():
+        return set()
+    data = json.loads(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    return {str(p) for p in (data.get("module_level_skips") or [])}
+
+
+def _is_module_level_skip(node: ast.AST) -> bool:
+    """True for module-level pytest.importorskip(...) or pytest.skip(...)."""
+    if not isinstance(node, ast.Expr):
+        return False
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    # pytest.importorskip / pytest.skip
+    if isinstance(func, ast.Attribute) and func.attr in {"importorskip", "skip"}:
+        if isinstance(func.value, ast.Name) and func.value.id == "pytest":
+            return True
+    # bare importorskip if from pytest import importorskip — skip for now
+    return False
+
+
+def scan_file(path: Path) -> list[dict[str, object]]:
+    src = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError as exc:
+        return [{"path": str(path), "reason": f"syntax_error:{exc}"}]
+    hits: list[dict[str, object]] = []
+    for node in tree.body:  # module body only
+        if _is_module_level_skip(node):
+            hits.append(
+                {
+                    "path": str(path.as_posix()),
+                    "lineno": getattr(node, "lineno", 0),
+                    "reason": "module_level_pytest_skip",
+                }
+            )
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default="tests", help="tests root directory")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = REPO_ROOT / args.root
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    allow = _load_allowlist()
+    violations: list[dict[str, object]] = []
+    for py in sorted(root.rglob("*.py")):
+        rel = py.relative_to(REPO_ROOT).as_posix()
+        for hit in scan_file(py):
+            # normalize path relative
+            p = hit.get("path", rel)
+            if isinstance(p, str) and p.startswith(str(REPO_ROOT)):
+                p = Path(p).relative_to(REPO_ROOT).as_posix()
+                hit["path"] = p
+            elif isinstance(p, str) and not p.startswith("tests"):
+                # path may be absolute from ast
+                try:
+                    hit["path"] = Path(p).resolve().relative_to(REPO_ROOT).as_posix()
+                except Exception:
+                    hit["path"] = rel
+            if hit["path"] in allow:
+                continue
+            violations.append(hit)
+
+    report = {
+        "ok": not violations,
+        "violation_count": len(violations),
+        "violations": violations,
+        "allowlist": str(ALLOWLIST_PATH.relative_to(REPO_ROOT)),
+    }
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(
+            f"pytest-skip-policy: violations={len(violations)} "
+            f"allowlist_entries={len(allow)}"
+        )
+        for v in violations:
+            print(f"  FAIL {v['path']}:{v.get('lineno')} — {v['reason']}")
+        if not violations:
+            print("  PASS")
+        else:
+            print(
+                "\nActionable: remove module-level pytest.importorskip/skip, "
+                "install the dependency in CI, or add an explicit allowlist "
+                f"entry in {ALLOWLIST_PATH.name} with justification."
+            )
+    return 0 if not violations else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/budget_audit/test_adversarial_property.py
+++ b/tests/budget_audit/test_adversarial_property.py
@@ -7,7 +7,6 @@ import zipfile
 from pathlib import Path
 
 import pytest
-pytest.importorskip("hypothesis")
 from hypothesis import given, settings
 from hypothesis import strategies as st
 

--- a/tests/unit/test_pr_reviewability.py
+++ b/tests/unit/test_pr_reviewability.py
@@ -104,6 +104,27 @@ def test_declared_pass_without_gates(monkeypatch: pytest.MonkeyPatch) -> None:
     assert any(v["reason"] == "declared_pass_without_gates" for v in viol)
 
 
+def test_prose_mention_of_pass_is_not_status_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: describing the gate must not trip declared_pass_without_gates."""
+    import scripts.ops.check_pr_reviewability as mod
+
+    monkeypatch.setattr(mod, "_load_exception", lambda: None)
+    viol = evaluate(
+        base="origin/main",
+        draft=False,
+        paths=["scripts/a.py"],
+        body=(
+            "required_checks_present fail-closed when body declares PASS\n"
+            "awaiting canonical CI\n"
+        ),
+        head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        required_checks_present=None,
+    )
+    assert not any(v["reason"] == "declared_pass_without_gates" for v in viol)
+
+
 def test_main_with_paths(monkeypatch: pytest.MonkeyPatch) -> None:
     import scripts.ops.check_pr_reviewability as mod
 

--- a/tests/unit/test_pr_reviewability.py
+++ b/tests/unit/test_pr_reviewability.py
@@ -132,3 +132,95 @@ def test_exception_waives(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     paths = [f"scripts/f{i}.py" for i in range(65)]
     viol = evaluate(base="origin/main", draft=False, paths=paths)
     assert not any(v["reason"] == "too_many_files" for v in viol)
+
+
+def test_extract_claimed_shas_markdown_bold_head_sha() -> None:
+    """Regression: #136 body format **HEAD SHA:** `...` must be detected."""
+    from scripts.ops.check_pr_reviewability import extract_claimed_head_shas
+
+    body = (
+        "## Exact HEAD under test\n\n"
+        "- **HEAD SHA:** `5f5111885a3ff9fa205c3a39ee28fab039c2e67d`\n"
+        "- **Base:** `main` @ `e985088dbbac8de88ddbdabbebf889e4e17c4764`\n"
+    )
+    claimed = extract_claimed_head_shas(body)
+    assert claimed == ["5f5111885a3ff9fa205c3a39ee28fab039c2e67d"]
+
+
+def test_body_sha_mismatch_markdown_format_like_pr136(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.ops.check_pr_reviewability as mod
+
+    monkeypatch.setattr(mod, "_load_exception", lambda: None)
+    body = (
+        "## Exact HEAD under test\n\n"
+        "- **HEAD SHA:** `5f5111885a3ff9fa205c3a39ee28fab039c2e67d`\n"
+        "- **Base:** `main` @ `e985088dbbac8de88ddbdabbebf889e4e17c4764`\n\n"
+        "## Validation\n\n"
+        "- [x] local gates PASS\n"
+    )
+    viol = evaluate(
+        base="origin/main",
+        draft=False,
+        paths=["scripts/ops/check_pr_reviewability.py"],
+        body=body,
+        head_sha="e1ecc04b9245cd78dfd275c5e37e3c982c4e9d66",
+        required_checks_present=True,
+    )
+    assert any(v["reason"] == "body_ci_sha_mismatch" for v in viol)
+    mismatch = next(v for v in viol if v["reason"] == "body_ci_sha_mismatch")
+    assert str(mismatch["claimed"]).startswith("5f51118")
+
+
+def test_body_sha_match_markdown_when_head_correct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.ops.check_pr_reviewability as mod
+
+    monkeypatch.setattr(mod, "_load_exception", lambda: None)
+    head = "e1ecc04b9245cd78dfd275c5e37e3c982c4e9d66"
+    body = f"- **HEAD SHA:** `{head}`\n"
+    viol = evaluate(
+        base="origin/main",
+        draft=False,
+        paths=["scripts/a.py"],
+        body=body,
+        head_sha=head,
+        required_checks_present=True,
+    )
+    assert not any(v["reason"] == "body_ci_sha_mismatch" for v in viol)
+
+
+def test_declared_pass_fails_when_required_checks_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PASS claims are fail-closed unless required_checks_present is True."""
+    import scripts.ops.check_pr_reviewability as mod
+
+    monkeypatch.setattr(mod, "_load_exception", lambda: None)
+    viol = evaluate(
+        base="origin/main",
+        draft=False,
+        paths=["scripts/a.py"],
+        body="Status: PASS — all green",
+        head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        required_checks_present=None,  # unknown
+    )
+    assert any(v["reason"] == "declared_pass_without_gates" for v in viol)
+
+
+def test_missing_required_check_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.ops.check_pr_reviewability as mod
+
+    monkeypatch.setattr(mod, "_load_exception", lambda: None)
+    viol = evaluate(
+        base="origin/main",
+        draft=False,
+        paths=["scripts/a.py"],
+        body="CI_GREEN",
+        head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        required_checks_present=True,
+        required_check_names=["Lint (ruff)", "Security (bandit)"],
+    )
+    assert any(v["reason"] == "missing_required_checks" for v in viol)

--- a/tests/unit/test_pytest_skip_policy.py
+++ b/tests/unit/test_pytest_skip_policy.py
@@ -1,0 +1,32 @@
+"""Tests for pytest skip policy gate."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.check_pytest_skip_policy import main, scan_file
+
+
+def test_scan_detects_module_level_importorskip(tmp_path: Path) -> None:
+    p = tmp_path / "test_x.py"
+    p.write_text(
+        "import pytest\npytest.importorskip('hypothesis')\n\ndef test_a():\n    assert True\n",
+        encoding="utf-8",
+    )
+    hits = scan_file(p)
+    assert hits and hits[0]["reason"] == "module_level_pytest_skip"
+
+
+def test_scan_ignores_function_level_skip(tmp_path: Path) -> None:
+    p = tmp_path / "test_y.py"
+    p.write_text(
+        "import pytest\n\ndef test_a():\n    pytest.skip('local')\n    assert False\n",
+        encoding="utf-8",
+    )
+    assert scan_file(p) == []
+
+
+def test_main_passes_on_current_tests() -> None:
+    # budget adversarial no longer has module-level importorskip
+    assert main(["--root", "tests"]) == 0


### PR DESCRIPTION
## Summary

Residual false-green and reviewability hardening.

## Exact HEAD under test

- **HEAD SHA:** `5e436e4735e85ec244aa6a7127515962e567d703`
- **Base:** `main` @ `76c3a0040b949abf6c02592cea61d305a09818a8`

## Changes

1. hypothesis in requirements + CI; budget adversarial always runs
2. check_pytest_skip_policy + CI job Pytest Skip Policy
3. Markdown-aware HEAD SHA extraction (#136 format regression)
4. Status-like PASS claims require required_checks_present=true

## Validation

- unit tests green locally
- awaiting canonical CI on this HEAD