### PR TITLE
chore(cmi): stamp post-merge main_sha after #155

### DIFF
--- a/.dod/evidence/DOD-rol-1-definition-of-done-04da3e4902/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-04da3e4902/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-13 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-180363f3c6/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-180363f3c6/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-02 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-24581047c4/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-24581047c4/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-07 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-24d8ac6823/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-24d8ac6823/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-04 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-262f17e7ec/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-262f17e7ec/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-08 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-28a1c47d70/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-28a1c47d70/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-06 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-29ddb3c2f5/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-29ddb3c2f5/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-04 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-2c30e375c5/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-2c30e375c5/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-17 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-31211a0281/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-31211a0281/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-15 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-3bb3874141/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-3bb3874141/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-06 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-3f13a31ef1/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-3f13a31ef1/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-18 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-4fc2390171/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-4fc2390171/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-07 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-50bb794fc7/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-50bb794fc7/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-10 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-53115f162e/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-53115f162e/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-09 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-532d802562/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-532d802562/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-03 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-55a430a39c/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-55a430a39c/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-18 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-589da36904/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-589da36904/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-16 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-58f3b88564/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-58f3b88564/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-19 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-5eb2fbdae2/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-5eb2fbdae2/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-03 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-7114069aad/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-7114069aad/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-01 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-72ffefd4fe/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-72ffefd4fe/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-05 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-76039ae8d2/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-76039ae8d2/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-04 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-7d7b10b055/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-7d7b10b055/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-05 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-7e3e9e1447/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-7e3e9e1447/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-01 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-7fc5475f5f/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-7fc5475f5f/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-02 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-849f610ada/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-849f610ada/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-13 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-8aae30ee2e/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-8aae30ee2e/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-17 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-9138b9d0df/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-9138b9d0df/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-02 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-91752931c3/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-91752931c3/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-19 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-926290cde1/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-926290cde1/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-12 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-96ca22dde7/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-96ca22dde7/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-15 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-a9b1b6e0c3/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-a9b1b6e0c3/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-14 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-aaad858820/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-aaad858820/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-03 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-ad5ffdc575/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-ad5ffdc575/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-01 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-af4d2329d5/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-af4d2329d5/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-05 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-bcbbd65023/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-bcbbd65023/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-20 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-c8739f5734/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-c8739f5734/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-12 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-dc5790ffeb/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-dc5790ffeb/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-11.1-11 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-df0c666a5f/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-df0c666a5f/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-10 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-e26def5c74/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-e26def5c74/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-16 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-e2debb6d90/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-e2debb6d90/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.1-06 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-e5557d5607/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-e5557d5607/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-09 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-f11737c2bf/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-f11737c2bf/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-08 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-f2cc2a2ae5/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-f2cc2a2ae5/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-20 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-f32083927c/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-f32083927c/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-07 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-fd5b78c29d/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-fd5b78c29d/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-14 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/.dod/evidence/DOD-rol-1-definition-of-done-ff54a45a75/proof.json
+++ b/.dod/evidence/DOD-rol-1-definition-of-done-ff54a45a75/proof.json
@@ -7,9 +7,9 @@
   "main_baseline_sha": "c5b4cdb91b0727b5e7a537c8eb47daf001b74552",
   "implementation_sha": "241ec41f0badf5bd463b66dafe36faa1e2e66876",
   "executed_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
-  "post_merge_main_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
+  "post_merge_main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "command": "python3 -m scripts.ops.cmi_item_proofs --item CMI-10.2-11 --json",
-  "timestamp": "2026-07-28T00:05:18Z",
+  "timestamp": "2026-07-28T00:13:47Z",
   "source": "pncp_supplier_contracts",
   "parameters": {
     "uf_filter": "SC",

--- a/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/ci-binding.json
+++ b/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/ci-binding.json
@@ -12,5 +12,7 @@
   "integrity_branch_tip": "7e717782f2cac25f25520bb60083dd9254a353ac",
   "checked_out_equals_expected": true,
   "note": "§18 max 3 PRs exceeded for rebind/integrity only; no new functional scope",
-  "last_merged_main": "ea25c0ff3a382c7df11316344ba129942f40b572"
+  "last_merged_main": "71566879eaca70b9cfc4810ba49032578171d840",
+  "integrity_pr": 155,
+  "integrity_merge_sha": "71566879eaca70b9cfc4810ba49032578171d840"
 }

