### PR TITLE
fix(universe): RealDictCursor support for weekly open-tenders collect

### DIFF
--- a/scripts/lib/universe.py
+++ b/scripts/lib/universe.py
@@ -348,7 +348,25 @@ def _parse_seed_row(seed_row: int, row: tuple[Any, ...], radius_km: float) -> di
     }
 
 
+def _row_get(row: Any, key: str, index: int) -> Any:
+    """Read a column from tuple rows or mapping rows (e.g. RealDictCursor)."""
+    if isinstance(row, dict):
+        return row[key]
+    # psycopg2 RealDictRow is a mapping; plain sequences unpack by position.
+    try:
+        return row[key]  # type: ignore[index]
+    except (KeyError, TypeError, IndexError):
+        return row[index]
+
+
 def _load_db_entities(conn: Any) -> dict[str, dict[str, Any]]:
+    """Load active SC entities keyed by CNPJ8.
+
+    Supports both tuple cursors and dict-like cursors (``RealDictCursor``).
+    Weekly uses RealDictCursor; unpacking dict rows as tuples previously
+    bound column *names* (e.g. ``\"id\"``) and crashed with
+    ``int('id')`` during open-tenders collection.
+    """
     with conn.cursor() as cursor:
         cursor.execute(
             """
@@ -357,14 +375,18 @@ def _load_db_entities(conn: Any) -> dict[str, dict[str, Any]]:
             WHERE is_active IS TRUE
             """
         )
-        return {
-            normalize_cnpj8(str(cnpj8)): {
+        out: dict[str, dict[str, Any]] = {}
+        for row in cursor.fetchall():
+            entity_id = _row_get(row, "id", 0)
+            cnpj8 = _row_get(row, "cnpj_8", 1)
+            razao_social = _row_get(row, "razao_social", 2)
+            municipio = _row_get(row, "municipio", 3)
+            out[normalize_cnpj8(str(cnpj8))] = {
                 "id": int(entity_id),
                 "razao_social": razao_social,
                 "municipio": municipio,
             }
-            for entity_id, cnpj8, razao_social, municipio in cursor.fetchall()
-        }
+        return out
 
 
 def _validate_universe(universe: CanonicalUniverse) -> None:

--- a/tests/test_universe.py
+++ b/tests/test_universe.py
@@ -121,3 +121,61 @@ def test_no_negative_metrics() -> None:
     """No coverage metric is negative."""
     assert CANONICAL_UNIVERSE > 0, "CANONICAL_UNIVERSE must be positive"
     assert normalize_cnpj8("") == "", "normalize_cnpj8 of empty must be empty (not negative)"
+
+
+# ---------------------------------------------------------------------------
+# _load_db_entities — RealDictCursor compatibility (weekly uses RealDictCursor)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+
+    def execute(self, *_a, **_k) -> None:
+        return None
+
+    def fetchall(self) -> list:
+        return self._rows
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_a) -> None:
+        return None
+
+
+class _FakeConn:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor(self._rows)
+
+
+def test_load_db_entities_tuple_rows() -> None:
+    from scripts.lib.universe import _load_db_entities
+
+    conn = _FakeConn([(42, "12345678", "Prefeitura X", "Chapecó")])
+    out = _load_db_entities(conn)
+    assert out["12345678"]["id"] == 42
+    assert out["12345678"]["municipio"] == "Chapecó"
+
+
+def test_load_db_entities_dict_rows_realdict() -> None:
+    """Weekly connects with RealDictCursor — must not int('id') on column names."""
+    from scripts.lib.universe import _load_db_entities
+
+    conn = _FakeConn(
+        [
+            {
+                "id": 99,
+                "cnpj_8": "87654321",
+                "razao_social": "Municipio Y",
+                "municipio": "Florianópolis",
+            }
+        ]
+    )
+    out = _load_db_entities(conn)
+    assert out["87654321"]["id"] == 99
+    assert out["87654321"]["razao_social"] == "Municipio Y"


### PR DESCRIPTION
## Summary
- `_load_db_entities` crashed under weekly's `RealDictCursor` with `int('id')` when unpacking dict rows as tuples.
- That blocked `pncp_opportunities` collection on VPS after PR #181 merge (`exit_code=3`).
- Fix: read columns by name for mappings and by index for sequences.
- Tests for tuple and dict rows.

## Test plan
- [x] `pytest tests/test_universe.py` (15 passed)
- [x] Re-run `python -m scripts.ops.weekly_cycle --strict` on VPS after merge