### PR TITLE
ci(reviewability): revalidate on ready_for_review and edited

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,53 +450,9 @@ jobs:
           git rev-parse --verify "$BASE_REF"
           python -m scripts.ops.check_generated_artifacts_policy --base "$BASE_REF"
 
-  # ==========================================================================
-  # PR REVIEWABILITY POLICY — fail-closed size/capability/binary gates
-  # ==========================================================================
-  pr-reviewability-policy:
-    name: PR Reviewability Policy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Run PR reviewability gate
-        env:
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
-            BASE_REF="${{ github.event.pull_request.base.sha }}"
-          else
-            git fetch --no-tags origin main
-            BASE_REF="origin/main"
-          fi
-          git rev-parse --verify "$BASE_REF"
-          DRAFT_FLAG=""
-          if [ "${PR_DRAFT:-false}" = "true" ]; then
-            DRAFT_FLAG="--draft"
-          fi
-          if [ -z "${PR_NUMBER}" ]; then
-            DRAFT_FLAG="--draft"
-          fi
-          # Body consistency from event payload (no soft-fail / || true).
-          EXTRA=""
-          if [ -n "${PR_NUMBER}" ] && [ -n "${PR_BODY}" ]; then
-            printf '%s\n' "$PR_BODY" > /tmp/pr-body.md
-            EXTRA="--body-file /tmp/pr-body.md --head-sha ${HEAD_SHA}"
-          fi
-          # shellcheck disable=SC2086
-          python -m scripts.ops.check_pr_reviewability --base "$BASE_REF" $DRAFT_FLAG $EXTRA
+  # PR Reviewability Policy lives in .github/workflows/pr-reviewability.yml
+  # (light workflow: opened/synchronize/reopened/ready_for_review/edited).
+  # Job name remains "PR Reviewability Policy" — required on main protection.
 
   # ============================================================================
   # SECURITY — bandit (fail-closed, sem continue-on-error)

--- a/.github/workflows/pr-reviewability.yml
+++ b/.github/workflows/pr-reviewability.yml
@@ -1,0 +1,77 @@
+# Lightweight PR Reviewability Policy
+#
+# Revalidates size/capability/binary + body HEAD/PASS consistency without
+# re-running the full CI suite. Critical for body edits and draft→ready.
+#
+# Events:
+#   opened | synchronize | reopened — code / base changes
+#   ready_for_review — draft → ready (stricter non-draft limits apply)
+#   edited — title/body change (HEAD SHA / PASS claim consistency)
+#
+# Job name MUST stay "PR Reviewability Policy" — required on main protection.
+
+name: PR Reviewability
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+
+concurrency:
+  group: pr-reviewability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  pr-reviewability-policy:
+    name: PR Reviewability Policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Run PR reviewability gate
+        env:
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          echo "pr-reviewability: action=${PR_ACTION} draft=${PR_DRAFT:-} head=${HEAD_SHA} pr=${PR_NUMBER}"
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            BASE_REF="${{ github.event.pull_request.base.sha }}"
+          else
+            git fetch --no-tags origin main
+            BASE_REF="origin/main"
+          fi
+          git rev-parse --verify "$BASE_REF"
+          DRAFT_FLAG=""
+          if [ "${PR_DRAFT:-false}" = "true" ]; then
+            DRAFT_FLAG="--draft"
+          fi
+          EXTRA=""
+          if [ -n "${PR_NUMBER}" ] && [ -n "${PR_BODY}" ]; then
+            printf '%s\n' "$PR_BODY" > /tmp/pr-body.md
+            EXTRA="--body-file /tmp/pr-body.md --head-sha ${HEAD_SHA}"
+          fi
+          # shellcheck disable=SC2086
+          python -m scripts.ops.check_pr_reviewability --base "$BASE_REF" $DRAFT_FLAG $EXTRA

--- a/docs/ops/branch-protection-main.md
+++ b/docs/ops/branch-protection-main.md
@@ -2,9 +2,11 @@
 
 Apply after governance gates land on `main`. Discover real check names from the latest green CI run; do not invent names.
 
-## Required status checks (canonical CI)
+## Required status checks (canonical)
 
-From `.github/workflows/ci.yml` job `name:` fields:
+Job `name:` fields that must appear as required contexts on `main`:
+
+From `.github/workflows/ci.yml`:
 
 - `Lint (ruff)`
 - `Type Check (mypy)`
@@ -15,8 +17,26 @@ From `.github/workflows/ci.yml` job `name:` fields:
 - `Security (bandit)`
 - `Dependency Audit (pip-audit)`
 - `Generated Artifacts Policy`
-- `PR Reviewability Policy`
 - `Pytest Skip Policy`
+
+From `.github/workflows/pr-reviewability.yml` (light, dedicated):
+
+- `PR Reviewability Policy`
+
+### When reviewability revalidates
+
+`pr-reviewability.yml` runs on `pull_request` types:
+
+| Event | Why |
+|-------|-----|
+| `opened` | new PR |
+| `synchronize` | new commits |
+| `reopened` | reopened PR |
+| `ready_for_review` | draft → ready (non-draft limits) |
+| `edited` | title/body change (HEAD SHA / PASS claims) |
+
+This avoids re-running the full CI suite on body-only edits while keeping
+the same required check context name for branch protection.
 
 ## Apply via GitHub API
 


### PR DESCRIPTION
## Summary

- Extract **PR Reviewability Policy** into lightweight `.github/workflows/pr-reviewability.yml`
- Trigger types: `opened`, `synchronize`, `reopened`, **`ready_for_review`**, **`edited`**
- Remove duplicate heavy job from `ci.yml` (comment points to light workflow)
- Job name unchanged: `PR Reviewability Policy` (required on main)

## Exact HEAD under test

- **HEAD SHA:** `2b96d3fd3f0083ca970ef9fe2bcdeb9f50ce0850`
- **Base:** `main`

## Why

Default `pull_request` does not include `edited` or `ready_for_review`, so body SHA/PASS fixes and draft→ready never revalidated the gate without a new commit. Full CI on every body edit would be too heavy.

## Flags

| Flag | Value |
|------|-------|
| production_touched | false |
| soak_touched | false |
| human_acceptance_forged | false |