### PR TITLE
fix(reviewability): ignore body SHA mismatch on draft PRs

### DIFF
--- a/scripts/ops/check_pr_reviewability.py
+++ b/scripts/ops/check_pr_reviewability.py
@@ -269,6 +269,7 @@ def evaluate(
             "too_many_files",
             "too_many_textual_lines",
             "multi_capability_mix",
+            "body_ci_sha_mismatch",  # draft tip may move before body refresh
         }:
             # Draft may exceed size while being rebuilt; still flag binaries.
             return

--- a/tests/unit/test_pr_reviewability.py
+++ b/tests/unit/test_pr_reviewability.py
@@ -245,3 +245,20 @@ def test_missing_required_check_names(monkeypatch: pytest.MonkeyPatch) -> None:
         required_check_names=["Lint (ruff)", "Security (bandit)"],
     )
     assert any(v["reason"] == "missing_required_checks" for v in viol)
+
+
+def test_draft_allows_body_sha_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Draft tips often move before the body is refreshed — do not block rebuilds."""
+    import scripts.ops.check_pr_reviewability as mod
+
+    monkeypatch.setattr(mod, "_load_exception", lambda: None)
+    body = "- **HEAD SHA:** `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`\n"
+    viol = evaluate(
+        base="origin/main",
+        draft=True,
+        paths=["scripts/a.py"],
+        body=body,
+        head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        required_checks_present=True,
+    )
+    assert not any(v["reason"] == "body_ci_sha_mismatch" for v in viol)


### PR DESCRIPTION
## Summary

Draft PRs may re-push before the body is refreshed; do not fail reviewability on body_ci_sha_mismatch while draft=true. Ready PRs still fail-closed.

## Exact HEAD under test

- **HEAD SHA:** `72b51b10cd498a9681b89d821a359aaff6b5a2ef`
- **Base:** `main` @ `b4a7e69cbf06ba76622fb12d3335b28be16ba958`