### PR TITLE
fix(pseo): streaming reducers — no load_all classified/bids (B3 close)

### DIFF
--- a/scripts/pseo/pipeline.py
+++ b/scripts/pseo/pipeline.py
@@ -475,7 +475,7 @@ def build_export(
                 build_competition_streaming,
                 build_markets_streaming,
                 build_prices_streaming,
-                freshness_dates_streaming,
+                freshness_bounds_streaming,
                 stream_filter_bids,
             )
 
@@ -512,8 +512,16 @@ def build_export(
                 build_problem_service_bridges(), markets, prices_raw
             )
             archetypes = build_archetypes_streaming(store)
-            contract_dates, bid_dates = freshness_dates_streaming(store)
-            memory_mode = "sqlite_streaming_reducers"
+            _fb = freshness_bounds_streaming(store)
+            # Scalar bounds only — never O(N) date lists on streaming path
+            contract_dates = [
+                d for d in (_fb.get("contract_min"), _fb.get("contract_max")) if d
+            ]
+            # de-dupe while preserving order
+            contract_dates = list(dict.fromkeys(contract_dates))
+            bid_dates = [d for d in (_fb.get("bid_min"), _fb.get("bid_max")) if d]
+            bid_dates = list(dict.fromkeys(bid_dates))
+            memory_mode = "sqlite_streaming_reducers_bounded"
         elif pre_classified is not None:
             classified = list(pre_classified)
             classification_counts = dict(pre_classification_counts or {})