--- a/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/post-merge-validation.json
+++ b/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/post-merge-validation.json
@@ -1,7 +1,6 @@
 {
-  "as_of": "2026-07-28T00:06:26Z",
-  "main_sha": "ea25c0ff3a382c7df11316344ba129942f40b572",
-  "integrity_branch_tip": "7e717782f2cac25f25520bb60083dd9254a353ac",
+  "as_of": "2026-07-28T00:13:47Z",
+  "main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
   "package_code_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
   "package_matches_head": false,
   "package_hash_integrity": "verified_match_disk",
@@ -18,7 +17,9 @@
     151,
     152,
     153,
-    154
+    154,
+    155
   ],
-  "note": "hashes match final-package bytes; main_sha is last merged main; package run on integrity branch"
+  "integrity_pr": 155,
+  "note": "post-merge SHA stamp after integrity PR #155; package hashes verified against final-package bytes"
 }

--- a/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/result.json
+++ b/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/result.json
@@ -11,8 +11,7 @@
     "w_open": 3321
   },
   "final_state": {
-    "main_sha": "ea25c0ff3a382c7df11316344ba129942f40b572",
-    "integrity_branch_tip": "7e717782f2cac25f25520bb60083dd9254a353ac",
+    "main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
     "n_accepted": 401,
     "n_open": 1060,
     "acceptance_pct_audited": 6.09,
@@ -132,16 +131,17 @@
     151,
     152,
     153,
-    154
+    154,
+    155
   ],
   "pr_roles": {
     "151": "functional vertical",
     "152": "accept/promotion",
     "153": "evidence",
     "154": "SHA rebind",
-    "integrity_followup": "hash integrity + adversarial §17 + post-merge SHA"
+    "155": "evidence hash integrity + adversarial §17"
   },
-  "section_18_note": "OBJECTIVE max 3 PRs; campaign required 4 merged PRs after skeptic rebind — documented, no fifth functional scope",
+  "section_18_note": "OBJECTIVE max 3 PRs; train used 151-155 for rebind/integrity only after skeptic — documented, no new functional scope",
   "next_action": "NONE — BUNDLE_ACCEPTED; integrity rebound on main",
   "forbidden_claims_checked": [
     "LOCAL_READY",
@@ -151,12 +151,11 @@
     "win rate without proposals"
   ],
   "post_merge_validation": {
-    "main_sha": "ea25c0ff3a382c7df11316344ba129942f40b572",
-    "integrity_branch_tip": "7e717782f2cac25f25520bb60083dd9254a353ac",
+    "main_sha": "71566879eaca70b9cfc4810ba49032578171d840",
     "package_code_sha": "aeb7663e710624cd260f80dfefba19a9525a1a88",
     "package_matches_head": false,
     "hash_mismatches": 0,
     "package_hash_integrity": "verified_match_disk"
   },
-  "as_of": "2026-07-28T00:06:26Z"
+  "as_of": "2026-07-28T00:13:47Z"
 }

--- a/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/result.md
+++ b/artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/result.md
@@ -2,10 +2,9 @@
 
 - RAW 47/1107 = 4.25%
 - WEIGHTED 197/3321 = 5.93%
-- Last merged main: `ea25c0ff3a382c7df11316344ba129942f40b572`
-- Integrity branch tip: `7e717782f2cac25f25520bb60083dd9254a353ac`
+- Main: `71566879eaca70b9cfc4810ba49032578171d840`
 - Package run SHA: `aeb7663e710624cd260f80dfefba19a9525a1a88`
 - Item proofs: 47/47
 - Hash integrity: verified match disk (0 mismatches)
-- PRs: 151, 152, 153, 154 (+ this integrity PR)
-- §18 note: max 3 exceeded for rebind/integrity only
+- PRs: 151, 152, 153, 154, 155
+- §18 note: max 3 exceeded for rebind/integrity only (documented)


### PR DESCRIPTION
## Summary

Post-merge SHA stamp for CMI after integrity PR #155:

- result/post-merge/ci-binding main_sha = current main tip base
- per-item proof post_merge_main_sha aligned
- package hash integrity still 0 mismatches (unchanged package bytes)

No functional code.

## HEAD SHA

**HEAD SHA:** `bc6bfb71cbbf6769eb8bf19e2019c253e7b62616`

## Test plan

- [x] Hash verify still 0 mismatches
- [x] Local reviewability PASS
