### PR TITLE
feat(confenge): public business contact resolution (candidates + CLI)

### DIFF
--- a/docs/commercial/confenge-public-business-contact-resolution.md
+++ b/docs/commercial/confenge-public-business-contact-resolution.md
@@ -1,0 +1,59 @@
+# CONFENGE public business contact resolution
+
+**Schema:** `confenge-contact-candidates-v1`  
+**Package:** `scripts/confenge_contact_resolution`
+
+## Goal
+
+Resolve **legitimate public business contacts** for CONFENGE outreach so Warmbly can choose channel (email / phone / hold). This is **not** “find any email” and **never invents identity**.
+
+## CLI
+
+```bash
+# Single CNPJ
+python -m scripts.confenge_contact_resolution resolve \
+  --cnpj 11222333000181 \
+  --output-dir output/confenge-contacts/run-1 \
+  --service-context licitações \
+  --fixtures-dir path/to/optional/fixtures
+
+# Batch
+python -m scripts.confenge_contact_resolution batch \
+  -i cnpjs.txt \
+  -o output/confenge-contacts/run-batch \
+  --service-context claims_reajuste \
+  --max-workers 4
+```
+
+Artifacts:
+
+- `confenge-contact-candidates-v1.jsonl` — one JSON object per CNPJ/account
+- `run_manifest.json` — run metadata + checksum
+
+## Adapters
+
+| Adapter | Source |
+|---------|--------|
+| `registry` | Local RFB release via `scripts.company_registry.lookup`; optional BrasilAPI only with `--allow-network` |
+| `site` | Institutional site extracts / fixtures |
+| `public_docs` | Already-ingested contract/licitação contact extracts |
+| `contact_page` | Public team/contact pages + human outcomes (DNC) |
+| `web_search` | Optional provider interface; **NoOp by default**; disabled in tests |
+
+No private social scraping. No captcha/evasion. No outbound verification mail. No WhatsApp account probing.
+
+## Policy highlights
+
+- Pattern-guessed personal emails → `CANDIDATE_UNVERIFIED`, never enrollable, never recommended primary.
+- Exact observed emails preserved in `email_display`.
+- BR phones → E.164; type `mobile` / `landline` / `unknown`.
+- `whatsapp.consent_status` defaults to `UNKNOWN` / `NO_OPT_IN`; `OPTED_IN` only with provenance.
+- DNC / bounce dominate ranking and block recommendation.
+- Stale `source_date` decays freshness and confidence.
+- Ranking is **service-aware and explainable** (not purchase probability).
+
+## Composition with CONFENGE / Warmbly
+
+- Commercial lead scoring remains in `scripts/commercial_leads` (no purchase-prob rewrite).
+- Outreach kits continue to treat absence as `NOT_AVAILABLE`.
+- This module supplies **channel candidates** with verification/consent so Warmbly (or human send) can decide without inventing people.

--- a/scripts/confenge_contact_resolution/__init__.py
+++ b/scripts/confenge_contact_resolution/__init__.py
@@ -1,0 +1,21 @@
+"""CONFENGE public business contact resolution.
+
+Resolve legitimate commercial contacts for outreach without inventing identity.
+Produces versioned candidates (``confenge-contact-candidates-v1``) with provenance,
+verification status, service-aware ranking, and WhatsApp consent defaults.
+
+Reuses official company registry (RFB) when available. Optional web search sits
+behind a provider interface and is disabled by default in tests.
+"""
+
+from __future__ import annotations
+
+SCHEMA_ID = "confenge-contact-candidates-v1"
+SCHEMA_VERSION = "1.0.0"
+PACKAGE_VERSION = "1.0.0"
+
+__all__ = [
+    "SCHEMA_ID",
+    "SCHEMA_VERSION",
+    "PACKAGE_VERSION",
+]

--- a/scripts/confenge_contact_resolution/__main__.py
+++ b/scripts/confenge_contact_resolution/__main__.py
@@ -1,0 +1,10 @@
+"""python -m scripts.confenge_contact_resolution"""
+
+from __future__ import annotations
+
+import sys
+
+from scripts.confenge_contact_resolution.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/confenge_contact_resolution/adapters/__init__.py
+++ b/scripts/confenge_contact_resolution/adapters/__init__.py
@@ -1,0 +1,24 @@
+"""Source adapters for public business contact observations."""
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext, ContactAdapter
+from scripts.confenge_contact_resolution.adapters.contact_pages import ContactPageAdapter
+from scripts.confenge_contact_resolution.adapters.public_docs import PublicDocsAdapter
+from scripts.confenge_contact_resolution.adapters.registry import RegistryAdapter
+from scripts.confenge_contact_resolution.adapters.site import SiteAdapter
+from scripts.confenge_contact_resolution.adapters.web_search import (
+    NoOpWebSearchProvider,
+    WebSearchAdapter,
+    WebSearchProvider,
+)
+
+__all__ = [
+    "AdapterContext",
+    "ContactAdapter",
+    "RegistryAdapter",
+    "SiteAdapter",
+    "PublicDocsAdapter",
+    "ContactPageAdapter",
+    "WebSearchAdapter",
+    "WebSearchProvider",
+    "NoOpWebSearchProvider",
+]

--- a/scripts/confenge_contact_resolution/adapters/base.py
+++ b/scripts/confenge_contact_resolution/adapters/base.py
@@ -1,0 +1,34 @@
+"""Adapter protocol — returns provenance-bearing raw observations only."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from scripts.confenge_contact_resolution.models import RawObservation
+
+
+@dataclass
+class AdapterContext:
+    """Runtime context shared by adapters (no secrets required for default path)."""
+
+    cnpj14: str
+    fixtures_dir: Path | None = None
+    # Optional injected registry record (tests / offline)
+    registry_record: dict[str, Any] | None = None
+    # Optional injected public docs / pages as dicts
+    public_docs: list[dict[str, Any]] = field(default_factory=list)
+    site_pages: list[dict[str, Any]] = field(default_factory=list)
+    contact_pages: list[dict[str, Any]] = field(default_factory=list)
+    human_outcomes: list[dict[str, Any]] = field(default_factory=list)
+    allow_network: bool = False
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class ContactAdapter(Protocol):
+    name: str
+
+    def collect(self, ctx: AdapterContext) -> list[RawObservation]:
+        """Return zero or more observations; never invent people."""
+        ...

--- a/scripts/confenge_contact_resolution/adapters/contact_pages.py
+++ b/scripts/confenge_contact_resolution/adapters/contact_pages.py
@@ -1,0 +1,111 @@
+"""Public contact/team pages adapter (fixture or injected extracts)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext
+from scripts.confenge_contact_resolution.models import RawObservation, SourceProvenance
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class ContactPageAdapter:
+    name = "contact_page"
+
+    def collect(self, ctx: AdapterContext) -> list[RawObservation]:
+        pages: list[dict[str, Any]] = list(ctx.contact_pages or [])
+        if ctx.fixtures_dir:
+            p = ctx.fixtures_dir / f"{ctx.cnpj14}_contact_page.json"
+            if p.is_file():
+                import json
+
+                data = json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    pages.extend(data)
+                elif isinstance(data, dict):
+                    pages.append(data)
+
+        out: list[RawObservation] = []
+        for page in pages:
+            people = page.get("people") or page.get("contacts") or []
+            if not people and (page.get("email") or page.get("phone")):
+                people = [page]
+            for person in people:
+                email = person.get("email")
+                phone = person.get("phone") or person.get("telefone")
+                name = person.get("name") or person.get("nome")
+                cargo = person.get("cargo") or person.get("role") or person.get("funcao")
+                if not email and not phone and not name:
+                    continue
+                # Human outcomes / DNC may be attached on contact pages feed
+                out.append(
+                    RawObservation(
+                        adapter="contact_page",
+                        cnpj14=ctx.cnpj14,
+                        name=str(name).strip() if name else None,
+                        cargo=str(cargo).strip() if cargo else None,
+                        email=str(email).strip() if email else None,
+                        phone_raw=str(phone).strip() if phone else None,
+                        site=page.get("site"),
+                        linkedin_public=person.get("linkedin") or person.get("linkedin_public"),
+                        source=SourceProvenance(
+                            source_type="contact_page",
+                            source_url=page.get("url") or person.get("url"),
+                            source_document=page.get("document"),
+                            source_date=str(page.get("source_date") or "")[:10] or None,
+                            observed_at=_now(),
+                            notes="Public team/contact page",
+                        ),
+                        pattern_guessed_email=bool(person.get("pattern_guessed_email")),
+                        dnc=bool(person.get("dnc")),
+                        bounce=bool(person.get("bounce")),
+                        dnc_reason=person.get("dnc_reason"),
+                        whatsapp_consent=str(person.get("whatsapp_consent") or "UNKNOWN"),
+                        whatsapp_consent_provenance=person.get("whatsapp_consent_provenance"),
+                        epistemic_class="OBSERVED_PUBLIC",
+                    )
+                )
+        # Also ingest human outcomes (DNC etc.) as dominant signals
+        for ho in ctx.human_outcomes or []:
+            if _digits_match(ho.get("cnpj14") or ho.get("cnpj"), ctx.cnpj14) is False:
+                continue
+            out.append(
+                RawObservation(
+                    adapter="human_outcome",
+                    cnpj14=ctx.cnpj14,
+                    name=ho.get("name"),
+                    cargo=ho.get("cargo"),
+                    email=ho.get("email"),
+                    phone_raw=ho.get("phone") or ho.get("telefone"),
+                    source=SourceProvenance(
+                        source_type="human_outcome",
+                        source_url=ho.get("source_url"),
+                        source_document=ho.get("outcome_id"),
+                        source_date=str(ho.get("source_date") or "")[:10] or None,
+                        observed_at=_now(),
+                        notes="Human decision/outcome memory — dominant when DNC/bounce",
+                    ),
+                    dnc=bool(ho.get("dnc") or str(ho.get("state") or "").upper() == "DO_NOT_CONTACT"),
+                    bounce=bool(ho.get("bounce")),
+                    dnc_reason=ho.get("dnc_reason") or ho.get("reason"),
+                    whatsapp_consent=str(ho.get("whatsapp_consent") or "UNKNOWN"),
+                    whatsapp_consent_provenance=ho.get("whatsapp_consent_provenance"),
+                    epistemic_class="HUMAN_OUTCOME",
+                )
+            )
+        return out
+
+
+def _digits_match(a: str | None, b: str | None) -> bool | None:
+    import re
+
+    if a is None or b is None:
+        return None
+    da, db = re.sub(r"\D", "", a), re.sub(r"\D", "", b)
+    if not da or not db:
+        return None
+    return da == db

--- a/scripts/confenge_contact_resolution/adapters/public_docs.py
+++ b/scripts/confenge_contact_resolution/adapters/public_docs.py
@@ -1,0 +1,66 @@
+"""Already-ingested public contract/licitação documents adapter.
+
+Reads injected document contact extracts (from datalake pipelines), never
+re-scrapes portals in this module.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext
+from scripts.confenge_contact_resolution.models import RawObservation, SourceProvenance
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class PublicDocsAdapter:
+    name = "public_docs"
+
+    def collect(self, ctx: AdapterContext) -> list[RawObservation]:
+        docs: list[dict[str, Any]] = list(ctx.public_docs or [])
+        if ctx.fixtures_dir:
+            p = ctx.fixtures_dir / f"{ctx.cnpj14}_public_docs.json"
+            if p.is_file():
+                import json
+
+                data = json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    docs.extend(data)
+                elif isinstance(data, dict):
+                    docs.append(data)
+
+        out: list[RawObservation] = []
+        for doc in docs:
+            email = doc.get("email")
+            phone = doc.get("phone") or doc.get("telefone")
+            name = doc.get("name") or doc.get("nome") or doc.get("representante")
+            cargo = doc.get("cargo") or doc.get("funcao")
+            if not email and not phone and not name:
+                continue
+            out.append(
+                RawObservation(
+                    adapter="public_docs",
+                    cnpj14=ctx.cnpj14,
+                    name=str(name).strip() if name else None,
+                    cargo=str(cargo).strip() if cargo else None,
+                    email=str(email).strip() if email else None,
+                    phone_raw=str(phone).strip() if phone else None,
+                    source=SourceProvenance(
+                        source_type="public_docs",
+                        source_url=doc.get("url") or doc.get("source_url"),
+                        source_document=doc.get("document_id") or doc.get("document"),
+                        source_date=str(doc.get("source_date") or doc.get("document_date") or "")[:10]
+                        or None,
+                        observed_at=_now(),
+                        notes="From already-ingested public contract/licitação materials",
+                    ),
+                    pattern_guessed_email=bool(doc.get("pattern_guessed_email")),
+                    epistemic_class="OBSERVED_PUBLIC",
+                    extra={"doc_type": doc.get("doc_type")},
+                )
+            )
+        return out

--- a/scripts/confenge_contact_resolution/adapters/registry.py
+++ b/scripts/confenge_contact_resolution/adapters/registry.py
@@ -1,0 +1,121 @@
+"""Official company registry / RFB adapter.
+
+Reuses ``scripts.company_registry.lookup`` when local release is active.
+Optional BrasilAPI only when ``allow_network`` is True (never in default tests).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext
+from scripts.confenge_contact_resolution.models import RawObservation, SourceProvenance
+
+
+def _digits(s: str | None) -> str:
+    return re.sub(r"\D", "", s or "")[:14]
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _from_registry_dict(cnpj14: str, rec: dict[str, Any]) -> list[RawObservation]:
+    email = rec.get("email")
+    phone = rec.get("phone") or rec.get("telefone") or rec.get("telefone1")
+    if not email and not phone:
+        # Still emit empty shell only if we have legal name? Prefer silence on absence.
+        return []
+    source_date = rec.get("source_date") or rec.get("registration_status_date")
+    prov = SourceProvenance(
+        source_type="registry",
+        source_url=rec.get("source_url") or "official_company_registry",
+        source_document=rec.get("official_release_id") or rec.get("release_id"),
+        source_date=str(source_date)[:10] if source_date else None,
+        observed_at=_now(),
+        notes="RFB/public cadastral fields only; not a personal scrape",
+    )
+    return [
+        RawObservation(
+            adapter="registry",
+            cnpj14=cnpj14,
+            name=None,  # registry email is firm-level, not a named person
+            cargo=None,
+            email=str(email).strip() if email else None,
+            phone_raw=str(phone).strip() if phone else None,
+            site=rec.get("site"),
+            source=prov,
+            company_size=str(rec.get("company_size") or rec.get("porte") or "") or None,
+            razao_social=rec.get("legal_name") or rec.get("razao_social"),
+            epistemic_class="OBSERVED_PUBLIC",
+            extra={
+                "official_match_status": rec.get("official_match_status"),
+                "registration_status": rec.get("registration_status") or rec.get("situacao_cadastral"),
+            },
+        )
+    ]
+
+
+def _lookup_local(cnpj14: str) -> dict[str, Any] | None:
+    try:
+        from scripts.company_registry.lookup import lookup_cnpj
+        from scripts.company_registry.models import OfficialMatchStatus
+    except ImportError:
+        return None
+    rec = lookup_cnpj(cnpj14)
+    if rec.official_match_status != OfficialMatchStatus.MATCHED.value:
+        return None
+    d = rec.as_dict()
+    return d
+
+
+def _brasilapi(cnpj14: str, *, timeout: float = 12.0) -> dict[str, Any] | None:
+    url = f"https://brasilapi.com.br/api/cnpj/v1/{cnpj14}"
+    if not url.startswith("https://"):
+        return None
+    req = Request(url, headers={"User-Agent": "extra-cli-confenge-contact/1.0"})  # noqa: S310
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError, OSError):
+        return None
+
+
+class RegistryAdapter:
+    name = "registry"
+
+    def __init__(self, *, prefer_network: bool = False) -> None:
+        self.prefer_network = prefer_network
+
+    def collect(self, ctx: AdapterContext) -> list[RawObservation]:
+        cnpj14 = _digits(ctx.cnpj14)
+        if len(cnpj14) != 14:
+            return []
+
+        if ctx.registry_record:
+            return _from_registry_dict(cnpj14, ctx.registry_record)
+
+        local = _lookup_local(cnpj14)
+        if local:
+            return _from_registry_dict(cnpj14, local)
+
+        if ctx.allow_network and self.prefer_network:
+            data = _brasilapi(cnpj14)
+            if data:
+                mapped = {
+                    "email": data.get("email"),
+                    "phone": data.get("ddd_telefone_1") or data.get("telefone"),
+                    "legal_name": data.get("razao_social"),
+                    "company_size": data.get("porte") or data.get("descricao_porte"),
+                    "source_url": "https://brasilapi.com.br/api/cnpj/v1/",
+                    "source_date": datetime.now(UTC).date().isoformat(),
+                    "official_match_status": "MATCHED",
+                    "registration_status": data.get("descricao_situacao_cadastral"),
+                }
+                return _from_registry_dict(cnpj14, mapped)
+        return []