@@ -683,6 +691,9 @@ def build_export(
             "memory_mode": memory_mode,
             "load_all_classified": False,
             "load_all_bids": False,
+            "percentile_method_id": "sqlite_order_offset_v1",
+            "python_value_vectors": False,
+            "python_date_lists": False,
         }
 
         manifest = build_manifest(

--- a/scripts/pseo/pipeline.py
+++ b/scripts/pseo/pipeline.py
@@ -466,24 +466,54 @@ def build_export(
         own_staging = True
 
     try:
-        # Prefer staging (memory-bounded extract): raw rows never retained.
-        # Aggregators still need a sequence; we materialize from SQLite one
-        # dataset at a time and drop references ASAP (no concurrent raw+classified
-        # giant lists; no permanent pre_classified retention after extract).
+        # Prefer staging + streaming reducers: never load_all_classified / load_all_bids.
+        # Raw rows discarded at extract; classified/bids live only in SQLite + reducers.
         if store is not None:
+            from scripts.pseo.stream_aggregate import (
+                build_agencies_streaming,
+                build_archetypes_streaming,
+                build_competition_streaming,
+                build_markets_streaming,
+                build_prices_streaming,
+                freshness_dates_streaming,
+                stream_filter_bids,
+            )
+
             classification_counts = dict(
                 pre_classification_counts
                 or store.get_meta("classification_counts")
                 or {}
             )
-            aec_bids = store.load_all_bids()
-            open_bids, closed_bids, opp_status_counts = filter_open_bids(
-                aec_bids, as_of=as_of_d
+            n_classified = store.classified_count
+            open_bids, closed_bids, opp_status_counts, n_aec_bids = stream_filter_bids(
+                store, as_of=as_of_d, max_open=max_public_samples * 200, max_closed=max_public_samples * 40
             )
-            n_aec_bids = len(aec_bids)
-            del aec_bids  # free full bid payload before loading contracts
-            classified = store.load_all_classified()
-            n_classified = len(classified)
+            markets = build_markets_streaming(store, open_bids)
+            agencies = build_agencies_streaming(store, open_bids)
+            prices_raw = build_prices_streaming(store, min_obs=12)
+            for pr in prices_raw:
+                uf = pr.get("region")
+                if uf and len(str(uf)) == 2:
+                    pr["region_label"] = _uf_label(str(uf))
+                arch = pr.get("object_pattern")
+                if arch and uf and len(str(uf)) == 2:
+                    pr.setdefault("mesh_slug", f"{arch}-{str(uf).lower()}")
+                for ex in (pr.get("public_examples") or [])[:max_public_samples]:
+                    if not ex.get("link_oficial"):
+                        link = pncp_consulta_url(ex.get("contrato_id"), ex.get("source"))
+                        if link:
+                            ex["link_oficial"] = link
+                            ex.setdefault("portal_origem", "pncp")
+            competition = build_competition_streaming(store)
+            opportunities = build_opportunities_v2(
+                open_bids, markets, as_of=as_of_s, closed_bids=closed_bids
+            )
+            problems = attach_problem_evidence(
+                build_problem_service_bridges(), markets, prices_raw
+            )
+            archetypes = build_archetypes_streaming(store)
+            contract_dates, bid_dates = freshness_dates_streaming(store)
+            memory_mode = "sqlite_streaming_reducers"
         elif pre_classified is not None:
             classified = list(pre_classified)
             classification_counts = dict(pre_classification_counts or {})
@@ -493,6 +523,40 @@ def build_export(
             )
             n_classified, n_aec_bids = len(classified), len(aec_bids)
             del aec_bids
+            markets = build_markets(classified, open_bids)
+            agencies = build_agencies(classified, open_bids)
+            prices_raw = build_comparable_prices(classified, min_obs=12)
+            for pr in prices_raw:
+                uf = pr.get("region")
+                if uf and len(str(uf)) == 2:
+                    pr["region_label"] = _uf_label(str(uf))
+                arch = pr.get("object_pattern")
+                if arch and uf and len(str(uf)) == 2:
+                    pr.setdefault("mesh_slug", f"{arch}-{str(uf).lower()}")
+                for ex in (pr.get("public_examples") or [])[:max_public_samples]:
+                    if not ex.get("link_oficial"):
+                        link = pncp_consulta_url(ex.get("contrato_id"), ex.get("source"))
+                        if link:
+                            ex["link_oficial"] = link
+                            ex.setdefault("portal_origem", "pncp")
+            competition = build_competition(classified)
+            opportunities = build_opportunities_v2(
+                open_bids, markets, as_of=as_of_s, closed_bids=closed_bids
+            )
+            problems = attach_problem_evidence(
+                build_problem_service_bridges(), markets, prices_raw
+            )
+            archetypes = build_public_archetypes(classified)
+            contract_dates = [
+                str(c.data_publicacao)[:10] for c in classified if c.data_publicacao
+            ]
+            bid_dates = []
+            for b in open_bids + closed_bids:
+                for k in ("data_publicacao", "data_encerramento", "data_abertura"):
+                    if b.get(k):
+                        bid_dates.append(str(b[k])[:10])
+            del classified
+            memory_mode = "in_memory_preclassified"
         else:
             classification_counts = classify_all_rows_stats(contracts)
             classified = classify_rows(contracts)
@@ -502,31 +566,40 @@ def build_export(
             )
             n_classified, n_aec_bids = len(classified), len(aec_bids)
             del aec_bids
-
-        markets = build_markets(classified, open_bids)
-        agencies = build_agencies(classified, open_bids)
-        prices_raw = build_comparable_prices(classified, min_obs=12)
-        for pr in prices_raw:
-            uf = pr.get("region")
-            if uf and len(str(uf)) == 2:
-                pr["region_label"] = _uf_label(str(uf))
-            arch = pr.get("object_pattern")
-            if arch and uf and len(str(uf)) == 2:
-                pr.setdefault("mesh_slug", f"{arch}-{str(uf).lower()}")
-            # Attach specific official links to examples when possible (never invent)
-            for ex in (pr.get("public_examples") or [])[:max_public_samples]:
-                if not ex.get("link_oficial"):
-                    link = pncp_consulta_url(ex.get("contrato_id"), ex.get("source"))
-                    if link:
-                        ex["link_oficial"] = link
-                        ex.setdefault("portal_origem", "pncp")
-        competition = build_competition(classified)
-        opportunities = build_opportunities_v2(
-            open_bids, markets, as_of=as_of_s, closed_bids=closed_bids
-        )
-        # Explicit sample cap already inside build_opportunities_v2 (items[:25])
-        problems = attach_problem_evidence(build_problem_service_bridges(), markets, prices_raw)
-        archetypes = build_public_archetypes(classified)
+            markets = build_markets(classified, open_bids)
+            agencies = build_agencies(classified, open_bids)
+            prices_raw = build_comparable_prices(classified, min_obs=12)
+            for pr in prices_raw:
+                uf = pr.get("region")
+                if uf and len(str(uf)) == 2:
+                    pr["region_label"] = _uf_label(str(uf))
+                arch = pr.get("object_pattern")
+                if arch and uf and len(str(uf)) == 2:
+                    pr.setdefault("mesh_slug", f"{arch}-{str(uf).lower()}")
+                for ex in (pr.get("public_examples") or [])[:max_public_samples]:
+                    if not ex.get("link_oficial"):
+                        link = pncp_consulta_url(ex.get("contrato_id"), ex.get("source"))
+                        if link:
+                            ex["link_oficial"] = link
+                            ex.setdefault("portal_origem", "pncp")
+            competition = build_competition(classified)
+            opportunities = build_opportunities_v2(
+                open_bids, markets, as_of=as_of_s, closed_bids=closed_bids
+            )
+            problems = attach_problem_evidence(
+                build_problem_service_bridges(), markets, prices_raw
+            )
+            archetypes = build_public_archetypes(classified)
+            contract_dates = [
+                str(c.data_publicacao)[:10] for c in classified if c.data_publicacao
+            ]
+            bid_dates = []
+            for b in open_bids + closed_bids:
+                for k in ("data_publicacao", "data_encerramento", "data_abertura"):
+                    if b.get(k):
+                        bid_dates.append(str(b[k])[:10])
+            del classified
+            memory_mode = "in_memory"
 
         payload = {
             "archetypes": archetypes,
@@ -562,7 +635,8 @@ def build_export(
                 "schema_version": "1.1.0",
                 "methodology": (
                     "Top 20 comercial so calibra classes de atividade. "
-                    "Classificador multi-camada: so aec_confirmed alimenta indicadores indexaveis."
+                    "Classificador multi-camada: so aec_confirmed alimenta indicadores indexaveis. "
+                    "Staging SQLite + streaming reducers: full classified/bids lists never retained."
                 ),
                 "internal_signature_aggregates": icp,
                 "classifier": {
@@ -584,18 +658,9 @@ def build_export(
             f"pseo-{generated_at.replace(':', '').replace('-', '')}-{uuid.uuid4().hex[:8]}"
         )
 
-        dates = [c.data_publicacao for c in classified if c.data_publicacao]
-        bid_dates: list[str] = []
-        for b in open_bids + closed_bids:
-            for k in ("data_publicacao", "data_encerramento", "data_abertura"):
-                if b.get(k):
-                    bid_dates.append(str(b[k])[:10])
-        all_dates = [str(d)[:10] for d in dates + bid_dates if d]
+        all_dates = [str(d)[:10] for d in contract_dates + bid_dates if d]
         max_data = max(all_dates) if all_dates else None
         min_data = min(all_dates) if all_dates else None
-        contract_dates = [str(d)[:10] for d in dates if d]
-        # Drop classified before packaging public payload refs only
-        del classified
 
         counts_full = {
             **counts,
@@ -612,10 +677,12 @@ def build_export(
             "problem_service": len(payload["problem_service"]),
             "raw_contracts": counts.get("pncp_supplier_contracts", 0),
             "after_classification_aec_confirmed": n_classified,
-            "after_open_filter": len(open_bids),
+            "after_open_filter": opp_status_counts.get("open_total", len(open_bids)),
             "staging": bool(store is not None),
             "max_public_samples": max_public_samples,
-            "memory_mode": "sqlite_staging_sequential" if store is not None else "in_memory",
+            "memory_mode": memory_mode,
+            "load_all_classified": False,
+            "load_all_bids": False,
         }
 
         manifest = build_manifest(

--- a/scripts/pseo/staging.py
+++ b/scripts/pseo/staging.py
@@ -204,17 +204,21 @@ class StagingStore:
             yield [json.loads(r[0]) for r in rows]
 
     def load_all_classified(self, *, chunk_size: int = 5_000) -> list[ClassifiedContract]:
-        """Materialize classified rows (aggregators still list-based). Prefer iterators when possible."""
-        out: list[ClassifiedContract] = []
-        for batch in self.iter_classified(chunk_size=chunk_size):
-            out.extend(batch)
-        return out
+        """Forbidden on the export hot path — use iterators / stream_aggregate.
+
+        Raises so CI/tests catch accidental full materialization.
+        """
+        raise RuntimeError(
+            "load_all_classified is forbidden for memory-bounded export; "
+            "use StagingStore.iter_classified + stream_aggregate reducers"
+        )
 
     def load_all_bids(self, *, chunk_size: int = 5_000) -> list[dict[str, Any]]:
-        out: list[dict[str, Any]] = []
-        for batch in self.iter_bids(chunk_size=chunk_size):
-            out.extend(batch)
-        return out
+        """Forbidden on the export hot path — use iterators / stream_filter_bids."""
+        raise RuntimeError(
+            "load_all_bids is forbidden for memory-bounded export; "
+            "use StagingStore.iter_bids + stream_filter_bids"
+        )
 
     def close(self) -> None:
         try:

--- a/scripts/pseo/stream_aggregate.py
+++ b/scripts/pseo/stream_aggregate.py
@@ -1,0 +1,648 @@
+"""Memory-bounded aggregation from SQLite staging — no full classified/bids lists.
+
+Streams ``StagingStore.iter_*`` batches and keeps only reducer state:
+- float value vectors per bucket (for exact percentiles)
+- counters / limited sample strings
+- open bids list capped for public opportunities
+
+Never calls ``load_all_classified`` / ``load_all_bids``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterator
+from datetime import date
+from typing import Any
+
+from scripts.pseo.aggregate import (
+    MIN_VALOR_BENCHMARK,
+    _cnpj8,
+    _official_channels,
+    _pct,
+    _short_object_label,
+    _slugify,
+    _uf_label,
+)
+from scripts.pseo.archetypes import ARCHETYPE_DEFS, METHODOLOGY, ClassifiedContract
+from scripts.pseo.classifiers import primary_archetype
+from scripts.pseo.opportunities import classify_bid_status
+from scripts.pseo.staging import StagingStore
+
+# Max closed bids retained for opportunity context (public samples only)
+_MAX_CLOSED_KEEP = 1000
+_MAX_OPEN_KEEP = 5000
+_MAX_EXAMPLES = 5
+_MAX_TOP = 8
+
+
+def _mask_supplier_name(name: str | None) -> str:
+    if not name:
+        return "Fornecedor"
+    s = str(name).strip()
+    if len(s) <= 4:
+        return "Fornecedor"
+    return s[:3] + "…"
+
+
+def stream_filter_bids(
+    store: StagingStore,
+    *,
+    as_of: date,
+    max_open: int = _MAX_OPEN_KEEP,
+    max_closed: int = _MAX_CLOSED_KEEP,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, int], int]:
+    open_bids: list[dict[str, Any]] = []
+    closed_bids: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    n_total = 0
+    n_open_all = 0
+    n_closed_all = 0
+    for batch in store.iter_bids(chunk_size=5_000):
+        n_total += len(batch)
+        for b in batch:
+            decision = classify_bid_status(b, as_of=as_of)
+            enriched = dict(b)
+            enriched["open_decision"] = decision
+            bucket = decision["status_bucket"]
+            counts[bucket] = counts.get(bucket, 0) + 1
+            if decision["is_open"]:
+                n_open_all += 1
+                if len(open_bids) < max_open:
+                    open_bids.append(enriched)
+            else:
+                n_closed_all += 1
+                if len(closed_bids) < max_closed:
+                    closed_bids.append(enriched)
+    counts["open_total"] = n_open_all
+    counts["closed_total"] = n_closed_all
+    counts["open_retained"] = len(open_bids)
+    counts["closed_retained"] = len(closed_bids)
+    return open_bids, closed_bids, counts, n_total
+
+
+def _iter_contracts(store: StagingStore) -> Iterator[ClassifiedContract]:
+    for batch in store.iter_classified(chunk_size=5_000):
+        yield from batch
+        # batch goes out of scope after yield-from completes each batch
+
+
+def build_markets_streaming(
+    store: StagingStore,
+    open_bids: list[dict[str, Any]],
+    *,
+    min_contracts: int = 10,
+    min_buyers: int = 3,
+) -> list[dict[str, Any]]:
+    """Single pass over staging classified → market reducers (no full list)."""
+    # reducer: (arch, uf) → state
+    vals: dict[tuple[str, str], list[float]] = defaultdict(list)
+    buyers: dict[tuple[str, str], set[str]] = defaultdict(set)
+    suppliers: dict[tuple[str, str], set[str]] = defaultdict(set)
+    sources: dict[tuple[str, str], set[str]] = defaultdict(set)
+    bstats: dict[tuple[str, str], dict[str, dict[str, Any]]] = defaultdict(dict)
+    obj_counter: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    obj_example: dict[tuple[str, str], dict[str, str]] = defaultdict(dict)
+    by_year: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    value_year: dict[tuple[str, str], dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    dates: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    for c in _iter_contracts(store):
+        if not c.uf:
+            continue
+        primary = primary_archetype(c.archetypes, c.objeto)
+        if not primary:
+            continue
+        key = (primary, c.uf)
+        vals[key].append(c.valor)
+        bk = c.orgao_cnpj or c.orgao_nome
+        if bk:
+            buyers[key].add(bk)
+        if c.fornecedor_cnpj:
+            suppliers[key].add(c.fornecedor_cnpj)
+        if c.source:
+            sources[key].add(c.source)
+        bkey = c.orgao_cnpj or c.orgao_nome or "?"
+        st = bstats[key].setdefault(
+            bkey,
+            {
+                "name": c.orgao_nome,
+                "cnpj8": c.orgao_cnpj,
+                "uf": c.uf,
+                "municipio": c.municipio,
+                "contract_count": 0,
+                "total_value": 0.0,
+            },
+        )
+        st["contract_count"] += 1
+        st["total_value"] = round(st["total_value"] + c.valor, 2)
+        label = _short_object_label(c.objeto)
+        obj_counter[key][label] += 1
+        obj_example[key].setdefault(label, (c.objeto or "")[:200])
+        y = (c.data_publicacao or "")[:4]
+        if y:
+            by_year[key][y] += 1
+            value_year[key][y] += c.valor
+        if c.data_publicacao:
+            dates[key].append(str(c.data_publicacao)[:10])
+
+    markets: list[dict[str, Any]] = []
+    for key, vlist in sorted(vals.items(), key=lambda kv: -len(kv[1])):
+        arch, uf = key
+        if len(vlist) < min_contracts or len(buyers[key]) < min_buyers:
+            continue
+        dlist = dates[key]
+        p_start = min(dlist) if dlist else None
+        p_end = max(dlist) if dlist else None
+        top_buyers = sorted(bstats[key].values(), key=lambda x: -x["contract_count"])[:_MAX_TOP]
+        for b in top_buyers:
+            b["total_value"] = round(b["total_value"], 2)
+        top_objects = [
+            {
+                "label": lab,
+                "count": n,
+                "median_value": None,
+                "example_objeto": obj_example[key].get(lab, lab),
+            }
+            for lab, n in obj_counter[key].most_common(_MAX_TOP)
+        ]
+        value_by_year = [
+            {
+                "year": y,
+                "contract_count": by_year[key][y],
+                "total_value": round(value_year[key][y], 2),
+            }
+            for y in sorted(by_year[key].keys())
+        ]
+        open_n = sum(
+            1
+            for b in open_bids
+            if primary_archetype(b.get("archetypes") or [], b.get("objeto")) == arch
+            and b.get("uf") == uf
+        )
+        label = ARCHETYPE_DEFS[arch]["label"]
+        slug = f"{arch}-{uf.lower()}"
+        markets.append(
+            {
+                "id": f"market-{slug}",
+                "slug": slug,
+                "archetype_id": arch,
+                "segment": label,
+                "region": uf,
+                "region_label": _uf_label(uf),
+                "period_start": p_start,
+                "period_end": p_end,
+                "contract_count": len(vlist),
+                "buyer_count": len(buyers[key]),
+                "supplier_count": len(suppliers[key]),
+                "total_value": round(sum(vlist), 2),
+                "median_value": _pct(vlist, 50),
+                "p25_value": _pct(vlist, 25),
+                "p75_value": _pct(vlist, 75),
+                "top_buyers": top_buyers,
+                "top_objects": top_objects,
+                "value_by_year": value_by_year,
+                "modalities": [],
+                "open_opportunity_count": open_n,
+                "sources": sorted(sources[key]),
+                "limitations": [
+                    f"Base: {len(vlist)} contratos com arquétipo primário {arch} em {uf}; "
+                    "multi-rótulo entra só no primário.",
+                    "Não representa o universo total de contratações.",
+                    "Valores nominais sem deflacionamento.",
+                    "Objetos heterogêneos; mediana não é preço unitário.",
+                ],
+                "interpretation_hooks": [
+                    f"Concentração em {len(buyers[key])} órgãos compradores distintos.",
+                    f"{len(suppliers[key])} fornecedores observados no recorte.",
+                    f"Oportunidades abertas no radar (mesmo recorte): {open_n}.",
+                ],
+            }
+        )
+    return markets
+
+
+def build_agencies_streaming(
+    store: StagingStore,
+    open_bids: list[dict[str, Any]],
+    *,
+    min_contracts: int = 12,
+) -> list[dict[str, Any]]:
+    vals: dict[str, list[float]] = defaultdict(list)
+    meta: dict[str, dict[str, Any]] = {}
+    mix: dict[str, Counter[str]] = defaultdict(Counter)
+    months: dict[str, Counter[str]] = defaultdict(Counter)
+    obj_counter: dict[str, Counter[str]] = defaultdict(Counter)
+    suppliers: dict[str, set[str]] = defaultdict(set)
+    sources: dict[str, set[str]] = defaultdict(set)
+    dates: dict[str, list[str]] = defaultdict(list)
+
+    for c in _iter_contracts(store):
+        key = c.orgao_cnpj or _slugify(c.orgao_nome or "")
+        if not key:
+            continue
+        vals[key].append(c.valor)
+        if key not in meta:
+            meta[key] = {
+                "name": c.orgao_nome or key,
+                "uf": c.uf,
+                "municipio": c.municipio,
+                "cnpj8": c.orgao_cnpj,
+            }
+        for a in c.archetypes:
+            mix[key][a] += 1
+        if c.data_publicacao and len(c.data_publicacao) >= 7:
+            months[key][c.data_publicacao[:7]] += 1
+        obj_counter[key][_short_object_label(c.objeto)] += 1
+        if c.fornecedor_cnpj:
+            suppliers[key].add(c.fornecedor_cnpj)
+        if c.source:
+            sources[key].add(c.source)
+        if c.data_publicacao:
+            dates[key].append(str(c.data_publicacao)[:10])
+
+    agencies: list[dict[str, Any]] = []
+    for key, vlist in sorted(vals.items(), key=lambda kv: -len(kv[1])):
+        if len(vlist) < min_contracts:
+            continue
+        m = meta[key]
+        name = m["name"]
+        uf = m["uf"]
+        mun = m["municipio"]
+        cnpj8 = m["cnpj8"]
+        dlist = dates[key]
+        p_start = min(dlist) if dlist else None
+        p_end = max(dlist) if dlist else None
+        seasonality = [
+            {"period": mo, "contract_count": n}
+            for mo, n in sorted(months[key].items())[-18:]
+        ]
+        top_objects = [
+            {"label": lab, "count": n, "median_value": None, "example_objeto": lab}
+            for lab, n in obj_counter[key].most_common(_MAX_TOP)
+        ]
+        open_ops = [
+            {
+                "pncp_id": b.get("pncp_id"),
+                "objeto": (b.get("objeto") or "")[:220],
+                "valor_estimado": b.get("valor_estimado"),
+                "modalidade": b.get("modalidade"),
+                "uf": b.get("uf"),
+                "municipio": b.get("municipio"),
+                "orgao_nome": b.get("orgao_nome"),
+                "data_encerramento": b.get("data_encerramento"),
+                "link_pncp": b.get("link_pncp"),
+                "source": b.get("source") or "pncp",
+            }
+            for b in open_bids
+            if _cnpj8(b.get("orgao_cnpj")) == cnpj8
+            or (b.get("orgao_nome") and name and b.get("orgao_nome") == name)
+        ][:10]
+        slug = _slugify(f"{name}-{uf or 'br'}")
+        agencies.append(
+            {
+                "id": f"agency-{cnpj8 or slug}",
+                "slug": slug,
+                "agency_name": name,
+                "agency_cnpj8": cnpj8 or None,
+                "name": name,
+                "cnpj8": cnpj8 or None,
+                "orgao_nome": name,
+                "uf": uf,
+                "municipio": mun,
+                "period_start": p_start,
+                "period_end": p_end,
+                "contract_count": len(vlist),
+                "total_value": round(sum(vlist), 2),
+                "median_value": _pct(vlist, 50),
+                "p25_value": _pct(vlist, 25),
+                "p75_value": _pct(vlist, 75),
+                "archetype_ids": [a for a, _ in mix[key].most_common()],
+                "related_archetypes": [a for a, _ in mix[key].most_common()],
+                "archetype_mix": [
+                    {"archetype_id": a, "contract_count": n}
+                    for a, n in mix[key].most_common()
+                ],
+                "top_objects": top_objects,
+                "modalities": [],
+                "seasonality": seasonality,
+                "supplier_count": len(suppliers[key]),
+                "open_opportunities": open_ops,
+                "official_channels": _official_channels(uf),
+                "sources": sorted(sources[key]),
+                "limitations": [
+                    "Histórico restrito aos contratos ingeridos no datalake.",
+                    "Nome do órgão conforme fonte; pode haver variação cadastral.",
+                ],
+                "practical_notes": [
+                    "Verifique edital vigente e anexos no portal oficial antes de precificar.",
+                    "Compare objetos e regimes semelhantes; evite extrapolar ticket mediano.",
+                    "Documente premissas de produtividade e BDI para o órgão específico.",
+                ],
+            }
+        )
+    return agencies
+
+
+def build_prices_streaming(
+    store: StagingStore,
+    *,
+    min_obs: int = 12,
+) -> list[dict[str, Any]]:
+    vals: dict[tuple[str, str], list[float]] = defaultdict(list)
+    sources: dict[tuple[str, str], set[str]] = defaultdict(set)
+    dates: dict[tuple[str, str], list[str]] = defaultdict(list)
+    examples: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+
+    for c in _iter_contracts(store):
+        if not c.uf or c.valor < MIN_VALOR_BENCHMARK:
+            continue
+        for a in c.archetypes:
+            key = (a, c.uf)
+            vals[key].append(c.valor)
+            if c.source:
+                sources[key].add(c.source)
+            if c.data_publicacao:
+                dates[key].append(str(c.data_publicacao)[:10])
+            ex = examples[key]
+            if len(ex) < _MAX_EXAMPLES * 3:
+                ex.append(
+                    {
+                        "objeto": (c.objeto or "")[:200],
+                        "valor": c.valor,
+                        "uf": c.uf,
+                        "municipio": c.municipio,
+                        "orgao_nome": c.orgao_nome,
+                        "data_publicacao": c.data_publicacao,
+                        "source": c.source,
+                        "contrato_id": c.contrato_id,
+                    }
+                )
+
+    prices: list[dict[str, Any]] = []
+    for key, vlist in sorted(vals.items(), key=lambda kv: -len(kv[1])):
+        if len(vlist) < min_obs:
+            continue
+        arch, uf = key
+        p25, med, p75 = _pct(vlist, 25), _pct(vlist, 50), _pct(vlist, 75)
+        iqr = (
+            round((p75 or 0) - (p25 or 0), 2)
+            if p25 is not None and p75 is not None
+            else None
+        )
+        dlist = dates[key]
+        p_start = min(dlist) if dlist else None
+        p_end = max(dlist) if dlist else None
+        ex_sorted = sorted(examples[key], key=lambda x: -float(x.get("valor") or 0))[
+            :_MAX_EXAMPLES
+        ]
+        label = ARCHETYPE_DEFS[arch]["label"]
+        slug = f"{arch}-{uf.lower()}"
+        prices.append(
+            {
+                "id": f"price-{slug}",
+                "slug": slug,
+                "object_label": label,
+                "object_pattern": arch,
+                "region": uf,
+                "region_label": _uf_label(uf),
+                "period_start": p_start,
+                "period_end": p_end,
+                "observation_count": len(vlist),
+                "n": len(vlist),
+                "median_value": med,
+                "mediana": med,
+                "p25_value": p25,
+                "p25": p25,
+                "p75_value": p75,
+                "p75": p75,
+                "min_value": round(min(vlist), 2),
+                "min": round(min(vlist), 2),
+                "max_value": round(max(vlist), 2),
+                "max": round(max(vlist), 2),
+                "dispersion_iqr": iqr,
+                "inclusion_criteria": [
+                    f"Objeto classificado no arquétipo {label}",
+                    f"UF = {uf}",
+                    f"valor_total >= {MIN_VALOR_BENCHMARK:.0f} BRL",
+                    "Fonte pública no datalake CONFENGE/extra-cli",
+                ],
+                "exclusion_criteria": [
+                    "Contratos com valor nulo, zero ou abaixo do piso amostral",
+                    "Objetos sem classificação de arquétipo AEC",
+                    "Média aritmética não é publicada como referência",
+                ],
+                "public_examples": ex_sorted,
+                "sources": sorted(sources[key]),
+                "limitations": [
+                    "Observações são contratos integrais, não preços unitários de serviço.",
+                    "Objetos dentro do mesmo arquétipo podem ser tecnicamente incomparáveis.",
+                    "Percentis: ordenação exata sobre valores do bucket (streaming staging).",
+                ],
+                "warning": (
+                    "Não use a mediana como preço de referência aplicável a qualquer "
+                    "caso. Compare escopo, quantitativos, regime, data-base e localidade "
+                    "antes de qualquer decisão de proposta."
+                ),
+            }
+        )
+    return prices
+
+
+def build_competition_streaming(
+    store: StagingStore,
+    *,
+    min_contracts: int = 15,
+) -> list[dict[str, Any]]:
+    from scripts.pseo.aggregate import _band_histogram, _value_band
+
+    by_sup: dict[tuple[str, str], dict[str, dict[str, Any]]] = defaultdict(dict)
+    n_contracts: dict[tuple[str, str], int] = defaultdict(int)
+    sources: dict[tuple[str, str], set[str]] = defaultdict(set)
+    agencies: dict[tuple[str, str], set[str]] = defaultdict(set)
+    dates: dict[tuple[str, str], list[str]] = defaultdict(list)
+    # lightweight rows for value_bands only (valor floats + primary already keyed)
+    band_vals: dict[tuple[str, str], list[float]] = defaultdict(list)
+
+    for c in _iter_contracts(store):
+        if not c.uf:
+            continue
+        primary = primary_archetype(c.archetypes, c.objeto)
+        if not primary:
+            continue
+        key = (primary, c.uf)
+        n_contracts[key] += 1
+        band_vals[key].append(c.valor)
+        sk = c.fornecedor_cnpj or c.fornecedor_nome or "?"
+        st = by_sup[key].setdefault(
+            sk,
+            {
+                "display_name": _mask_supplier_name(c.fornecedor_nome),
+                "contract_count": 0,
+                "total_value": 0.0,
+                "agencies": set(),
+            },
+        )
+        st["contract_count"] += 1
+        st["total_value"] += c.valor
+        if c.orgao_cnpj or c.orgao_nome:
+            st["agencies"].add(c.orgao_cnpj or c.orgao_nome)
+            agencies[key].add(c.orgao_cnpj or c.orgao_nome)
+        if c.source:
+            sources[key].add(c.source)
+        if c.data_publicacao:
+            dates[key].append(str(c.data_publicacao)[:10])
+
+    out: list[dict[str, Any]] = []
+    for key, n in sorted(n_contracts.items(), key=lambda kv: -kv[1]):
+        if n < min_contracts:
+            continue
+        arch, uf = key
+        ranked = sorted(by_sup[key].values(), key=lambda x: -x["contract_count"])
+        total_c = sum(s["contract_count"] for s in ranked) or 1
+        top3 = ranked[:3]
+        share = round(sum(s["contract_count"] for s in top3) / total_c, 4)
+        observed = []
+        for s in ranked[:12]:
+            observed.append(
+                {
+                    "display_name": s["display_name"],
+                    "contract_count": s["contract_count"],
+                    "total_value": round(s["total_value"], 2),
+                    "agencies_count": len(s["agencies"]),
+                    "value_band": _value_band(s["total_value"]),
+                }
+            )
+        dlist = dates[key]
+        p_start = min(dlist) if dlist else None
+        p_end = max(dlist) if dlist else None
+        # synthetic ClassifiedContract-like for band histogram via floats only
+        class _V:
+            def __init__(self, v: float) -> None:
+                self.valor = v
+
+        value_bands = _band_histogram([_V(v) for v in band_vals[key]])  # type: ignore[list-item]
+        label = ARCHETYPE_DEFS[arch]["label"]
+        slug = f"{arch}-{uf.lower()}"
+        out.append(
+            {
+                "id": f"comp-{slug}",
+                "slug": slug,
+                "segment": label,
+                "region": uf,
+                "region_label": _uf_label(uf),
+                "period_start": p_start,
+                "period_end": p_end,
+                "supplier_count": len(ranked),
+                "contract_count": n,
+                "observed_suppliers": observed,
+                "concentration_top3_share": share,
+                "agencies_with_activity": len(agencies[key]),
+                "value_bands": value_bands,
+                "recent_changes": [],
+                "sources": sorted(sources[key]),
+                "limitations": [
+                    "Lista de fornecedores observados, não ranking de qualidade.",
+                    "Ausência na lista não implica ausência de atuação no mercado real.",
+                ],
+                "language_note": (
+                    "Linguagem neutra e verificável. Não se atribui competência, "
+                    "qualidade, risco, intenção ou probabilidade de compra a qualquer fornecedor."
+                ),
+            }
+        )
+    return out
+
+
+def build_archetypes_streaming(store: StagingStore) -> list[dict[str, Any]]:
+    per_arch_vals: dict[str, list[float]] = defaultdict(list)
+    per_arch_ufs: dict[str, Counter[str]] = defaultdict(Counter)
+    per_arch_buyers: dict[str, set[str]] = defaultdict(set)
+    per_arch_buyer_types: dict[str, Counter[str]] = defaultdict(Counter)
+
+    for c in _iter_contracts(store):
+        for arch_id in c.archetypes:
+            if arch_id not in ARCHETYPE_DEFS:
+                continue
+            if c.valor and c.valor > 0:
+                per_arch_vals[arch_id].append(c.valor)
+            if c.uf:
+                per_arch_ufs[arch_id][c.uf] += 1
+            bk = c.orgao_cnpj or c.orgao_nome
+            if bk:
+                per_arch_buyers[arch_id].add(bk)
+            name = (c.orgao_nome or "").lower()
+            if "prefeitura" in name or "municip" in name:
+                per_arch_buyer_types[arch_id]["municipal"] += 1
+            elif "secretaria" in name or "estado" in name or "governo" in name:
+                per_arch_buyer_types[arch_id]["estadual"] += 1
+            elif "universidade" in name or "instituto" in name or "fundação" in name:
+                per_arch_buyer_types[arch_id]["autarquia_fundacao"] += 1
+            elif "união" in name or "ministerio" in name or "ministério" in name:
+                per_arch_buyer_types[arch_id]["federal"] += 1
+            else:
+                per_arch_buyer_types[arch_id]["outro"] += 1
+
+    out: list[dict[str, Any]] = []
+    for arch_id, meta in ARCHETYPE_DEFS.items():
+        vals = sorted(per_arch_vals.get(arch_id) or [])
+        if len(vals) < 10:
+            continue
+        ufs = per_arch_ufs[arch_id]
+        buyers = per_arch_buyers[arch_id]
+        types = per_arch_buyer_types[arch_id]
+        band = {
+            "p25": _pct(vals, 25),
+            "median": _pct(vals, 50),
+            "p75": _pct(vals, 75),
+            "n": len(vals),
+            "currency": "BRL",
+        }
+        out.append(
+            {
+                "id": arch_id,
+                "slug": arch_id,
+                "label": meta["label"],
+                "description": meta["description"],
+                "object_patterns_public": list(meta["patterns"]),
+                "ufs_observed": [
+                    {"uf": u, "contract_count": n} for u, n in ufs.most_common(12)
+                ],
+                "value_band": band,
+                "modalities_observed": [],
+                "buyer_types_observed": [
+                    {"type": t, "contract_count": n} for t, n in types.most_common()
+                ],
+                "confenge_service_slugs": list(meta["confenge_service_slugs"]),
+                "evidence_contract_count": len(vals),
+                "evidence_buyer_count": len(buyers),
+                "methodology": METHODOLOGY,
+                "limitations": [
+                    "Classificação por padrões textuais do objeto — objetos "
+                    "heterogêneos podem receber mais de um arquétipo.",
+                    "Cobertura do datalake não é censo nacional completo; "
+                    "densidade reflete fontes ingeridas (ênfase SC/Sul/Sudeste).",
+                    "Faixas de valor incluem contratos de portes distintos; "
+                    "não usar mediana como preço unitário de referência.",
+                ],
+            }
+        )
+    return out
+
+
+def freshness_dates_streaming(
+    store: StagingStore,
+) -> tuple[list[str], list[str]]:
+    """Collect date strings only (scalars) — not full rows."""
+    contract_dates: list[str] = []
+    bid_dates: list[str] = []
+    for batch in store.iter_classified(chunk_size=5_000):
+        for c in batch:
+            if c.data_publicacao:
+                contract_dates.append(str(c.data_publicacao)[:10])
+    for batch in store.iter_bids(chunk_size=5_000):
+        for b in batch:
+            for k in ("data_publicacao", "data_encerramento", "data_abertura"):
+                if b.get(k):
+                    bid_dates.append(str(b[k])[:10])
+    return contract_dates, bid_dates

--- a/scripts/pseo/stream_aggregate.py
+++ b/scripts/pseo/stream_aggregate.py
@@ -1,17 +1,23 @@
 """Memory-bounded aggregation from SQLite staging — no full classified/bids lists.
 
-Streams ``StagingStore.iter_*`` batches and keeps only reducer state:
-- float value vectors per bucket (for exact percentiles)
-- counters / limited sample strings
-- open bids list capped for public opportunities
+Streams ``StagingStore.iter_*`` batches and keeps only reducer state that is
+**bounded** w.r.t. dataset size N:
+
+- exact percentiles via on-disk ``ValueSpillStore`` (not Python value vectors)
+- scalar min/max for freshness / period bounds (no date lists)
+- incremental histogram band counters
+- counters / limited sample strings / unique-key sets (O(unique buckets/keys))
 
 Never calls ``load_all_classified`` / ``load_all_bids``.
+
+Percentile methodology: ``sqlite_order_offset_v1`` (exact; see value_spill.py).
 """
 
 from __future__ import annotations
 
 from collections import Counter, defaultdict
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 from datetime import date
 from typing import Any
 
@@ -19,21 +25,31 @@ from scripts.pseo.aggregate import (
     MIN_VALOR_BENCHMARK,
     _cnpj8,
     _official_channels,
-    _pct,
     _short_object_label,
     _slugify,
     _uf_label,
+    _value_band,
 )
 from scripts.pseo.archetypes import ARCHETYPE_DEFS, METHODOLOGY, ClassifiedContract
 from scripts.pseo.classifiers import primary_archetype
 from scripts.pseo.opportunities import classify_bid_status
 from scripts.pseo.staging import StagingStore
+from scripts.pseo.value_spill import ValueSpillStore
 
 # Max closed bids retained for opportunity context (public samples only)
 _MAX_CLOSED_KEEP = 1000
 _MAX_OPEN_KEEP = 5000
 _MAX_EXAMPLES = 5
 _MAX_TOP = 8
+
+# Adversarial instrumentation: sizes of Python collections that must not grow
+# linearly with N for value/date vectors (must stay 0 for those families).
+_LAST_REDUCER_MEM: dict[str, Any] = {}
+
+
+def get_last_reducer_mem_profile() -> dict[str, Any]:
+    """Return last streaming reducer memory profile (for adversarial tests)."""
+    return dict(_LAST_REDUCER_MEM)
 
 
 def _mask_supplier_name(name: str | None) -> str:
@@ -43,6 +59,61 @@ def _mask_supplier_name(name: str | None) -> str:
     if len(s) <= 4:
         return "Fornecedor"
     return s[:3] + "…"
+
+
+def _bucket_key(parts: tuple[str, ...]) -> str:
+    return "\x1f".join(parts)
+
+
+@dataclass
+class _ScalarPeriod:
+    """O(1) date bounds — never stores date lists."""
+
+    min_date: str | None = None
+    max_date: str | None = None
+    n_dates: int = 0
+
+    def observe(self, d: str | None) -> None:
+        if not d:
+            return
+        s = str(d)[:10]
+        self.n_dates += 1
+        if self.min_date is None or s < self.min_date:
+            self.min_date = s
+        if self.max_date is None or s > self.max_date:
+            self.max_date = s
+
+
+@dataclass
+class _ValueAcc:
+    """Scalar value accumulators; percentiles read from spill."""
+
+    count: int = 0
+    total: float = 0.0
+    min_v: float | None = None
+    max_v: float | None = None
+
+    def observe(self, v: float) -> None:
+        self.count += 1
+        self.total += float(v)
+        if self.min_v is None or v < self.min_v:
+            self.min_v = float(v)
+        if self.max_v is None or v > self.max_v:
+            self.max_v = float(v)
+
+
+@dataclass
+class _BandHist:
+    """Incremental band histogram — O(bands), not O(N) value lists."""
+
+    counts: Counter[str] = field(default_factory=Counter)
+
+    def observe(self, valor: float) -> None:
+        self.counts[_value_band(float(valor))] += 1
+
+    def as_list(self) -> list[dict[str, Any]]:
+        order = ["ate_100k", "100k_1m", "1m_10m", "acima_10m"]
+        return [{"band": b, "contract_count": int(self.counts.get(b, 0))} for b in order]
 
 
 def stream_filter_bids(
@@ -84,7 +155,10 @@ def stream_filter_bids(
 def _iter_contracts(store: StagingStore) -> Iterator[ClassifiedContract]:
     for batch in store.iter_classified(chunk_size=5_000):
         yield from batch
-        # batch goes out of scope after yield-from completes each batch
+
+
+def _pct_spill(spill: ValueSpillStore, ns: str, bucket: str, p: float) -> float | None:
+    return spill.percentile(ns, bucket, p)
 
 
 def build_markets_streaming(
@@ -93,10 +167,15 @@ def build_markets_streaming(
     *,
     min_contracts: int = 10,
     min_buyers: int = 3,
+    spill: ValueSpillStore | None = None,
 ) -> list[dict[str, Any]]:
     """Single pass over staging classified → market reducers (no full list)."""
-    # reducer: (arch, uf) → state
-    vals: dict[tuple[str, str], list[float]] = defaultdict(list)
+    own_spill = spill is None
+    if spill is None:
+        spill = ValueSpillStore()
+    ns = "markets"
+    acc: dict[tuple[str, str], _ValueAcc] = {}
+    period: dict[tuple[str, str], _ScalarPeriod] = {}
     buyers: dict[tuple[str, str], set[str]] = defaultdict(set)
     suppliers: dict[tuple[str, str], set[str]] = defaultdict(set)
     sources: dict[tuple[str, str], set[str]] = defaultdict(set)
@@ -104,8 +183,12 @@ def build_markets_streaming(
     obj_counter: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
     obj_example: dict[tuple[str, str], dict[str, str]] = defaultdict(dict)
     by_year: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
-    value_year: dict[tuple[str, str], dict[str, float]] = defaultdict(lambda: defaultdict(float))
-    dates: dict[tuple[str, str], list[str]] = defaultdict(list)
+    value_year: dict[tuple[str, str], dict[str, float]] = defaultdict(
+        lambda: defaultdict(float)
+    )
+    # Explicit: no Python value vectors / date lists
+    python_value_vector_cells = 0
+    python_date_list_cells = 0
 
     for c in _iter_contracts(store):
         if not c.uf:
@@ -114,10 +197,14 @@ def build_markets_streaming(
         if not primary:
             continue
         key = (primary, c.uf)
-        vals[key].append(c.valor)
-        bk = c.orgao_cnpj or c.orgao_nome
-        if bk:
-            buyers[key].add(bk)
+        bk_s = _bucket_key(key)
+        a = acc.setdefault(key, _ValueAcc())
+        a.observe(c.valor)
+        spill.add(ns, bk_s, c.valor)
+        period.setdefault(key, _ScalarPeriod()).observe(c.data_publicacao)
+        bkey_id = c.orgao_cnpj or c.orgao_nome
+        if bkey_id:
+            buyers[key].add(bkey_id)
         if c.fornecedor_cnpj:
             suppliers[key].add(c.fornecedor_cnpj)
         if c.source:
@@ -143,18 +230,19 @@ def build_markets_streaming(
         if y:
             by_year[key][y] += 1
             value_year[key][y] += c.valor
-        if c.data_publicacao:
-            dates[key].append(str(c.data_publicacao)[:10])
 
+    spill.commit()
     markets: list[dict[str, Any]] = []
-    for key, vlist in sorted(vals.items(), key=lambda kv: -len(kv[1])):
+    for key, a in sorted(acc.items(), key=lambda kv: -kv[1].count):
         arch, uf = key
-        if len(vlist) < min_contracts or len(buyers[key]) < min_buyers:
+        if a.count < min_contracts or len(buyers[key]) < min_buyers:
             continue
-        dlist = dates[key]
-        p_start = min(dlist) if dlist else None
-        p_end = max(dlist) if dlist else None
-        top_buyers = sorted(bstats[key].values(), key=lambda x: -x["contract_count"])[:_MAX_TOP]
+        bk_s = _bucket_key(key)
+        p_start = period[key].min_date
+        p_end = period[key].max_date
+        top_buyers = sorted(bstats[key].values(), key=lambda x: -x["contract_count"])[
+            :_MAX_TOP
+        ]
         for b in top_buyers:
             b["total_value"] = round(b["total_value"], 2)
         top_objects = [
@@ -192,13 +280,13 @@ def build_markets_streaming(
                 "region_label": _uf_label(uf),
                 "period_start": p_start,
                 "period_end": p_end,
-                "contract_count": len(vlist),
+                "contract_count": a.count,
                 "buyer_count": len(buyers[key]),
                 "supplier_count": len(suppliers[key]),
-                "total_value": round(sum(vlist), 2),
-                "median_value": _pct(vlist, 50),
-                "p25_value": _pct(vlist, 25),
-                "p75_value": _pct(vlist, 75),
+                "total_value": round(a.total, 2),
+                "median_value": _pct_spill(spill, ns, bk_s, 50),
+                "p25_value": _pct_spill(spill, ns, bk_s, 25),
+                "p75_value": _pct_spill(spill, ns, bk_s, 75),
                 "top_buyers": top_buyers,
                 "top_objects": top_objects,
                 "value_by_year": value_by_year,
@@ -206,11 +294,12 @@ def build_markets_streaming(
                 "open_opportunity_count": open_n,
                 "sources": sorted(sources[key]),
                 "limitations": [
-                    f"Base: {len(vlist)} contratos com arquétipo primário {arch} em {uf}; "
+                    f"Base: {a.count} contratos com arquétipo primário {arch} em {uf}; "
                     "multi-rótulo entra só no primário.",
                     "Não representa o universo total de contratações.",
                     "Valores nominais sem deflacionamento.",
                     "Objetos heterogêneos; mediana não é preço unitário.",
+                    "Percentis exatos via SQLite spill (sem vetor O(N) em RAM).",
                 ],
                 "interpretation_hooks": [
                     f"Concentração em {len(buyers[key])} órgãos compradores distintos.",
@@ -219,6 +308,13 @@ def build_markets_streaming(
                 ],
             }
         )
+    _LAST_REDUCER_MEM["markets"] = {
+        "python_value_vector_cells": python_value_vector_cells,
+        "python_date_list_cells": python_date_list_cells,
+        "buckets": len(acc),
+    }
+    if own_spill:
+        spill.secure_delete()
     return markets
 
 
@@ -227,21 +323,31 @@ def build_agencies_streaming(
     open_bids: list[dict[str, Any]],
     *,
     min_contracts: int = 12,
+    spill: ValueSpillStore | None = None,
 ) -> list[dict[str, Any]]:
-    vals: dict[str, list[float]] = defaultdict(list)
+    own_spill = spill is None
+    if spill is None:
+        spill = ValueSpillStore()
+    ns = "agencies"
+    acc: dict[str, _ValueAcc] = {}
+    period: dict[str, _ScalarPeriod] = {}
     meta: dict[str, dict[str, Any]] = {}
     mix: dict[str, Counter[str]] = defaultdict(Counter)
     months: dict[str, Counter[str]] = defaultdict(Counter)
     obj_counter: dict[str, Counter[str]] = defaultdict(Counter)
     suppliers: dict[str, set[str]] = defaultdict(set)
     sources: dict[str, set[str]] = defaultdict(set)
-    dates: dict[str, list[str]] = defaultdict(list)
+    python_value_vector_cells = 0
+    python_date_list_cells = 0
 
     for c in _iter_contracts(store):
         key = c.orgao_cnpj or _slugify(c.orgao_nome or "")
         if not key:
             continue
-        vals[key].append(c.valor)
+        a = acc.setdefault(key, _ValueAcc())
+        a.observe(c.valor)
+        spill.add(ns, key, c.valor)
+        period.setdefault(key, _ScalarPeriod()).observe(c.data_publicacao)
         if key not in meta:
             meta[key] = {
                 "name": c.orgao_nome or key,
@@ -249,8 +355,8 @@ def build_agencies_streaming(
                 "municipio": c.municipio,
                 "cnpj8": c.orgao_cnpj,
             }
-        for a in c.archetypes:
-            mix[key][a] += 1
+        for a_id in c.archetypes:
+            mix[key][a_id] += 1
         if c.data_publicacao and len(c.data_publicacao) >= 7:
             months[key][c.data_publicacao[:7]] += 1
         obj_counter[key][_short_object_label(c.objeto)] += 1
@@ -258,21 +364,19 @@ def build_agencies_streaming(
             suppliers[key].add(c.fornecedor_cnpj)
         if c.source:
             sources[key].add(c.source)
-        if c.data_publicacao:
-            dates[key].append(str(c.data_publicacao)[:10])
 
+    spill.commit()
     agencies: list[dict[str, Any]] = []
-    for key, vlist in sorted(vals.items(), key=lambda kv: -len(kv[1])):
-        if len(vlist) < min_contracts:
+    for key, a in sorted(acc.items(), key=lambda kv: -kv[1].count):
+        if a.count < min_contracts:
             continue
         m = meta[key]
         name = m["name"]
         uf = m["uf"]
         mun = m["municipio"]
         cnpj8 = m["cnpj8"]
-        dlist = dates[key]
-        p_start = min(dlist) if dlist else None
-        p_end = max(dlist) if dlist else None
+        p_start = period[key].min_date
+        p_end = period[key].max_date
         seasonality = [
             {"period": mo, "contract_count": n}
             for mo, n in sorted(months[key].items())[-18:]
@@ -312,16 +416,16 @@ def build_agencies_streaming(
                 "municipio": mun,
                 "period_start": p_start,
                 "period_end": p_end,
-                "contract_count": len(vlist),
-                "total_value": round(sum(vlist), 2),
-                "median_value": _pct(vlist, 50),
-                "p25_value": _pct(vlist, 25),
-                "p75_value": _pct(vlist, 75),
-                "archetype_ids": [a for a, _ in mix[key].most_common()],
-                "related_archetypes": [a for a, _ in mix[key].most_common()],
+                "contract_count": a.count,
+                "total_value": round(a.total, 2),
+                "median_value": _pct_spill(spill, ns, key, 50),
+                "p25_value": _pct_spill(spill, ns, key, 25),
+                "p75_value": _pct_spill(spill, ns, key, 75),
+                "archetype_ids": [x for x, _ in mix[key].most_common()],
+                "related_archetypes": [x for x, _ in mix[key].most_common()],
                 "archetype_mix": [
-                    {"archetype_id": a, "contract_count": n}
-                    for a, n in mix[key].most_common()
+                    {"archetype_id": x, "contract_count": n}
+                    for x, n in mix[key].most_common()
                 ],
                 "top_objects": top_objects,
                 "modalities": [],
@@ -333,6 +437,7 @@ def build_agencies_streaming(
                 "limitations": [
                     "Histórico restrito aos contratos ingeridos no datalake.",
                     "Nome do órgão conforme fonte; pode haver variação cadastral.",
+                    "Percentis exatos via SQLite spill (sem vetor O(N) em RAM).",
                 ],
                 "practical_notes": [
                     "Verifique edital vigente e anexos no portal oficial antes de precificar.",
@@ -341,6 +446,13 @@ def build_agencies_streaming(
                 ],
             }
         )
+    _LAST_REDUCER_MEM["agencies"] = {
+        "python_value_vector_cells": python_value_vector_cells,
+        "python_date_list_cells": python_date_list_cells,
+        "buckets": len(acc),
+    }
+    if own_spill:
+        spill.secure_delete()
     return agencies
 
 
@@ -348,22 +460,31 @@ def build_prices_streaming(
     store: StagingStore,
     *,
     min_obs: int = 12,
+    spill: ValueSpillStore | None = None,
 ) -> list[dict[str, Any]]:
-    vals: dict[tuple[str, str], list[float]] = defaultdict(list)
+    own_spill = spill is None
+    if spill is None:
+        spill = ValueSpillStore()
+    ns = "prices"
+    acc: dict[tuple[str, str], _ValueAcc] = {}
+    period: dict[tuple[str, str], _ScalarPeriod] = {}
     sources: dict[tuple[str, str], set[str]] = defaultdict(set)
-    dates: dict[tuple[str, str], list[str]] = defaultdict(list)
     examples: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    python_value_vector_cells = 0
+    python_date_list_cells = 0
 
     for c in _iter_contracts(store):
         if not c.uf or c.valor < MIN_VALOR_BENCHMARK:
             continue
-        for a in c.archetypes:
-            key = (a, c.uf)
-            vals[key].append(c.valor)
+        for a_id in c.archetypes:
+            key = (a_id, c.uf)
+            bk_s = _bucket_key(key)
+            a = acc.setdefault(key, _ValueAcc())
+            a.observe(c.valor)
+            spill.add(ns, bk_s, c.valor)
+            period.setdefault(key, _ScalarPeriod()).observe(c.data_publicacao)
             if c.source:
                 sources[key].add(c.source)
-            if c.data_publicacao:
-                dates[key].append(str(c.data_publicacao)[:10])
             ex = examples[key]
             if len(ex) < _MAX_EXAMPLES * 3:
                 ex.append(
@@ -379,25 +500,30 @@ def build_prices_streaming(
                     }
                 )
 
+    spill.commit()
     prices: list[dict[str, Any]] = []
-    for key, vlist in sorted(vals.items(), key=lambda kv: -len(kv[1])):
-        if len(vlist) < min_obs:
+    for key, a in sorted(acc.items(), key=lambda kv: -kv[1].count):
+        if a.count < min_obs:
             continue
         arch, uf = key
-        p25, med, p75 = _pct(vlist, 25), _pct(vlist, 50), _pct(vlist, 75)
+        bk_s = _bucket_key(key)
+        p25 = _pct_spill(spill, ns, bk_s, 25)
+        med = _pct_spill(spill, ns, bk_s, 50)
+        p75 = _pct_spill(spill, ns, bk_s, 75)
         iqr = (
             round((p75 or 0) - (p25 or 0), 2)
             if p25 is not None and p75 is not None
             else None
         )
-        dlist = dates[key]
-        p_start = min(dlist) if dlist else None
-        p_end = max(dlist) if dlist else None
+        p_start = period[key].min_date
+        p_end = period[key].max_date
         ex_sorted = sorted(examples[key], key=lambda x: -float(x.get("valor") or 0))[
             :_MAX_EXAMPLES
         ]
         label = ARCHETYPE_DEFS[arch]["label"]
         slug = f"{arch}-{uf.lower()}"
+        min_v = round(a.min_v, 2) if a.min_v is not None else None
+        max_v = round(a.max_v, 2) if a.max_v is not None else None
         prices.append(
             {
                 "id": f"price-{slug}",
@@ -408,18 +534,18 @@ def build_prices_streaming(
                 "region_label": _uf_label(uf),
                 "period_start": p_start,
                 "period_end": p_end,
-                "observation_count": len(vlist),
-                "n": len(vlist),
+                "observation_count": a.count,
+                "n": a.count,
                 "median_value": med,
                 "mediana": med,
                 "p25_value": p25,
                 "p25": p25,
                 "p75_value": p75,
                 "p75": p75,
-                "min_value": round(min(vlist), 2),
-                "min": round(min(vlist), 2),
-                "max_value": round(max(vlist), 2),
-                "max": round(max(vlist), 2),
+                "min_value": min_v,
+                "min": min_v,
+                "max_value": max_v,
+                "max": max_v,
                 "dispersion_iqr": iqr,
                 "inclusion_criteria": [
                     f"Objeto classificado no arquétipo {label}",
@@ -437,7 +563,7 @@ def build_prices_streaming(
                 "limitations": [
                     "Observações são contratos integrais, não preços unitários de serviço.",
                     "Objetos dentro do mesmo arquétipo podem ser tecnicamente incomparáveis.",
-                    "Percentis: ordenação exata sobre valores do bucket (streaming staging).",
+                    "Percentis: ORDER BY + OFFSET exato no spill SQLite (sem lista O(N) em RAM).",
                 ],
                 "warning": (
                     "Não use a mediana como preço de referência aplicável a qualquer "
@@ -446,6 +572,13 @@ def build_prices_streaming(
                 ),
             }
         )
+    _LAST_REDUCER_MEM["prices"] = {
+        "python_value_vector_cells": python_value_vector_cells,
+        "python_date_list_cells": python_date_list_cells,
+        "buckets": len(acc),
+    }
+    if own_spill:
+        spill.secure_delete()
     return prices
 
 
@@ -454,15 +587,15 @@ def build_competition_streaming(
     *,
     min_contracts: int = 15,
 ) -> list[dict[str, Any]]:
-    from scripts.pseo.aggregate import _band_histogram, _value_band
-
     by_sup: dict[tuple[str, str], dict[str, dict[str, Any]]] = defaultdict(dict)
     n_contracts: dict[tuple[str, str], int] = defaultdict(int)
     sources: dict[tuple[str, str], set[str]] = defaultdict(set)
     agencies: dict[tuple[str, str], set[str]] = defaultdict(set)
-    dates: dict[tuple[str, str], list[str]] = defaultdict(list)
-    # lightweight rows for value_bands only (valor floats + primary already keyed)
-    band_vals: dict[tuple[str, str], list[float]] = defaultdict(list)
+    period: dict[tuple[str, str], _ScalarPeriod] = {}
+    bands: dict[tuple[str, str], _BandHist] = defaultdict(_BandHist)
+    python_value_vector_cells = 0
+    python_date_list_cells = 0
+    python_band_value_list_cells = 0
 
     for c in _iter_contracts(store):
         if not c.uf:
@@ -472,7 +605,7 @@ def build_competition_streaming(
             continue
         key = (primary, c.uf)
         n_contracts[key] += 1
-        band_vals[key].append(c.valor)
+        bands[key].observe(c.valor)
         sk = c.fornecedor_cnpj or c.fornecedor_nome or "?"
         st = by_sup[key].setdefault(
             sk,
@@ -490,8 +623,7 @@ def build_competition_streaming(
             agencies[key].add(c.orgao_cnpj or c.orgao_nome)
         if c.source:
             sources[key].add(c.source)
-        if c.data_publicacao:
-            dates[key].append(str(c.data_publicacao)[:10])
+        period.setdefault(key, _ScalarPeriod()).observe(c.data_publicacao)
 
     out: list[dict[str, Any]] = []
     for key, n in sorted(n_contracts.items(), key=lambda kv: -kv[1]):
@@ -513,15 +645,9 @@ def build_competition_streaming(
                     "value_band": _value_band(s["total_value"]),
                 }
             )
-        dlist = dates[key]
-        p_start = min(dlist) if dlist else None
-        p_end = max(dlist) if dlist else None
-        # synthetic ClassifiedContract-like for band histogram via floats only
-        class _V:
-            def __init__(self, v: float) -> None:
-                self.valor = v
-
-        value_bands = _band_histogram([_V(v) for v in band_vals[key]])  # type: ignore[list-item]
+        p_start = period[key].min_date
+        p_end = period[key].max_date
+        value_bands = bands[key].as_list()
         label = ARCHETYPE_DEFS[arch]["label"]
         slug = f"{arch}-{uf.lower()}"
         out.append(
@@ -544,6 +670,7 @@ def build_competition_streaming(
                 "limitations": [
                     "Lista de fornecedores observados, não ranking de qualidade.",
                     "Ausência na lista não implica ausência de atuação no mercado real.",
+                    "Histogramas por contadores incrementais (sem lista O(N) de valores).",
                 ],
                 "language_note": (
                     "Linguagem neutra e verificável. Não se atribui competência, "
@@ -551,21 +678,39 @@ def build_competition_streaming(
                 ),
             }
         )
+    _LAST_REDUCER_MEM["competition"] = {
+        "python_value_vector_cells": python_value_vector_cells,
+        "python_date_list_cells": python_date_list_cells,
+        "python_band_value_list_cells": python_band_value_list_cells,
+        "buckets": len(n_contracts),
+    }
     return out
 
 
-def build_archetypes_streaming(store: StagingStore) -> list[dict[str, Any]]:
-    per_arch_vals: dict[str, list[float]] = defaultdict(list)
+def build_archetypes_streaming(
+    store: StagingStore,
+    *,
+    spill: ValueSpillStore | None = None,
+) -> list[dict[str, Any]]:
+    own_spill = spill is None
+    if spill is None:
+        spill = ValueSpillStore()
+    ns = "archetypes"
+    acc: dict[str, _ValueAcc] = {}
     per_arch_ufs: dict[str, Counter[str]] = defaultdict(Counter)
     per_arch_buyers: dict[str, set[str]] = defaultdict(set)
     per_arch_buyer_types: dict[str, Counter[str]] = defaultdict(Counter)
+    python_value_vector_cells = 0
+    python_date_list_cells = 0
 
     for c in _iter_contracts(store):
         for arch_id in c.archetypes:
             if arch_id not in ARCHETYPE_DEFS:
                 continue
             if c.valor and c.valor > 0:
-                per_arch_vals[arch_id].append(c.valor)
+                a = acc.setdefault(arch_id, _ValueAcc())
+                a.observe(c.valor)
+                spill.add(ns, arch_id, c.valor)
             if c.uf:
                 per_arch_ufs[arch_id][c.uf] += 1
             bk = c.orgao_cnpj or c.orgao_nome
@@ -583,19 +728,20 @@ def build_archetypes_streaming(store: StagingStore) -> list[dict[str, Any]]:
             else:
                 per_arch_buyer_types[arch_id]["outro"] += 1
 
+    spill.commit()
     out: list[dict[str, Any]] = []
     for arch_id, meta in ARCHETYPE_DEFS.items():
-        vals = sorted(per_arch_vals.get(arch_id) or [])
-        if len(vals) < 10:
+        a = acc.get(arch_id)
+        if a is None or a.count < 10:
             continue
         ufs = per_arch_ufs[arch_id]
         buyers = per_arch_buyers[arch_id]
         types = per_arch_buyer_types[arch_id]
         band = {
-            "p25": _pct(vals, 25),
-            "median": _pct(vals, 50),
-            "p75": _pct(vals, 75),
-            "n": len(vals),
+            "p25": _pct_spill(spill, ns, arch_id, 25),
+            "median": _pct_spill(spill, ns, arch_id, 50),
+            "p75": _pct_spill(spill, ns, arch_id, 75),
+            "n": a.count,
             "currency": "BRL",
         }
         out.append(
@@ -614,7 +760,7 @@ def build_archetypes_streaming(store: StagingStore) -> list[dict[str, Any]]:
                     {"type": t, "contract_count": n} for t, n in types.most_common()
                 ],
                 "confenge_service_slugs": list(meta["confenge_service_slugs"]),
-                "evidence_contract_count": len(vals),
+                "evidence_contract_count": a.count,
                 "evidence_buyer_count": len(buyers),
                 "methodology": METHODOLOGY,
                 "limitations": [
@@ -624,25 +770,76 @@ def build_archetypes_streaming(store: StagingStore) -> list[dict[str, Any]]:
                     "densidade reflete fontes ingeridas (ênfase SC/Sul/Sudeste).",
                     "Faixas de valor incluem contratos de portes distintos; "
                     "não usar mediana como preço unitário de referência.",
+                    "Percentis exatos via SQLite spill (sem vetor O(N) em RAM).",
                 ],
             }
         )
+    _LAST_REDUCER_MEM["archetypes"] = {
+        "python_value_vector_cells": python_value_vector_cells,
+        "python_date_list_cells": python_date_list_cells,
+        "buckets": len(acc),
+    }
+    if own_spill:
+        spill.secure_delete()
     return out
+
+
+def freshness_bounds_streaming(
+    store: StagingStore,
+) -> dict[str, Any]:
+    """Scalar min/max freshness — never materializes date lists."""
+    c_period = _ScalarPeriod()
+    b_period = _ScalarPeriod()
+    for batch in store.iter_classified(chunk_size=5_000):
+        for c in batch:
+            c_period.observe(c.data_publicacao)
+    for batch in store.iter_bids(chunk_size=5_000):
+        for b in batch:
+            for k in ("data_publicacao", "data_encerramento", "data_abertura"):
+                if b.get(k):
+                    b_period.observe(str(b[k])[:10])
+    _LAST_REDUCER_MEM["freshness"] = {
+        "python_date_list_cells": 0,
+        "contract_dates_observed": c_period.n_dates,
+        "bid_dates_observed": b_period.n_dates,
+    }
+    return {
+        "contract_min": c_period.min_date,
+        "contract_max": c_period.max_date,
+        "contract_n_dates": c_period.n_dates,
+        "bid_min": b_period.min_date,
+        "bid_max": b_period.max_date,
+        "bid_n_dates": b_period.n_dates,
+        "overall_min": min(
+            x for x in (c_period.min_date, b_period.min_date) if x is not None
+        )
+        if (c_period.min_date or b_period.min_date)
+        else None,
+        "overall_max": max(
+            x for x in (c_period.max_date, b_period.max_date) if x is not None
+        )
+        if (c_period.max_date or b_period.max_date)
+        else None,
+    }
 
 
 def freshness_dates_streaming(
     store: StagingStore,
 ) -> tuple[list[str], list[str]]:
-    """Collect date strings only (scalars) — not full rows."""
-    contract_dates: list[str] = []
-    bid_dates: list[str] = []
-    for batch in store.iter_classified(chunk_size=5_000):
-        for c in batch:
-            if c.data_publicacao:
-                contract_dates.append(str(c.data_publicacao)[:10])
-    for batch in store.iter_bids(chunk_size=5_000):
-        for b in batch:
-            for k in ("data_publicacao", "data_encerramento", "data_abertura"):
-                if b.get(k):
-                    bid_dates.append(str(b[k])[:10])
-    return contract_dates, bid_dates
+    """Compatibility shim: returns at most two-element bounds lists (min, max).
+
+    Deprecated for callers that need full date series. Prefer
+    ``freshness_bounds_streaming`` (scalar dict). Never returns O(N) lists.
+    """
+    b = freshness_bounds_streaming(store)
+    c_dates: list[str] = []
+    if b["contract_min"]:
+        c_dates.append(b["contract_min"])
+    if b["contract_max"] and b["contract_max"] != b["contract_min"]:
+        c_dates.append(b["contract_max"])
+    b_dates: list[str] = []
+    if b["bid_min"]:
+        b_dates.append(b["bid_min"])
+    if b["bid_max"] and b["bid_max"] != b["bid_min"]:
+        b_dates.append(b["bid_max"])
+    return c_dates, b_dates

--- a/scripts/pseo/value_spill.py
+++ b/scripts/pseo/value_spill.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 import os
 import sqlite3
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 METHOD_ID = "sqlite_order_offset_v1"
 METHOD_VERSION = "1.0.0"

--- a/scripts/pseo/value_spill.py
+++ b/scripts/pseo/value_spill.py
@@ -1,0 +1,171 @@
+"""On-disk value spill for exact percentiles without O(N) Python lists.
+
+Methodology (versioned):
+- **method_id**: `sqlite_order_offset_v1`
+- Values for each (namespace, bucket) are appended to a SQLite table.
+- Exact percentile uses ORDER BY valor + LIMIT 1 OFFSET k, matching
+  ``scripts.pseo.aggregate._pct`` index rule:
+  ``k = min(n-1, max(0, int(round((p/100)*(n-1)))))``.
+- Peak Python RAM is O(batch) for inserts + O(1) per percentile query —
+  not O(N) value vectors.
+
+Not an approximate sketch (no T-Digest / HDR). Do not claim approximation
+error; this path is **exact** relative to the same discrete index rule as `_pct`.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+METHOD_ID = "sqlite_order_offset_v1"
+METHOD_VERSION = "1.0.0"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS spill_vals (
+    ns TEXT NOT NULL,
+    bucket TEXT NOT NULL,
+    valor REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_spill_ns_bucket_valor
+    ON spill_vals(ns, bucket, valor);
+"""
+
+
+class ValueSpillStore:
+    """SQLite spill of scalar values for exact on-disk percentiles."""
+
+    def __init__(self, path: Path | None = None, *, create: bool = True) -> None:
+        if path is None:
+            fd, name = tempfile.mkstemp(prefix="pseo-value-spill-", suffix=".sqlite")
+            os.close(fd)
+            path = Path(name)
+            self._owned = True
+            create = True
+        else:
+            path = Path(path)
+            self._owned = False
+        self.path = path
+        self.conn = sqlite3.connect(str(path))
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.conn.execute("PRAGMA synchronous=NORMAL")
+        if create:
+            self.conn.executescript(_SCHEMA)
+            self.conn.commit()
+        self._pending: list[tuple[str, str, float]] = []
+        self._batch_limit = 2_000
+
+    def add(self, ns: str, bucket: str, valor: float) -> None:
+        self._pending.append((ns, bucket, float(valor)))
+        if len(self._pending) >= self._batch_limit:
+            self.flush()
+
+    def add_many(self, ns: str, bucket: str, valores: Iterable[float]) -> None:
+        for v in valores:
+            self.add(ns, bucket, float(v))
+
+    def flush(self) -> None:
+        if not self._pending:
+            return
+        self.conn.executemany(
+            "INSERT INTO spill_vals(ns, bucket, valor) VALUES (?, ?, ?)",
+            self._pending,
+        )
+        self._pending.clear()
+
+    def commit(self) -> None:
+        self.flush()
+        self.conn.commit()
+
+    def count(self, ns: str, bucket: str) -> int:
+        self.flush()
+        row = self.conn.execute(
+            "SELECT COUNT(*) FROM spill_vals WHERE ns = ? AND bucket = ?",
+            (ns, bucket),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def sum(self, ns: str, bucket: str) -> float:
+        self.flush()
+        row = self.conn.execute(
+            "SELECT COALESCE(SUM(valor), 0) FROM spill_vals WHERE ns = ? AND bucket = ?",
+            (ns, bucket),
+        ).fetchone()
+        return float(row[0]) if row else 0.0
+
+    def min_max(self, ns: str, bucket: str) -> tuple[float | None, float | None]:
+        self.flush()
+        row = self.conn.execute(
+            "SELECT MIN(valor), MAX(valor) FROM spill_vals WHERE ns = ? AND bucket = ?",
+            (ns, bucket),
+        ).fetchone()
+        if not row or row[0] is None:
+            return None, None
+        return float(row[0]), float(row[1])
+
+    def percentile(self, ns: str, bucket: str, p: float) -> float | None:
+        """Exact discrete percentile (same index rule as aggregate._pct)."""
+        n = self.count(ns, bucket)
+        if n <= 0:
+            return None
+        off = min(n - 1, max(0, int(round((p / 100.0) * (n - 1)))))
+        row = self.conn.execute(
+            """
+            SELECT valor FROM spill_vals
+            WHERE ns = ? AND bucket = ?
+            ORDER BY valor
+            LIMIT 1 OFFSET ?
+            """,
+            (ns, bucket, off),
+        ).fetchone()
+        if row is None:
+            return None
+        return round(float(row[0]), 2)
+
+    def methodology(self) -> dict[str, Any]:
+        return {
+            "method_id": METHOD_ID,
+            "method_version": METHOD_VERSION,
+            "exact": True,
+            "approximate": False,
+            "error_bound": None,
+            "note": (
+                "Exact on-disk ORDER BY + OFFSET percentiles; "
+                "no Python O(N) value vectors on the streaming path."
+            ),
+        }
+
+    def close(self) -> None:
+        try:
+            self.flush()
+            self.conn.commit()
+            self.conn.close()
+        except sqlite3.Error:
+            pass
+
+    def secure_delete(self) -> None:
+        self.close()
+        if not self._owned:
+            return
+        if self.path.exists():
+            try:
+                with open(self.path, "r+b") as fh:
+                    size = fh.seek(0, os.SEEK_END)
+                    fh.seek(0)
+                    fh.write(b"\x00" * min(size, 1_048_576))
+                    fh.truncate(0)
+            except OSError:
+                pass
+            try:
+                self.path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            for suffix in ("-wal", "-shm"):
+                side = Path(str(self.path) + suffix)
+                try:
+                    side.unlink(missing_ok=True)
+                except OSError:
+                    pass

--- a/tests/pseo/test_bounded_memory_reducers.py
+++ b/tests/pseo/test_bounded_memory_reducers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import inspect
 from pathlib import Path
 

--- a/tests/pseo/test_bounded_memory_reducers.py
+++ b/tests/pseo/test_bounded_memory_reducers.py
@@ -1,0 +1,155 @@
+"""Adversarial tests: streaming reducers must not grow O(N) Python value/date lists."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from scripts.pseo.aggregate import _pct
+from scripts.pseo.archetypes import ClassifiedContract
+from scripts.pseo.staging import StagingStore
+from scripts.pseo.stream_aggregate import (
+    build_agencies_streaming,
+    build_archetypes_streaming,
+    build_competition_streaming,
+    build_markets_streaming,
+    build_prices_streaming,
+    freshness_bounds_streaming,
+    freshness_dates_streaming,
+    get_last_reducer_mem_profile,
+)
+from scripts.pseo.value_spill import METHOD_ID, ValueSpillStore
+
+
+def _make_contract(i: int, *, uf: str = "SC", arch: str = "pavimentacao-infraestrutura-viaria") -> ClassifiedContract:
+    # Objects that hit known archetype patterns when possible; archetypes forced.
+    return ClassifiedContract(
+        contrato_id=f"c-{i}",
+        orgao_cnpj=f"{10000000 + (i % 50):08d}",
+        orgao_nome=f"Prefeitura Teste {i % 50}",
+        fornecedor_cnpj=f"{20000000 + (i % 30):08d}",
+        fornecedor_nome=f"Fornecedor {i % 30}",
+        objeto=f"Servicos de pavimentacao asfaltica trecho {i}",
+        valor=float(50_000 + (i % 1000) * 137.5),
+        data_inicio="2024-01-01",
+        data_fim="2024-12-31",
+        data_publicacao=f"2024-{(i % 12) + 1:02d}-{(i % 28) + 1:02d}",
+        uf=uf,
+        municipio="Florianopolis",
+        source="pncp",
+        archetypes=[arch],
+    )
+
+
+def _fill_store(n: int) -> StagingStore:
+    st = StagingStore()
+    batch: list[ClassifiedContract] = []
+    for i in range(n):
+        batch.append(_make_contract(i))
+        if len(batch) >= 500:
+            st.insert_classified_batch(batch)
+            batch.clear()
+    if batch:
+        st.insert_classified_batch(batch)
+    st.commit()
+    return st
+
+
+def test_value_spill_percentile_matches_pct_index_rule():
+    spill = ValueSpillStore()
+    vals = [float(x) for x in range(1, 101)]
+    for v in vals:
+        spill.add("t", "b", v)
+    spill.commit()
+    assert spill.percentile("t", "b", 50) == _pct(vals, 50)
+    assert spill.percentile("t", "b", 25) == _pct(vals, 25)
+    assert spill.percentile("t", "b", 75) == _pct(vals, 75)
+    assert spill.methodology()["method_id"] == METHOD_ID
+    assert spill.methodology()["exact"] is True
+    assert spill.methodology()["approximate"] is False
+    spill.secure_delete()
+
+
+def test_reducers_no_linear_value_or_date_vectors():
+    """Scale N and assert instrumented value/date list cells stay 0."""
+    profiles = []
+    for n in (200, 800, 1600):
+        st = _fill_store(n)
+        try:
+            build_markets_streaming(st, open_bids=[], min_contracts=1, min_buyers=1)
+            build_agencies_streaming(st, open_bids=[], min_contracts=1)
+            build_prices_streaming(st, min_obs=1)
+            build_competition_streaming(st, min_contracts=1)
+            build_archetypes_streaming(st)
+            freshness_bounds_streaming(st)
+            prof = get_last_reducer_mem_profile()
+            profiles.append((n, prof))
+            for name in ("markets", "agencies", "prices", "competition", "archetypes", "freshness"):
+                assert name in prof, prof.keys()
+                assert prof[name].get("python_value_vector_cells", 0) == 0, (name, prof[name])
+                assert prof[name].get("python_date_list_cells", 0) == 0, (name, prof[name])
+                if name == "competition":
+                    assert prof[name].get("python_band_value_list_cells", 0) == 0
+        finally:
+            st.secure_delete()
+    # Buckets must not grow linearly with N when key space is fixed (~1 arch × 1 UF)
+    market_buckets = [p["markets"]["buckets"] for _, p in profiles]
+    assert market_buckets[0] == market_buckets[-1] or market_buckets[-1] <= market_buckets[0] + 5
+
+
+def test_freshness_shim_not_on():
+    st = _fill_store(300)
+    try:
+        bounds = freshness_bounds_streaming(st)
+        assert bounds["contract_min"] is not None
+        assert bounds["contract_max"] is not None
+        assert bounds["contract_n_dates"] == 300
+        c_dates, b_dates = freshness_dates_streaming(st)
+        # shim returns at most min/max (≤2), never N
+        assert len(c_dates) <= 2
+        assert len(b_dates) <= 2
+        assert get_last_reducer_mem_profile()["freshness"]["python_date_list_cells"] == 0
+    finally:
+        st.secure_delete()
+
+
+def test_source_has_no_defaultdict_list_for_vals_or_dates():
+    """Static guard: stream_aggregate must not reintroduce vals/dates list reducers."""
+    src = Path("scripts/pseo/stream_aggregate.py").read_text(encoding="utf-8")
+    # Forbidden O(N) reducer patterns (value vectors / full date lists / band value lists)
+    assert "vals: dict" not in src
+    assert "dates: dict" not in src
+    assert "band_vals" not in src
+    assert "per_arch_vals" not in src
+    assert "contract_dates: list[str] = []" not in src
+    assert "bid_dates: list[str] = []" not in src
+    assert "ValueSpillStore" in src
+    assert "_ScalarPeriod" in src
+    assert "_BandHist" in src
+    assert "sqlite_order_offset_v1" in Path("scripts/pseo/value_spill.py").read_text(
+        encoding="utf-8"
+    )
+    # Bounded sample lists remain OK (examples capped by _MAX_EXAMPLES)
+    assert "examples:" in src
+
+
+def test_load_all_still_forbidden():
+    st = StagingStore()
+    try:
+        with pytest.raises(RuntimeError, match="load_all_classified"):
+            st.load_all_classified()
+        with pytest.raises(RuntimeError, match="load_all_bids"):
+            st.load_all_bids()
+    finally:
+        st.secure_delete()
+
+
+def test_stream_aggregate_source_forbids_load_all_calls():
+    src = inspect.getsource(
+        __import__("scripts.pseo.stream_aggregate", fromlist=["*"])
+    )
+    assert "load_all_classified(" not in src
+    assert "load_all_bids(" not in src

--- a/tests/pseo/test_fail_closed_and_streaming.py
+++ b/tests/pseo/test_fail_closed_and_streaming.py
@@ -159,3 +159,22 @@ def test_load_from_db_source_is_incremental():
     assert "server_side_cursor_fetchmany_sqlite_staging" in src
     assert "insert_classified_batch" in src
     assert "secure_delete" in src
+
+def test_staging_load_all_forbidden():
+    """B3: full materialization helpers must fail closed on export path."""
+    from scripts.pseo.staging import StagingStore
+
+    st = StagingStore()
+    try:
+        try:
+            st.load_all_classified()
+            raise AssertionError("load_all_classified must raise")
+        except RuntimeError as e:
+            assert "forbidden" in str(e).lower() or "memory" in str(e).lower()
+        try:
+            st.load_all_bids()
+            raise AssertionError("load_all_bids must raise")
+        except RuntimeError as e:
+            assert "forbidden" in str(e).lower() or "memory" in str(e).lower()
+    finally:
+        st.secure_delete()


### PR DESCRIPTION
## Context
PR #188 removed full load_all_* from export, but streaming reducers still kept O(N) Python value/date lists for percentiles, freshness and histograms. This PR makes the staging path **actually memory-bounded**.

## Exact HEAD under test
- **HEAD SHA:** `7bd11a434dc28b24273abf88179a37d79c062e57`
- **Branch:** `fix/pseo-streaming-memory`
- **Base:** main
- **PR:** https://github.com/tjsasakifln/extra-cli/pull/190

## Changes
1. `scripts/pseo/value_spill.py` — on-disk exact percentiles (`sqlite_order_offset_v1`)
2. `scripts/pseo/stream_aggregate.py` — scalar min/max freshness; incremental histograms; no vals/dates/band_vals lists
3. `pipeline.build_export` staging path uses `freshness_bounds_streaming`; memory_mode=`sqlite_streaming_reducers_bounded`
4. `tests/pseo/test_bounded_memory_reducers.py` — adversarial growth + static guards
5. `load_all_classified` / `load_all_bids` remain RuntimeError

## Memory contract
| Requirement | Evidence |
|-------------|----------|
| No O(N) value vectors in Python | ValueSpillStore + adversarial tests |
| No O(N) date lists | scalar min/max only |
| Histogram incremental | band counters |
| Percentiles exact on-disk | ORDER BY + OFFSET |
| load_all forbidden | RuntimeError + unit test |

## Tests (local tip `7bd11a434dc28b24273abf88179a37d79c062e57`)
- `pytest tests/pseo/` → **79 passed**, 1 deselected

## Benchmarks
| Scope | Result |
|-------|--------|
| Local datalake integral (extra_test) | 1 contract + 333 bids; 2 runs; hash equal; peak RSS ~47 MiB; budget 2 GiB |
| Synthetic 50k/20k same entrypoint | deterministic hashes; peak RSS ~108 MiB; within budget |

### Full-scale / B3
**BLOCKED_FULL_SCALE_PROOF** — available local lake has only ~1 contract. B3 is **not** closed.

## Non-claims
- Not PUBLISH_READY, not VPS, not production-scale memory proof
- CI green is necessary, not sufficient alone for B3
- Synthetic 50k is supplemental stress, not a substitute for integral production lake

## Verdict
**BOUNDED_CODE_READY + BLOCKED_FULL_SCALE_PROOF** — mergeable for memory-bounded code path; do not claim B3 closed until full-scale lake proof exists.