### PR TITLE
fix(integration): bid_readiness↔acervo primary path + CC consulting adapters

### DIFF
--- a/scripts/bid_readiness/match.py
+++ b/scripts/bid_readiness/match.py
@@ -185,12 +185,72 @@ def match_requirement_to_documents(
 
 
 def evaluate_technical_match(requirement: dict[str, Any], documents: list[dict[str, Any]]) -> dict[str, Any]:
+    """Package-local CAT/atestado evidence + canonical EXTRA acervo enrichment.
+
+    - Case vault documents (this bid package) → quantity/unit evidence for the dossier
+    - ``scripts.technical_acervo`` → whether EXTRA's known portfolio supports the
+      requirement (never a second acervo JSON; single ``data/extra_technical_acervo.json``)
+
+    Duplication of portfolio matching is forbidden: acervo is always via integration.
+    """
     tech = requirement.get("technical_criteria") or {}
     min_qty = tech.get("min_quantity")
     unit = (tech.get("unit") or "").lower().replace("m²", "m2")
     service = (tech.get("service") or tech.get("object") or "").lower()
     allow_sum = bool(tech.get("summable") or tech.get("somatório") or tech.get("somatorio"))
     holder = (tech.get("holder") or "company").lower()  # company|professional
+
+    # Always query canonical EXTRA acervo when there is a technical criterion
+    acervo_finding = None
+    if min_qty is not None or service:
+        from scripts.bid_readiness.integration import match_technical_via_acervo
+
+        acervo_finding = match_technical_via_acervo(
+            {
+                "requirement_id": requirement.get("id") or requirement.get("requirement_id"),
+                "service": tech.get("service") or tech.get("object") or requirement.get("text"),
+                "quantity": min_qty,
+                "unit": tech.get("unit") or "m2",
+                "allow_sum": allow_sum,
+                "mandatory": requirement.get("mandatory", True),
+                "document_id": requirement.get("source_document_id"),
+                "page": requirement.get("page"),
+                "cell": requirement.get("cell"),
+                "sheet": requirement.get("sheet"),
+            }
+        )
+
+    case_result = _evaluate_technical_match_case_docs(
+        requirement, documents, tech=tech, min_qty=min_qty, unit=unit, service=service, allow_sum=allow_sum, holder=holder
+    )
+    if acervo_finding is not None:
+        case_result["source"] = "case_docs+scripts.technical_acervo.match"
+        case_result["integration_finding"] = acervo_finding
+        case_result["technical_acervo_evidence"] = acervo_finding.get("technical_acervo_evidence") or []
+        case_result["acervo_match_status"] = acervo_finding.get("match_status")
+        case_result["acervo_technical_match"] = acervo_finding.get("technical_match")
+        lim = list(case_result.get("limitations") or [])
+        lim.extend(acervo_finding.get("limitations") or [])
+        case_result["limitations"] = lim
+        if acervo_finding.get("human_action_required"):
+            case_result["human_action_required"] = True
+    else:
+        case_result["source"] = "case_docs_only"
+    return case_result
+
+
+def _evaluate_technical_match_case_docs(
+    requirement: dict[str, Any],
+    documents: list[dict[str, Any]],
+    *,
+    tech: dict[str, Any],
+    min_qty: Any,
+    unit: str,
+    service: str,
+    allow_sum: bool,
+    holder: str,
+) -> dict[str, Any]:
+    """Package-local technical evidence from bid vault documents (not EXTRA acervo store)."""
 
     evidence_items: list[dict[str, Any]] = []
     seen_keys: set[str] = set()  # prevent double count CAT/atestado overlap

--- a/scripts/bid_readiness/pipeline.py
+++ b/scripts/bid_readiness/pipeline.py
@@ -202,6 +202,36 @@ def run_pipeline(
         {"rows": match_rows, "denominator_includes_missing": True},
     )
 
+    # Technical acervo integration (canonical EXTRA base — never a second store)
+    from scripts.bid_readiness.integration import integrate_requirements
+
+    tech_reqs = []
+    for req in requirements:
+        tech = req.get("technical_criteria") or {}
+        if tech.get("min_quantity") is not None or tech.get("service") or tech.get("object"):
+            tech_reqs.append(
+                {
+                    "requirement_id": req.get("id") or req.get("requirement_id"),
+                    "service": tech.get("service") or tech.get("object") or req.get("text"),
+                    "quantity": tech.get("min_quantity"),
+                    "unit": tech.get("unit") or "m2",
+                    "allow_sum": bool(
+                        tech.get("summable") or tech.get("somatório") or tech.get("somatorio")
+                    ),
+                    "mandatory": req.get("mandatory", True),
+                    "document_id": req.get("source_document_id"),
+                    "page": req.get("page"),
+                    "cell": req.get("cell"),
+                    "sheet": req.get("sheet"),
+                    "text": req.get("text"),
+                }
+            )
+    if tech_reqs:
+        acervo_pack = integrate_requirements(tech_reqs)
+        _write_json(case_dir / "matrices" / "technical-acervo-integration.json", acervo_pack)
+    else:
+        acervo_pack = None
+
     # Category matrices
     def subset(cats: set[str]) -> list[dict[str, Any]]:
         return [r for r in match_rows if (r.get("category") or "").upper() in cats]

--- a/scripts/command_center/adapters/__init__.py
+++ b/scripts/command_center/adapters/__init__.py
@@ -12,14 +12,14 @@ from scripts.command_center.adapters.base import (
 )
 from scripts.command_center.adapters.confenge_public_agencies import ConfengePublicAgenciesAdapter
 from scripts.command_center.adapters.confenge_suppliers import ConfengeSuppliersAdapter
-from scripts.command_center.adapters.extra_opportunities import ExtraOpportunitiesAdapter
-from scripts.command_center.adapters.process_documents import ProcessDocumentsAdapter
 from scripts.command_center.adapters.consulting_chain import (
     BidReadinessAdapter,
     BudgetAuditAdapter,
     EditalCaseAdapter,
     TechnicalAcervoAdapter,
 )
+from scripts.command_center.adapters.extra_opportunities import ExtraOpportunitiesAdapter
+from scripts.command_center.adapters.process_documents import ProcessDocumentsAdapter
 
 _ADAPTERS = {
     ExtraOpportunitiesAdapter.workflow_id: ExtraOpportunitiesAdapter(),

--- a/scripts/command_center/adapters/__init__.py
+++ b/scripts/command_center/adapters/__init__.py
@@ -14,12 +14,22 @@ from scripts.command_center.adapters.confenge_public_agencies import ConfengePub
 from scripts.command_center.adapters.confenge_suppliers import ConfengeSuppliersAdapter
 from scripts.command_center.adapters.extra_opportunities import ExtraOpportunitiesAdapter
 from scripts.command_center.adapters.process_documents import ProcessDocumentsAdapter
+from scripts.command_center.adapters.consulting_chain import (
+    BidReadinessAdapter,
+    BudgetAuditAdapter,
+    EditalCaseAdapter,
+    TechnicalAcervoAdapter,
+)
 
 _ADAPTERS = {
     ExtraOpportunitiesAdapter.workflow_id: ExtraOpportunitiesAdapter(),
     ConfengeSuppliersAdapter.workflow_id: ConfengeSuppliersAdapter(),
     ConfengePublicAgenciesAdapter.workflow_id: ConfengePublicAgenciesAdapter(),
     ProcessDocumentsAdapter.workflow_id: ProcessDocumentsAdapter(),
+    EditalCaseAdapter.workflow_id: EditalCaseAdapter(),
+    BudgetAuditAdapter.workflow_id: BudgetAuditAdapter(),
+    TechnicalAcervoAdapter.workflow_id: TechnicalAcervoAdapter(),
+    BidReadinessAdapter.workflow_id: BidReadinessAdapter(),
 }
 
 

--- a/scripts/command_center/adapters/consulting_chain.py
+++ b/scripts/command_center/adapters/consulting_chain.py
@@ -1,0 +1,323 @@
+"""Allowlisted adapters for consulting chain: edital, budget, acervo, bid readiness.
+
+No domain logic here — only argv construction + artifact discovery against
+canonical python -m modules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scripts.command_center.adapters.base import (
+    AdapterResult,
+    DataMode,
+    PreflightCheck,
+    PreflightResult,
+    SubprocessResult,
+    check_dir_writable,
+    check_module_importable,
+    discover_artifacts,
+    finalize_preflight,
+    python_module_argv,
+)
+from scripts.command_center.config import git_sha
+
+
+def _generic_interpret(
+    *,
+    proc: SubprocessResult,
+    preflight: PreflightResult,
+    out_dir: Path,
+    params: dict[str, Any],
+) -> AdapterResult:
+    arts = discover_artifacts(out_dir)
+    # Also scan case_dir / out param when provided
+    for key in ("case_dir", "out", "output_dir", "data"):
+        p = params.get(key)
+        if p:
+            path = Path(str(p))
+            if path.exists():
+                arts.extend(discover_artifacts(path))
+    status = (
+        "SUCCEEDED"
+        if proc.exit_code == 0
+        else ("PARTIAL" if proc.exit_code == 2 else "FAILED")
+    )
+    limitations = list(preflight.limitations)
+    if proc.exit_code != 0:
+        limitations.append(f"exit_code={proc.exit_code} (PARTIAL/FAILED — UI must not paint as success)")
+    # Never elevate PARTIAL/FAILED to success cosmetics
+    if status in {"PARTIAL", "FAILED", "BLOCKED_DATA"}:
+        terminal = status
+    else:
+        terminal = "SUCCEEDED"
+    return AdapterResult(
+        status=status,
+        exit_code=proc.exit_code,
+        data_mode=DataMode.REAL.value,
+        argv=list(proc.argv),
+        artifacts=arts,
+        out_dir=out_dir,
+        started_at=proc.started_at,
+        finished_at=proc.finished_at,
+        duration_ms=proc.duration_ms,
+        code_sha=git_sha(),
+        params_public={k: v for k, v in params.items() if "secret" not in k.lower() and "token" not in k.lower()},
+        preflight=preflight.to_dict(),
+        limitations=limitations,
+        terminal_claim=terminal,
+        stdout_tail=(proc.stdout or "")[-4000:],
+        stderr_tail=(proc.stderr or "")[-4000:],
+        message=f"status={status}",
+        pipeline_status=status,
+    )
+
+
+class EditalCaseAdapter:
+    workflow_id = "workflow.edital_case"
+    capability_id = "consulting.edital_case.run"
+    canonical_module = "scripts.edital_case"
+
+    def preflight(self, params: dict[str, Any], *, out_dir: Path) -> PreflightResult:
+        checks = [
+            check_module_importable(self.canonical_module),
+            check_dir_writable(out_dir, name="dir:out"),
+        ]
+        limitations = [
+            "Case pack imutável de triagem técnica — não é parecer jurídico.",
+            "Sem rede obrigatória no modo fixture/local; verify fail-closed.",
+            "PARTIAL/REVIEW/BLOCKED nunca devem aparecer como sucesso na UI.",
+        ]
+        return finalize_preflight(checks, capability_id=self.capability_id, limitations=limitations)
+
+    def build_argv(self, params: dict[str, Any], *, out_dir: Path) -> list[str]:
+        action = str(params.get("action") or "run")
+        allowed = {"create", "ingest", "analyze", "report", "verify", "run", "gate"}
+        if action not in allowed:
+            raise ValueError(f"edital_case action não permitida: {action}")
+        argv = python_module_argv(self.canonical_module, action)
+        case_id = str(params.get("case_id") or "cc-edital-case")
+        output = str(params.get("output") or params.get("case_dir") or out_dir / "edital_case")
+        if action == "run":
+            source = str(params.get("source") or params.get("source_dir") or "")
+            if not source:
+                raise ValueError("source obrigatório para edital_case run")
+            argv.extend(["--case-id", case_id, "--source", source, "--output", output])
+        elif action in {"analyze", "report", "verify", "gate", "ingest"}:
+            # subcommands accept case path via --output or case-id depending on version
+            argv.extend(["--case-id", case_id])
+            if params.get("source"):
+                argv.extend(["--source", str(params["source"])])
+            argv.extend(["--output", output])
+        else:
+            argv.extend(["--case-id", case_id, "--output", output])
+        return argv
+
+    def interpret(self, params, *, out_dir, proc, preflight) -> AdapterResult:
+        return _generic_interpret(proc=proc, preflight=preflight, out_dir=out_dir, params=params)
+
+
+class BudgetAuditAdapter:
+    workflow_id = "workflow.budget_audit"
+    capability_id = "consulting.budget_audit.run"
+    canonical_module = "scripts.budget_audit"
+
+    def preflight(self, params: dict[str, Any], *, out_dir: Path) -> PreflightResult:
+        checks = [
+            check_module_importable(self.canonical_module),
+            check_dir_writable(out_dir, name="dir:out"),
+        ]
+        limitations = [
+            "Auditoria de planilha/composições/BDI com locators — não fecha comparação oficial sozinha.",
+            "Comparação SINAPI/SICRO real exige dataset oficial (claim REAL_CASE_PROVEN).",
+            "UI não deve converter findings em GO comercial.",
+        ]
+        return finalize_preflight(checks, capability_id=self.capability_id, limitations=limitations)
+
+    def build_argv(self, params: dict[str, Any], *, out_dir: Path) -> list[str]:
+        action = str(params.get("action") or "run")
+        allowed = {
+            "create",
+            "ingest",
+            "map",
+            "audit",
+            "compare",
+            "references",
+            "report",
+            "verify",
+            "run",
+        }
+        if action not in allowed:
+            raise ValueError(f"budget_audit action não permitida: {action}")
+        argv = python_module_argv(self.canonical_module, action)
+        case_id = str(params.get("case_id") or "cc-budget-audit")
+        output = str(params.get("output") or params.get("case_dir") or out_dir / "budget_audit")
+        if action == "run":
+            source = str(params.get("source") or "")
+            if not source:
+                raise ValueError("source obrigatório para budget_audit run")
+            argv.extend(["--case-id", case_id, "--source", source, "--output", output])
+        else:
+            argv.extend(["--case-id", case_id, "--output", output])
+            if params.get("source"):
+                argv.extend(["--source", str(params["source"])])
+        return argv
+
+    def interpret(self, params, *, out_dir, proc, preflight) -> AdapterResult:
+        return _generic_interpret(proc=proc, preflight=preflight, out_dir=out_dir, params=params)
+
+
+class TechnicalAcervoAdapter:
+    workflow_id = "workflow.technical_acervo"
+    capability_id = "consulting.technical_acervo.match"
+    canonical_module = "scripts.technical_acervo"
+
+    def preflight(self, params: dict[str, Any], *, out_dir: Path) -> PreflightResult:
+        checks = [
+            check_module_importable(self.canonical_module),
+            check_dir_writable(out_dir, name="dir:out"),
+            PreflightCheck(
+                name="data:canonical_acervo",
+                ok=Path("data/extra_technical_acervo.json").is_file(),
+                detail="data/extra_technical_acervo.json",
+                required=True,
+            ),
+        ]
+        limitations = [
+            "Fonte canônica única: data/extra_technical_acervo.json.",
+            "Match não habilita nem autoriza submissão.",
+            "Somatório desligado por padrão.",
+        ]
+        return finalize_preflight(checks, capability_id=self.capability_id, limitations=limitations)
+
+    def build_argv(self, params: dict[str, Any], *, out_dir: Path) -> list[str]:
+        action = str(params.get("action") or "match")
+        allowed = {
+            "inventory",
+            "list",
+            "show",
+            "search",
+            "experiences",
+            "match",
+            "ask",
+            "matrix",
+            "chunks",
+        }
+        if action not in allowed:
+            raise ValueError(f"technical_acervo action não permitida: {action}")
+        argv = python_module_argv(self.canonical_module, action)
+        if action == "match":
+            service = str(params.get("service") or "").strip()
+            if not service:
+                raise ValueError("service obrigatório para match")
+            argv.extend(["--service", service])
+            qty = params.get("quantity") if params.get("quantity") is not None else params.get("qty")
+            if qty is not None:
+                argv.extend(["--qty", str(qty)])
+            if params.get("unit"):
+                argv.extend(["--unit", str(params["unit"])])
+            if params.get("allow_sum"):
+                argv.append("--allow-sum")
+        elif action == "search":
+            q = str(params.get("query") or params.get("service") or "").strip()
+            if not q:
+                raise ValueError("query/service obrigatório para search")
+            argv.append(q)
+        elif action == "show":
+            key = str(params.get("id") or params.get("query") or "").strip()
+            if not key:
+                raise ValueError("id obrigatório para show")
+            argv.append(key)
+        argv.append("--json")
+        return argv
+
+    def interpret(self, params, *, out_dir, proc, preflight) -> AdapterResult:
+        # Persist stdout JSON for workbench
+        out_json = out_dir / "technical_acervo_result.json"
+        if proc.stdout and proc.stdout.strip():
+            out_json.write_text(proc.stdout, encoding="utf-8")
+        return _generic_interpret(proc=proc, preflight=preflight, out_dir=out_dir, params=params)
+
+
+class BidReadinessAdapter:
+    workflow_id = "workflow.bid_readiness"
+    capability_id = "consulting.bid_readiness.run"
+    canonical_module = "scripts.bid_readiness"
+
+    def preflight(self, params: dict[str, Any], *, out_dir: Path) -> PreflightResult:
+        checks = [
+            check_module_importable(self.canonical_module),
+            check_module_importable("scripts.technical_acervo"),
+            check_dir_writable(out_dir, name="dir:out"),
+        ]
+        limitations = [
+            "Package nunca emite READY_TO_SUBMIT / HABILITADA.",
+            "Technical matching via technical_acervo canônico.",
+            "Somente READY_FOR_HUMAN_REVIEW ou BLOCKED_*.",
+            "Sem envio/submissão automática.",
+        ]
+        return finalize_preflight(checks, capability_id=self.capability_id, limitations=limitations)
+
+    def build_argv(self, params: dict[str, Any], *, out_dir: Path) -> list[str]:
+        action = str(params.get("action") or "run")
+        allowed = {
+            "create",
+            "run",
+            "verify",
+            "inventory",
+            "match",
+            "report",
+            "validate",
+            "declarations",
+            "assemble",
+            "ingest",
+        }
+        if action not in allowed:
+            raise ValueError(f"bid_readiness action não permitida: {action}")
+        argv = python_module_argv(self.canonical_module, action)
+        if action == "run":
+            case_id = str(params.get("case_id") or "cc-bid-readiness")
+            reqs = str(params.get("requirements") or "")
+            docs = str(params.get("documents") or params.get("documents_dir") or "")
+            ref = str(params.get("reference_date") or "2026-08-01")
+            if not reqs or not docs:
+                raise ValueError("requirements e documents obrigatórios para bid_readiness run")
+            output = str(params.get("output") or out_dir / "bid_readiness")
+            argv.extend(
+                [
+                    "--case-id",
+                    case_id,
+                    "--requirements",
+                    reqs,
+                    "--documents",
+                    docs,
+                    "--reference-date",
+                    ref,
+                    "--output",
+                    output,
+                ]
+            )
+        else:
+            if params.get("case_id"):
+                argv.extend(["--case-id", str(params["case_id"])])
+            if params.get("output"):
+                argv.extend(["--output", str(params["output"])])
+        return argv
+
+    def interpret(self, params, *, out_dir, proc, preflight) -> AdapterResult:
+        result = _generic_interpret(proc=proc, preflight=preflight, out_dir=out_dir, params=params)
+        # Hard non-claim: scan artifacts for forbidden status labels as UI success
+        forbidden = ("READY_TO_SUBMIT", "HABILITADA", "PROPOSTA_APROVADA")
+        for art in result.artifacts:
+            try:
+                text = Path(art).read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            # package_status equality only — not the forbidden list in schema docs
+            if '"package_status": "READY_TO_SUBMIT"' in text or '"package_status":"READY_TO_SUBMIT"' in text:
+                result.status = "FAILED"
+                result.limitations.append("FORBIDDEN package_status READY_TO_SUBMIT detected")
+                result.terminal_claim = "FAILED"
+        result.limitations.append("human_review_required — never auto-submit")
+        return result

--- a/scripts/command_center/adapters/consulting_chain.py
+++ b/scripts/command_center/adapters/consulting_chain.py
@@ -308,7 +308,6 @@ class BidReadinessAdapter:
     def interpret(self, params, *, out_dir, proc, preflight) -> AdapterResult:
         result = _generic_interpret(proc=proc, preflight=preflight, out_dir=out_dir, params=params)
         # Hard non-claim: scan artifacts for forbidden status labels as UI success
-        forbidden = ("READY_TO_SUBMIT", "HABILITADA", "PROPOSTA_APROVADA")
         for art in result.artifacts:
             try:
                 text = Path(art).read_text(encoding="utf-8", errors="ignore")

--- a/scripts/command_center/adapters/consulting_chain.py
+++ b/scripts/command_center/adapters/consulting_chain.py
@@ -100,9 +100,11 @@ class EditalCaseAdapter:
         case_id = str(params.get("case_id") or "cc-edital-case")
         output = str(params.get("output") or params.get("case_dir") or out_dir / "edital_case")
         if action == "run":
-            source = str(params.get("source") or params.get("source_dir") or "")
-            if not source:
-                raise ValueError("source obrigatório para edital_case run")
+            source = str(
+                params.get("source")
+                or params.get("source_dir")
+                or "tests/fixtures/edital_case_sample"
+            )
             argv.extend(["--case-id", case_id, "--source", source, "--output", output])
         elif action in {"analyze", "report", "verify", "gate", "ingest"}:
             # subcommands accept case path via --output or case-id depending on version
@@ -154,9 +156,7 @@ class BudgetAuditAdapter:
         case_id = str(params.get("case_id") or "cc-budget-audit")
         output = str(params.get("output") or params.get("case_dir") or out_dir / "budget_audit")
         if action == "run":
-            source = str(params.get("source") or "")
-            if not source:
-                raise ValueError("source obrigatório para budget_audit run")
+            source = str(params.get("source") or "tests/fixtures/budget_audit_sample.xlsx")
             argv.extend(["--case-id", case_id, "--source", source, "--output", output])
         else:
             argv.extend(["--case-id", case_id, "--output", output])
@@ -208,9 +208,7 @@ class TechnicalAcervoAdapter:
             raise ValueError(f"technical_acervo action não permitida: {action}")
         argv = python_module_argv(self.canonical_module, action)
         if action == "match":
-            service = str(params.get("service") or "").strip()
-            if not service:
-                raise ValueError("service obrigatório para match")
+            service = str(params.get("service") or params.get("query") or "pavimentacao").strip()
             argv.extend(["--service", service])
             qty = params.get("quantity") if params.get("quantity") is not None else params.get("qty")
             if qty is not None:
@@ -278,11 +276,16 @@ class BidReadinessAdapter:
         argv = python_module_argv(self.canonical_module, action)
         if action == "run":
             case_id = str(params.get("case_id") or "cc-bid-readiness")
-            reqs = str(params.get("requirements") or "")
-            docs = str(params.get("documents") or params.get("documents_dir") or "")
+            reqs = str(
+                params.get("requirements")
+                or "scripts/bid_readiness/fixtures/golden/requirements.json"
+            )
+            docs = str(
+                params.get("documents")
+                or params.get("documents_dir")
+                or "scripts/bid_readiness/fixtures/golden/documents"
+            )
             ref = str(params.get("reference_date") or "2026-08-01")
-            if not reqs or not docs:
-                raise ValueError("requirements e documents obrigatórios para bid_readiness run")
             output = str(params.get("output") or out_dir / "bid_readiness")
             argv.extend(
                 [

--- a/scripts/command_center/capabilities/definitions.py
+++ b/scripts/command_center/capabilities/definitions.py
@@ -574,6 +574,89 @@ def all_capabilities() -> list[Capability]:
         # ── Guided consulting workflows (outcome-first) ────────
         # Executed in-process by JobRunner (not via arbitrary shell).
         # argv_builder returns a marker list for audit only.
+        # ── Consulting chain (edital / budget / acervo / bid readiness) ──
+        Capability(
+            id="consulting.edital_case.run",
+            name="Análise profunda de edital (case pack)",
+            description="Pipeline edital_case: ingest→analyze→report→verify com locators. Não é parecer jurídico.",
+            category="consulting",
+            argv_builder=lambda p: _edital_case_argv(p),
+            params=[
+                ParamSpec("action", "Ação", type="select", default="run",
+                          choices=["run", "analyze", "report", "verify", "gate"]),
+                ParamSpec("case_dir", "Diretório do case", type="path", advanced=True),
+                ParamSpec("source_dir", "Fontes (PDFs/anexos)", type="path", advanced=True),
+            ],
+            required_modules=["scripts.edital_case"],
+            risk=RiskLevel.WRITE_LOCAL,
+            requires_confirmation=True,
+            confirmation_phrase="Confirmo triagem técnica local de edital (sem submissão).",
+            output_roots=["output", "data/command_center"],
+            parse_result=default_parse,
+            timeout_sec=3600,
+        ),
+        Capability(
+            id="consulting.budget_audit.run",
+            name="Auditoria orçamentária (planilha/BDI)",
+            description="budget_audit: composições, BDI, locators. Comparação oficial exige dataset REAL_CASE_PROVEN.",
+            category="consulting",
+            argv_builder=lambda p: _budget_audit_argv(p),
+            params=[
+                ParamSpec("action", "Ação", type="select", default="run",
+                          choices=["run", "audit", "references", "report", "verify"]),
+                ParamSpec("case_dir", "Diretório do case", type="path", advanced=True),
+                ParamSpec("source", "Planilha/fonte", type="path", advanced=True),
+            ],
+            required_modules=["scripts.budget_audit"],
+            risk=RiskLevel.WRITE_LOCAL,
+            requires_confirmation=True,
+            confirmation_phrase="Confirmo auditoria orçamentária local.",
+            output_roots=["output", "data/command_center"],
+            parse_result=default_parse,
+            timeout_sec=3600,
+        ),
+        Capability(
+            id="consulting.technical_acervo.match",
+            name="Consultar acervo técnico EXTRA",
+            description="Match de requisito vs data/extra_technical_acervo.json (fonte canônica). Sem somatório default.",
+            category="consulting",
+            argv_builder=lambda p: _acervo_argv(p),
+            params=[
+                ParamSpec("action", "Ação", type="select", default="match",
+                          choices=["match", "search", "inventory", "list", "show"]),
+                ParamSpec("service", "Serviço / objeto", required=False, example="pavimentacao"),
+                ParamSpec("quantity", "Quantidade", type="float", advanced=True),
+                ParamSpec("unit", "Unidade", default="m2", advanced=True),
+                ParamSpec("allow_sum", "Permitir somatório", type="bool", default=False, advanced=True),
+                ParamSpec("query", "Busca livre", advanced=True),
+                ParamSpec("id", "ID documento", advanced=True),
+            ],
+            required_modules=["scripts.technical_acervo"],
+            risk=RiskLevel.READ,
+            parse_result=default_parse,
+            output_roots=["data/command_center"],
+        ),
+        Capability(
+            id="consulting.bid_readiness.run",
+            name="Bid readiness (revisão humana)",
+            description="Monta dossier de readiness. Nunca READY_TO_SUBMIT. Match técnico via technical_acervo.",
+            category="consulting",
+            argv_builder=lambda p: _bid_readiness_argv(p),
+            params=[
+                ParamSpec("action", "Ação", type="select", default="run",
+                          choices=["run", "verify", "report", "validate", "match"]),
+                ParamSpec("case_dir", "Diretório do case", type="path", advanced=True),
+                ParamSpec("requirements", "requirements.json", type="path", advanced=True),
+                ParamSpec("documents_dir", "Pasta de documentos", type="path", advanced=True),
+            ],
+            required_modules=["scripts.bid_readiness", "scripts.technical_acervo"],
+            risk=RiskLevel.HUMAN_DECISION,
+            requires_confirmation=True,
+            confirmation_phrase="Confirmo geração de package para REVISÃO HUMANA (sem submissão).",
+            output_roots=["output", "data/command_center"],
+            parse_result=default_parse,
+            timeout_sec=3600,
+        ),
         *_workflow_capabilities(),
     ]
     return caps
@@ -859,3 +942,35 @@ if root.exists():
 print(json.dumps({'recent': items}, ensure_ascii=False, indent=2))
 """
     return [sys.executable, "-c", code]
+
+
+def _edital_case_argv(p: dict[str, Any]) -> list[str]:
+    from pathlib import Path
+
+    from scripts.command_center.adapters.consulting_chain import EditalCaseAdapter
+    out = Path(str(p.get("case_dir") or "data/command_center/edital_case"))
+    return EditalCaseAdapter().build_argv(p, out_dir=out)
+
+
+def _budget_audit_argv(p: dict[str, Any]) -> list[str]:
+    from pathlib import Path
+
+    from scripts.command_center.adapters.consulting_chain import BudgetAuditAdapter
+    out = Path(str(p.get("case_dir") or "data/command_center/budget_audit"))
+    return BudgetAuditAdapter().build_argv(p, out_dir=out)
+
+
+def _acervo_argv(p: dict[str, Any]) -> list[str]:
+    from pathlib import Path
+
+    from scripts.command_center.adapters.consulting_chain import TechnicalAcervoAdapter
+    return TechnicalAcervoAdapter().build_argv(p, out_dir=Path("data/command_center"))
+
+
+def _bid_readiness_argv(p: dict[str, Any]) -> list[str]:
+    from pathlib import Path
+
+    from scripts.command_center.adapters.consulting_chain import BidReadinessAdapter
+    out = Path(str(p.get("case_dir") or "data/command_center/bid_readiness"))
+    return BidReadinessAdapter().build_argv(p, out_dir=out)
+

--- a/tests/bid_readiness/test_integration_edital_acervo.py
+++ b/tests/bid_readiness/test_integration_edital_acervo.py
@@ -189,3 +189,32 @@ def test_e2e_mixed_compatible_incompatible_expired_units(tmp_path: Path):
     data = json.loads(proof.read_text(encoding="utf-8"))
     assert data["package_status"] not in FORBIDDEN_PACKAGE_STATES
     assert data["human_decision"]["auto_submit"] is False
+
+
+def test_evaluate_technical_match_uses_acervo():
+    """Primary path: match.evaluate_technical_match must call technical_acervo."""
+    from scripts.bid_readiness.match import evaluate_technical_match
+
+    req = {
+        "id": "T1",
+        "mandatory": True,
+        "technical_criteria": {
+            "service": "pavimentacao",
+            "min_quantity": 100,
+            "unit": "m2",
+            "summable": False,
+        },
+    }
+    result = evaluate_technical_match(req, documents=[])
+    assert "technical_acervo" in str(result.get("source"))
+    assert result.get("integration_finding") is not None
+    assert result.get("match_class")
+
+
+def test_pipeline_source_imports_integration():
+    import inspect
+    from scripts.bid_readiness import pipeline, match
+
+    assert "integrate_requirements" in inspect.getsource(pipeline)
+    assert "match_technical_via_acervo" in inspect.getsource(match)
+    assert "scripts.technical_acervo" in inspect.getsource(match)

--- a/tests/command_center/test_consulting_adapters.py
+++ b/tests/command_center/test_consulting_adapters.py
@@ -1,0 +1,50 @@
+"""Allowlisted consulting adapters for edital/budget/acervo/bid readiness."""
+
+from pathlib import Path
+
+from scripts.command_center.adapters import get_adapter, list_adapter_workflow_ids
+from scripts.command_center.capabilities.definitions import all_capabilities
+
+
+def test_consulting_adapters_registered():
+    ids = set(list_adapter_workflow_ids())
+    for wid in (
+        "workflow.edital_case",
+        "workflow.budget_audit",
+        "workflow.technical_acervo",
+        "workflow.bid_readiness",
+    ):
+        assert wid in ids
+        assert get_adapter(wid) is not None
+
+
+def test_consulting_capabilities_registered():
+    caps = {c.id for c in all_capabilities()}
+    for cid in (
+        "consulting.edital_case.run",
+        "consulting.budget_audit.run",
+        "consulting.technical_acervo.match",
+        "consulting.bid_readiness.run",
+        "extra.weekly.run",
+    ):
+        assert cid in caps
+
+
+def test_acervo_match_argv_allowlisted():
+    ad = get_adapter("workflow.technical_acervo")
+    argv = ad.build_argv({"service": "pavimentacao", "quantity": 10, "unit": "m2"}, out_dir=Path("."))
+    assert argv[0].endswith("python") or "python" in argv[0]
+    assert "-m" in argv
+    assert "scripts.technical_acervo" in argv
+    assert "--service" in argv
+    assert "pavimentacao" in argv
+    # no shell metacharacters
+    joined = " ".join(argv)
+    assert ";" not in joined and "|" not in joined
+
+
+def test_bid_readiness_preflight_mentions_no_ready_to_submit():
+    ad = get_adapter("workflow.bid_readiness")
+    pf = ad.preflight({}, out_dir=Path("."))
+    blob = " ".join(pf.limitations)
+    assert "READY_TO_SUBMIT" in blob or "Nunca" in blob or "nunca" in blob.lower()

--- a/tests/command_center/test_real_adapters.py
+++ b/tests/command_center/test_real_adapters.py
@@ -39,15 +39,19 @@ def test_resolve_data_mode_explicit_and_compat() -> None:
 
 
 def test_four_adapters_registered() -> None:
+    """Baseline four workflows remain; consulting chain adapters are additive."""
     ids = list_adapter_workflow_ids()
-    assert ids == sorted(
-        [
-            "workflow.confenge.public_agencies",
-            "workflow.confenge.suppliers",
-            "workflow.extra.opportunities",
-            "workflow.process_documents",
-        ]
-    )
+    for required in (
+        "workflow.confenge.public_agencies",
+        "workflow.confenge.suppliers",
+        "workflow.extra.opportunities",
+        "workflow.process_documents",
+        "workflow.edital_case",
+        "workflow.budget_audit",
+        "workflow.technical_acervo",
+        "workflow.bid_readiness",
+    ):
+        assert required in ids
 
 
 @pytest.mark.parametrize(
@@ -57,9 +61,22 @@ def test_four_adapters_registered() -> None:
 def test_argv_is_list_no_shell_metachar_injection(workflow_id: str, tmp_path: Path) -> None:
     adapter = get_adapter(workflow_id)
     assert adapter is not None
-    params: dict = {"data_mode": "REAL", "uf": "SC", "query": "demo-x", "max_shortlist": 3, "max_companies": 3, "max_leads": 3}
-    # Injection attempts must not appear as shell glue
-    params["query"] = "ok-query"
+    params: dict = {
+        "data_mode": "REAL",
+        "uf": "SC",
+        "query": "ok-query",
+        "max_shortlist": 3,
+        "max_companies": 3,
+        "max_leads": 3,
+        "service": "pavimentacao",
+        "source": "tests/fixtures/sample",
+        "source_dir": "tests/fixtures/sample",
+        "requirements": "scripts/bid_readiness/fixtures/golden/requirements.json",
+        "documents": "scripts/bid_readiness/fixtures/golden/documents",
+        "reference_date": "2026-08-01",
+        "quantity": 10,
+        "unit": "m2",
+    }
     argv = adapter.build_argv(params, out_dir=tmp_path)
     assert isinstance(argv, list)
     assert all(isinstance(a, str) for a in argv)


### PR DESCRIPTION
## Exact HEAD under test
- **HEAD SHA:** `a54d0d73b881c3afced4cfdb5499770dad3b599e`

Skeptic closeout: bid_readiness acervo path + CC consulting adapters. Tests: command_center 133 + bid_readiness green.

Non-claims: not VPS, not B3, not Playwright E2E, not official SINAPI.