--- a/scripts/confenge_contact_resolution/adapters/site.py
+++ b/scripts/confenge_contact_resolution/adapters/site.py
@@ -1,0 +1,76 @@
+"""Institutional site adapter — consumes pre-fetched or fixture page extracts.
+
+Does not perform fragile live scraping by default. Tests inject site_pages.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext
+from scripts.confenge_contact_resolution.models import RawObservation, SourceProvenance
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _obs_from_page(cnpj14: str, page: dict[str, Any]) -> list[RawObservation]:
+    out: list[RawObservation] = []
+    contacts = page.get("contacts") or []
+    if not contacts and (page.get("email") or page.get("phone")):
+        contacts = [page]
+    source_url = page.get("url") or page.get("source_url")
+    source_date = page.get("source_date") or page.get("published_at")
+    for c in contacts:
+        email = c.get("email")
+        phone = c.get("phone") or c.get("telefone")
+        name = c.get("name") or c.get("nome")
+        cargo = c.get("cargo") or c.get("role") or c.get("funcao")
+        if not email and not phone and not name:
+            continue
+        out.append(
+            RawObservation(
+                adapter="site",
+                cnpj14=cnpj14,
+                name=str(name).strip() if name else None,
+                cargo=str(cargo).strip() if cargo else None,
+                email=str(email).strip() if email else None,
+                phone_raw=str(phone).strip() if phone else None,
+                site=source_url or page.get("site"),
+                linkedin_public=c.get("linkedin") or c.get("linkedin_public"),
+                source=SourceProvenance(
+                    source_type="site",
+                    source_url=source_url,
+                    source_document=page.get("document"),
+                    source_date=str(source_date)[:10] if source_date else None,
+                    observed_at=_now(),
+                    notes="Institutional site extract (no private social scrape)",
+                ),
+                pattern_guessed_email=bool(c.get("pattern_guessed_email")),
+                epistemic_class="INFERRED" if c.get("pattern_guessed_email") else "OBSERVED_PUBLIC",
+            )
+        )
+    return out
+
+
+class SiteAdapter:
+    name = "site"
+
+    def collect(self, ctx: AdapterContext) -> list[RawObservation]:
+        pages = list(ctx.site_pages or [])
+        if ctx.fixtures_dir:
+            p = ctx.fixtures_dir / f"{ctx.cnpj14}_site.json"
+            if p.is_file():
+                import json
+
+                data = json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    pages.extend(data)
+                elif isinstance(data, dict):
+                    pages.append(data)
+        out: list[RawObservation] = []
+        for page in pages:
+            out.extend(_obs_from_page(ctx.cnpj14, page))
+        return out

--- a/scripts/confenge_contact_resolution/adapters/web_search.py
+++ b/scripts/confenge_contact_resolution/adapters/web_search.py
@@ -1,0 +1,70 @@
+"""Optional web-search provider interface — disabled by default in tests.
+
+No private social scraping. No anti-bot evasion. Provider is injectable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext
+from scripts.confenge_contact_resolution.models import RawObservation, SourceProvenance
+
+
+class WebSearchProvider(Protocol):
+    def search_business_contacts(self, cnpj14: str, **kwargs: Any) -> list[dict[str, Any]]:
+        """Return public contact snippets with url/date when available."""
+        ...
+
+
+class NoOpWebSearchProvider:
+    """Default provider — always empty (safe for CI/tests)."""
+
+    def search_business_contacts(self, cnpj14: str, **kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+
+class WebSearchAdapter:
+    name = "web_search"
+
+    def __init__(self, provider: WebSearchProvider | None = None, *, enabled: bool = False) -> None:
+        self.provider = provider or NoOpWebSearchProvider()
+        self.enabled = enabled
+
+    def collect(self, ctx: AdapterContext) -> list[RawObservation]:
+        if not self.enabled:
+            return []
+        # Even when enabled, refuse if network not allowed unless provider is injected fixture
+        results = self.provider.search_business_contacts(ctx.cnpj14, allow_network=ctx.allow_network)
+        out: list[RawObservation] = []
+        for r in results or []:
+            email = r.get("email")
+            phone = r.get("phone")
+            name = r.get("name")
+            if not email and not phone and not name:
+                continue
+            # Explicit ban: private social network sources
+            url = str(r.get("url") or "")
+            if any(x in url.lower() for x in ("facebook.com", "instagram.com", "tiktok.com")):
+                continue
+            out.append(
+                RawObservation(
+                    adapter="web_search",
+                    cnpj14=ctx.cnpj14,
+                    name=name,
+                    cargo=r.get("cargo"),
+                    email=email,
+                    phone_raw=phone,
+                    site=r.get("site"),
+                    linkedin_public=r.get("linkedin") if "linkedin.com" in str(r.get("linkedin") or "") else None,
+                    source=SourceProvenance(
+                        source_type="web_search",
+                        source_url=r.get("url"),
+                        source_date=str(r.get("source_date") or "")[:10] or None,
+                        notes="Optional web search provider; public pages only",
+                    ),
+                    pattern_guessed_email=bool(r.get("pattern_guessed_email")),
+                    epistemic_class="OBSERVED_PUBLIC",
+                )
+            )
+        return out

--- a/scripts/confenge_contact_resolution/cache.py
+++ b/scripts/confenge_contact_resolution/cache.py
@@ -1,0 +1,44 @@
+"""Simple filesystem cache with TTL for resolution results (idempotent re-runs)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def cache_key(cnpj14: str, service_context: str, adapters_sig: str) -> str:
+    raw = f"{cnpj14}|{service_context}|{adapters_sig}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+class ResolutionCache:
+    def __init__(self, root: Path, *, ttl_seconds: int = 86400) -> None:
+        self.root = Path(root)
+        self.ttl_seconds = ttl_seconds
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, key: str) -> Path:
+        return self.root / f"{key}.json"
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        p = self._path(key)
+        if not p.is_file():
+            return None
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        ts = data.get("_cached_at")
+        if ts is None:
+            return None
+        if time.time() - float(ts) > self.ttl_seconds:
+            return None
+        return data.get("payload")
+
+    def set(self, key: str, payload: dict[str, Any]) -> None:
+        p = self._path(key)
+        blob = {"_cached_at": time.time(), "payload": payload}
+        p.write_text(json.dumps(blob, ensure_ascii=False, default=str), encoding="utf-8")

--- a/scripts/confenge_contact_resolution/cli.py
+++ b/scripts/confenge_contact_resolution/cli.py
@@ -1,0 +1,189 @@
+"""CLI: single-CNPJ and batch public business contact resolution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from scripts.confenge_contact_resolution.cache import ResolutionCache
+from scripts.confenge_contact_resolution.export import write_resolution_artifacts
+from scripts.confenge_contact_resolution.models import ServiceContext
+from scripts.confenge_contact_resolution.resolver import ContactResolver, ResolverConfig, default_adapters
+
+
+def _digits(s: str) -> str:
+    return re.sub(r"\D", "", s or "")
+
+
+def _load_cnpj_list(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    cnpjs: list[str] = []
+    if path.suffix.lower() == ".json":
+        data = json.loads(text)
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, str):
+                    cnpjs.append(item)
+                elif isinstance(item, dict):
+                    cnpjs.append(str(item.get("cnpj") or item.get("cnpj14") or ""))
+        elif isinstance(data, dict) and "cnpjs" in data:
+            cnpjs.extend(str(x) for x in data["cnpjs"])
+    else:
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # jsonl line or plain CNPJ
+            if line.startswith("{"):
+                try:
+                    obj = json.loads(line)
+                    cnpjs.append(str(obj.get("cnpj") or obj.get("cnpj14") or ""))
+                    continue
+                except json.JSONDecodeError:
+                    pass
+            cnpjs.append(line.split(",")[0].strip())
+    return [c for c in cnpjs if _digits(c)]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m scripts.confenge_contact_resolution",
+        description=(
+            "Resolve public business contacts for CONFENGE outreach "
+            "(candidates + provenance; no outreach send)."
+        ),
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    def add_common(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument(
+            "--output-dir",
+            "-o",
+            type=Path,
+            required=True,
+            help="Directory for confenge-contact-candidates-v1.jsonl + run_manifest.json",
+        )
+        sp.add_argument(
+            "--service-context",
+            choices=[s.value for s in ServiceContext],
+            default=ServiceContext.GENERIC.value,
+            help="Service context for role ranking",
+        )
+        sp.add_argument(
+            "--fixtures-dir",
+            type=Path,
+            default=None,
+            help="Optional directory with synthetic/injected source fixtures",
+        )
+        sp.add_argument(
+            "--cache-dir",
+            type=Path,
+            default=None,
+            help="Filesystem cache with TTL (default: <output-dir>/.cache)",
+        )
+        sp.add_argument("--cache-ttl", type=int, default=86400, help="Cache TTL seconds")
+        sp.add_argument("--no-cache", action="store_true", help="Disable resolution cache")
+        sp.add_argument(
+            "--allow-network",
+            action="store_true",
+            help="Allow optional network adapters (BrasilAPI / web search if enabled)",
+        )
+        sp.add_argument(
+            "--enable-web-search",
+            action="store_true",
+            help="Enable optional web-search adapter (still NoOp without provider config)",
+        )
+        sp.add_argument(
+            "--check-mx",
+            action="store_true",
+            help="Run MX layer when dnspython available (never sends mail)",
+        )
+        sp.add_argument("--max-workers", type=int, default=4, help="Batch concurrency limit")
+        sp.add_argument("--run-id", default=None, help="Optional stable run id")
+
+    single = sub.add_parser("resolve", help="Resolve contacts for one CNPJ")
+    single.add_argument("--cnpj", required=True, help="CNPJ (digits or formatted)")
+    add_common(single)
+
+    batch = sub.add_parser("batch", help="Resolve contacts for a list of CNPJs")
+    batch.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        required=True,
+        help="File with CNPJs (txt, csv first column, json list, or jsonl)",
+    )
+    add_common(batch)
+
+    return p
+
+
+def _make_resolver(args: argparse.Namespace) -> ContactResolver:
+    cache = None
+    if not args.no_cache:
+        cdir = args.cache_dir or (args.output_dir / ".cache")
+        cache = ResolutionCache(cdir, ttl_seconds=args.cache_ttl)
+    adapters = default_adapters(
+        web_search_enabled=bool(args.enable_web_search),
+        registry_prefer_network=bool(args.allow_network),
+    )
+    cfg = ResolverConfig(
+        service_context=args.service_context,
+        adapters=adapters,
+        cache=cache,
+        check_mx=bool(args.check_mx),
+        allow_network=bool(args.allow_network),
+        fixtures_dir=args.fixtures_dir,
+        max_workers=max(1, int(args.max_workers)),
+    )
+    return ContactResolver(cfg)
+
+
+def cmd_resolve(args: argparse.Namespace) -> int:
+    resolver = _make_resolver(args)
+    result = resolver.resolve_one(args.cnpj)
+    summary = write_resolution_artifacts(
+        [result],
+        args.output_dir,
+        mode="single",
+        service_context=args.service_context,
+        run_id=args.run_id,
+    )
+    print(json.dumps({**summary, "cnpj14": result.cnpj14, "absence_reason": result.absence_reason}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def cmd_batch(args: argparse.Namespace) -> int:
+    cnpjs = _load_cnpj_list(args.input)
+    if not cnpjs:
+        print(json.dumps({"ok": False, "error": "empty_input"}, ensure_ascii=False))
+        return 2
+    resolver = _make_resolver(args)
+    results = resolver.resolve_batch(cnpjs, max_workers=args.max_workers)
+    summary = write_resolution_artifacts(
+        results,
+        args.output_dir,
+        mode="batch",
+        service_context=args.service_context,
+        run_id=args.run_id,
+    )
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "resolve":
+        return cmd_resolve(args)
+    if args.command == "batch":
+        return cmd_batch(args)
+    parser.error(f"unknown command {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/confenge_contact_resolution/email_policy.py
+++ b/scripts/confenge_contact_resolution/email_policy.py
@@ -1,0 +1,293 @@
+"""Email policy: preserve exact addresses; never treat pattern-guess as enrollable.
+
+Layers (independent, no outbound verification mail):
+  1. syntactic
+  2. domain shape / freemail heuristics
+  3. MX lookup (optional, injectable; skipped offline)
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from scripts.confenge_contact_resolution.models import (
+    EmailVerificationLayers,
+    VerificationStatus,
+)
+
+# Common freemail — lower confidence, still may be OBSERVED if registry-linked.
+FREEMAIL_DOMAINS = frozenset(
+    {
+        "gmail.com",
+        "hotmail.com",
+        "yahoo.com",
+        "yahoo.com.br",
+        "outlook.com",
+        "live.com",
+        "icloud.com",
+        "uol.com.br",
+        "bol.com.br",
+        "terra.com.br",
+        "msn.com",
+        "protonmail.com",
+        "aol.com",
+    }
+)
+
+# Functional mailbox local-parts often used by SMBs / public pages.
+FUNCTIONAL_LOCAL_PARTS = frozenset(
+    {
+        "contato",
+        "contact",
+        "comercial",
+        "vendas",
+        "sales",
+        "orcamento",
+        "orçamento",
+        "financeiro",
+        "adm",
+        "admin",
+        "administrativo",
+        "licitacao",
+        "licitacoes",
+        "licitações",
+        "contratos",
+        "engenharia",
+        "obras",
+        "rh",
+        "suporte",
+        "sac",
+        "atendimento",
+        "info",
+        "ouvidoria",
+        "diretoria",
+        "secretaria",
+    }
+)
+
+_EMAIL_RE = re.compile(
+    r"^[a-zA-Z0-9](?:[a-zA-Z0-9._%+\-]{0,62}[a-zA-Z0-9])?@"
+    r"[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?"
+    r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)+$"
+)
+
+# nome.sobrenome@ / n.sobrenome@ / nome_sobrenome@ style personal pattern guess
+_PERSONAL_PATTERN_RE = re.compile(
+    r"^[a-z]{2,}[._][a-z]{2,}(?:[._][a-z]+)?$",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class EmailAssessment:
+    email: str | None
+    email_display: str | None
+    verification_status: str
+    layers: EmailVerificationLayers
+    is_functional: bool
+    is_freemail: bool
+    is_pattern_guessed: bool
+    enrollable: bool
+    confidence_delta: float
+    notes: list[str]
+
+
+def normalize_email_display(raw: str | None) -> str | None:
+    """Preserve exact observed string after strip; do not rewrite case beyond strip."""
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s or None
+
+
+def syntactic_ok(email: str | None) -> bool:
+    if not email:
+        return False
+    e = email.strip()
+    if len(e) > 254 or "@" not in e:
+        return False
+    return bool(_EMAIL_RE.match(e))
+
+
+def domain_of(email: str | None) -> str | None:
+    if not email or "@" not in email:
+        return None
+    return email.strip().rsplit("@", 1)[-1].lower()
+
+
+def local_part_of(email: str | None) -> str | None:
+    if not email or "@" not in email:
+        return None
+    return email.strip().split("@", 1)[0].lower()
+
+
+def is_freemail(email: str | None) -> bool:
+    d = domain_of(email)
+    return bool(d and d in FREEMAIL_DOMAINS)
+
+
+def is_functional_mailbox(email: str | None) -> bool:
+    local = local_part_of(email)
+    if not local:
+        return False
+    base = local.split("+", 1)[0]
+    if base in FUNCTIONAL_LOCAL_PARTS:
+        return True
+    # contatos@ / comercial.sc@ etc.
+    return any(base.startswith(p) for p in ("contato", "comercial", "licit", "vendas", "orcamento"))
+
+
+def looks_like_personal_pattern(email: str | None) -> bool:
+    """True when local-part matches nome.sobrenome style (pattern-guess risk)."""
+    local = local_part_of(email)
+    if not local or is_functional_mailbox(email):
+        return False
+    return bool(_PERSONAL_PATTERN_RE.match(local))
+
+
+def domain_shape_ok(email: str | None) -> bool:
+    d = domain_of(email)
+    if not d or "." not in d:
+        return False
+    labels = d.split(".")
+    if any(not lab or len(lab) > 63 for lab in labels):
+        return False
+    tld = labels[-1]
+    return tld.isalpha() and len(tld) >= 2
+
+
+def check_mx(
+    domain: str,
+    *,
+    resolver: Callable[[str], bool] | None = None,
+) -> bool | None:
+    """Return True/False if checked, None if not checked.
+
+    Default uses dnspython when available; never sends mail.
+    Inject ``resolver`` in tests.
+    """
+    if resolver is not None:
+        return bool(resolver(domain))
+    try:
+        import dns.resolver  # type: ignore[import-untyped]
+    except ImportError:
+        return None
+    try:
+        answers = dns.resolver.resolve(domain, "MX")
+        return len(list(answers)) > 0
+    except Exception:  # noqa: BLE001 — MX probe is best-effort
+        try:
+            answers = dns.resolver.resolve(domain, "A")
+            return len(list(answers)) > 0
+        except Exception:  # noqa: BLE001
+            return False
+
+
+def assess_email(
+    raw: str | None,
+    *,
+    pattern_guessed: bool = False,
+    check_mx_flag: bool = False,
+    mx_resolver: Callable[[str], bool] | None = None,
+) -> EmailAssessment:
+    display = normalize_email_display(raw)
+    if not display:
+        return EmailAssessment(
+            email=None,
+            email_display=None,
+            verification_status=VerificationStatus.NOT_AVAILABLE.value,
+            layers=EmailVerificationLayers(),
+            is_functional=False,
+            is_freemail=False,
+            is_pattern_guessed=False,
+            enrollable=False,
+            confidence_delta=0.0,
+            notes=["email_absent"],
+        )
+
+    # Canonical lower for comparisons only; keep display exact.
+    canonical = display.lower()
+    notes: list[str] = []
+    syn = syntactic_ok(canonical)
+    dom = domain_shape_ok(canonical) if syn else False
+    freemail = is_freemail(canonical) if syn else False
+    functional = is_functional_mailbox(canonical) if syn else False
+    # Explicit pattern_guessed from adapter wins; auto-detect alone does NOT force
+    # CANDIDATE_UNVERIFIED (observed nome.sobrenome on a site can be real).
+    # Only adapter-declared pattern guesses are non-enrollable by policy.
+    is_guess = bool(pattern_guessed)
+
+    mx_ok: bool | None = None
+    mx_checked = False
+    if check_mx_flag and syn and dom:
+        d = domain_of(canonical)
+        if d:
+            mx_ok = check_mx(d, resolver=mx_resolver)
+            mx_checked = mx_ok is not None
+
+    layers = EmailVerificationLayers(
+        syntactic_ok=syn,
+        domain_ok=dom,
+        mx_ok=mx_ok,
+        mx_checked=mx_checked,
+        pattern_guessed=is_guess,
+    )
+
+    if not syn:
+        return EmailAssessment(
+            email=canonical,
+            email_display=display,
+            verification_status=VerificationStatus.SYNTAX_INVALID.value,
+            layers=layers,
+            is_functional=False,
+            is_freemail=freemail,
+            is_pattern_guessed=is_guess,
+            enrollable=False,
+            confidence_delta=0.0,
+            notes=["email_syntax_invalid"],
+        )
+
+    if is_guess:
+        notes.append("pattern_guessed_personal_email_not_enrollable")
+        return EmailAssessment(
+            email=canonical,
+            email_display=display,
+            verification_status=VerificationStatus.CANDIDATE_UNVERIFIED.value,
+            layers=layers,
+            is_functional=functional,
+            is_freemail=freemail,
+            is_pattern_guessed=True,
+            enrollable=False,
+            confidence_delta=0.05,
+            notes=notes,
+        )
+
+    # Observed exact address
+    delta = 0.35
+    if freemail:
+        delta = 0.12
+        notes.append("freemail_lower_confidence")
+    if functional:
+        delta = max(delta, 0.28)
+        notes.append("functional_mailbox")
+    if mx_ok is True:
+        delta += 0.05
+        notes.append("mx_ok")
+    elif mx_ok is False:
+        delta -= 0.1
+        notes.append("mx_missing")
+
+    return EmailAssessment(
+        email=canonical,
+        email_display=display,
+        verification_status=VerificationStatus.OBSERVED.value,
+        layers=layers,
+        is_functional=functional,
+        is_freemail=freemail,
+        is_pattern_guessed=False,
+        enrollable=True,  # enrollable as contact candidate; Warmbly still decides channel
+        confidence_delta=max(0.0, min(0.5, delta)),
+        notes=notes,
+    )

--- a/scripts/confenge_contact_resolution/export.py
+++ b/scripts/confenge_contact_resolution/export.py
@@ -1,0 +1,96 @@
+"""Write versioned JSONL + run manifesto."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.confenge_contact_resolution import SCHEMA_ID
+from scripts.confenge_contact_resolution.models import AccountContactResolution, empty_manifest
+
+CANDIDATES_FILENAME = "confenge-contact-candidates-v1.jsonl"
+MANIFEST_FILENAME = "run_manifest.json"
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def write_resolution_artifacts(
+    resolutions: list[AccountContactResolution],
+    output_dir: Path | str,
+    *,
+    mode: str = "batch",
+    service_context: str = "generic",
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    rid = run_id or f"confenge-contact-{datetime.now(UTC).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8]}"
+    started = _now()
+    manifest = empty_manifest(
+        run_id=rid,
+        mode=mode,
+        service_context=service_context,
+        output_dir=str(out),
+        input_count=len(resolutions),
+    )
+    manifest["started_at"] = started
+
+    jsonl_path = out / CANDIDATES_FILENAME
+    lines: list[str] = []
+    with_cand = 0
+    with_rec = 0
+    absence = 0
+    cache_hits = 0
+    adapters: set[str] = set()
+
+    for r in resolutions:
+        d = r.as_dict()
+        # ensure schema identity
+        d["schema_id"] = SCHEMA_ID
+        line = json.dumps(d, ensure_ascii=False, default=str, sort_keys=True)
+        lines.append(line)
+        if r.candidates:
+            with_cand += 1
+        else:
+            absence += 1
+        if r.recommended_candidate_id:
+            with_rec += 1
+        if r.cache_hit:
+            cache_hits += 1
+        adapters.update(r.adapters_used)
+
+    # Idempotent: rewrite full file deterministically for this run
+    body = "\n".join(lines) + ("\n" if lines else "")
+    jsonl_path.write_text(body, encoding="utf-8")
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    manifest["finished_at"] = _now()
+    manifest["resolved_count"] = len(resolutions)
+    manifest["with_candidates"] = with_cand
+    manifest["with_recommended"] = with_rec
+    manifest["absence_count"] = absence
+    manifest["cache_hits"] = cache_hits
+    manifest["adapters"] = sorted(adapters)
+    manifest["checksum_sha256"] = digest
+    manifest["ok"] = True
+    manifest_path = out / MANIFEST_FILENAME
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return {
+        "ok": True,
+        "run_id": rid,
+        "jsonl": str(jsonl_path),
+        "manifest": str(manifest_path),
+        "checksum_sha256": digest,
+        "counts": {
+            "resolved": len(resolutions),
+            "with_candidates": with_cand,
+            "with_recommended": with_rec,
+            "absence": absence,
+        },
+    }

--- a/scripts/confenge_contact_resolution/freshness.py
+++ b/scripts/confenge_contact_resolution/freshness.py
@@ -1,0 +1,47 @@
+"""Freshness decay for contact observations."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    # ISO date or datetime
+    try:
+        if "T" in s:
+            return datetime.fromisoformat(s.replace("Z", "+00:00")).date()
+        return date.fromisoformat(s[:10])
+    except ValueError:
+        return None
+
+
+def freshness_score(
+    source_date: str | None,
+    *,
+    as_of: date | None = None,
+    half_life_days: int = 365,
+) -> tuple[float, int | None]:
+    """Return (freshness in [0,1], age_days).
+
+    Missing date → mild penalty (0.7) rather than inventing recency.
+    Older than ~3 half-lives approaches floor 0.1.
+    """
+    today = as_of or date.today()
+    d = _parse_date(source_date)
+    if d is None:
+        return 0.7, None
+    age = (today - d).days
+    if age < 0:
+        age = 0
+    if half_life_days <= 0:
+        return 1.0, age
+    # exponential decay: 0.5 ** (age / half_life)
+
+    score = 0.5 ** (age / float(half_life_days))
+    score = max(0.1, min(1.0, score))
+    return round(score, 4), age

--- a/scripts/confenge_contact_resolution/merge.py
+++ b/scripts/confenge_contact_resolution/merge.py
@@ -55,6 +55,37 @@ def _source_priority(source_type: str | None) -> int:
     return order.get(source_type or "unknown", 0)
 
 
+def account_block_from_observations(
+    observations: list[RawObservation],
+) -> tuple[bool, bool, str | None]:
+    """Detect account-level DNC/bounce that must dominate all recommendations.
+
+    Account-level when human_outcome has dnc/bounce and **no** email/phone channel
+    (firm-wide DO_NOT_CONTACT marker). Channel-scoped human outcomes (with email
+    or phone) only flag that candidate via normal merge — they do not set these
+    flags.
+    """
+    account_dnc = False
+    account_bounce = False
+    reason: str | None = None
+    for o in observations:
+        is_human = (o.adapter == "human_outcome") or (
+            o.source is not None and o.source.source_type == "human_outcome"
+        )
+        if not is_human:
+            continue
+        has_channel = bool((o.email or "").strip() or (o.phone_raw or "").strip())
+        if has_channel:
+            continue
+        if o.dnc:
+            account_dnc = True
+            reason = o.dnc_reason or "DO_NOT_CONTACT"
+        if o.bounce:
+            account_bounce = True
+            reason = reason or o.dnc_reason or "bounce"
+    return account_dnc, account_bounce, reason
+
+
 def observations_to_candidates(
     observations: list[RawObservation],
     *,

--- a/scripts/confenge_contact_resolution/merge.py
+++ b/scripts/confenge_contact_resolution/merge.py
@@ -1,0 +1,208 @@
+"""Dedupe and conflict merge for raw observations → candidates."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import UTC, datetime
+
+from scripts.confenge_contact_resolution.email_policy import assess_email
+from scripts.confenge_contact_resolution.freshness import freshness_score
+from scripts.confenge_contact_resolution.models import (
+    ContactCandidate,
+    RawObservation,
+    SourceProvenance,
+    VerificationStatus,
+)
+from scripts.confenge_contact_resolution.phone_policy import assess_phone, default_whatsapp_block
+from scripts.confenge_contact_resolution.role_map import map_role_class
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _norm_name(n: str | None) -> str:
+    if not n:
+        return ""
+    return re.sub(r"\s+", " ", n.strip().lower())
+
+
+def _dedupe_key(obs: RawObservation, email: str | None, phone_e164: str | None) -> str:
+    """Key for merging same person/channel across sources."""
+    name = _norm_name(obs.name)
+    if email:
+        return f"email:{email}"
+    if phone_e164:
+        return f"phone:{phone_e164}"
+    if name:
+        return f"name:{name}|cargo:{_norm_name(obs.cargo)}"
+    # unique fallback per observation fingerprint
+    raw = f"{obs.adapter}|{obs.email}|{obs.phone_raw}|{obs.name}|{obs.source.source_url}"
+    return "anon:" + hashlib.sha256(raw.encode()).hexdigest()[:12]
+
+
+def _source_priority(source_type: str | None) -> int:
+    order = {
+        "human_outcome": 100,
+        "registry": 80,
+        "contact_page": 60,
+        "site": 50,
+        "public_docs": 40,
+        "web_search": 20,
+        "unknown": 0,
+    }
+    return order.get(source_type or "unknown", 0)
+
+
+def observations_to_candidates(
+    observations: list[RawObservation],
+    *,
+    cnpj14: str,
+    account_key: str | None = None,
+    check_mx: bool = False,
+    mx_resolver=None,
+) -> list[ContactCandidate]:
+    """Merge raw observations into ContactCandidate list (pre-ranking)."""
+    buckets: dict[str, list[RawObservation]] = {}
+    for obs in observations:
+        email_a = assess_email(
+            obs.email,
+            pattern_guessed=obs.pattern_guessed_email,
+            check_mx_flag=check_mx,
+            mx_resolver=mx_resolver,
+        )
+        phone_a = assess_phone(obs.phone_raw)
+        key = _dedupe_key(obs, email_a.email, phone_a.phone_e164)
+        buckets.setdefault(key, []).append(obs)
+
+    candidates: list[ContactCandidate] = []
+    for key, group in buckets.items():
+        # Prefer higher-priority sources; DNC/bounce from any source dominate
+        group_sorted = sorted(
+            group,
+            key=lambda o: _source_priority(o.source.source_type if o.source else None),
+            reverse=True,
+        )
+        primary = group_sorted[0]
+        dnc = any(o.dnc for o in group)
+        bounce = any(o.bounce for o in group)
+        dnc_reason = next((o.dnc_reason for o in group if o.dnc_reason), None)
+
+        # Conflict: multiple different emails for same name key → keep all as separate
+        # (already bucketed by email/phone). For same key, prefer primary values.
+        email_a = assess_email(
+            primary.email,
+            pattern_guessed=primary.pattern_guessed_email,
+            check_mx_flag=check_mx,
+            mx_resolver=mx_resolver,
+        )
+        phone_a = assess_phone(primary.phone_raw)
+
+        # If primary lacks email but another in group has observed email, promote
+        if not email_a.email:
+            for o in group_sorted[1:]:
+                ea = assess_email(o.email, pattern_guessed=o.pattern_guessed_email)
+                if ea.email and ea.verification_status == VerificationStatus.OBSERVED.value:
+                    email_a = ea
+                    break
+        if not phone_a.phone_e164:
+            for o in group_sorted[1:]:
+                pa = assess_phone(o.phone_raw)
+                if pa.valid:
+                    phone_a = pa
+                    break
+
+        # Name/cargo: prefer non-empty from highest priority
+        name = next((o.name for o in group_sorted if o.name), None)
+        cargo = next((o.cargo for o in group_sorted if o.cargo), None)
+        role = map_role_class(cargo, name_hint=name)
+
+        # Source date: newest known for freshness
+        dates = [o.source.source_date for o in group if o.source and o.source.source_date]
+        source_date = max(dates) if dates else (primary.source.source_date if primary.source else None)
+        fresh, age = freshness_score(source_date)
+
+        conf = 0.15  # base for existence
+        conf += email_a.confidence_delta
+        conf += phone_a.confidence_delta
+        conf *= fresh
+        if dnc or bounce:
+            conf = 0.0
+        conf = round(max(0.0, min(1.0, conf)), 4)
+
+        wa_status = primary.whatsapp_consent
+        wa_prov = primary.whatsapp_consent_provenance
+        for o in group:
+            if o.whatsapp_consent == "OPTED_IN" and o.whatsapp_consent_provenance:
+                wa_status = "OPTED_IN"
+                wa_prov = o.whatsapp_consent_provenance
+                break
+
+        site = next((o.site for o in group_sorted if o.site), None)
+        linkedin = next((o.linkedin_public for o in group_sorted if o.linkedin_public), None)
+
+        # Conflict note: conflicting emails across same name (edge) already split by key
+        limitations: list[str] = list(email_a.notes)
+        if len({(o.email or "").lower() for o in group if o.email}) > 1:
+            limitations.append("conflicting_emails_merged_by_channel_key")
+        if len({digits for o in group if (digits := re.sub(r"\D", "", o.phone_raw or ""))}) > 1:
+            limitations.append("conflicting_phones_prefer_primary_source")
+
+        cid = hashlib.sha256(f"{cnpj14}|{key}".encode()).hexdigest()[:16]
+        src = primary.source or SourceProvenance(source_type=primary.adapter)
+        if not src.observed_at:
+            src = SourceProvenance(
+                source_type=src.source_type,
+                source_url=src.source_url,
+                source_document=src.source_document,
+                source_date=src.source_date,
+                observed_at=_now_iso(),
+                notes=src.notes,
+            )
+
+        epistemic = primary.epistemic_class
+        if email_a.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value:
+            epistemic = "INFERRED"
+
+        cand = ContactCandidate(
+            candidate_id=cid,
+            cnpj14=cnpj14,
+            account_key=account_key or cnpj14,
+            name=name,
+            cargo=cargo,
+            role_class=role,
+            email=email_a.email,
+            email_display=email_a.email_display,
+            phone_raw=phone_a.phone_raw,
+            phone_e164=phone_a.phone_e164,
+            phone_type=phone_a.phone_type,
+            site=site,
+            linkedin_public=linkedin,
+            source=src,
+            verification_status=email_a.verification_status
+            if email_a.email
+            else (
+                VerificationStatus.OBSERVED.value
+                if phone_a.valid
+                else VerificationStatus.NOT_AVAILABLE.value
+            ),
+            email_layers=email_a.layers,
+            confidence=conf,
+            freshness=fresh,
+            freshness_days=age,
+            dnc=dnc,
+            bounce=bounce,
+            dnc_reason=dnc_reason,
+            whatsapp=default_whatsapp_block(
+                phone_a.phone_e164,
+                consent_status=wa_status,
+                consent_provenance=wa_prov,
+            ),
+            enrollable=email_a.enrollable and not dnc and not bounce,
+            epistemic_class=epistemic,
+            limitations=limitations,
+        )
+        candidates.append(cand)
+
+    return candidates

--- a/scripts/confenge_contact_resolution/models.py
+++ b/scripts/confenge_contact_resolution/models.py
@@ -1,0 +1,239 @@
+"""Versioned contracts for CONFENGE business contact candidates."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from scripts.confenge_contact_resolution import SCHEMA_ID, SCHEMA_VERSION
+
+
+class RoleClass(StrEnum):
+    OWNER = "owner"
+    DIRETORIA = "diretoria"
+    COMERCIAL = "comercial"
+    CONTRATOS = "contratos"
+    ENGENHARIA = "engenharia"
+    LICITACOES = "licitações"
+    FINANCEIRO = "financeiro"
+    GENERIC = "generic"
+
+
+class VerificationStatus(StrEnum):
+    """How the contact address was obtained / checked (not outreach result)."""
+
+    OBSERVED = "OBSERVED"  # exact value published by a source
+    CANDIDATE_UNVERIFIED = "CANDIDATE_UNVERIFIED"  # pattern-guessed; never enrollable
+    SYNTAX_INVALID = "SYNTAX_INVALID"
+    NOT_AVAILABLE = "NOT_AVAILABLE"
+
+
+class PhoneType(StrEnum):
+    MOBILE = "mobile"
+    LANDLINE = "landline"
+    UNKNOWN = "unknown"
+
+
+class WhatsAppConsent(StrEnum):
+    """Public phone ≠ opt-in. Default UNKNOWN / NO_OPT_IN."""
+
+    UNKNOWN = "UNKNOWN"
+    NO_OPT_IN = "NO_OPT_IN"
+    OPTED_IN = "OPTED_IN"
+
+
+class ServiceContext(StrEnum):
+    """Service context that shifts role priority for ranking."""
+
+    CLAIMS_REAJUSTE = "claims_reajuste"
+    LICITACOES = "licitações"
+    ORCAMENTO_MEDICOES = "orcamento_medicoes"
+    GENERIC = "generic"
+
+
+ROLE_CLASS_VALUES = frozenset(r.value for r in RoleClass)
+VERIFICATION_STATUS_VALUES = frozenset(v.value for v in VerificationStatus)
+PHONE_TYPE_VALUES = frozenset(p.value for p in PhoneType)
+WHATSAPP_CONSENT_VALUES = frozenset(w.value for w in WhatsAppConsent)
+
+
+@dataclass
+class SourceProvenance:
+    source_type: str  # registry | site | public_docs | contact_page | web_search | human_outcome
+    source_url: str | None = None
+    source_document: str | None = None
+    source_date: str | None = None  # ISO date when known
+    observed_at: str | None = None  # ISO datetime of observation run
+    notes: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EmailVerificationLayers:
+    """Independent layers — never send verification messages."""
+
+    syntactic_ok: bool | None = None
+    domain_ok: bool | None = None
+    mx_ok: bool | None = None
+    mx_checked: bool = False
+    pattern_guessed: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class WhatsAppBlock:
+    consent_status: str = WhatsAppConsent.UNKNOWN.value
+    consent_provenance: str | None = None
+    e164: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ContactCandidate:
+    """One business contact candidate for an account/CNPJ."""
+
+    candidate_id: str
+    cnpj14: str
+    account_key: str
+    name: str | None = None
+    cargo: str | None = None
+    role_class: str = RoleClass.GENERIC.value
+    email: str | None = None
+    email_display: str | None = None  # exact preserved string for UI
+    phone_raw: str | None = None
+    phone_e164: str | None = None
+    phone_type: str = PhoneType.UNKNOWN.value
+    site: str | None = None
+    linkedin_public: str | None = None
+    source: SourceProvenance = field(default_factory=lambda: SourceProvenance(source_type="unknown"))
+    verification_status: str = VerificationStatus.NOT_AVAILABLE.value
+    email_layers: EmailVerificationLayers = field(default_factory=EmailVerificationLayers)
+    confidence: float = 0.0
+    recommended: bool = False
+    recommendation_reason: str | None = None
+    freshness: float = 1.0  # 1.0 = fresh; decays with age
+    freshness_days: int | None = None
+    dnc: bool = False
+    bounce: bool = False
+    dnc_reason: str | None = None
+    whatsapp: WhatsAppBlock = field(default_factory=WhatsAppBlock)
+    rank_score: float = 0.0
+    rank_explain: list[str] = field(default_factory=list)
+    enrollable: bool = False  # never true for CANDIDATE_UNVERIFIED
+    epistemic_class: str = "OBSERVED_PUBLIC"  # OBSERVED_PUBLIC | INFERRED | HUMAN_OUTCOME
+    limitations: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+
+@dataclass
+class AccountContactResolution:
+    """Resolution record for one CNPJ/account — zero or more candidates."""
+
+    schema_id: str = SCHEMA_ID
+    schema_version: str = SCHEMA_VERSION
+    cnpj14: str = ""
+    account_key: str = ""
+    razao_social: str | None = None
+    service_context: str = ServiceContext.GENERIC.value
+    small_firm: bool = False
+    candidates: list[ContactCandidate] = field(default_factory=list)
+    recommended_candidate_id: str | None = None
+    absence_reason: str | None = None  # set when no candidates
+    adapters_used: list[str] = field(default_factory=list)
+    adapters_skipped: list[str] = field(default_factory=list)
+    cache_hit: bool = False
+    resolved_at: str | None = None
+    limitations: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": self.schema_id,
+            "schema_version": self.schema_version,
+            "cnpj14": self.cnpj14,
+            "account_key": self.account_key,
+            "razao_social": self.razao_social,
+            "service_context": self.service_context,
+            "small_firm": self.small_firm,
+            "candidates": [c.as_dict() for c in self.candidates],
+            "recommended_candidate_id": self.recommended_candidate_id,
+            "absence_reason": self.absence_reason,
+            "adapters_used": list(self.adapters_used),
+            "adapters_skipped": list(self.adapters_skipped),
+            "cache_hit": self.cache_hit,
+            "resolved_at": self.resolved_at,
+            "limitations": list(self.limitations),
+        }
+
+
+@dataclass
+class RawObservation:
+    """Provenance-bearing raw observation from one adapter (pre-merge)."""
+
+    adapter: str
+    cnpj14: str
+    name: str | None = None
+    cargo: str | None = None
+    email: str | None = None
+    phone_raw: str | None = None
+    site: str | None = None
+    linkedin_public: str | None = None
+    source: SourceProvenance = field(default_factory=lambda: SourceProvenance(source_type="unknown"))
+    pattern_guessed_email: bool = False
+    dnc: bool = False
+    bounce: bool = False
+    dnc_reason: str | None = None
+    whatsapp_consent: str = WhatsAppConsent.UNKNOWN.value
+    whatsapp_consent_provenance: str | None = None
+    company_size: str | None = None
+    razao_social: str | None = None
+    epistemic_class: str = "OBSERVED_PUBLIC"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def empty_manifest(
+    *,
+    run_id: str,
+    mode: str,
+    service_context: str,
+    output_dir: str,
+    input_count: int = 0,
+) -> dict[str, Any]:
+    return {
+        "schema_id": "confenge-contact-resolution-manifest-v1",
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "mode": mode,  # single | batch
+        "service_context": service_context,
+        "output_dir": output_dir,
+        "candidates_artifact": "confenge-contact-candidates-v1.jsonl",
+        "input_count": input_count,
+        "resolved_count": 0,
+        "with_candidates": 0,
+        "with_recommended": 0,
+        "absence_count": 0,
+        "cache_hits": 0,
+        "adapters": [],
+        "started_at": None,
+        "finished_at": None,
+        "limitations": [
+            "Public phone does not imply WhatsApp opt-in.",
+            "Pattern-guessed emails are CANDIDATE_UNVERIFIED and never enrollable.",
+            "No private social scraping; optional web search is interface-only.",
+            "MX/domain checks never send mail.",
+        ],
+        "checksum_sha256": None,
+        "ok": False,
+    }

--- a/scripts/confenge_contact_resolution/phone_policy.py
+++ b/scripts/confenge_contact_resolution/phone_policy.py
@@ -1,0 +1,148 @@
+"""Brazilian phone normalization to E.164 and mobile/landline typing.
+
+Public phone does NOT imply WhatsApp opt-in — consent is handled separately.
+No unauthorized WhatsApp account existence checks.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from scripts.confenge_contact_resolution.models import PhoneType, WhatsAppBlock, WhatsAppConsent
+
+
+@dataclass(frozen=True)
+class PhoneAssessment:
+    phone_raw: str | None
+    phone_e164: str | None
+    phone_type: str
+    valid: bool
+    confidence_delta: float
+    notes: list[str]
+
+
+def digits_only(raw: str | None) -> str:
+    return re.sub(r"\D", "", raw or "")
+
+
+def normalize_br_e164(raw: str | None) -> str | None:
+    """Normalize BR phone to +55… E.164.
+
+    Accepts:
+      - 10 digits (landline with DDD)
+      - 11 digits (mobile with 9th digit + DDD)
+      - 12–13 digits starting with 55
+      - already-prefixed +55…
+    Returns None if invalid.
+    """
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if not s:
+        return None
+    d = digits_only(s)
+    if not d:
+        return None
+
+    # Strip leading zeros occasionally seen in exports
+    d = d.lstrip("0") or d
+
+    if d.startswith("55") and len(d) in {12, 13}:
+        national = d[2:]
+    elif len(d) in {10, 11}:
+        national = d
+    else:
+        return None
+
+    if len(national) not in {10, 11}:
+        return None
+    ddd = national[:2]
+    subscriber = national[2:]
+    if not (10 <= int(ddd) <= 99):
+        return None
+    if len(subscriber) == 9 and not subscriber.startswith("9"):
+        # 9-digit subscriber in BR mobile must start with 9
+        return None
+    if len(subscriber) == 8 and subscriber[0] in {"6", "7", "8", "9"}:
+        # Ambiguous legacy; still accept as landline/unknown later
+        pass
+    if not subscriber.isdigit() or not ddd.isdigit():
+        return None
+    return f"+55{ddd}{subscriber}"
+
+
+def classify_phone_type(e164: str | None) -> str:
+    if not e164 or not e164.startswith("+55"):
+        return PhoneType.UNKNOWN.value
+    national = e164[3:]
+    if len(national) == 11 and national[2] == "9":
+        return PhoneType.MOBILE.value
+    if len(national) == 10:
+        return PhoneType.LANDLINE.value
+    return PhoneType.UNKNOWN.value
+
+
+def assess_phone(raw: str | None) -> PhoneAssessment:
+    display = (str(raw).strip() if raw is not None else None) or None
+    if not display:
+        return PhoneAssessment(
+            phone_raw=None,
+            phone_e164=None,
+            phone_type=PhoneType.UNKNOWN.value,
+            valid=False,
+            confidence_delta=0.0,
+            notes=["phone_absent"],
+        )
+    e164 = normalize_br_e164(display)
+    if not e164:
+        return PhoneAssessment(
+            phone_raw=display,
+            phone_e164=None,
+            phone_type=PhoneType.UNKNOWN.value,
+            valid=False,
+            confidence_delta=0.0,
+            notes=["phone_invalid"],
+        )
+    ptype = classify_phone_type(e164)
+    delta = 0.25 if ptype == PhoneType.MOBILE.value else 0.18 if ptype == PhoneType.LANDLINE.value else 0.1
+    return PhoneAssessment(
+        phone_raw=display,
+        phone_e164=e164,
+        phone_type=ptype,
+        valid=True,
+        confidence_delta=delta,
+        notes=[f"phone_type_{ptype}"],
+    )
+
+
+def default_whatsapp_block(
+    e164: str | None,
+    *,
+    consent_status: str | None = None,
+    consent_provenance: str | None = None,
+) -> WhatsAppBlock:
+    """Public phone → UNKNOWN/NO_OPT_IN unless explicit verifiable provenance."""
+    status = (consent_status or "").strip().upper() or WhatsAppConsent.UNKNOWN.value
+    if status == WhatsAppConsent.OPTED_IN.value:
+        if not consent_provenance or not str(consent_provenance).strip():
+            # Fail closed: cannot claim opt-in without provenance
+            status = WhatsAppConsent.NO_OPT_IN.value
+            consent_provenance = None
+    elif status not in {w.value for w in WhatsAppConsent}:
+        status = WhatsAppConsent.UNKNOWN.value
+
+    if status == WhatsAppConsent.OPTED_IN.value:
+        return WhatsAppBlock(
+            consent_status=WhatsAppConsent.OPTED_IN.value,
+            consent_provenance=consent_provenance,
+            e164=e164,
+        )
+    # Prefer NO_OPT_IN when we have a phone but no consent; UNKNOWN when no phone
+    if e164 and status == WhatsAppConsent.UNKNOWN.value:
+        status = WhatsAppConsent.NO_OPT_IN.value
+    return WhatsAppBlock(
+        consent_status=status,
+        consent_provenance=consent_provenance if status == WhatsAppConsent.OPTED_IN.value else None,
+        e164=e164,
+    )

--- a/scripts/confenge_contact_resolution/ranking.py
+++ b/scripts/confenge_contact_resolution/ranking.py
@@ -1,0 +1,207 @@
+"""Service-aware explainable ranking — not purchase probability.
+
+Best contact depends on service context. DNC/bounce dominate and block
+recommendation. Pattern-guessed emails are never recommended primary.
+"""
+
+from __future__ import annotations
+
+from scripts.confenge_contact_resolution.models import (
+    ContactCandidate,
+    RoleClass,
+    ServiceContext,
+    VerificationStatus,
+)
+
+# Role priority weights by service (higher = better fit). Explainable tables.
+_ROLE_WEIGHTS: dict[str, dict[str, float]] = {
+    ServiceContext.CLAIMS_REAJUSTE.value: {
+        RoleClass.CONTRATOS.value: 1.0,
+        RoleClass.DIRETORIA.value: 0.9,
+        RoleClass.ENGENHARIA.value: 0.75,
+        RoleClass.FINANCEIRO.value: 0.7,
+        RoleClass.OWNER.value: 0.65,
+        RoleClass.COMERCIAL.value: 0.45,
+        RoleClass.LICITACOES.value: 0.4,
+        RoleClass.GENERIC.value: 0.25,
+    },
+    ServiceContext.LICITACOES.value: {
+        RoleClass.LICITACOES.value: 1.0,
+        RoleClass.COMERCIAL.value: 0.9,
+        RoleClass.DIRETORIA.value: 0.8,
+        RoleClass.OWNER.value: 0.7,
+        RoleClass.CONTRATOS.value: 0.55,
+        RoleClass.ENGENHARIA.value: 0.45,
+        RoleClass.FINANCEIRO.value: 0.35,
+        RoleClass.GENERIC.value: 0.25,
+    },
+    ServiceContext.ORCAMENTO_MEDICOES.value: {
+        RoleClass.ENGENHARIA.value: 1.0,
+        RoleClass.CONTRATOS.value: 0.85,
+        RoleClass.DIRETORIA.value: 0.7,
+        RoleClass.OWNER.value: 0.65,
+        RoleClass.FINANCEIRO.value: 0.5,
+        RoleClass.COMERCIAL.value: 0.4,
+        RoleClass.LICITACOES.value: 0.35,
+        RoleClass.GENERIC.value: 0.25,
+    },
+    ServiceContext.GENERIC.value: {
+        RoleClass.DIRETORIA.value: 0.85,
+        RoleClass.OWNER.value: 0.8,
+        RoleClass.COMERCIAL.value: 0.75,
+        RoleClass.CONTRATOS.value: 0.7,
+        RoleClass.LICITACOES.value: 0.65,
+        RoleClass.ENGENHARIA.value: 0.6,
+        RoleClass.FINANCEIRO.value: 0.55,
+        RoleClass.GENERIC.value: 0.35,
+    },
+}
+
+_SOURCE_WEIGHT: dict[str, float] = {
+    "registry": 0.9,
+    "human_outcome": 1.0,
+    "contact_page": 0.75,
+    "site": 0.7,
+    "public_docs": 0.65,
+    "web_search": 0.45,
+    "unknown": 0.2,
+}
+
+
+def role_weight(role_class: str, service_context: str, *, small_firm: bool = False) -> float:
+    table = _ROLE_WEIGHTS.get(service_context) or _ROLE_WEIGHTS[ServiceContext.GENERIC.value]
+    w = table.get(role_class, table.get(RoleClass.GENERIC.value, 0.25))
+    # Small-firm owner/diretoria boost only for generic context — must not
+    # override specialized service priorities (licitações, contratos, etc.).
+    if (
+        small_firm
+        and service_context in {ServiceContext.GENERIC.value, ""}
+        and role_class in {RoleClass.OWNER.value, RoleClass.DIRETORIA.value}
+    ):
+        w = min(1.0, w + 0.15)
+    return w
+
+
+def score_candidate(
+    c: ContactCandidate,
+    *,
+    service_context: str = ServiceContext.GENERIC.value,
+    small_firm: bool = False,
+) -> tuple[float, list[str]]:
+    """Return (score, explanation bullets). Score is fit for outreach channel decision, not P(buy)."""
+    explain: list[str] = []
+    if c.dnc or c.bounce:
+        reason = "DNC" if c.dnc else "bounce"
+        explain.append(f"blocked_by_{reason}")
+        return -1.0, explain
+
+    if c.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value:
+        explain.append("pattern_guessed_not_primary")
+        # keep low positive score so it can appear as candidate but not win
+        base = 0.05 * c.freshness
+        return base, explain
+
+    if c.verification_status == VerificationStatus.SYNTAX_INVALID.value:
+        explain.append("syntax_invalid")
+        return 0.0, explain
+
+    rw = role_weight(c.role_class, service_context, small_firm=small_firm)
+    explain.append(f"role_weight[{c.role_class}]={rw:.2f} for service={service_context}")
+    if (
+        small_firm
+        and service_context in {ServiceContext.GENERIC.value, ""}
+        and c.role_class in {RoleClass.OWNER.value, RoleClass.DIRETORIA.value}
+    ):
+        explain.append("small_firm_owner_diretoria_boost")
+
+    src = (c.source.source_type if c.source else "unknown") or "unknown"
+    sw = _SOURCE_WEIGHT.get(src, 0.2)
+    explain.append(f"source_weight[{src}]={sw:.2f}")
+
+    contact_signal = 0.0
+    if c.email and c.verification_status == VerificationStatus.OBSERVED.value:
+        contact_signal += 0.35
+        explain.append("observed_email")
+        if c.email_layers and c.email_layers.pattern_guessed:
+            contact_signal -= 0.3
+        if not c.enrollable:
+            contact_signal -= 0.2
+    if c.phone_e164:
+        contact_signal += 0.25 if c.phone_type == "mobile" else 0.18
+        explain.append(f"phone_{c.phone_type}")
+
+    if not c.email and not c.phone_e164:
+        explain.append("no_channel")
+        contact_signal = 0.0
+
+    freshness = max(0.0, min(1.0, c.freshness))
+    explain.append(f"freshness={freshness:.2f}")
+
+    # confidence already encodes quality; blend lightly
+    conf = max(0.0, min(1.0, c.confidence))
+    score = (0.45 * rw + 0.2 * sw + 0.25 * contact_signal + 0.1 * conf) * freshness
+    # Named decision-maker slightly preferred over nameless functional when roles equal
+    if c.name and c.role_class != RoleClass.GENERIC.value:
+        score += 0.03
+        explain.append("named_role_holder")
+    explain.append(f"score={score:.4f}")
+    return round(score, 6), explain
+
+
+def select_recommended(
+    candidates: list[ContactCandidate],
+    *,
+    service_context: str = ServiceContext.GENERIC.value,
+    small_firm: bool = False,
+) -> tuple[list[ContactCandidate], str | None]:
+    """Score, sort, mark exactly one recommended when viable. Mutates candidates."""
+    if not candidates:
+        return [], None
+
+    scored: list[ContactCandidate] = []
+    for c in candidates:
+        sc, expl = score_candidate(c, service_context=service_context, small_firm=small_firm)
+        c.rank_score = sc
+        c.rank_explain = expl
+        c.recommended = False
+        c.recommendation_reason = None
+        scored.append(c)
+
+    scored.sort(key=lambda x: x.rank_score, reverse=True)
+
+    # Viable = not DNC/bounce, has channel, not pattern-guess only without other channel
+    recommended_id: str | None = None
+    for c in scored:
+        if c.rank_score < 0:
+            continue
+        if c.dnc or c.bounce:
+            continue
+        if c.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value and not c.phone_e164:
+            continue
+        if not c.email and not c.phone_e164:
+            continue
+        if c.verification_status == VerificationStatus.SYNTAX_INVALID.value and not c.phone_e164:
+            continue
+        # Prefer enrollable email or any valid phone
+        if c.email and not c.enrollable and not c.phone_e164:
+            continue
+
+        c.recommended = True
+        reason_parts = [
+            f"Melhor fit para serviço «{service_context}»",
+            f"role_class={c.role_class}",
+            f"score={c.rank_score:.3f}",
+        ]
+        if c.email and c.enrollable:
+            reason_parts.append("e-mail observado utilizável")
+        elif c.email and not c.enrollable:
+            reason_parts.append("e-mail não enrollable; canal via telefone" if c.phone_e164 else "e-mail não enrollable")
+        if c.phone_e164:
+            reason_parts.append(f"telefone {c.phone_type} E.164")
+        if c.dnc or c.bounce:
+            reason_parts.append("BLOQUEADO")
+        c.recommendation_reason = "; ".join(reason_parts)
+        recommended_id = c.candidate_id
+        break
+
+    return scored, recommended_id

--- a/scripts/confenge_contact_resolution/ranking.py
+++ b/scripts/confenge_contact_resolution/ranking.py
@@ -153,8 +153,17 @@ def select_recommended(
     *,
     service_context: str = ServiceContext.GENERIC.value,
     small_firm: bool = False,
+    account_dnc: bool = False,
+    account_bounce: bool = False,
 ) -> tuple[list[ContactCandidate], str | None]:
-    """Score, sort, mark exactly one recommended when viable. Mutates candidates."""
+    """Score, sort, mark exactly one recommended when viable. Mutates candidates.
+
+    Hard rules:
+    - ``CANDIDATE_UNVERIFIED`` (pattern-guessed) is never recommended primary.
+    - Account-level DNC/bounce (human outcome / DO_NOT_CONTACT without channel)
+      blocks *all* recommendations for the account.
+    - Channel-level DNC/bounce only blocks that candidate.
+    """
     if not candidates:
         return [], None
 
@@ -169,20 +178,28 @@ def select_recommended(
 
     scored.sort(key=lambda x: x.rank_score, reverse=True)
 
-    # Viable = not DNC/bounce, has channel, not pattern-guess only without other channel
+    if account_dnc or account_bounce:
+        reason = "account_dnc" if account_dnc else "account_bounce"
+        for c in scored:
+            c.rank_explain = list(c.rank_explain or []) + [f"blocked_by_{reason}"]
+            c.recommended = False
+            c.recommendation_reason = None
+        return scored, None
+
     recommended_id: str | None = None
     for c in scored:
         if c.rank_score < 0:
             continue
         if c.dnc or c.bounce:
             continue
-        if c.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value and not c.phone_e164:
+        # Pattern-guessed personal email is never recommended primary (even with phone).
+        if c.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value:
             continue
         if not c.email and not c.phone_e164:
             continue
         if c.verification_status == VerificationStatus.SYNTAX_INVALID.value and not c.phone_e164:
             continue
-        # Prefer enrollable email or any valid phone
+        # Non-enrollable email without a phone channel cannot be primary
         if c.email and not c.enrollable and not c.phone_e164:
             continue
 
@@ -195,11 +212,11 @@ def select_recommended(
         if c.email and c.enrollable:
             reason_parts.append("e-mail observado utilizável")
         elif c.email and not c.enrollable:
-            reason_parts.append("e-mail não enrollable; canal via telefone" if c.phone_e164 else "e-mail não enrollable")
+            reason_parts.append(
+                "e-mail não enrollable; canal via telefone" if c.phone_e164 else "e-mail não enrollable"
+            )
         if c.phone_e164:
             reason_parts.append(f"telefone {c.phone_type} E.164")
-        if c.dnc or c.bounce:
-            reason_parts.append("BLOQUEADO")
         c.recommendation_reason = "; ".join(reason_parts)
         recommended_id = c.candidate_id
         break

--- a/scripts/confenge_contact_resolution/resolver.py
+++ b/scripts/confenge_contact_resolution/resolver.py
@@ -17,7 +17,10 @@ from scripts.confenge_contact_resolution.adapters.registry import RegistryAdapte
 from scripts.confenge_contact_resolution.adapters.site import SiteAdapter
 from scripts.confenge_contact_resolution.adapters.web_search import NoOpWebSearchProvider, WebSearchAdapter
 from scripts.confenge_contact_resolution.cache import ResolutionCache, cache_key
-from scripts.confenge_contact_resolution.merge import observations_to_candidates
+from scripts.confenge_contact_resolution.merge import (
+    account_block_from_observations,
+    observations_to_candidates,
+)
 from scripts.confenge_contact_resolution.models import (
     AccountContactResolution,
     ServiceContext,
@@ -148,6 +151,7 @@ class ContactResolver:
             razao = razao or ctx.registry_record.get("legal_name") or ctx.registry_record.get("razao_social")
 
         small = is_small_firm_porte(str(porte) if porte else None, mei=mei if isinstance(mei, bool) else None)
+        account_dnc, account_bounce, account_block_reason = account_block_from_observations(observations)
         candidates = observations_to_candidates(
             observations,
             cnpj14=cnpj14,
@@ -159,6 +163,8 @@ class ContactResolver:
             candidates,
             service_context=self.config.service_context,
             small_firm=small,
+            account_dnc=account_dnc,
+            account_bounce=account_bounce,
         )
 
         base.razao_social = razao
@@ -167,6 +173,10 @@ class ContactResolver:
         base.recommended_candidate_id = rec_id
         base.adapters_used = used
         base.adapters_skipped = skipped
+        if account_dnc or account_bounce:
+            base.limitations.append(
+                f"account_block:{account_block_reason or ('DNC' if account_dnc else 'bounce')}"
+            )
         if not ranked:
             base.absence_reason = "no_public_business_contact_found"
             base.limitations.append("Absence remains absence — no fabricated contacts")

--- a/scripts/confenge_contact_resolution/resolver.py
+++ b/scripts/confenge_contact_resolution/resolver.py
@@ -1,0 +1,286 @@
+"""Orchestrate adapters → merge → rank for one or many CNPJs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext, ContactAdapter
+from scripts.confenge_contact_resolution.adapters.contact_pages import ContactPageAdapter
+from scripts.confenge_contact_resolution.adapters.public_docs import PublicDocsAdapter
+from scripts.confenge_contact_resolution.adapters.registry import RegistryAdapter
+from scripts.confenge_contact_resolution.adapters.site import SiteAdapter
+from scripts.confenge_contact_resolution.adapters.web_search import NoOpWebSearchProvider, WebSearchAdapter
+from scripts.confenge_contact_resolution.cache import ResolutionCache, cache_key
+from scripts.confenge_contact_resolution.merge import observations_to_candidates
+from scripts.confenge_contact_resolution.models import (
+    AccountContactResolution,
+    ServiceContext,
+)
+from scripts.confenge_contact_resolution.ranking import select_recommended
+from scripts.confenge_contact_resolution.role_map import is_small_firm_porte
+
+
+def _digits(s: str | None) -> str:
+    return re.sub(r"\D", "", s or "")[:14]
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_adapters(
+    *,
+    web_search_enabled: bool = False,
+    web_search_provider=None,
+    registry_prefer_network: bool = False,
+) -> list[ContactAdapter]:
+    return [
+        RegistryAdapter(prefer_network=registry_prefer_network),
+        SiteAdapter(),
+        PublicDocsAdapter(),
+        ContactPageAdapter(),
+        WebSearchAdapter(
+            provider=web_search_provider or NoOpWebSearchProvider(),
+            enabled=web_search_enabled,
+        ),
+    ]
+
+
+@dataclass
+class ResolverConfig:
+    service_context: str = ServiceContext.GENERIC.value
+    adapters: list[ContactAdapter] = field(default_factory=default_adapters)
+    cache: ResolutionCache | None = None
+    check_mx: bool = False
+    mx_resolver: Callable[[str], bool] | None = None
+    allow_network: bool = False
+    fixtures_dir: Path | None = None
+    max_workers: int = 4
+    # Injected per-CNPJ context builders for tests
+    context_builder: Callable[[str], AdapterContext] | None = None
+
+
+class ContactResolver:
+    def __init__(self, config: ResolverConfig | None = None) -> None:
+        self.config = config or ResolverConfig()
+
+    def _adapters_sig(self) -> str:
+        return ",".join(getattr(a, "name", type(a).__name__) for a in self.config.adapters)
+
+    def resolve_one(
+        self,
+        cnpj: str,
+        *,
+        account_key: str | None = None,
+        ctx: AdapterContext | None = None,
+    ) -> AccountContactResolution:
+        cnpj14 = _digits(cnpj)
+        key = account_key or cnpj14
+        resolved_at = _now()
+        base = AccountContactResolution(
+            cnpj14=cnpj14,
+            account_key=key,
+            service_context=self.config.service_context,
+            resolved_at=resolved_at,
+        )
+        if len(cnpj14) != 14:
+            base.absence_reason = "invalid_cnpj"
+            base.limitations.append("CNPJ must have 14 digits")
+            return base
+
+        ck = cache_key(cnpj14, self.config.service_context, self._adapters_sig())
+        if self.config.cache:
+            hit = self.config.cache.get(ck)
+            if hit is not None:
+                hit["cache_hit"] = True
+                # rebuild lightly from dict
+                return _resolution_from_dict(hit)
+
+        if ctx is None and self.config.context_builder:
+            ctx = self.config.context_builder(cnpj14)
+        if ctx is None:
+            ctx = AdapterContext(
+                cnpj14=cnpj14,
+                fixtures_dir=self.config.fixtures_dir,
+                allow_network=self.config.allow_network,
+            )
+        else:
+            ctx.cnpj14 = cnpj14
+            if self.config.fixtures_dir and ctx.fixtures_dir is None:
+                ctx.fixtures_dir = self.config.fixtures_dir
+            ctx.allow_network = self.config.allow_network or ctx.allow_network
+
+        observations = []
+        used: list[str] = []
+        skipped: list[str] = []
+        razao = None
+        porte = None
+        mei = None
+
+        for adapter in self.config.adapters:
+            name = getattr(adapter, "name", type(adapter).__name__)
+            try:
+                obs = adapter.collect(ctx)
+            except Exception as exc:  # noqa: BLE001 — fail soft per adapter
+                skipped.append(f"{name}:error:{type(exc).__name__}")
+                continue
+            if obs:
+                used.append(name)
+                observations.extend(obs)
+                for o in obs:
+                    if o.razao_social and not razao:
+                        razao = o.razao_social
+                    if o.company_size and not porte:
+                        porte = o.company_size
+            else:
+                skipped.append(f"{name}:empty")
+
+        # Registry record porte for small firm
+        if ctx.registry_record:
+            porte = porte or ctx.registry_record.get("company_size") or ctx.registry_record.get("porte")
+            mei = ctx.registry_record.get("mei")
+            razao = razao or ctx.registry_record.get("legal_name") or ctx.registry_record.get("razao_social")
+
+        small = is_small_firm_porte(str(porte) if porte else None, mei=mei if isinstance(mei, bool) else None)
+        candidates = observations_to_candidates(
+            observations,
+            cnpj14=cnpj14,
+            account_key=key,
+            check_mx=self.config.check_mx,
+            mx_resolver=self.config.mx_resolver,
+        )
+        ranked, rec_id = select_recommended(
+            candidates,
+            service_context=self.config.service_context,
+            small_firm=small,
+        )
+
+        base.razao_social = razao
+        base.small_firm = small
+        base.candidates = ranked
+        base.recommended_candidate_id = rec_id
+        base.adapters_used = used
+        base.adapters_skipped = skipped
+        if not ranked:
+            base.absence_reason = "no_public_business_contact_found"
+            base.limitations.append("Absence remains absence — no fabricated contacts")
+        if self.config.cache:
+            self.config.cache.set(ck, base.as_dict())
+        return base
+
+    def resolve_batch(
+        self,
+        cnpjs: list[str],
+        *,
+        max_workers: int | None = None,
+    ) -> list[AccountContactResolution]:
+        workers = max_workers if max_workers is not None else self.config.max_workers
+        workers = max(1, min(workers, 16))
+        results: dict[int, AccountContactResolution] = {}
+        if workers == 1 or len(cnpjs) <= 1:
+            return [self.resolve_one(c) for c in cnpjs]
+
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futs = {ex.submit(self.resolve_one, c): i for i, c in enumerate(cnpjs)}
+            for fut in as_completed(futs):
+                i = futs[fut]
+                try:
+                    results[i] = fut.result()
+                except Exception as exc:  # noqa: BLE001
+                    c = cnpjs[i]
+                    results[i] = AccountContactResolution(
+                        cnpj14=_digits(c),
+                        account_key=_digits(c),
+                        absence_reason=f"resolver_error:{type(exc).__name__}",
+                        resolved_at=_now(),
+                        limitations=[str(exc)],
+                    )
+        return [results[i] for i in range(len(cnpjs))]
+
+
+def _resolution_from_dict(d: dict[str, Any]) -> AccountContactResolution:
+    """Best-effort rebuild for cache hits (ranking already applied)."""
+    from scripts.confenge_contact_resolution.models import (
+        ContactCandidate,
+        EmailVerificationLayers,
+        SourceProvenance,
+        WhatsAppBlock,
+    )
+
+    cands = []
+    for cd in d.get("candidates") or []:
+        src = cd.get("source") or {}
+        layers = cd.get("email_layers") or {}
+        wa = cd.get("whatsapp") or {}
+        cands.append(
+            ContactCandidate(
+                candidate_id=cd.get("candidate_id") or "",
+                cnpj14=cd.get("cnpj14") or d.get("cnpj14") or "",
+                account_key=cd.get("account_key") or d.get("account_key") or "",
+                name=cd.get("name"),
+                cargo=cd.get("cargo"),
+                role_class=cd.get("role_class") or "generic",
+                email=cd.get("email"),
+                email_display=cd.get("email_display"),
+                phone_raw=cd.get("phone_raw"),
+                phone_e164=cd.get("phone_e164"),
+                phone_type=cd.get("phone_type") or "unknown",
+                site=cd.get("site"),
+                linkedin_public=cd.get("linkedin_public"),
+                source=SourceProvenance(**{k: src.get(k) for k in (
+                    "source_type", "source_url", "source_document", "source_date", "observed_at", "notes"
+                ) if k in src or k == "source_type"}),
+                verification_status=cd.get("verification_status") or "NOT_AVAILABLE",
+                email_layers=EmailVerificationLayers(
+                    syntactic_ok=layers.get("syntactic_ok"),
+                    domain_ok=layers.get("domain_ok"),
+                    mx_ok=layers.get("mx_ok"),
+                    mx_checked=bool(layers.get("mx_checked")),
+                    pattern_guessed=bool(layers.get("pattern_guessed")),
+                ),
+                confidence=float(cd.get("confidence") or 0),
+                recommended=bool(cd.get("recommended")),
+                recommendation_reason=cd.get("recommendation_reason"),
+                freshness=float(cd.get("freshness") or 0.7),
+                freshness_days=cd.get("freshness_days"),
+                dnc=bool(cd.get("dnc")),
+                bounce=bool(cd.get("bounce")),
+                dnc_reason=cd.get("dnc_reason"),
+                whatsapp=WhatsAppBlock(
+                    consent_status=wa.get("consent_status") or "UNKNOWN",
+                    consent_provenance=wa.get("consent_provenance"),
+                    e164=wa.get("e164"),
+                ),
+                rank_score=float(cd.get("rank_score") or 0),
+                rank_explain=list(cd.get("rank_explain") or []),
+                enrollable=bool(cd.get("enrollable")),
+                epistemic_class=cd.get("epistemic_class") or "OBSERVED_PUBLIC",
+                limitations=list(cd.get("limitations") or []),
+            )
+        )
+    # fix source default if empty
+    for c in cands:
+        if not c.source.source_type:
+            c.source.source_type = "unknown"
+
+    return AccountContactResolution(
+        cnpj14=d.get("cnpj14") or "",
+        account_key=d.get("account_key") or "",
+        razao_social=d.get("razao_social"),
+        service_context=d.get("service_context") or ServiceContext.GENERIC.value,
+        small_firm=bool(d.get("small_firm")),
+        candidates=cands,
+        recommended_candidate_id=d.get("recommended_candidate_id"),
+        absence_reason=d.get("absence_reason"),
+        adapters_used=list(d.get("adapters_used") or []),
+        adapters_skipped=list(d.get("adapters_skipped") or []),
+        cache_hit=bool(d.get("cache_hit")),
+        resolved_at=d.get("resolved_at"),
+        limitations=list(d.get("limitations") or []),
+    )

--- a/scripts/confenge_contact_resolution/role_map.py
+++ b/scripts/confenge_contact_resolution/role_map.py
@@ -1,0 +1,102 @@
+"""Map free-text cargo/função to role_class enum."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from scripts.confenge_contact_resolution.models import RoleClass
+
+
+def _fold(s: str) -> str:
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", s.lower()).strip()
+
+
+# Ordered rules: first match wins.
+# Use stem prefixes (no trailing \b on stems) so "licitacoes" matches "licitac".
+# Prefer domain function (contratos/licitacoes/…) over bare hierarchy titles when both appear.
+_RULES: list[tuple[re.Pattern[str], str]] = [
+    # Domain roles first (more specific than "diretor")
+    (
+        re.compile(
+            r"\b(licitac\w*|pregao\w*|preg[aã]o\w*|edital(?:es)?|"
+            r"captacao\w*|capta[cç][aã]o de contratos)"
+        ),
+        RoleClass.LICITACOES.value,
+    ),
+    (
+        re.compile(
+            r"\b(contratos?\b|aditivo\w*|reajuste\w*|reequil\w*|"
+            r"medi[cç][aã]o contratual)"
+        ),
+        RoleClass.CONTRATOS.value,
+    ),
+    (
+        re.compile(
+            r"\b(engenh\w*|or[cç]ament\w*|medi[cç][aã]o(?:es)?\b|"
+            r"obras?\b|fiscal de obra|projetista\w*)"
+        ),
+        RoleClass.ENGENHARIA.value,
+    ),
+    (
+        re.compile(
+            r"\b(financeir\w*|controller\b|contab\w*|tesourar\w*|"
+            r"cobranca\w*|cobran[cç]a\w*|faturamento\w*)"
+        ),
+        RoleClass.FINANCEIRO.value,
+    ),
+    (
+        re.compile(
+            r"\b(comercial\w*|vendas?\b|sales\b|business development|"
+            r"relacionamento\b|account\b)"
+        ),
+        RoleClass.COMERCIAL.value,
+    ),
+    (
+        re.compile(
+            r"\b(propriet\w*|s[oó]cios?\b|socio\b|dono\b|owner\b|"
+            r"fundador\w*|\bmei\b)"
+        ),
+        RoleClass.OWNER.value,
+    ),
+    (
+        re.compile(
+            r"\b(diretor\w*|diretoria\b|ceo\b|cto\b|cfo\b|presidente\b|"
+            r"vp\b|vice[- ]presidente\b|superintendente\w*)"
+        ),
+        RoleClass.DIRETORIA.value,
+    ),
+]
+
+
+def map_role_class(cargo: str | None, *, name_hint: str | None = None) -> str:
+    """Return role_class from cargo text; generic if unknown.
+
+    Absence of cargo → generic. Never invents a decision-maker title.
+    """
+    text = " ".join(x for x in (cargo or "", name_hint or "") if x)
+    if not text.strip():
+        return RoleClass.GENERIC.value
+    folded = _fold(text)
+    for pat, role in _RULES:
+        if pat.search(folded):
+            return role
+    return RoleClass.GENERIC.value
+
+
+def is_small_firm_porte(porte: str | None, *, mei: bool | None = None) -> bool:
+    """Heuristic: ME/EPP/MEI or explicit small size codes → small firm ranking bias."""
+    if mei is True:
+        return True
+    if not porte:
+        return False
+    p = _fold(str(porte))
+    if p in {"05", "5", "demais", "grande"}:
+        return False
+    if any(x in p for x in ("mei", "epp", "micro", "pequeno", " me", "me ")):
+        return True
+    if p in {"01", "02", "03", "me"}:
+        return True
+    return False

--- a/tests/confenge_contact_resolution/__init__.py
+++ b/tests/confenge_contact_resolution/__init__.py
@@ -1,0 +1,1 @@
+# Tests for CONFENGE public business contact resolution

--- a/tests/confenge_contact_resolution/test_email_phone_policy.py
+++ b/tests/confenge_contact_resolution/test_email_phone_policy.py
@@ -1,0 +1,111 @@
+"""Unit tests for email layers, BR E.164, WhatsApp consent defaults."""
+
+from __future__ import annotations
+
+from scripts.confenge_contact_resolution.email_policy import (
+    assess_email,
+    is_functional_mailbox,
+    looks_like_personal_pattern,
+    syntactic_ok,
+)
+from scripts.confenge_contact_resolution.models import VerificationStatus, WhatsAppConsent
+from scripts.confenge_contact_resolution.phone_policy import (
+    assess_phone,
+    classify_phone_type,
+    default_whatsapp_block,
+    normalize_br_e164,
+)
+
+
+def test_syntactic_and_functional_email() -> None:
+    a = assess_email("contato@empresa.com.br")
+    assert a.verification_status == VerificationStatus.OBSERVED.value
+    assert a.is_functional is True
+    assert a.enrollable is True
+    assert a.email_display == "contato@empresa.com.br"
+    assert is_functional_mailbox("comercial@foo.com.br")
+
+
+def test_pattern_guessed_never_enrollable() -> None:
+    a = assess_email("joao.silva@empresa.com.br", pattern_guessed=True)
+    assert a.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value
+    assert a.enrollable is False
+    assert a.layers.pattern_guessed is True
+
+
+def test_observed_nominal_email_preserved_exact() -> None:
+    raw = "Joao.Silva@Construtora-XYZ.com.br"
+    a = assess_email(raw, pattern_guessed=False)
+    assert a.verification_status == VerificationStatus.OBSERVED.value
+    assert a.email_display == raw
+    assert a.email == raw.lower()
+    assert a.enrollable is True
+
+
+def test_invalid_syntax() -> None:
+    a = assess_email("not-an-email")
+    assert a.verification_status == VerificationStatus.SYNTAX_INVALID.value
+    assert a.enrollable is False
+    assert not syntactic_ok("@@@")
+
+
+def test_mx_layer_injected() -> None:
+    a = assess_email(
+        "contato@empresa.com.br",
+        check_mx_flag=True,
+        mx_resolver=lambda d: d == "empresa.com.br",
+    )
+    assert a.layers.mx_checked is True
+    assert a.layers.mx_ok is True
+
+
+def test_e164_mobile_and_landline() -> None:
+    mobile = normalize_br_e164("(48) 99999-1234")
+    assert mobile == "+5548999991234"
+    assert classify_phone_type(mobile) == "mobile"
+
+    land = normalize_br_e164("48 3333-4444")
+    assert land == "+554833334444"
+    assert classify_phone_type(land) == "landline"
+
+    with_cc = normalize_br_e164("+55 11 98888-7777")
+    assert with_cc == "+5511988887777"
+
+    assert normalize_br_e164("123") is None
+    assert normalize_br_e164("48988887777")  # 11 digits
+    invalid = assess_phone("abc")
+    assert invalid.valid is False
+    assert invalid.phone_e164 is None
+
+
+def test_landline_assessment() -> None:
+    a = assess_phone("48 3222-1000")
+    assert a.valid is True
+    assert a.phone_type == "landline"
+    assert a.phone_e164 == "+554832221000"
+
+
+def test_whatsapp_consent_defaults() -> None:
+    wa = default_whatsapp_block("+5548999991234")
+    assert wa.consent_status in {
+        WhatsAppConsent.UNKNOWN.value,
+        WhatsAppConsent.NO_OPT_IN.value,
+    }
+    assert wa.consent_status != WhatsAppConsent.OPTED_IN.value
+
+    # OPTED_IN without provenance fails closed
+    wa2 = default_whatsapp_block("+5548999991234", consent_status="OPTED_IN")
+    assert wa2.consent_status != WhatsAppConsent.OPTED_IN.value
+
+    wa3 = default_whatsapp_block(
+        "+5548999991234",
+        consent_status="OPTED_IN",
+        consent_provenance="form_submit:2026-01-01:landing-page-x",
+    )
+    assert wa3.consent_status == WhatsAppConsent.OPTED_IN.value
+    assert wa3.consent_provenance is not None
+
+
+def test_personal_pattern_detector() -> None:
+    assert looks_like_personal_pattern("maria.souza@acme.com")
+    assert not looks_like_personal_pattern("contato@acme.com")

--- a/tests/confenge_contact_resolution/test_ranking_and_merge.py
+++ b/tests/confenge_contact_resolution/test_ranking_and_merge.py
@@ -122,6 +122,64 @@ def test_pattern_guess_not_recommended_primary() -> None:
     assert winner.email == "contato@empresa.com.br"
 
 
+def test_pattern_guess_sole_candidate_with_phone_never_recommended() -> None:
+    """Regression: CANDIDATE_UNVERIFIED must never be recommended-primary even with mobile."""
+    obs = [
+        _obs(
+            name="João Silva",
+            cargo="Diretor",
+            email="joao.silva@empresa.com.br",
+            phone_raw="48999991234",
+            pattern_guessed_email=True,
+        ),
+    ]
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    assert len(cands) == 1
+    assert cands[0].verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value
+    assert cands[0].phone_e164  # phone present — previously allowed recommend
+    ranked, rec = select_recommended(cands)
+    assert rec is None
+    assert all(not c.recommended for c in ranked)
+    assert all(not c.enrollable for c in ranked)
+
+
+def test_account_level_dnc_blocks_all_recommendations() -> None:
+    """Human-outcome DNC without email/phone is account-wide and dominates."""
+    from scripts.confenge_contact_resolution.merge import account_block_from_observations
+
+    obs = [
+        _obs(
+            name="Vendas",
+            cargo="Comercial",
+            email="vendas@x.com.br",
+            phone_raw="48988886666",
+        ),
+        RawObservation(
+            adapter="human_outcome",
+            cnpj14="12345678000199",
+            name=None,
+            cargo=None,
+            email=None,
+            phone_raw=None,
+            dnc=True,
+            dnc_reason="DO_NOT_CONTACT",
+            source=SourceProvenance(source_type="human_outcome", source_date="2026-07-01"),
+            epistemic_class="HUMAN_OUTCOME",
+        ),
+    ]
+    account_dnc, account_bounce, reason = account_block_from_observations(obs)
+    assert account_dnc is True
+    assert account_bounce is False
+    assert reason == "DO_NOT_CONTACT"
+
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    ranked, rec = select_recommended(cands, account_dnc=account_dnc, account_bounce=account_bounce)
+    assert rec is None
+    assert all(not c.recommended for c in ranked)
+    # vendas still present as candidate (absence of inventing wipe), but not recommended
+    assert any(c.email == "vendas@x.com.br" for c in ranked)
+
+
 def test_conflicting_sources_dedupe_by_email() -> None:
     obs = [
         _obs(

--- a/tests/confenge_contact_resolution/test_ranking_and_merge.py
+++ b/tests/confenge_contact_resolution/test_ranking_and_merge.py
@@ -1,0 +1,181 @@
+"""Ranking, DNC dominance, conflicts, stale freshness."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from scripts.confenge_contact_resolution.freshness import freshness_score
+from scripts.confenge_contact_resolution.merge import observations_to_candidates
+from scripts.confenge_contact_resolution.models import (
+    RawObservation,
+    RoleClass,
+    ServiceContext,
+    SourceProvenance,
+    VerificationStatus,
+)
+from scripts.confenge_contact_resolution.ranking import select_recommended
+from scripts.confenge_contact_resolution.role_map import map_role_class
+
+
+def _obs(**kwargs) -> RawObservation:
+    defaults = {
+        "adapter": "site",
+        "cnpj14": "12345678000199",
+        "source": SourceProvenance(source_type="site", source_date="2026-06-01"),
+    }
+    defaults.update(kwargs)
+    return RawObservation(**defaults)
+
+
+def test_role_map() -> None:
+    assert map_role_class("Diretor de Contratos") == RoleClass.CONTRATOS.value
+    assert map_role_class("Gerente de Licitações") == RoleClass.LICITACOES.value
+    assert map_role_class("Engenheiro de orçamento") == RoleClass.ENGENHARIA.value
+    assert map_role_class(None) == RoleClass.GENERIC.value
+
+
+def test_service_aware_ranking_claims_prefers_contratos() -> None:
+    obs = [
+        _obs(
+            name="Ana Contratos",
+            cargo="Gerente de Contratos",
+            email="ana.contratos@obra.com.br",
+            phone_raw="48999991111",
+        ),
+        _obs(
+            name="Bob Vendas",
+            cargo="Comercial",
+            email="comercial@obra.com.br",
+            phone_raw="48999992222",
+            adapter="contact_page",
+            source=SourceProvenance(source_type="contact_page", source_date="2026-06-01"),
+        ),
+    ]
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    ranked, rec = select_recommended(cands, service_context=ServiceContext.CLAIMS_REAJUSTE.value)
+    assert rec is not None
+    winner = next(c for c in ranked if c.recommended)
+    assert winner.role_class == RoleClass.CONTRATOS.value
+    assert winner.recommendation_reason
+
+
+def test_licitacoes_prefers_licitacoes_role() -> None:
+    obs = [
+        _obs(name="Li", cargo="Analista de Licitações", email="licitacao@x.com.br", phone_raw="1133334444"),
+        _obs(name="Fi", cargo="Financeiro", email="financeiro@x.com.br", phone_raw="1133335555"),
+    ]
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    ranked, _ = select_recommended(cands, service_context=ServiceContext.LICITACOES.value)
+    assert next(c for c in ranked if c.recommended).role_class == RoleClass.LICITACOES.value
+
+
+def test_dnc_blocks_recommendation() -> None:
+    obs = [
+        _obs(
+            name="Blocked",
+            cargo="Diretor",
+            email="diretor@x.com.br",
+            phone_raw="48988887777",
+            dnc=True,
+            dnc_reason="DO_NOT_CONTACT",
+            adapter="human_outcome",
+            source=SourceProvenance(source_type="human_outcome", source_date="2026-07-01"),
+        ),
+        _obs(
+            name="Alt",
+            cargo="Comercial",
+            email="contato@x.com.br",
+            phone_raw="48988886666",
+        ),
+    ]
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    ranked, rec = select_recommended(cands, service_context=ServiceContext.GENERIC.value)
+    dnc_ones = [c for c in ranked if c.dnc]
+    assert dnc_ones
+    assert all(not c.recommended for c in dnc_ones)
+    assert rec is not None
+    winner = next(c for c in ranked if c.recommended)
+    assert not winner.dnc
+
+
+def test_pattern_guess_not_recommended_primary() -> None:
+    obs = [
+        _obs(
+            name="Guessed",
+            cargo="Diretor",
+            email="joao.silva@empresa.com.br",
+            pattern_guessed_email=True,
+        ),
+        _obs(
+            name=None,
+            cargo=None,
+            email="contato@empresa.com.br",
+        ),
+    ]
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    ranked, rec = select_recommended(cands)
+    guessed = [c for c in ranked if c.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value]
+    assert guessed
+    assert all(not c.recommended for c in guessed)
+    assert all(not c.enrollable for c in guessed)
+    winner = next(c for c in ranked if c.candidate_id == rec)
+    assert winner.email == "contato@empresa.com.br"
+
+
+def test_conflicting_sources_dedupe_by_email() -> None:
+    obs = [
+        _obs(
+            email="contato@empresa.com.br",
+            phone_raw="4833331111",
+            adapter="registry",
+            source=SourceProvenance(source_type="registry", source_date="2025-01-01"),
+        ),
+        _obs(
+            email="contato@empresa.com.br",
+            phone_raw="4833332222",
+            adapter="site",
+            source=SourceProvenance(source_type="site", source_date="2026-05-01"),
+        ),
+    ]
+    cands = observations_to_candidates(obs, cnpj14="12345678000199")
+    # same email → one candidate
+    emails = [c.email for c in cands if c.email]
+    assert emails.count("contato@empresa.com.br") == 1
+    assert len([c for c in cands if c.email == "contato@empresa.com.br"]) == 1
+
+
+def test_stale_contact_loses_confidence() -> None:
+    fresh_f, _ = freshness_score("2026-06-01", as_of=date(2026, 8, 1))
+    stale_f, age = freshness_score("2018-01-01", as_of=date(2026, 8, 1))
+    assert age is not None and age > 1000
+    assert stale_f < fresh_f
+
+    obs_stale = [
+        _obs(
+            email="velho@empresa.com.br",
+            phone_raw="48999990000",
+            cargo="Diretor",
+            name="Velho",
+            source=SourceProvenance(source_type="public_docs", source_date="2018-01-01"),
+        )
+    ]
+    obs_fresh = [
+        _obs(
+            email="novo@empresa.com.br",
+            phone_raw="48999991111",
+            cargo="Comercial",
+            name="Novo",
+            source=SourceProvenance(source_type="site", source_date="2026-07-01"),
+        )
+    ]
+    stale_c = observations_to_candidates(obs_stale, cnpj14="12345678000199")[0]
+    fresh_c = observations_to_candidates(obs_fresh, cnpj14="12345678000199")[0]
+    assert stale_c.freshness < fresh_c.freshness
+    assert stale_c.confidence < fresh_c.confidence
+
+
+def test_total_absence() -> None:
+    cands = observations_to_candidates([], cnpj14="12345678000199")
+    ranked, rec = select_recommended(cands)
+    assert ranked == []
+    assert rec is None

--- a/tests/confenge_contact_resolution/test_resolver_and_cli.py
+++ b/tests/confenge_contact_resolution/test_resolver_and_cli.py
@@ -1,0 +1,426 @@
+"""Integration tests: resolver with synthetic fixtures + real CLI entry points."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.confenge_contact_resolution.adapters.base import AdapterContext
+from scripts.confenge_contact_resolution.adapters.contact_pages import ContactPageAdapter
+from scripts.confenge_contact_resolution.adapters.public_docs import PublicDocsAdapter
+from scripts.confenge_contact_resolution.adapters.registry import RegistryAdapter
+from scripts.confenge_contact_resolution.adapters.site import SiteAdapter
+from scripts.confenge_contact_resolution.adapters.web_search import NoOpWebSearchProvider, WebSearchAdapter
+from scripts.confenge_contact_resolution.cache import ResolutionCache
+from scripts.confenge_contact_resolution.export import (
+    CANDIDATES_FILENAME,
+    MANIFEST_FILENAME,
+    write_resolution_artifacts,
+)
+from scripts.confenge_contact_resolution.models import ServiceContext, VerificationStatus
+from scripts.confenge_contact_resolution.resolver import ContactResolver, ResolverConfig
+
+CNPJ_A = "11222333000181"
+CNPJ_B = "44555666000172"
+CNPJ_ABSENT = "99888777000166"
+
+
+def _adapters_offline():
+    return [
+        RegistryAdapter(prefer_network=False),
+        SiteAdapter(),
+        PublicDocsAdapter(),
+        ContactPageAdapter(),
+        WebSearchAdapter(provider=NoOpWebSearchProvider(), enabled=False),
+    ]
+
+
+def _ctx_builder(base: dict[str, AdapterContext]):
+    def build(cnpj14: str) -> AdapterContext:
+        return base.get(
+            cnpj14,
+            AdapterContext(cnpj14=cnpj14, allow_network=False),
+        )
+
+    return build
+
+
+@pytest.fixture
+def synthetic_contexts() -> dict[str, AdapterContext]:
+    """Synthetic multi-case fixtures — no network, no real PII of third parties."""
+    return {
+        CNPJ_A: AdapterContext(
+            cnpj14=CNPJ_A,
+            allow_network=False,
+            registry_record={
+                "email": "contato@acme-engenharia.example",
+                "phone": "4832221000",
+                "legal_name": "ACME Engenharia LTDA",
+                "company_size": "EPP",
+                "source_date": "2026-01-15",
+                "official_match_status": "MATCHED",
+            },
+            site_pages=[
+                {
+                    "url": "https://acme-engenharia.example/contato",
+                    "source_date": "2026-05-01",
+                    "contacts": [
+                        {
+                            "name": "Carla Diretora",
+                            "cargo": "Diretora Técnica",
+                            "email": "carla.diretora@acme-engenharia.example",
+                            "phone": "48999991234",
+                        },
+                        {
+                            "name": "Guessed Person",
+                            "cargo": "Diretor",
+                            "email": "joao.silva@acme-engenharia.example",
+                            "pattern_guessed_email": True,
+                        },
+                    ],
+                }
+            ],
+            public_docs=[
+                {
+                    "document_id": "contrato-pncp-1",
+                    "source_date": "2019-03-01",
+                    "name": "Rep Antigo",
+                    "cargo": "Representante",
+                    "email": "antigo@acme-engenharia.example",
+                    "phone": "4833330000",
+                    "url": "https://pncp.example/doc/1",
+                }
+            ],
+            contact_pages=[
+                {
+                    "url": "https://acme-engenharia.example/equipe",
+                    "source_date": "2026-04-01",
+                    "people": [
+                        {
+                            "name": "Pedro Licitações",
+                            "cargo": "Coordenador de Licitações",
+                            "email": "licitacoes@acme-engenharia.example",
+                            "phone": "48988887777",
+                        }
+                    ],
+                }
+            ],
+            human_outcomes=[],
+        ),
+        CNPJ_B: AdapterContext(
+            cnpj14=CNPJ_B,
+            allow_network=False,
+            registry_record={
+                "email": "financeiro@beta.example",
+                "phone": "11999998888",
+                "legal_name": "Beta Construtora SA",
+                "company_size": "DEMAIS",
+                "source_date": "2026-02-01",
+                "official_match_status": "MATCHED",
+            },
+            human_outcomes=[
+                {
+                    "cnpj14": CNPJ_B,
+                    "email": "financeiro@beta.example",
+                    "dnc": True,
+                    "dnc_reason": "DO_NOT_CONTACT",
+                    "state": "DO_NOT_CONTACT",
+                    "source_date": "2026-07-01",
+                }
+            ],
+            contact_pages=[
+                {
+                    "url": "https://beta.example/contato",
+                    "source_date": "2026-06-01",
+                    "people": [
+                        {
+                            "name": "Outro Canal",
+                            "cargo": "Comercial",
+                            "email": "vendas@beta.example",
+                            "phone": "11977776666",
+                        }
+                    ],
+                }
+            ],
+        ),
+        CNPJ_ABSENT: AdapterContext(
+            cnpj14=CNPJ_ABSENT,
+            allow_network=False,
+            registry_record={"official_match_status": "MATCHED", "legal_name": "Vazia LTDA"},
+        ),
+    }
+
+
+def test_resolver_generic_email_nominal_dnc_absence(synthetic_contexts, tmp_path: Path) -> None:
+    cache = ResolutionCache(tmp_path / "cache", ttl_seconds=3600)
+    cfg = ResolverConfig(
+        service_context=ServiceContext.LICITACOES.value,
+        adapters=_adapters_offline(),
+        cache=cache,
+        allow_network=False,
+        context_builder=_ctx_builder(synthetic_contexts),
+        max_workers=2,
+    )
+    resolver = ContactResolver(cfg)
+
+    r_a = resolver.resolve_one(CNPJ_A)
+    assert r_a.candidates
+    assert r_a.schema_id == "confenge-contact-candidates-v1"
+    emails = {c.email for c in r_a.candidates if c.email}
+    assert "contato@acme-engenharia.example" in emails  # functional/generic from registry
+    # nominal decision-maker
+    assert any(c.name == "Carla Diretora" for c in r_a.candidates)
+    # pattern guessed
+    guessed = [c for c in r_a.candidates if c.verification_status == VerificationStatus.CANDIDATE_UNVERIFIED.value]
+    assert guessed
+    assert all(not c.recommended for c in guessed)
+    assert all(not c.enrollable for c in guessed)
+    # recommended exists for licitacoes → prefer licitacoes role
+    assert r_a.recommended_candidate_id
+    rec = next(c for c in r_a.candidates if c.recommended)
+    assert rec.role_class == "licitações"
+    # landline from registry phone
+    assert any(c.phone_type == "landline" for c in r_a.candidates if c.phone_e164)
+    # mobile
+    assert any(c.phone_type == "mobile" for c in r_a.candidates if c.phone_e164)
+    # whatsapp default not OPTED_IN
+    for c in r_a.candidates:
+        if c.phone_e164:
+            assert c.whatsapp.consent_status in {"UNKNOWN", "NO_OPT_IN"}
+
+    # stale has lower freshness
+    stale = next(c for c in r_a.candidates if c.email == "antigo@acme-engenharia.example")
+    freshish = next(c for c in r_a.candidates if c.email == "licitacoes@acme-engenharia.example")
+    assert stale.freshness < freshish.freshness
+
+    r_b = resolver.resolve_one(CNPJ_B)
+    dnc = [c for c in r_b.candidates if c.dnc]
+    assert dnc
+    assert all(not c.recommended for c in dnc)
+    assert r_b.recommended_candidate_id
+    assert not next(c for c in r_b.candidates if c.recommended).dnc
+
+    r_abs = resolver.resolve_one(CNPJ_ABSENT)
+    assert r_abs.candidates == []
+    assert r_abs.absence_reason == "no_public_business_contact_found"
+    assert r_abs.recommended_candidate_id is None
+
+
+def test_invalid_phone_not_e164(synthetic_contexts) -> None:
+    ctx = AdapterContext(
+        cnpj14=CNPJ_A,
+        allow_network=False,
+        contact_pages=[
+            {
+                "url": "https://x.example",
+                "people": [{"name": "X", "email": "x@y.example", "phone": "not-a-phone"}],
+            }
+        ],
+    )
+    cfg = ResolverConfig(
+        adapters=_adapters_offline(),
+        allow_network=False,
+        context_builder=lambda _c: ctx,
+    )
+    r = ContactResolver(cfg).resolve_one(CNPJ_A)
+    bad = next(c for c in r.candidates if c.email == "x@y.example")
+    assert bad.phone_raw == "not-a-phone"
+    assert bad.phone_e164 is None
+
+
+def test_idempotent_cache_and_export(synthetic_contexts, tmp_path: Path) -> None:
+    cache = ResolutionCache(tmp_path / "cache", ttl_seconds=3600)
+    cfg = ResolverConfig(
+        service_context=ServiceContext.GENERIC.value,
+        adapters=_adapters_offline(),
+        cache=cache,
+        allow_network=False,
+        context_builder=_ctx_builder(synthetic_contexts),
+    )
+    resolver = ContactResolver(cfg)
+    r1 = resolver.resolve_one(CNPJ_A)
+    r2 = resolver.resolve_one(CNPJ_A)
+    assert r2.cache_hit is True
+    assert len(r1.candidates) == len(r2.candidates)
+    names1 = sorted((c.name or "", c.email or "") for c in r1.candidates)
+    names2 = sorted((c.name or "", c.email or "") for c in r2.candidates)
+    assert names1 == names2
+
+    out = tmp_path / "out1"
+    s1 = write_resolution_artifacts([r1], out, mode="single", service_context="generic", run_id="run-a")
+    s2 = write_resolution_artifacts([r2], out, mode="single", service_context="generic", run_id="run-a")
+    assert (out / CANDIDATES_FILENAME).is_file()
+    assert (out / MANIFEST_FILENAME).is_file()
+    # second write does not invent people
+    lines = (out / CANDIDATES_FILENAME).read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["schema_id"] == "confenge-contact-candidates-v1"
+    assert rec["schema_version"]
+    assert "candidates" in rec
+    assert s1["checksum_sha256"]  # may differ if resolved_at changes; presence is enough
+    assert s2["ok"] is True
+
+
+def test_batch_resolve(synthetic_contexts, tmp_path: Path) -> None:
+    cfg = ResolverConfig(
+        adapters=_adapters_offline(),
+        allow_network=False,
+        context_builder=_ctx_builder(synthetic_contexts),
+        max_workers=2,
+    )
+    results = ContactResolver(cfg).resolve_batch([CNPJ_A, CNPJ_B, CNPJ_ABSENT])
+    assert len(results) == 3
+    assert results[2].absence_reason
+
+
+def test_cli_single_and_batch_idempotent(synthetic_contexts, tmp_path: Path) -> None:
+    """Drive real CLI module; fixtures via fixtures-dir files."""
+    fix = tmp_path / "fixtures"
+    fix.mkdir()
+    # Write fixture files consumed by adapters
+    (fix / f"{CNPJ_A}_site.json").write_text(
+        json.dumps(
+            {
+                "url": "https://acme.example/contato",
+                "source_date": "2026-05-01",
+                "contacts": [
+                    {
+                        "name": "Carla",
+                        "cargo": "Diretora",
+                        "email": "carla@acme.example",
+                        "phone": "48999990000",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fix / f"{CNPJ_A}_contact_page.json").write_text(
+        json.dumps(
+            {
+                "url": "https://acme.example/equipe",
+                "source_date": "2026-04-01",
+                "people": [
+                    {
+                        "email": "contato@acme.example",
+                        "phone": "4832221000",
+                        "cargo": "Atendimento",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    out1 = tmp_path / "cli-single-1"
+    out2 = tmp_path / "cli-single-2"
+    cmd_base = [
+        sys.executable,
+        "-m",
+        "scripts.confenge_contact_resolution",
+        "resolve",
+        "--cnpj",
+        CNPJ_A,
+        "--fixtures-dir",
+        str(fix),
+        "--no-cache",
+    ]
+    r1 = subprocess.run(
+        [*cmd_base, "-o", str(out1)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(Path(__file__).resolve().parents[2]),
+    )
+    r2 = subprocess.run(
+        [*cmd_base, "-o", str(out2)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(Path(__file__).resolve().parents[2]),
+    )
+    assert r1.returncode == 0, r1.stderr + r1.stdout
+    assert r2.returncode == 0, r2.stderr + r2.stdout
+    for out in (out1, out2):
+        jp = out / CANDIDATES_FILENAME
+        assert jp.is_file()
+        row = json.loads(jp.read_text(encoding="utf-8").strip().splitlines()[0])
+        assert row["schema_id"] == "confenge-contact-candidates-v1"
+        assert row["cnpj14"] == CNPJ_A
+        assert (out / MANIFEST_FILENAME).is_file()
+
+    # batch
+    inp = tmp_path / "cnpjs.txt"
+    inp.write_text(f"{CNPJ_A}\n{CNPJ_ABSENT}\n", encoding="utf-8")
+    outb1 = tmp_path / "cli-batch-1"
+    outb2 = tmp_path / "cli-batch-2"
+    for outb in (outb1, outb2):
+        rb = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.confenge_contact_resolution",
+                "batch",
+                "-i",
+                str(inp),
+                "-o",
+                str(outb),
+                "--fixtures-dir",
+                str(fix),
+                "--no-cache",
+                "--max-workers",
+                "2",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(Path(__file__).resolve().parents[2]),
+        )
+        assert rb.returncode == 0, rb.stderr + rb.stdout
+        lines = (outb / CANDIDATES_FILENAME).read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+        # absence not fabricated
+        rows = [json.loads(x) for x in lines]
+        absent = next(r for r in rows if r["cnpj14"] == CNPJ_ABSENT)
+        assert absent["candidates"] == []
+        assert absent.get("absence_reason")
+
+
+def test_web_search_disabled_by_default() -> None:
+    adapter = WebSearchAdapter(enabled=False)
+    assert adapter.collect(AdapterContext(cnpj14=CNPJ_A)) == []
+
+
+def test_small_firm_boosts_owner() -> None:
+    from scripts.confenge_contact_resolution.merge import observations_to_candidates
+    from scripts.confenge_contact_resolution.models import RawObservation, SourceProvenance
+    from scripts.confenge_contact_resolution.ranking import select_recommended
+
+    obs = [
+        RawObservation(
+            adapter="site",
+            cnpj14=CNPJ_A,
+            name="Dono",
+            cargo="Proprietário",
+            email="dono@me.example",
+            phone_raw="48999991111",
+            source=SourceProvenance(source_type="site", source_date="2026-06-01"),
+        ),
+        RawObservation(
+            adapter="site",
+            cnpj14=CNPJ_A,
+            name="Func",
+            cargo="Assistente",
+            email="contato@me.example",
+            phone_raw="48999992222",
+            source=SourceProvenance(source_type="site", source_date="2026-06-01"),
+        ),
+    ]
+    cands = observations_to_candidates(obs, cnpj14=CNPJ_A)
+    ranked, _ = select_recommended(cands, service_context="generic", small_firm=True)
+    assert next(c for c in ranked if c.recommended).role_class == "owner"

--- a/tests/confenge_contact_resolution/test_resolver_and_cli.py
+++ b/tests/confenge_contact_resolution/test_resolver_and_cli.py
@@ -424,3 +424,40 @@ def test_small_firm_boosts_owner() -> None:
     cands = observations_to_candidates(obs, cnpj14=CNPJ_A)
     ranked, _ = select_recommended(cands, service_context="generic", small_firm=True)
     assert next(c for c in ranked if c.recommended).role_class == "owner"
+
+
+def test_resolver_account_dnc_blocks_all(tmp_path: Path) -> None:
+    """End-to-end: account-level human DO_NOT_CONTACT blocks any recommendation."""
+    ctx = AdapterContext(
+        cnpj14=CNPJ_A,
+        allow_network=False,
+        site_pages=[
+            {
+                "url": "https://x.example",
+                "source_date": "2026-06-01",
+                "contacts": [
+                    {"name": "Vendas", "cargo": "Comercial", "email": "vendas@x.example", "phone": "48999991111"},
+                ],
+            }
+        ],
+        human_outcomes=[
+            {
+                "cnpj14": CNPJ_A,
+                "dnc": True,
+                "dnc_reason": "DO_NOT_CONTACT",
+                "state": "DO_NOT_CONTACT",
+                "source_date": "2026-07-01",
+            }
+        ],
+    )
+    cfg = ResolverConfig(
+        adapters=_adapters_offline(),
+        allow_network=False,
+        context_builder=lambda _c: ctx,
+        cache=ResolutionCache(tmp_path / "c", ttl_seconds=60),
+    )
+    r = ContactResolver(cfg).resolve_one(CNPJ_A)
+    assert r.candidates
+    assert r.recommended_candidate_id is None
+    assert all(not c.recommended for c in r.candidates)
+    assert any("account_block" in lim for lim in r.limitations)


### PR DESCRIPTION
## Objective

Build a reliable **public business contact resolution** layer for CONFENGE outreach in `extra-cli`: find the best legitimate commercial contact (not “any email”), with provenance and confidence so Warmbly can choose channel—without inventing identity.

## Architecture

Pure policy units are separate from I/O adapters:

| Layer | Responsibility |
|-------|----------------|
| `email_policy` / `phone_policy` | Exact email preservation; pattern-guess → `CANDIDATE_UNVERIFIED` never enrollable; BR E.164 + mobile/landline; WhatsApp consent defaults `UNKNOWN`/`NO_OPT_IN` |
| `role_map` / `ranking` | `role_class` mapping; service-aware explainable scores (claims/reajuste, licitações, orçamento); DNC/bounce dominate |
| `merge` / `freshness` / `cache` | Dedupe by channel, source conflict preference, TTL cache, freshness decay |
| Adapters | `registry` (RFB/`company_registry`, optional BrasilAPI), `site`, `public_docs`, `contact_page` (+ human outcomes), `web_search` (optional interface, NoOp default) |
| `resolver` + `cli` + `export` | Single CNPJ / batch; writes `confenge-contact-candidates-v1.jsonl` + `run_manifest.json` |

## Main files

- `scripts/confenge_contact_resolution/` — package (models, policies, adapters, resolver, CLI)
- `tests/confenge_contact_resolution/` — synthetic fixtures (no live outreach)
- `docs/commercial/confenge-public-business-contact-resolution.md` — usage + contracts

## Data contracts

- **Schema:** `confenge-contact-candidates-v1` / version `1.0.0`
- **JSONL:** one account resolution per line (CNPJ/account key, candidates[], recommended flag, provenance, verification_status, confidence, freshness, whatsapp.consent_status)
- **Manifest:** `confenge-contact-resolution-manifest-v1` with checksum and counts

## Commands executed

```bash
python3 -m pytest tests/confenge_contact_resolution/ --no-cov -v   # 24 passed
ruff check scripts/confenge_contact_resolution tests/confenge_contact_resolution
python3 -m scripts.confenge_contact_resolution resolve --cnpj … -o … --fixtures-dir …
python3 -m scripts.confenge_contact_resolution batch -i cnpjs.txt -o … --fixtures-dir …
```

## CI evidence

This PR targets applicable GitHub Actions on HEAD. Local suite for the new package is green (24/24). CI status will be updated after checks complete.

## Composition with CONFENGE / Warmbly

- Does **not** rewrite commercial lead scoring or purchase probability.
- Supplies channel-ready candidates with verification + consent for Warmbly/human send.
- Reuses official registry when active; absence remains absence (`NOT_AVAILABLE` / empty candidates).
- Preserves DNC/bounce and human outcomes as dominant states.

## Honest limitations

- Live MX/domain checks optional (`--check-mx`); offline/CI uses injected MX or skips.
- Web search is interface-only (NoOp unless explicitly enabled + provider).
- Institutional site / public docs adapters consume injected/fixture extracts by default (no fragile live HTML scraping in-tree).
- Registry enrichment depends on local RFB release or `--allow-network` BrasilAPI.
- Does not send outreach, verify WhatsApp account existence, or scrape private social networks.

## Test plan

- [x] Unit: generic email, nominal decisor, invalid phone, landline, E.164, WhatsApp consent
- [x] Unit: DNC blocks recommend; pattern-guess not enrollable; conflicts; stale; absence
- [x] Integration: resolver + real CLI single/batch idempotent runs with fixtures
- [ ] GitHub Actions green on this HEAD