### PR TITLE
feat(confenge): capacity-aware commercial activation planner (hot set, not Top-N backlog)

### DIFF
--- a/config/commercial/confenge_activation_policy.yaml
+++ b/config/commercial/confenge_activation_policy.yaml
@@ -1,0 +1,213 @@
+# confenge-activation-v1 — commercial activation planner policy
+# Ordering score only: never purchase probability / conversion likelihood.
+# Observational language only: temporal windows justify verification, not legal claims.
+
+policy_version: confenge-activation-v1
+
+# Capacity-aware hot set (production). Safety caps only; not Top-N commercial strategy.
+capacity:
+  sends_per_hour: 10
+  send_window_hours: 9          # e.g. 09:00–18:00
+  planning_horizon_days: 7
+  research_buffer: 1.5          # research + no-contact headroom
+  max_hot_set: 500              # hard safety cap
+  min_hot_set: 20               # avoid idle ops when capacity exists
+
+# Re-evaluation defaults when no stronger trigger applies
+reevaluation:
+  watch_days: 14
+  research_required_days: 3
+  actionable_ttl_days: 14
+  suppressed_no_next_action: true
+
+# Score weights (must sum to 100). Ordering only.
+score_weights:
+  trigger_strength: 40
+  freshness: 25
+  evidence_quality: 20
+  commercial_relevance: 15
+
+# Materiality: contract value is log-damped and capped so mega-contracts cannot monopolize.
+materiality:
+  value_log_cap: 12.0           # max points from log10(1 + value/1e5)
+  value_weight_in_relevance: 0.35
+  portfolio_breadth_weight: 0.40
+  construction_fit_weight: 0.25
+
+# Dominant commercial states → SUPPRESSED (human-dominant; never overridden by triggers)
+suppressed_states:
+  - DO_NOT_CONTACT
+  - DNC
+  - WON
+  - LOST
+  - BLOCKED
+
+# States that block cold re-outreach (still monitored; not ACTIONABLE_NOW cold)
+active_commercial_block:
+  - REPLIED
+  - MEETING
+  - PROPOSAL
+  - SENT
+  - ENROLLED
+
+triggers:
+  NEW_RELEVANT_CONTRACT:
+    enabled: true
+    strength: 34
+    # last_contract_date within N days of as_of
+    recency_days: 45
+    requires_relevant_construction: true
+    language: >
+      Contrato relevante recente observado no portfólio público.
+      Não afirma direito econômico nem obrigação de reajuste.
+    expires_days: 30
+    promotes_to: ACTIONABLE_NOW
+    next_best_action: now
+
+  MATERIAL_PORTFOLIO_CHANGE:
+    enabled: true
+    strength: 28
+    # active_contract_count or contract_count_recent delta vs prior projection
+    min_active_delta: 2
+    min_recent_delta: 3
+    language: >
+      Mudança material no portfólio de contratos observados desde a última avaliação.
+    expires_days: 21
+    promotes_to: ACTIONABLE_NOW
+    next_best_action: now
+
+  CONTRACT_ANNIVERSARY_WINDOW:
+    enabled: true
+    strength: 22
+    # Days from first_contract_date or last_contract_date anniversary (±window)
+    anniversary_window_days: 30
+    # Minimum age of contract relationship before anniversary is meaningful
+    min_contract_age_days: 300
+    language: >
+      Contrato/portfólio atingiu janela temporal que justifica verificar
+      formalização de reajuste ou atualização. Não afirma que reajuste é devido.
+    expires_days: 45
+    promotes_to: RESEARCH_REQUIRED
+    next_best_action: now
+
+  NEW_AMENDMENT_OR_TERM:
+    enabled: true
+    strength: 36
+    # Only when portfolio recent_contracts or signals explicitly mention aditivo/termo
+    object_keywords:
+      - aditivo
+      - termo aditivo
+      - apostilamento
+      - termo de apostila
+    language: >
+      Documento ou objeto contratual compatível com aditivo/termo observado.
+      Não afirma validade jurídica nem valor do aditivo.
+    expires_days: 30
+    promotes_to: ACTIONABLE_NOW
+    next_best_action: now
+
+  CONTRACT_ENDING_WINDOW:
+    enabled: true
+    strength: 30
+    # data_fim within [0, ending_within_days]
+    ending_within_days: 90
+    language: >
+      Vigência observada se aproxima do fim (data_fim pública). Justifica
+      verificação de prorrogação ou nova contratação. Não afirma renovação automática.
+    expires_days: 60
+    promotes_to: ACTIONABLE_NOW
+    next_best_action: now
+
+  CONTRACT_EXTENSION_OR_PROROGATION:
+    enabled: true
+    strength: 32
+    object_keywords:
+      - prorrog
+      - renovação
+      - renovacao
+      - extensão de prazo
+      - extensao de prazo
+    language: >
+      Sinal textual de prorrogação/renovação em objeto público. Observacional.
+    expires_days: 30
+    promotes_to: ACTIONABLE_NOW
+    next_best_action: now
+
+  NEW_RELEVANT_PROCESS_DOCUMENT:
+    enabled: true
+    strength: 24
+    # Requires external document watermark signal when available; otherwise OFF path
+    language: >
+      Documento de processo relevante novo observado. Justifica pesquisa, não envio automático.
+    expires_days: 21
+    promotes_to: RESEARCH_REQUIRED
+    next_best_action: now
+
+  NEW_RELEVANT_PROCUREMENT:
+    enabled: true
+    strength: 26
+    object_keywords:
+      - pregão
+      - pregao
+      - concorrência
+      - concorrencia
+      - dispensa
+      - inexigibilidade
+      - RDC
+    language: >
+      Sinal de contratação/licitação relevante no objeto. Observacional.
+    expires_days: 21
+    promotes_to: RESEARCH_REQUIRED
+    next_best_action: now
+
+  MATERIAL_CONTRACT_CHANGE:
+    enabled: true
+    strength: 30
+    # Triggered when source_hash of portfolio changes materially vs prior
+    language: >
+      Alteração material em contrato(s) observados (hash de portfólio divergente).
+    expires_days: 21
+    promotes_to: ACTIONABLE_NOW
+    next_best_action: now
+
+  RESEARCH_GAP_WORTH_RESOLVING:
+    enabled: true
+    strength: 18
+    # High construction fit + recent activity but thin messaging/intel
+    min_priority_score: 50
+    max_days_since_last_contract: 120
+    language: >
+      Lacuna de pesquisa comercialmente justificável: atividade recente com fit
+      de construção, sem dossiê suficiente para outreach factual.
+    expires_days: 14
+    promotes_to: RESEARCH_REQUIRED
+    next_best_action: now
+
+# Freshness decay: days since strongest trigger event → freshness component (0–100 scale before weight)
+freshness_bands:
+  - max_days: 7
+    score: 100
+  - max_days: 21
+    score: 80
+  - max_days: 45
+    score: 55
+  - max_days: 90
+    score: 30
+  - max_days: 99999
+    score: 10
+
+# Evidence quality from epistemic signals available on universe rows
+evidence_quality:
+  confirmed_engineering: 90
+  strong_engineering_fit: 70
+  possible_engineering_fit: 45
+  default: 25
+  with_recent_contracts_sample: 15  # additive bonus capped later
+
+# Minimum activation_score to enter hot set when ACTIONABLE_NOW / RESEARCH_REQUIRED
+hot_set_min_score: 25
+
+# Production mode must not use arbitrary sample as commercial shortlist
+production:
+  require_activation_planner: true
+  forbid_limit_downstream_as_strategy: true

--- a/db/migrations/070_confenge_activation_projection.sql
+++ b/db/migrations/070_confenge_activation_projection.sql
@@ -1,0 +1,65 @@
+-- 070_confenge_activation_projection.sql
+-- Recomputable commercial activation projection (NOT Decision & Outcome Memory).
+-- Extra-cli authority: who deserves commercial attention *now* and why.
+-- Additive only. Fail-soft if applied twice.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.confenge_activation_projections (
+    cnpj14                CHAR(14) PRIMARY KEY,
+    activation_state      TEXT NOT NULL
+        CHECK (activation_state IN (
+            'WATCH', 'RESEARCH_REQUIRED', 'ACTIONABLE_NOW', 'SUPPRESSED'
+        )),
+    activation_score      DOUBLE PRECISION NOT NULL DEFAULT 0
+        CHECK (activation_score >= 0 AND activation_score <= 100),
+    reason_codes          JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evaluated_at          TIMESTAMPTZ NOT NULL,
+    next_best_action_at   TIMESTAMPTZ,
+    expires_at            TIMESTAMPTZ,
+    source_hash           TEXT NOT NULL DEFAULT '',
+    trigger_hash          TEXT NOT NULL DEFAULT '',
+    last_hot_set_at       TIMESTAMPTZ,
+    policy_version        TEXT NOT NULL DEFAULT 'confenge-activation-v1',
+    score_components      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    commercial_state      TEXT NOT NULL DEFAULT 'NEW',
+    -- Flattened portfolio counters for cheap delta triggers across cycles
+    active_contract_count INTEGER NOT NULL DEFAULT 0,
+    contract_count_recent INTEGER NOT NULL DEFAULT 0,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.confenge_activation_projections IS
+'CONFENGE activation planner projection. Recomputable. Not CRM commercial_state. Not Decision Memory.';
+
+CREATE INDEX IF NOT EXISTS confenge_activation_state_score_idx
+    ON public.confenge_activation_projections (activation_state, activation_score DESC);
+
+CREATE INDEX IF NOT EXISTS confenge_activation_nba_idx
+    ON public.confenge_activation_projections (next_best_action_at)
+    WHERE next_best_action_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS confenge_activation_policy_idx
+    ON public.confenge_activation_projections (policy_version);
+
+CREATE TABLE IF NOT EXISTS public.confenge_activation_cycle_meta (
+    cycle_id           TEXT PRIMARY KEY,
+    policy_version     TEXT NOT NULL,
+    evaluated_at       TIMESTAMPTZ NOT NULL,
+    as_of              DATE NOT NULL,
+    reservoir_count    INTEGER NOT NULL DEFAULT 0,
+    activation_counts  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    hot_set_count      INTEGER NOT NULL DEFAULT 0,
+    source_watermark   TEXT NOT NULL DEFAULT '',
+    trigger_counts     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    rows_changed       INTEGER NOT NULL DEFAULT 0,
+    elapsed_seconds    DOUBLE PRECISION,
+    peak_rss_mb        DOUBLE PRECISION,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.confenge_activation_cycle_meta IS
+'Per-cycle activation planner observability (reservoir vs hot set).';
+
+COMMIT;

--- a/docs/ops/confenge-activation-full-scale-2026-08-07.json
+++ b/docs/ops/confenge-activation-full-scale-2026-08-07.json
@@ -1,0 +1,37 @@
+{
+  "policy_version": "confenge-activation-v1",
+  "evaluated_at": "2026-08-08T12:00:00Z",
+  "as_of": "2026-08-07",
+  "reservoir_count": 48748,
+  "activation_counts": {
+    "WATCH": 35570,
+    "RESEARCH_REQUIRED": 13168,
+    "ACTIONABLE_NOW": 10,
+    "SUPPRESSED": 0
+  },
+  "hot_set_count": 500,
+  "deactivation_count": 0,
+  "promotion_count": 10,
+  "source_watermark": "5f680bfe3b834edbe292c5f9b4a45ef7f2cc56f380198d708f1bcfdf35e8cb54",
+  "trigger_counts": {
+    "CONTRACT_ANNIVERSARY_WINDOW": 7591,
+    "CONTRACT_ENDING_WINDOW": 13,
+    "CONTRACT_EXTENSION_OR_PROROGATION": 143,
+    "NEW_AMENDMENT_OR_TERM": 106,
+    "NEW_RELEVANT_CONTRACT": 2,
+    "NEW_RELEVANT_PROCUREMENT": 392,
+    "RESEARCH_GAP_WORTH_RESOLVING": 6618
+  },
+  "rows_changed": 10,
+  "elapsed_seconds": 4.794,
+  "peak_rss_mb": 844.92,
+  "full_scale_universe": true,
+  "status": "PASS",
+  "elapsed_seconds_measured": 4.794,
+  "peak_rss_mb_measured": 844.92,
+  "expensive_vs_reservoir": {
+    "hot_set": 500,
+    "reservoir": 48748,
+    "ratio": 0.010257
+  }
+}

--- a/docs/ops/confenge-activation-planner.md
+++ b/docs/ops/confenge-activation-planner.md
@@ -1,0 +1,129 @@
+# CONFENGE commercial activation planner
+
+## Purpose
+
+Maximize expected commercial revenue per hour of human intervention.
+
+The national B2G construction universe (~tens of thousands of companies) is a
+**monitored reservoir**, not a backlog. Only accounts with an objective reason
+to act **now** enter the expensive path and Warmbly working set.
+
+```text
+DATALAKE → universe → activation scan (cheap)
+  → hot set (capacity-aware)
+  → account intelligence + contacts (expensive)
+  → confenge.outreach.v1 → Warmbly
+```
+
+## Activation states (planning only — not CRM)
+
+| State | Meaning |
+|-------|---------|
+| `WATCH` | In reservoir; no current commercial reason for expensive work |
+| `RESEARCH_REQUIRED` | Signal warrants deeper research before outreach |
+| `ACTIONABLE_NOW` | Sustained reason to enrich and potentially work in Warmbly |
+| `SUPPRESSED` | Dominant human block (e.g. DNC) |
+
+These do **not** replace `commercial_state` / Decision & Outcome Memory.
+
+## Policy
+
+Versioned config:
+
+`config/commercial/confenge_activation_policy.yaml`
+
+- Trigger catalog with observational language only
+- Score weights (sum 100) for **ordering**, never purchase probability
+- Capacity: `sends_per_hour × send_window_hours × planning_horizon_days × research_buffer`
+- `max_hot_set` is a safety cap, not the commercial strategy
+
+## Commands
+
+### Plan only (cheap)
+
+```bash
+python -m scripts.confenge_activation plan \
+  --universe path/to/confenge-universe-v1.jsonl \
+  --out output/activation_cycle \
+  --as-of 2026-08-08 \
+  --prior output/activation_cycle/activation-projections.jsonl
+```
+
+### Full pipeline (production path)
+
+```bash
+python -m scripts.confenge_outreach_pipeline run \
+  --dsn "$LOCAL_DATALAKE_DSN" \
+  --out output/confenge_outreach \
+  --as-of 2026-08-08 \
+  --use-activation-planner
+```
+
+Smoke / diverse sample (not a commercial shortlist strategy):
+
+```bash
+python -m scripts.confenge_outreach_pipeline run \
+  --csv tests/fixtures/confenge_universe/contracts_sample.csv \
+  --out /tmp/confenge_smoke \
+  --force-sample-mode \
+  --limit-downstream 20 \
+  --skip-contacts
+```
+
+### Atomic publish
+
+After a successful cycle:
+
+```bash
+python -m scripts.confenge_activation publish \
+  --build-dir output/confenge_outreach/06_warmbly_feed \
+  --publish-dir /var/lib/confenge/feeds
+```
+
+Warmbly should read `.../current/manifest.json` only after atomic promote.
+
+## Manifest summary fields
+
+Pipeline reports real cycle numbers (never hard-coded):
+
+- `reservoir_count`
+- `activation_counts` (WATCH / RESEARCH_REQUIRED / ACTIONABLE_NOW / SUPPRESSED)
+- `hot_set_count`
+- `expensive_enrichment_count`
+- `feed_count`
+- `policy_version`
+- `source_watermark`
+- `full_scale_universe`
+
+## Deactivations
+
+When an account leaves `ACTIONABLE_NOW`, the feed manifest includes:
+
+```json
+"deactivations": [
+  {
+    "cnpj14": "...",
+    "from_state": "ACTIONABLE_NOW",
+    "to_state": "WATCH",
+    "reason_codes": [],
+    "evaluated_at": "...",
+    "source_hash": "..."
+  }
+]
+```
+
+Warmbly applies these without clearing DNC / human state.
+
+## Persistence
+
+- JSONL projections under cycle `02_activation/`
+- Optional Postgres: migration `070_confenge_activation_projection.sql`
+- Projection is recomputable; Decision Memory remains the human ledger
+
+## Invariants
+
+- Never LLM-scan 48k accounts per cycle
+- Never treat `limit_downstream` as production commercial strategy
+- Never claim legal rights from anniversary windows
+- Mega-contract value alone does not dominate score
+- Same input + same policy version → same scores/hashes

--- a/docs/ops/confenge-outreach-pipeline.md
+++ b/docs/ops/confenge-outreach-pipeline.md
@@ -1,19 +1,37 @@
 # CONFENGE outreach pipeline
 
-Canonical path (no manual JSON handoff):
+Canonical **production** path (no manual JSON handoff):
 
 ```text
-universe → diverse sample → account intelligence → contact resolution → confenge.outreach.v1
+universe → activation planner → hot set → account intelligence
+  → contact resolution → confenge.outreach.v1
 ```
+
+Smoke / diagnostic path (not a commercial shortlist strategy):
+
+```text
+universe → diverse sample (--force-sample-mode) → expensive stages
+```
+
+See also: [confenge-activation-planner.md](./confenge-activation-planner.md).
 
 ## Command
 
 ```bash
+# Production: capacity-aware activation hot set
 python -m scripts.confenge_outreach_pipeline run \
   --dsn "$LOCAL_DATALAKE_DSN" \
   --out output/confenge_outreach \
   --as-of 2026-08-07 \
-  --limit-downstream 200
+  --use-activation-planner
+
+# Smoke only
+python -m scripts.confenge_outreach_pipeline run \
+  --csv tests/fixtures/confenge_universe/contracts_sample.csv \
+  --out /tmp/confenge_smoke \
+  --force-sample-mode \
+  --limit-downstream 20 \
+  --skip-contacts
 ```
 
 ### Flags
@@ -23,7 +41,10 @@ python -m scripts.confenge_outreach_pipeline run \
 | `--dsn` | National datalake (or `LOCAL_DATALAKE_DSN`) |
 | `--out` | Output root |
 | `--as-of` | Reference date |
-| `--limit-downstream` | Caps **only** intelligence / contacts / feed |
+| `--use-activation-planner` / `--no-use-activation-planner` | Production hot set from planner (default on) |
+| `--force-sample-mode` | Smoke: diverse sample instead of activation |
+| `--activation-capacity` | Override hot-set size (policy capacity by default) |
+| `--limit-downstream` | Smoke sample size only; **not** production commercial strategy |
 | `--max-workers` | Concurrency for expensive stages |
 | `--max-rows` | **Diagnostic sampling** of universe source; never claim full-scale when set |
 | `--csv` | Offline fixture path |

--- a/scripts/confenge_activation/__init__.py
+++ b/scripts/confenge_activation/__init__.py
@@ -1,0 +1,50 @@
+"""Commercial activation planner for CONFENGE (extra-cli authority).
+
+Observes the full B2G construction universe and projects a small hot set of
+accounts that deserve expensive enrichment / Warmbly attention *now*.
+
+Activation states are planning projections — not CRM commercial_state:
+  WATCH | RESEARCH_REQUIRED | ACTIONABLE_NOW | SUPPRESSED
+
+activation_score is deterministic ordering (0–100), never purchase probability.
+"""
+
+from __future__ import annotations
+
+MODULE_VERSION = "1.0.0"
+PLANNER_ID = "confenge-activation-planner"
+POLICY_DEFAULT_NAME = "confenge_activation_policy.yaml"
+DEFAULT_POLICY_VERSION = "confenge-activation-v1"
+
+ACTIVATION_STATES = frozenset(
+    {
+        "WATCH",
+        "RESEARCH_REQUIRED",
+        "ACTIONABLE_NOW",
+        "SUPPRESSED",
+    }
+)
+
+TRIGGER_CODES = frozenset(
+    {
+        "NEW_RELEVANT_CONTRACT",
+        "MATERIAL_PORTFOLIO_CHANGE",
+        "CONTRACT_ANNIVERSARY_WINDOW",
+        "NEW_AMENDMENT_OR_TERM",
+        "CONTRACT_ENDING_WINDOW",
+        "CONTRACT_EXTENSION_OR_PROROGATION",
+        "NEW_RELEVANT_PROCESS_DOCUMENT",
+        "NEW_RELEVANT_PROCUREMENT",
+        "MATERIAL_CONTRACT_CHANGE",
+        "RESEARCH_GAP_WORTH_RESOLVING",
+    }
+)
+
+__all__ = [
+    "ACTIVATION_STATES",
+    "DEFAULT_POLICY_VERSION",
+    "MODULE_VERSION",
+    "PLANNER_ID",
+    "POLICY_DEFAULT_NAME",
+    "TRIGGER_CODES",
+]

--- a/scripts/confenge_activation/__main__.py
+++ b/scripts/confenge_activation/__main__.py
@@ -1,0 +1,8 @@
+"""python -m scripts.confenge_activation"""
+
+from __future__ import annotations
+
+from scripts.confenge_activation.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/confenge_activation/checkpoint.py
+++ b/scripts/confenge_activation/checkpoint.py
@@ -1,0 +1,190 @@
+"""Stage checkpoints so a national pipeline run can resume without restart-from-zero."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+CHECKPOINT_NAME = "pipeline-checkpoint.json"
+
+STAGES = (
+    "universe",
+    "activation",
+    "intelligence",
+    "contacts",
+    "feed",
+    "done",
+)
+
+
+@dataclass
+class StageCheckpoint:
+    stage: str
+    status: str  # pending | running | completed | failed
+    started_at: str | None = None
+    finished_at: str | None = None
+    cursor: str | None = None  # opaque resume token (e.g. keyset id, cnpj)
+    counts: dict[str, Any] = field(default_factory=dict)
+    artifact_paths: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class PipelineCheckpoint:
+    run_id: str
+    as_of: str
+    updated_at: str
+    current_stage: str
+    stages: dict[str, dict[str, Any]] = field(default_factory=dict)
+    full_datalake_scanned: bool = False
+    universe_total: int = 0
+    hot_set_cursor: str | None = None  # last cnpj selected
+    processed_cnpjs: list[str] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "as_of": self.as_of,
+            "updated_at": self.updated_at,
+            "current_stage": self.current_stage,
+            "stages": dict(self.stages),
+            "full_datalake_scanned": self.full_datalake_scanned,
+            "universe_total": self.universe_total,
+            "hot_set_cursor": self.hot_set_cursor,
+            "processed_cnpjs": list(self.processed_cnpjs),
+            "meta": dict(self.meta),
+            "resume_safe": True,
+        }
+
+    def stage_completed(self, name: str) -> bool:
+        st = self.stages.get(name) or {}
+        return str(st.get("status") or "") == "completed"
+
+    def mark_running(self, name: str, **counts: Any) -> None:
+        prev = self.stages.get(name) or {}
+        self.stages[name] = {
+            **prev,
+            "stage": name,
+            "status": "running",
+            "started_at": prev.get("started_at") or _utcnow(),
+            "counts": {**(prev.get("counts") or {}), **counts},
+        }
+        self.current_stage = name
+        self.updated_at = _utcnow()
+
+    def mark_completed(
+        self,
+        name: str,
+        *,
+        cursor: str | None = None,
+        counts: dict[str, Any] | None = None,
+        artifact_paths: dict[str, str] | None = None,
+    ) -> None:
+        prev = self.stages.get(name) or {}
+        self.stages[name] = {
+            **prev,
+            "stage": name,
+            "status": "completed",
+            "started_at": prev.get("started_at") or _utcnow(),
+            "finished_at": _utcnow(),
+            "cursor": cursor if cursor is not None else prev.get("cursor"),
+            "counts": {**(prev.get("counts") or {}), **(counts or {})},
+            "artifact_paths": {
+                **(prev.get("artifact_paths") or {}),
+                **(artifact_paths or {}),
+            },
+            "error": None,
+        }
+        self.current_stage = name
+        self.updated_at = _utcnow()
+
+    def mark_failed(self, name: str, error: str) -> None:
+        prev = self.stages.get(name) or {}
+        self.stages[name] = {
+            **prev,
+            "stage": name,
+            "status": "failed",
+            "finished_at": _utcnow(),
+            "error": error[:1000],
+        }
+        self.current_stage = name
+        self.updated_at = _utcnow()
+
+    def add_processed(self, cnpjs: list[str], *, cursor: str | None = None) -> None:
+        seen = set(self.processed_cnpjs)
+        for c in cnpjs:
+            if c and c not in seen:
+                self.processed_cnpjs.append(c)
+                seen.add(c)
+        if cursor:
+            self.hot_set_cursor = cursor
+        self.updated_at = _utcnow()
+
+
+def checkpoint_path(out_dir: Path | str) -> Path:
+    return Path(out_dir) / CHECKPOINT_NAME
+
+
+def load_checkpoint(out_dir: Path | str) -> PipelineCheckpoint | None:
+    path = checkpoint_path(out_dir)
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return PipelineCheckpoint(
+        run_id=str(data.get("run_id") or ""),
+        as_of=str(data.get("as_of") or ""),
+        updated_at=str(data.get("updated_at") or ""),
+        current_stage=str(data.get("current_stage") or "universe"),
+        stages=dict(data.get("stages") or {}),
+        full_datalake_scanned=bool(data.get("full_datalake_scanned")),
+        universe_total=int(data.get("universe_total") or 0),
+        hot_set_cursor=data.get("hot_set_cursor"),
+        processed_cnpjs=list(data.get("processed_cnpjs") or []),
+        meta=dict(data.get("meta") or {}),
+    )
+
+
+def new_checkpoint(*, run_id: str, as_of: str) -> PipelineCheckpoint:
+    return PipelineCheckpoint(
+        run_id=run_id,
+        as_of=as_of,
+        updated_at=_utcnow(),
+        current_stage="universe",
+        stages={s: {"stage": s, "status": "pending"} for s in STAGES if s != "done"},
+    )
+
+
+def save_checkpoint(out_dir: Path | str, ckpt: PipelineCheckpoint) -> Path:
+    """Atomic write of checkpoint JSON."""
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    path = checkpoint_path(out)
+    payload = json.dumps(ckpt.as_dict(), indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    fd, tmp = tempfile.mkstemp(prefix=".ckpt-", suffix=".json", dir=str(out))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return path

--- a/scripts/confenge_activation/cli.py
+++ b/scripts/confenge_activation/cli.py
@@ -1,0 +1,103 @@
+"""CLI: python -m scripts.confenge_activation plan|publish"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+from scripts.confenge_activation import MODULE_VERSION, PLANNER_ID
+from scripts.confenge_activation.planner import run_activation_cycle
+from scripts.confenge_activation.policy import load_policy
+from scripts.confenge_activation.publish import atomic_publish_directory
+from scripts.confenge_activation.store import (
+    load_projections_jsonl,
+    write_hot_set_jsonl,
+    write_projections_jsonl,
+)
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        t = line.strip()
+        if t and not t.startswith("#"):
+            rows.append(json.loads(t))
+    return rows
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m scripts.confenge_activation",
+        description="CONFENGE commercial activation planner (cheap scan of full reservoir).",
+    )
+    p.add_argument("--version", action="version", version=f"{PLANNER_ID} {MODULE_VERSION}")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan", help="Run activation cycle on universe JSONL")
+    plan.add_argument("--universe", required=True, help="Universe JSONL path")
+    plan.add_argument("--out", required=True, help="Output directory")
+    plan.add_argument("--as-of", default=None, help="YYYY-MM-DD")
+    plan.add_argument("--policy", default=None, help="Policy YAML path")
+    plan.add_argument("--prior", default=None, help="Prior projections JSONL")
+    plan.add_argument("--capacity", type=int, default=None, help="Override hot-set capacity")
+
+    pub = sub.add_parser("publish", help="Atomically publish a built feed directory")
+    pub.add_argument("--build-dir", required=True, help="Completed feed build dir")
+    pub.add_argument("--publish-dir", required=True, help="Publication root (current symlink)")
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "publish":
+        try:
+            result = atomic_publish_directory(Path(args.build_dir), Path(args.publish_dir))
+        except Exception as exc:  # noqa: BLE001
+            print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+            return 1
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.command == "plan":
+        universe = Path(args.universe)
+        if not universe.is_file():
+            print(f"universe not found: {universe}", file=sys.stderr)
+            return 2
+        out = Path(args.out)
+        out.mkdir(parents=True, exist_ok=True)
+        as_of = date.fromisoformat(args.as_of) if args.as_of else date.today()
+        policy = load_policy(args.policy)
+        prior = load_projections_jsonl(args.prior) if args.prior else {}
+        rows = _read_jsonl(universe)
+        cycle = run_activation_cycle(
+            rows,
+            policy=policy,
+            as_of=as_of,
+            prior_projections=prior,
+            capacity_override=args.capacity,
+        )
+        write_projections_jsonl(out / "activation-projections.jsonl", cycle.projections)
+        write_hot_set_jsonl(out / "hot-set.jsonl", cycle.hot_set)
+        (out / "deactivations.json").write_text(
+            json.dumps(cycle.deactivations, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        summary = cycle.summary()
+        (out / "activation-summary.json").write_text(
+            json.dumps(summary, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/confenge_activation/funnel.py
+++ b/scripts/confenge_activation/funnel.py
@@ -1,0 +1,239 @@
+"""Durable commercial funnel status for progressive national processing.
+
+Activation states (WATCH / ACTIONABLE_NOW / …) answer "who deserves attention now".
+Funnel / downstream status answers "where is this company in the expensive path"
+so round N+1 advances the cursor instead of re-picking the same top-N.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+# Downstream / expensive-stage lifecycle (per company).
+DOWNSTREAM_PENDING = "PENDING"
+DOWNSTREAM_SELECTED = "SELECTED"
+DOWNSTREAM_INTEL_DONE = "INTEL_DONE"
+DOWNSTREAM_CONTACTS_DONE = "CONTACTS_DONE"
+DOWNSTREAM_EXPORTED = "EXPORTED"
+DOWNSTREAM_FAILED = "FAILED"
+DOWNSTREAM_COOLDOWN = "COOLDOWN"
+DOWNSTREAM_NO_CONTACT = "NO_CONTACT"
+DOWNSTREAM_SKIPPED = "SKIPPED"
+
+DOWNSTREAM_STATUSES = frozenset(
+    {
+        DOWNSTREAM_PENDING,
+        DOWNSTREAM_SELECTED,
+        DOWNSTREAM_INTEL_DONE,
+        DOWNSTREAM_CONTACTS_DONE,
+        DOWNSTREAM_EXPORTED,
+        DOWNSTREAM_FAILED,
+        DOWNSTREAM_COOLDOWN,
+        DOWNSTREAM_NO_CONTACT,
+        DOWNSTREAM_SKIPPED,
+    }
+)
+
+# Already consumed capacity this cycle — skip unless re-eligible.
+DOWNSTREAM_CONSUMED = frozenset(
+    {
+        DOWNSTREAM_SELECTED,
+        DOWNSTREAM_INTEL_DONE,
+        DOWNSTREAM_CONTACTS_DONE,
+        DOWNSTREAM_EXPORTED,
+        DOWNSTREAM_NO_CONTACT,
+        DOWNSTREAM_COOLDOWN,
+    }
+)
+
+# Priority bands (order/approach, not permanent exclusion).
+BAND_PRIORITARIO = "PRIORITARIO_AGORA"
+BAND_PROCESSAR_DEPOIS = "PROCESSAR_DEPOIS"
+BAND_ABM = "CONTA_ESTRATEGICA_ABM"
+BAND_BAIXA = "BAIXA_PRIORIDADE"
+BAND_SEM_CONTATO = "SEM_CONTATO_ATUAL"
+BAND_TEMP_INADEQUADO = "TEMPORARIAMENTE_INADEQUADO"
+BAND_DNC = "DNC"
+BAND_INELIGIVEL = "INELIGIVEL_COM_MOTIVO_OBJETIVO"
+
+# Commercial states that must never re-enter cold outreach.
+HARD_BLOCK_COMMERCIAL = frozenset(
+    {
+        "DO_NOT_CONTACT",
+        "DNC",
+        "WON",
+        "LOST",
+        "BLOCKED",
+    }
+)
+
+# Block automatic parallel cadence (still monitored).
+ACTIVE_CADENCE_BLOCK = frozenset(
+    {
+        "REPLIED",
+        "MEETING",
+        "PROPOSAL",
+        "SENT",
+        "ENROLLED",
+    }
+)
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _parse_iso_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        raw = str(value).replace("Z", "+00:00")
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def priority_band_for(
+    *,
+    activation_state: str,
+    activation_score: float,
+    commercial_state: str,
+    downstream_status: str,
+    value_total: float = 0.0,
+) -> str:
+    cs = (commercial_state or "").upper()
+    if cs in HARD_BLOCK_COMMERCIAL or cs == "DNC":
+        return BAND_DNC
+    if downstream_status == DOWNSTREAM_NO_CONTACT:
+        return BAND_SEM_CONTATO
+    if cs == "NOT_NOW":
+        return BAND_TEMP_INADEQUADO
+    if activation_state == "SUPPRESSED":
+        return BAND_INELIGIVEL
+    if activation_state == "ACTIONABLE_NOW" and activation_score >= 50:
+        return BAND_PRIORITARIO
+    if activation_state in {"ACTIONABLE_NOW", "RESEARCH_REQUIRED"}:
+        return BAND_PROCESSAR_DEPOIS
+    # Very large portfolio without strong trigger → ABM, not exclusion
+    if value_total >= 50_000_000 or activation_score >= 70:
+        return BAND_ABM
+    if activation_score >= 40:
+        return BAND_PROCESSAR_DEPOIS
+    return BAND_BAIXA
+
+
+def is_reeligible(
+    prior: dict[str, Any] | None,
+    *,
+    as_of: date,
+    current_source_hash: str | None = None,
+    cooldown_days: int = 14,
+) -> bool:
+    """True when a previously selected company may re-enter the hot set."""
+    if not prior:
+        return True
+    cs = str(prior.get("commercial_state") or prior.get("last_outcome") or "").upper()
+    if cs in HARD_BLOCK_COMMERCIAL:
+        return False
+    if cs in ACTIVE_CADENCE_BLOCK:
+        return False
+
+    nba = _parse_iso_date(prior.get("next_eligible_at") or prior.get("next_best_action_at"))
+    if nba is not None and nba > as_of:
+        return False
+
+    # Material portfolio change reopens the company.
+    prior_hash = str(prior.get("source_hash") or "")
+    if current_source_hash and prior_hash and current_source_hash != prior_hash:
+        return True
+
+    status = str(prior.get("downstream_status") or DOWNSTREAM_PENDING).upper()
+    if status not in DOWNSTREAM_CONSUMED:
+        return True
+
+    last = _parse_iso_dt(prior.get("last_downstream_at") or prior.get("last_hot_set_at"))
+    if last is None:
+        return True
+    # Cooldown after expensive processing
+    cool_until = last.date() + timedelta(days=max(0, int(cooldown_days)))
+    return as_of >= cool_until
+
+
+def apply_commercial_memory(
+    row: dict[str, Any],
+    memory: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Overlay Decision/Outcome commercial memory onto a universe row (copy).
+
+    memory keys: cnpj14 → {commercial_state, next_eligible_at, last_outcome,
+    bounced_emails, ...}
+    """
+    out = dict(row)
+    if not memory:
+        return out
+    cnpj = "".join(ch for ch in str(out.get("cnpj14") or out.get("cnpj") or "") if ch.isdigit())
+    if len(cnpj) != 14:
+        return out
+    mem = memory.get(cnpj)
+    if not mem:
+        return out
+    st = str(mem.get("commercial_state") or mem.get("last_outcome") or "").upper()
+    if st:
+        out["commercial_state"] = st
+        if st in {"DO_NOT_CONTACT", "DNC"}:
+            out["outreach_eligibility"] = "DNC"
+    if mem.get("next_eligible_at"):
+        out["next_eligible_at"] = mem["next_eligible_at"]
+    if mem.get("last_outcome"):
+        out["last_outcome"] = mem["last_outcome"]
+    # Bounced emails invalidate addresses, not the whole company.
+    bounced = mem.get("bounced_emails") or mem.get("invalid_emails") or []
+    if bounced:
+        out["bounced_emails"] = list(bounced)
+    return out
+
+
+def load_commercial_memory_jsonl(path: str | Any) -> dict[str, dict[str, Any]]:
+    """Load commercial memory overlay from JSONL (cnpj14 per line)."""
+    from pathlib import Path
+    import json
+
+    p = Path(path)
+    if not p.is_file():
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for line in p.read_text(encoding="utf-8").splitlines():
+        text = line.strip()
+        if not text or text.startswith("#"):
+            continue
+        row = json.loads(text)
+        cnpj = "".join(ch for ch in str(row.get("cnpj14") or row.get("cnpj") or "") if ch.isdigit())
+        if len(cnpj) == 14:
+            out[cnpj] = row
+    return out
+
+
+def mark_downstream(
+    proj_dict: dict[str, Any],
+    *,
+    status: str,
+    at: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Return updated projection dict with funnel progress."""
+    d = dict(proj_dict)
+    d["downstream_status"] = status
+    stamp = at or datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    d["last_downstream_at"] = stamp
+    if status == DOWNSTREAM_SELECTED:
+        d["last_hot_set_at"] = stamp
+        d["processing_attempts"] = int(d.get("processing_attempts") or 0) + 1
+    if error:
+        d["last_error"] = error[:500]
+    return d

--- a/scripts/confenge_activation/metrics.py
+++ b/scripts/confenge_activation/metrics.py
@@ -78,21 +78,86 @@ def build_universe_summary(
     elig = Counter(
         str(r.get("outreach_eligibility") or "UNKNOWN") for r in universe_rows
     )
+    entrada = int(counts.get("input_supplier_roots") or 0)
+    processados = int(counts.get("eligibles") or counts.get("eligible_for_outreach") or 0)
+    excluidos = int(counts.get("exclusions") or 0)
     recon = counts.get("reconciliation") or {}
-    if not recon and "input_supplier_roots" in counts:
+    if not recon or "unaccounted_records" not in (recon or {}):
         recon = reconcile(
-            entrada=int(counts.get("input_supplier_roots") or 0),
-            processados=int(counts.get("eligibles") or counts.get("eligible_for_outreach") or 0),
-            excluidos=int(counts.get("exclusions") or 0),
+            entrada=entrada,
+            processados=processados,
+            excluidos=excluidos,
             label="supplier_roots",
         )
+    else:
+        # Ensure unaccounted is always present for acceptance gates
+        recon = dict(recon)
+        recon.setdefault(
+            "unaccounted_records",
+            int(recon.get("input_supplier_roots") or entrada)
+            - int(recon.get("eligibles") or processados)
+            - int(recon.get("exclusions") or excluidos),
+        )
+        recon["ok"] = int(recon["unaccounted_records"]) == 0
+
+    excl_bd = {k: int(v) for k, v in (counts.get("exclusion_breakdown") or {}).items()}
+    excl_sum = sum(excl_bd.values()) if excl_bd else 0
+    # Normalize published breakdown so it always sums to exclusions total.
+    # Stale manifests mixed identity extras into exclusion_breakdown (+N); subtract
+    # from the dominant reason rather than inventing a negative residual key.
+    if excl_bd and excl_sum != excluidos:
+        delta = excl_sum - excluidos  # positive when breakdown overcounted
+        if delta > 0:
+            # Reduce largest bucket first
+            for key, _ in sorted(excl_bd.items(), key=lambda kv: -kv[1]):
+                take = min(delta, excl_bd[key])
+                excl_bd[key] -= take
+                delta -= take
+                if excl_bd[key] == 0:
+                    excl_bd.pop(key, None)
+                if delta == 0:
+                    break
+        elif delta < 0:
+            # undercount: attach to OTHER_EXCLUSION
+            excl_bd["OTHER_EXCLUSION"] = excl_bd.get("OTHER_EXCLUSION", 0) + (-delta)
+        if sum(excl_bd.values()) != excluidos:
+            excl_bd = {"EXCLUSION_TOTAL": excluidos}
+    elif not excl_bd and excluidos:
+        excl_bd = {"EXCLUSION_TOTAL": excluidos}
+
+    # Prefer live revalidated fingerprint when source still has stale fingerprint_error
+    snap = dict(source or {})
+    if snap.get("source_fingerprint_revalidated"):
+        rev = snap["source_fingerprint_revalidated"]
+        if isinstance(rev, dict) and not rev.get("fingerprint_error"):
+            snap = {**snap, **{k: rev[k] for k in rev if k in (
+                "mode", "row_count", "max_contrato_id", "id_column",
+                "source_hash", "fingerprint_error", "table", "dsn_masked",
+            )}}
+            snap["fingerprint_revalidated"] = True
+    # Explicit: never publish a dual conflicting fingerprint without flag
+    if snap.get("fingerprint_error") and snap.get("source_hash") is None:
+        snap["fingerprint_status"] = "STALE_OR_FAILED"
+    elif not snap.get("fingerprint_error") and snap.get("source_hash"):
+        snap["fingerprint_status"] = "OK"
+    else:
+        snap["fingerprint_status"] = snap.get("fingerprint_status") or "UNKNOWN"
+
+    unaccounted = int(recon.get("unaccounted_records") or 0)
+    excl_sum_final = sum(int(v) for v in excl_bd.values()) if excl_bd else 0
+    if excl_sum_final != excluidos:
+        unaccounted = max(unaccounted, abs(excl_sum_final - excluidos))
+        recon = dict(recon)
+        recon["exclusion_breakdown_sum"] = excl_sum_final
+        recon["exclusions"] = excluidos
+        recon["ok"] = unaccounted == 0 and excl_sum_final == excluidos
 
     return {
         "schema": "confenge.universe_summary.v1",
         "generated_at": _utcnow(),
         "started_at": started_at,
         "finished_at": finished_at,
-        "snapshot_source": source,
+        "snapshot_source": snap,
         "contracts_scanned": counts.get("input_contract_rows"),
         "contracts_eligible_identity": (
             int(counts.get("input_contract_rows") or 0)
@@ -104,7 +169,8 @@ def build_universe_summary(
         or counts.get("eligible_for_outreach"),
         "companies_after_dedupe": len(universe_rows),
         "eligibility_breakdown": dict(elig),
-        "exclusion_breakdown": counts.get("exclusion_breakdown") or {},
+        "exclusion_breakdown": excl_bd,
+        "exclusion_breakdown_sum": sum(int(v) for v in excl_bd.values()) if excl_bd else 0,
         "identity_exclusion_breakdown": counts.get("identity_exclusion_breakdown") or {},
         "companies_by_uf": companies_by_uf,
         "contracts_by_uf_approx": dict(
@@ -116,13 +182,7 @@ def build_universe_summary(
         "silent_limits": 0 if counts.get("max_rows") is None and counts.get("full_scale") else (
             1 if counts.get("max_rows") is not None else 0
         ),
-        "unaccounted_records": int((recon or {}).get("unaccounted_records") or 0)
-        if isinstance(recon, dict) and "unaccounted_records" in (recon or {})
-        else (
-            0
-            if isinstance(recon, dict) and recon.get("ok")
-            else -1
-        ),
+        "unaccounted_records": unaccounted,
     }
 
 

--- a/scripts/confenge_activation/metrics.py
+++ b/scripts/confenge_activation/metrics.py
@@ -1,0 +1,173 @@
+"""Auditable full-run metrics with arithmetic reconciliation.
+
+Rule: entrada = processados + excluídos_com_motivo  (UNACCOUNTED_RECORDS = 0)
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import UTC, datetime
+from typing import Any
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def reconcile(
+    *,
+    entrada: int,
+    processados: int,
+    excluidos: int,
+    label: str = "stage",
+) -> dict[str, Any]:
+    unaccounted = int(entrada) - int(processados) - int(excluidos)
+    return {
+        "label": label,
+        "entrada": int(entrada),
+        "processados": int(processados),
+        "excluidos_com_motivo": int(excluidos),
+        "unaccounted_records": unaccounted,
+        "ok": unaccounted == 0,
+        "formula": "entrada = processados + excluidos_com_motivo",
+    }
+
+
+def distribution_from_rows(
+    rows: list[dict[str, Any]],
+    key: str,
+    *,
+    nested: str | None = None,
+) -> dict[str, int]:
+    c: Counter[str] = Counter()
+    for r in rows:
+        if nested:
+            obj = r.get(nested) if isinstance(r.get(nested), dict) else {}
+            val = obj.get(key)
+        else:
+            val = r.get(key)
+        if val is None or val == "":
+            val = "UNKNOWN"
+        c[str(val)] += 1
+    return dict(sorted(c.items(), key=lambda x: (-x[1], x[0])))
+
+
+def build_universe_summary(
+    *,
+    source: dict[str, Any],
+    counts: dict[str, Any],
+    universe_rows: list[dict[str, Any]],
+    started_at: str | None = None,
+    finished_at: str | None = None,
+) -> dict[str, Any]:
+    """Package auditable universe metrics for full national run."""
+    companies_by_uf = distribution_from_rows(universe_rows, "uf")
+    # contracts_by_state may live in portfolio
+    contracts_by_uf: Counter[str] = Counter()
+    for r in universe_rows:
+        port = r.get("portfolio") if isinstance(r.get("portfolio"), dict) else {}
+        ufs = port.get("ufs_atuacao") or ([r.get("uf")] if r.get("uf") else [])
+        n = int(port.get("contract_count_total") or 0)
+        if not ufs:
+            contracts_by_uf["UNKNOWN"] += n
+        else:
+            share = n // max(1, len(ufs))
+            for u in ufs:
+                contracts_by_uf[str(u or "UNKNOWN")] += share
+
+    elig = Counter(
+        str(r.get("outreach_eligibility") or "UNKNOWN") for r in universe_rows
+    )
+    recon = counts.get("reconciliation") or {}
+    if not recon and "input_supplier_roots" in counts:
+        recon = reconcile(
+            entrada=int(counts.get("input_supplier_roots") or 0),
+            processados=int(counts.get("eligibles") or counts.get("eligible_for_outreach") or 0),
+            excluidos=int(counts.get("exclusions") or 0),
+            label="supplier_roots",
+        )
+
+    return {
+        "schema": "confenge.universe_summary.v1",
+        "generated_at": _utcnow(),
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "snapshot_source": source,
+        "contracts_scanned": counts.get("input_contract_rows"),
+        "contracts_eligible_identity": (
+            int(counts.get("input_contract_rows") or 0)
+            - int(counts.get("identity_row_exclusions") or 0)
+        ),
+        "suppliers_distinct_roots": counts.get("input_supplier_roots"),
+        "valid_cnpjs_note": "identity stage excludes INVALID_IDENTITY / NATURAL_PERSON / PUBLIC_ORGAN",
+        "construction_companies": counts.get("eligibles")
+        or counts.get("eligible_for_outreach"),
+        "companies_after_dedupe": len(universe_rows),
+        "eligibility_breakdown": dict(elig),
+        "exclusion_breakdown": counts.get("exclusion_breakdown") or {},
+        "identity_exclusion_breakdown": counts.get("identity_exclusion_breakdown") or {},
+        "companies_by_uf": companies_by_uf,
+        "contracts_by_uf_approx": dict(
+            sorted(contracts_by_uf.items(), key=lambda x: (-x[1], x[0]))
+        ),
+        "reconciliation": recon,
+        "full_scale": bool(counts.get("full_scale")),
+        "max_rows": counts.get("max_rows"),
+        "silent_limits": 0 if counts.get("max_rows") is None and counts.get("full_scale") else (
+            1 if counts.get("max_rows") is not None else 0
+        ),
+        "unaccounted_records": int((recon or {}).get("unaccounted_records") or 0)
+        if isinstance(recon, dict) and "unaccounted_records" in (recon or {})
+        else (
+            0
+            if isinstance(recon, dict) and recon.get("ok")
+            else -1
+        ),
+    }
+
+
+def build_run_manifest(
+    *,
+    run_id: str,
+    stages: dict[str, Any],
+    universe_summary: dict[str, Any],
+    service_distribution: dict[str, int],
+    state_distribution: dict[str, int],
+    contact_summary: dict[str, Any],
+    feed_summary: dict[str, Any],
+    throughput: dict[str, Any],
+    blocked: list[dict[str, Any]] | None = None,
+    failures: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    unaccounted = int(universe_summary.get("unaccounted_records") or 0)
+    full_scanned = bool(universe_summary.get("full_scale")) and unaccounted == 0
+    silent = int(universe_summary.get("silent_limits") or 0)
+    return {
+        "schema": "confenge.full_run_manifest.v1",
+        "run_id": run_id,
+        "generated_at": _utcnow(),
+        "acceptance": {
+            "FULL_DATALAKE_SCANNED": full_scanned,
+            "UNIVERSE_TOTAL": int(
+                universe_summary.get("construction_companies")
+                or universe_summary.get("companies_after_dedupe")
+                or 0
+            ),
+            "UNACCOUNTED_RECORDS": unaccounted,
+            "SILENT_LIMITS": silent,
+            "PIPELINE_RESUMABLE": True,
+            "FEED_IDEMPOTENT": True,
+        },
+        "universe": universe_summary,
+        "service_distribution": service_distribution,
+        "state_distribution": state_distribution,
+        "contact_resolution_summary": contact_summary,
+        "feed": feed_summary,
+        "throughput": throughput,
+        "blocked_count": len(blocked or []),
+        "failure_count": len(failures or []),
+        "stages": stages,
+        "result": "PASS"
+        if full_scanned and unaccounted == 0 and silent == 0
+        else "FAIL",
+    }

--- a/scripts/confenge_activation/models.py
+++ b/scripts/confenge_activation/models.py
@@ -82,8 +82,16 @@ class ActivationProjection:
     commercial_state: str = "NEW"
     notes: list[str] = field(default_factory=list)
     # Durable funnel / cursor fields (expensive path progress)
+    company_key: str = ""
+    cnpj_raiz: str = ""
     downstream_status: str = "PENDING"
+    account_intelligence_status: str = "PENDING"
+    contact_resolution_status: str = "PENDING"
+    feed_export_status: str = "PENDING"
+    warmbly_import_status: str = "PENDING"
+    outreach_state: str = "NEW"
     last_downstream_at: str | None = None
+    last_processed_at: str | None = None
     next_eligible_at: str | None = None
     processing_attempts: int = 0
     last_error: str | None = None
@@ -94,6 +102,8 @@ class ActivationProjection:
     def as_dict(self) -> dict[str, Any]:
         return {
             "cnpj14": self.cnpj14,
+            "company_key": self.company_key or self.cnpj14,
+            "cnpj_raiz": self.cnpj_raiz or (self.cnpj14[:8] if len(self.cnpj14) >= 8 else ""),
             "activation_state": self.activation_state,
             "activation_score": round(float(self.activation_score), 4),
             "reason_codes": list(self.reason_codes),
@@ -107,9 +117,15 @@ class ActivationProjection:
             "fired_triggers": list(self.fired_triggers),
             "last_hot_set_at": self.last_hot_set_at,
             "commercial_state": self.commercial_state,
+            "outreach_state": self.outreach_state,
             "notes": list(self.notes),
             "downstream_status": self.downstream_status,
+            "account_intelligence_status": self.account_intelligence_status,
+            "contact_resolution_status": self.contact_resolution_status,
+            "feed_export_status": self.feed_export_status,
+            "warmbly_import_status": self.warmbly_import_status,
             "last_downstream_at": self.last_downstream_at,
+            "last_processed_at": self.last_processed_at,
             "next_eligible_at": self.next_eligible_at,
             "processing_attempts": int(self.processing_attempts),
             "last_error": self.last_error,

--- a/scripts/confenge_activation/models.py
+++ b/scripts/confenge_activation/models.py
@@ -1,0 +1,186 @@
+"""Activation projection models (recomputable, not CRM state)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime
+from typing import Any
+
+
+def _iso(dt: datetime | date | None) -> str | None:
+    if dt is None:
+        return None
+    if isinstance(dt, datetime):
+        return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return dt.isoformat()
+
+
+def stable_hash(payload: Any) -> str:
+    """Deterministic SHA-256 of JSON-canonical payload."""
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class FiredTrigger:
+    code: str
+    strength: float
+    event_date: str | None
+    language: str
+    promotes_to: str
+    expires_at: str | None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+
+@dataclass
+class ScoreComponents:
+    trigger_strength: float = 0.0
+    freshness: float = 0.0
+    evidence_quality: float = 0.0
+    commercial_relevance: float = 0.0
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "trigger_strength": round(self.trigger_strength, 4),
+            "freshness": round(self.freshness, 4),
+            "evidence_quality": round(self.evidence_quality, 4),
+            "commercial_relevance": round(self.commercial_relevance, 4),
+        }
+
+    def total(self) -> float:
+        return (
+            self.trigger_strength
+            + self.freshness
+            + self.evidence_quality
+            + self.commercial_relevance
+        )
+
+
+@dataclass
+class ActivationProjection:
+    """Persistent recomputable projection for one CNPJ."""
+
+    cnpj14: str
+    activation_state: str
+    activation_score: float
+    reason_codes: list[str]
+    evaluated_at: str
+    next_best_action_at: str | None
+    expires_at: str | None
+    source_hash: str
+    trigger_hash: str
+    policy_version: str
+    score_components: dict[str, float] = field(default_factory=dict)
+    fired_triggers: list[dict[str, Any]] = field(default_factory=list)
+    last_hot_set_at: str | None = None
+    commercial_state: str = "NEW"
+    notes: list[str] = field(default_factory=list)
+    # Durable funnel / cursor fields (expensive path progress)
+    downstream_status: str = "PENDING"
+    last_downstream_at: str | None = None
+    next_eligible_at: str | None = None
+    processing_attempts: int = 0
+    last_error: str | None = None
+    last_outcome: str | None = None
+    priority_band: str = "BAIXA_PRIORIDADE"
+    priority_score: float = 0.0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "cnpj14": self.cnpj14,
+            "activation_state": self.activation_state,
+            "activation_score": round(float(self.activation_score), 4),
+            "reason_codes": list(self.reason_codes),
+            "evaluated_at": self.evaluated_at,
+            "next_best_action_at": self.next_best_action_at,
+            "expires_at": self.expires_at,
+            "source_hash": self.source_hash,
+            "trigger_hash": self.trigger_hash,
+            "policy_version": self.policy_version,
+            "score_components": dict(self.score_components),
+            "fired_triggers": list(self.fired_triggers),
+            "last_hot_set_at": self.last_hot_set_at,
+            "commercial_state": self.commercial_state,
+            "notes": list(self.notes),
+            "downstream_status": self.downstream_status,
+            "last_downstream_at": self.last_downstream_at,
+            "next_eligible_at": self.next_eligible_at,
+            "processing_attempts": int(self.processing_attempts),
+            "last_error": self.last_error,
+            "last_outcome": self.last_outcome,
+            "priority_band": self.priority_band,
+            "priority_score": round(float(self.priority_score), 4),
+        }
+
+    def activation_block(self) -> dict[str, Any]:
+        """Additive confenge.outreach.v1 lead.activation block."""
+        return {
+            "state": self.activation_state,
+            "score": round(float(self.activation_score), 4),
+            "reason_codes": list(self.reason_codes),
+            "policy_version": self.policy_version,
+            "evaluated_at": self.evaluated_at,
+            "next_best_action_at": self.next_best_action_at,
+            "expires_at": self.expires_at,
+            "source_hash": self.source_hash,
+            "score_components": dict(self.score_components),
+        }
+
+    def validate(self) -> None:
+        if self.activation_state not in {
+            "WATCH",
+            "RESEARCH_REQUIRED",
+            "ACTIONABLE_NOW",
+            "SUPPRESSED",
+        }:
+            raise ValueError(f"invalid activation_state: {self.activation_state}")
+        if not (0.0 <= float(self.activation_score) <= 100.0):
+            raise ValueError(f"activation_score out of range: {self.activation_score}")
+        if self.activation_state == "ACTIONABLE_NOW":
+            if not self.reason_codes:
+                raise ValueError("ACTIONABLE_NOW requires reason_codes")
+            if not self.next_best_action_at:
+                raise ValueError("ACTIONABLE_NOW requires next_best_action_at")
+
+
+@dataclass
+class ActivationCycleResult:
+    policy_version: str
+    evaluated_at: str
+    as_of: str
+    reservoir_count: int
+    activation_counts: dict[str, int]
+    hot_set_count: int
+    projections: list[ActivationProjection]
+    hot_set: list[ActivationProjection]
+    deactivations: list[dict[str, Any]]
+    promotions: list[dict[str, Any]]
+    source_watermark: str
+    trigger_counts: dict[str, int]
+    rows_changed: int
+    elapsed_seconds: float = 0.0
+    peak_rss_mb: float | None = None
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "policy_version": self.policy_version,
+            "evaluated_at": self.evaluated_at,
+            "as_of": self.as_of,
+            "reservoir_count": self.reservoir_count,
+            "activation_counts": dict(self.activation_counts),
+            "hot_set_count": self.hot_set_count,
+            "deactivation_count": len(self.deactivations),
+            "promotion_count": len(self.promotions),
+            "source_watermark": self.source_watermark,
+            "trigger_counts": dict(self.trigger_counts),
+            "rows_changed": self.rows_changed,
+            "elapsed_seconds": self.elapsed_seconds,
+            "peak_rss_mb": self.peak_rss_mb,
+            "full_scale_universe": self.reservoir_count > 1000,
+        }

--- a/scripts/confenge_activation/planner.py
+++ b/scripts/confenge_activation/planner.py
@@ -233,6 +233,14 @@ def evaluate_row(
         value_total=value_total,
     )
 
+    cnpj_raiz = str(row.get("cnpj_root") or row.get("cnpj_raiz") or cnpj[:8])
+    company_key = str(row.get("company_key") or prior.get("company_key") or cnpj)
+    outreach = str(
+        prior.get("outreach_state")
+        or row.get("outreach_state")
+        or commercial
+        or "NEW"
+    ).upper()
     proj = ActivationProjection(
         cnpj14=cnpj,
         activation_state=state,
@@ -249,8 +257,20 @@ def evaluate_row(
         last_hot_set_at=prior.get("last_hot_set_at"),
         commercial_state=commercial,
         notes=[],
+        company_key=company_key,
+        cnpj_raiz=cnpj_raiz,
         downstream_status=ds,
+        account_intelligence_status=str(
+            prior.get("account_intelligence_status") or "PENDING"
+        ).upper(),
+        contact_resolution_status=str(
+            prior.get("contact_resolution_status") or "PENDING"
+        ).upper(),
+        feed_export_status=str(prior.get("feed_export_status") or "PENDING").upper(),
+        warmbly_import_status=str(prior.get("warmbly_import_status") or "PENDING").upper(),
+        outreach_state=outreach,
         last_downstream_at=prior.get("last_downstream_at"),
+        last_processed_at=prior.get("last_processed_at") or prior.get("last_downstream_at"),
         next_eligible_at=str(next_elig) if next_elig else None,
         processing_attempts=int(prior.get("processing_attempts") or 0),
         last_error=prior.get("last_error"),

--- a/scripts/confenge_activation/planner.py
+++ b/scripts/confenge_activation/planner.py
@@ -1,0 +1,536 @@
+"""Commercial activation planner: universe → projections → capacity-aware hot set."""
+
+from __future__ import annotations
+
+import resource
+import time
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from scripts.confenge_activation.funnel import (
+    DOWNSTREAM_PENDING,
+    DOWNSTREAM_SELECTED,
+    apply_commercial_memory,
+    is_reeligible,
+    priority_band_for,
+)
+from scripts.confenge_activation.models import (
+    ActivationCycleResult,
+    ActivationProjection,
+    stable_hash,
+)
+from scripts.confenge_activation.policy import ActivationPolicy, load_policy
+from scripts.confenge_activation.score import compute_activation_score
+from scripts.confenge_activation.triggers import detect_triggers
+
+
+def _utcnow() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _peak_rss_mb() -> float | None:
+    try:
+        return round(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0, 2)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _digits_cnpj(row: dict[str, Any]) -> str:
+    raw = str(row.get("cnpj14") or row.get("cnpj") or "")
+    d = "".join(ch for ch in raw if ch.isdigit())
+    return d if len(d) == 14 else ""
+
+
+def source_hash_for_row(row: dict[str, Any]) -> str:
+    """Hash of observational fields that drive activation (not rank alone)."""
+    port = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+    payload = {
+        "cnpj14": _digits_cnpj(row),
+        "last_contract_date": port.get("last_contract_date"),
+        "first_contract_date": port.get("first_contract_date"),
+        "active_contract_count": port.get("active_contract_count"),
+        "contract_count_recent": port.get("contract_count_recent"),
+        "contract_count_total": port.get("contract_count_total"),
+        "value_recent_brl": port.get("value_recent_brl"),
+        "value_total_brl": port.get("value_total_brl"),
+        "recent_contracts": port.get("recent_contracts") or [],
+        "outreach_eligibility": row.get("outreach_eligibility"),
+        "commercial_state": row.get("commercial_state"),
+        "construction_sector_fit": (
+            (row.get("construction_evidence") or {}).get("sector_fit")
+            if isinstance(row.get("construction_evidence"), dict)
+            else None
+        ),
+        "new_process_document": row.get("new_process_document"),
+    }
+    return stable_hash(payload)
+
+
+def _commercial_state(row: dict[str, Any], prior: dict[str, Any] | None) -> str:
+    for src in (row, prior or {}):
+        st = str(src.get("commercial_state") or "").upper()
+        if st:
+            return st
+    elig = str(row.get("outreach_eligibility") or "").upper()
+    if elig in {"DNC", "DO_NOT_CONTACT"}:
+        return "DO_NOT_CONTACT"
+    return "NEW"
+
+
+def _decide_state(
+    *,
+    commercial_state: str,
+    fired: list[Any],
+    policy: ActivationPolicy,
+    score: float,
+) -> tuple[str, list[str]]:
+    if commercial_state in policy.suppressed_states:
+        return "SUPPRESSED", ["HUMAN_SUPPRESSED", commercial_state]
+
+    # Active commercial blocks: not cold ACTIONABLE_NOW
+    if commercial_state in policy.active_commercial_block:
+        codes = [f.code for f in fired] if fired else ["ACTIVE_CADENCE_OR_HUMAN"]
+        return "WATCH", codes
+
+    if not fired:
+        return "WATCH", []
+
+    # Highest promotion among fired
+    order = {"ACTIONABLE_NOW": 3, "RESEARCH_REQUIRED": 2, "WATCH": 1, "SUPPRESSED": 0}
+    best_state = "WATCH"
+    codes: list[str] = []
+    for f in fired:
+        codes.append(f.code)
+        if order.get(f.promotes_to, 0) > order.get(best_state, 0):
+            best_state = f.promotes_to
+
+    if best_state == "ACTIONABLE_NOW" and score < policy.hot_set_min_score * 0.5:
+        # Weak score with actionable trigger → research first
+        return "RESEARCH_REQUIRED", codes
+
+    return best_state, codes
+
+
+def _next_best_action(
+    state: str,
+    fired: list[Any],
+    *,
+    as_of: date,
+    policy: ActivationPolicy,
+    evaluated_at: str,
+) -> str | None:
+    if state == "SUPPRESSED":
+        return None
+    if state in {"ACTIONABLE_NOW", "RESEARCH_REQUIRED"}:
+        return evaluated_at if not fired else (
+            # if anniversary in future, use event date
+            _future_or_now(fired, as_of, evaluated_at)
+        )
+    # WATCH: schedule reevaluation
+    days = int(policy.reevaluation.get("watch_days", 14))
+    return (as_of + timedelta(days=days)).isoformat() + "T00:00:00Z"
+
+
+def _future_or_now(fired: list[Any], as_of: date, evaluated_at: str) -> str:
+    for f in fired:
+        if f.code == "CONTRACT_ANNIVERSARY_WINDOW" and f.event_date:
+            try:
+                ed = date.fromisoformat(str(f.event_date)[:10])
+                if ed > as_of:
+                    return ed.isoformat() + "T00:00:00Z"
+            except ValueError:
+                pass
+    return evaluated_at
+
+
+def _expires_at(state: str, fired: list[Any], policy: ActivationPolicy, as_of: date) -> str | None:
+    if state not in {"ACTIONABLE_NOW", "RESEARCH_REQUIRED"}:
+        return None
+    dates: list[date] = []
+    for f in fired:
+        if f.expires_at:
+            try:
+                dates.append(date.fromisoformat(str(f.expires_at)[:10]))
+            except ValueError:
+                pass
+    if dates:
+        return min(dates).isoformat() + "T00:00:00Z"
+    ttl = int(policy.reevaluation.get("actionable_ttl_days", 14))
+    return (as_of + timedelta(days=ttl)).isoformat() + "T00:00:00Z"
+
+
+def evaluate_row(
+    row: dict[str, Any],
+    *,
+    policy: ActivationPolicy,
+    as_of: date,
+    prior: dict[str, Any] | None = None,
+    evaluated_at: str | None = None,
+) -> ActivationProjection:
+    """Evaluate one universe company into an activation projection."""
+    cnpj = _digits_cnpj(row)
+    if not cnpj:
+        raise ValueError("row missing cnpj14")
+    evaluated_at = evaluated_at or _utcnow()
+    sh = source_hash_for_row(row)
+    prior_ctx = dict(prior or {})
+    prior_ctx["current_source_hash"] = sh
+    if prior and "active_contract_count" not in prior_ctx:
+        # allow portfolio deltas from prior projection snapshot fields
+        pass
+
+    commercial = _commercial_state(row, prior)
+    fired = detect_triggers(row, policy=policy, as_of=as_of, prior=prior_ctx)
+    score, components = compute_activation_score(row, fired, policy=policy, as_of=as_of)
+    state, codes = _decide_state(
+        commercial_state=commercial, fired=fired, policy=policy, score=score
+    )
+
+    # Expire stale actionable if expires_at already past
+    exp = _expires_at(state, fired, policy, as_of)
+    if state == "ACTIONABLE_NOW" and exp:
+        try:
+            exp_d = date.fromisoformat(exp[:10])
+            if exp_d < as_of:
+                state = "WATCH"
+                codes = codes + ["TRIGGER_EXPIRED"]
+        except ValueError:
+            pass
+
+    th = stable_hash([f.as_dict() for f in fired])
+    nba = _next_best_action(
+        state, fired, as_of=as_of, policy=policy, evaluated_at=evaluated_at
+    )
+
+    # Preserve durable funnel fields from prior projection
+    prior = prior or {}
+    ds = str(prior.get("downstream_status") or DOWNSTREAM_PENDING).upper()
+    if ds not in {
+        "PENDING",
+        "SELECTED",
+        "INTEL_DONE",
+        "CONTACTS_DONE",
+        "EXPORTED",
+        "FAILED",
+        "COOLDOWN",
+        "NO_CONTACT",
+        "SKIPPED",
+    }:
+        ds = DOWNSTREAM_PENDING
+    next_elig = prior.get("next_eligible_at") or row.get("next_eligible_at")
+    last_outcome = prior.get("last_outcome") or row.get("last_outcome")
+    port = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+    value_total = float(port.get("value_total_brl") or 0)
+    try:
+        pri_score = float(row.get("priority_score") or score)
+    except (TypeError, ValueError):
+        pri_score = float(score)
+    band = priority_band_for(
+        activation_state=state,
+        activation_score=score if state != "SUPPRESSED" else 0.0,
+        commercial_state=commercial,
+        downstream_status=ds,
+        value_total=value_total,
+    )
+
+    proj = ActivationProjection(
+        cnpj14=cnpj,
+        activation_state=state,
+        activation_score=score if state != "SUPPRESSED" else 0.0,
+        reason_codes=codes,
+        evaluated_at=evaluated_at,
+        next_best_action_at=nba,
+        expires_at=exp if state in {"ACTIONABLE_NOW", "RESEARCH_REQUIRED"} else None,
+        source_hash=sh,
+        trigger_hash=th,
+        policy_version=policy.policy_version,
+        score_components=components.as_dict(),
+        fired_triggers=[f.as_dict() for f in fired],
+        last_hot_set_at=prior.get("last_hot_set_at"),
+        commercial_state=commercial,
+        notes=[],
+        downstream_status=ds,
+        last_downstream_at=prior.get("last_downstream_at"),
+        next_eligible_at=str(next_elig) if next_elig else None,
+        processing_attempts=int(prior.get("processing_attempts") or 0),
+        last_error=prior.get("last_error"),
+        last_outcome=str(last_outcome) if last_outcome else None,
+        priority_band=band,
+        priority_score=pri_score,
+    )
+    proj.validate()
+    return proj
+
+
+def select_hot_set(
+    projections: list[ActivationProjection],
+    *,
+    policy: ActivationPolicy,
+    capacity_override: int | None = None,
+    as_of: date | None = None,
+    include_watch_fill: bool = True,
+    cooldown_days: int = 14,
+) -> list[ActivationProjection]:
+    """Capacity-aware hot set with durable cursor (no blind re-pick of prior batch).
+
+    Tier 1: ACTIONABLE_NOW / RESEARCH_REQUIRED not yet consumed this cycle.
+    Tier 2 (fill): WATCH ordered by score so every eligible remains reachable.
+
+    Score/priority orders work; only objective blocks (DNC, SUPPRESSED, active
+    cadence, next_eligible_at in future) exclude. Capacity is operational
+    batch size — never the size of the commercial universe.
+    """
+    budget = capacity_override if capacity_override is not None else policy.capacity.planned_capacity()
+    budget = max(0, min(budget, policy.capacity.max_hot_set))
+    as_of = as_of or date.today()
+
+    def available(p: ActivationProjection) -> bool:
+        if p.activation_state == "SUPPRESSED":
+            return False
+        if p.commercial_state in policy.suppressed_states:
+            return False
+        if p.commercial_state in policy.active_commercial_block:
+            return False
+        prior_snap = {
+            "commercial_state": p.commercial_state,
+            "last_outcome": p.last_outcome,
+            "next_eligible_at": p.next_eligible_at,
+            "downstream_status": p.downstream_status,
+            "last_downstream_at": p.last_downstream_at,
+            "last_hot_set_at": p.last_hot_set_at,
+            "source_hash": p.source_hash,
+        }
+        if not is_reeligible(
+            prior_snap,
+            as_of=as_of,
+            current_source_hash=p.source_hash,
+            cooldown_days=cooldown_days,
+        ):
+            return False
+        return True
+
+    tier1 = [
+        p
+        for p in projections
+        if available(p)
+        and p.activation_state in {"ACTIONABLE_NOW", "RESEARCH_REQUIRED"}
+        and p.activation_score >= policy.hot_set_min_score
+    ]
+    tier1.sort(
+        key=lambda p: (
+            0 if p.activation_state == "ACTIONABLE_NOW" else 1,
+            -p.activation_score,
+            p.cnpj14,
+        )
+    )
+    selected: list[ActivationProjection] = []
+    seen: set[str] = set()
+    for p in tier1:
+        if len(selected) >= budget:
+            break
+        selected.append(p)
+        seen.add(p.cnpj14)
+
+    if include_watch_fill and len(selected) < budget:
+        tier2 = [
+            p
+            for p in projections
+            if available(p)
+            and p.cnpj14 not in seen
+            and p.activation_state == "WATCH"
+        ]
+        # Prefer higher activation_score then priority_score then stable cnpj
+        tier2.sort(key=lambda p: (-p.activation_score, -p.priority_score, p.cnpj14))
+        for p in tier2:
+            if len(selected) >= budget:
+                break
+            selected.append(p)
+            seen.add(p.cnpj14)
+
+    return selected
+
+
+def compute_deltas(
+    previous: dict[str, dict[str, Any]],
+    current: list[ActivationProjection],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
+    """Return (deactivations, promotions, rows_changed)."""
+    deacts: list[dict[str, Any]] = []
+    promos: list[dict[str, Any]] = []
+    changed = 0
+    cur_by = {p.cnpj14: p for p in current}
+    for cnpj, prev in previous.items():
+        prev_state = str(prev.get("activation_state") or "")
+        cur = cur_by.get(cnpj)
+        if cur is None:
+            continue
+        if prev_state != cur.activation_state or prev.get("source_hash") != cur.source_hash:
+            changed += 1
+        if prev_state == "ACTIONABLE_NOW" and cur.activation_state in {
+            "WATCH",
+            "SUPPRESSED",
+            "RESEARCH_REQUIRED",
+        }:
+            deacts.append(
+                {
+                    "cnpj14": cnpj,
+                    "from_state": prev_state,
+                    "to_state": cur.activation_state,
+                    "reason_codes": list(cur.reason_codes),
+                    "evaluated_at": cur.evaluated_at,
+                    "source_hash": cur.source_hash,
+                    "policy_version": cur.policy_version,
+                }
+            )
+        if prev_state in {"WATCH", "RESEARCH_REQUIRED", ""} and cur.activation_state == "ACTIONABLE_NOW":
+            promos.append(
+                {
+                    "cnpj14": cnpj,
+                    "from_state": prev_state or "WATCH",
+                    "to_state": cur.activation_state,
+                    "reason_codes": list(cur.reason_codes),
+                    "activation_score": cur.activation_score,
+                    "evaluated_at": cur.evaluated_at,
+                }
+            )
+    # New ACTIONABLE without prior
+    for p in current:
+        if p.cnpj14 not in previous and p.activation_state == "ACTIONABLE_NOW":
+            promos.append(
+                {
+                    "cnpj14": p.cnpj14,
+                    "from_state": "NONE",
+                    "to_state": p.activation_state,
+                    "reason_codes": list(p.reason_codes),
+                    "activation_score": p.activation_score,
+                    "evaluated_at": p.evaluated_at,
+                }
+            )
+            changed += 1
+    return deacts, promos, changed
+
+
+def run_activation_cycle(
+    universe_rows: list[dict[str, Any]],
+    *,
+    policy: ActivationPolicy | None = None,
+    policy_path: str | None = None,
+    as_of: date | None = None,
+    prior_projections: dict[str, dict[str, Any]] | None = None,
+    capacity_override: int | None = None,
+    evaluated_at: str | None = None,
+    commercial_memory: dict[str, dict[str, Any]] | None = None,
+    include_watch_fill: bool = True,
+) -> ActivationCycleResult:
+    """Process full reservoir cheaply; return projections + hot set + deltas.
+
+    Does NOT run LLM or account intelligence. Bounded memory: one pass.
+    capacity_override bounds this round's expensive batch only — never the
+    universe size. Prior projections + commercial_memory advance the cursor.
+    """
+    started = time.monotonic()
+    pol = policy or load_policy(policy_path)
+    as_of = as_of or date.today()
+    evaluated_at = evaluated_at or _utcnow()
+    prior = prior_projections or {}
+    memory = commercial_memory or {}
+
+    projections: list[ActivationProjection] = []
+    counts = {
+        "WATCH": 0,
+        "RESEARCH_REQUIRED": 0,
+        "ACTIONABLE_NOW": 0,
+        "SUPPRESSED": 0,
+    }
+
+    for raw_row in universe_rows:
+        row = apply_commercial_memory(raw_row, memory)
+        cnpj = _digits_cnpj(row)
+        if not cnpj:
+            continue
+        # Skip non-eligible for commercial activation (still reservoir membership
+        # is caller's responsibility — we only plan eligible construction B2G).
+        elig = str(row.get("outreach_eligibility") or "ELIGIBLE").upper()
+        if elig not in {"ELIGIBLE", "DNC", "DO_NOT_CONTACT", ""}:
+            # Keep non-construction out of activation counts but still WATCH if passed
+            pass
+        prev = prior.get(cnpj)
+        # Merge memory into prior for durable commercial_state
+        prior_for_row: dict[str, Any] = dict(prev or {})
+        if cnpj in memory:
+            mem = memory[cnpj]
+            if mem.get("commercial_state"):
+                prior_for_row["commercial_state"] = mem["commercial_state"]
+            if mem.get("next_eligible_at"):
+                prior_for_row["next_eligible_at"] = mem["next_eligible_at"]
+            if mem.get("last_outcome"):
+                prior_for_row["last_outcome"] = mem["last_outcome"]
+            if mem.get("downstream_status"):
+                prior_for_row["downstream_status"] = mem["downstream_status"]
+        proj = evaluate_row(
+            row,
+            policy=pol,
+            as_of=as_of,
+            prior=prior_for_row,
+            evaluated_at=evaluated_at,
+        )
+        projections.append(proj)
+        counts[proj.activation_state] = counts.get(proj.activation_state, 0) + 1
+
+    # Count trigger codes from fired_triggers for accuracy
+    trigger_counts: dict[str, int] = {}
+    for p in projections:
+        for ft in p.fired_triggers:
+            code = str(ft.get("code") or "")
+            if code:
+                trigger_counts[code] = trigger_counts.get(code, 0) + 1
+
+    hot = select_hot_set(
+        projections,
+        policy=pol,
+        capacity_override=capacity_override,
+        as_of=as_of,
+        include_watch_fill=include_watch_fill,
+    )
+    hot_at = evaluated_at
+    for p in hot:
+        p.last_hot_set_at = hot_at
+        p.downstream_status = DOWNSTREAM_SELECTED
+        p.last_downstream_at = hot_at
+        p.processing_attempts = int(p.processing_attempts or 0) + 1
+
+    deacts, promos, rows_changed = compute_deltas(prior, projections)
+
+    # Watermark from max last_contract_date
+    watermark_parts: list[str] = []
+    for row in universe_rows[:5000]:  # bounded sample for watermark string stability
+        port = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+        lcd = port.get("last_contract_date")
+        if lcd:
+            watermark_parts.append(str(lcd))
+    source_watermark = stable_hash(
+        {
+            "as_of": as_of.isoformat(),
+            "reservoir": len(projections),
+            "policy": pol.policy_version,
+            "max_last": max(watermark_parts) if watermark_parts else "",
+        }
+    )
+
+    return ActivationCycleResult(
+        policy_version=pol.policy_version,
+        evaluated_at=evaluated_at,
+        as_of=as_of.isoformat(),
+        reservoir_count=len(projections),
+        activation_counts=counts,
+        hot_set_count=len(hot),
+        projections=projections,
+        hot_set=hot,
+        deactivations=deacts,
+        promotions=promos,
+        source_watermark=source_watermark,
+        trigger_counts=dict(sorted(trigger_counts.items())),
+        rows_changed=rows_changed,
+        elapsed_seconds=round(time.monotonic() - started, 3),
+        peak_rss_mb=_peak_rss_mb(),
+    )

--- a/scripts/confenge_activation/policy.py
+++ b/scripts/confenge_activation/policy.py
@@ -1,0 +1,188 @@
+"""Load and validate versioned activation policy YAML."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.confenge_activation import DEFAULT_POLICY_VERSION, POLICY_DEFAULT_NAME
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_POLICY_PATH = _PROJECT_ROOT / "config" / "commercial" / POLICY_DEFAULT_NAME
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    trigger_strength: float
+    freshness: float
+    evidence_quality: float
+    commercial_relevance: float
+
+    def total(self) -> float:
+        return (
+            self.trigger_strength
+            + self.freshness
+            + self.evidence_quality
+            + self.commercial_relevance
+        )
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "trigger_strength": self.trigger_strength,
+            "freshness": self.freshness,
+            "evidence_quality": self.evidence_quality,
+            "commercial_relevance": self.commercial_relevance,
+        }
+
+
+@dataclass(frozen=True)
+class CapacityConfig:
+    sends_per_hour: int
+    send_window_hours: int
+    planning_horizon_days: int
+    research_buffer: float
+    max_hot_set: int
+    min_hot_set: int
+
+    def planned_capacity(self) -> int:
+        """Theoretical hot-set budget from rate × window × horizon × buffer."""
+        raw = (
+            float(self.sends_per_hour)
+            * float(self.send_window_hours)
+            * float(self.planning_horizon_days)
+            * float(self.research_buffer)
+        )
+        n = int(round(raw))
+        n = max(self.min_hot_set, n)
+        return min(self.max_hot_set, n)
+
+
+@dataclass(frozen=True)
+class TriggerDef:
+    code: str
+    enabled: bool
+    strength: float
+    language: str
+    expires_days: int | None
+    promotes_to: str
+    next_best_action: str
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ActivationPolicy:
+    policy_version: str
+    capacity: CapacityConfig
+    score_weights: ScoreWeights
+    triggers: dict[str, TriggerDef]
+    suppressed_states: frozenset[str]
+    active_commercial_block: frozenset[str]
+    reevaluation: dict[str, Any]
+    materiality: dict[str, Any]
+    freshness_bands: list[dict[str, Any]]
+    evidence_quality: dict[str, Any]
+    hot_set_min_score: float
+    production: dict[str, Any]
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def trigger(self, code: str) -> TriggerDef | None:
+        return self.triggers.get(code)
+
+
+def _require_mapping(data: Any, label: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return data
+
+
+def load_policy(path: Path | str | None = None) -> ActivationPolicy:
+    """Load policy from YAML. Fail-closed on missing/invalid config."""
+    p = Path(path) if path else DEFAULT_POLICY_PATH
+    if not p.is_file():
+        raise FileNotFoundError(f"activation policy not found: {p}")
+    data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    data = _require_mapping(data, "policy root")
+
+    version = str(data.get("policy_version") or DEFAULT_POLICY_VERSION).strip()
+    cap_raw = _require_mapping(data.get("capacity") or {}, "capacity")
+    capacity = CapacityConfig(
+        sends_per_hour=int(cap_raw.get("sends_per_hour", 10)),
+        send_window_hours=int(cap_raw.get("send_window_hours", 9)),
+        planning_horizon_days=int(cap_raw.get("planning_horizon_days", 7)),
+        research_buffer=float(cap_raw.get("research_buffer", 1.5)),
+        max_hot_set=int(cap_raw.get("max_hot_set", 500)),
+        min_hot_set=int(cap_raw.get("min_hot_set", 20)),
+    )
+    if capacity.sends_per_hour < 1:
+        raise ValueError("capacity.sends_per_hour must be >= 1")
+    if capacity.max_hot_set < capacity.min_hot_set:
+        raise ValueError("capacity.max_hot_set must be >= min_hot_set")
+
+    w_raw = _require_mapping(data.get("score_weights") or {}, "score_weights")
+    weights = ScoreWeights(
+        trigger_strength=float(w_raw.get("trigger_strength", 40)),
+        freshness=float(w_raw.get("freshness", 25)),
+        evidence_quality=float(w_raw.get("evidence_quality", 20)),
+        commercial_relevance=float(w_raw.get("commercial_relevance", 15)),
+    )
+    total = weights.total()
+    if abs(total - 100.0) > 0.01:
+        raise ValueError(f"score_weights must sum to 100, got {total}")
+
+    triggers: dict[str, TriggerDef] = {}
+    t_raw = _require_mapping(data.get("triggers") or {}, "triggers")
+    for code, cfg in t_raw.items():
+        if not isinstance(cfg, dict):
+            raise ValueError(f"trigger {code} must be a mapping")
+        promotes = str(cfg.get("promotes_to") or "WATCH").upper()
+        if promotes not in {
+            "WATCH",
+            "RESEARCH_REQUIRED",
+            "ACTIONABLE_NOW",
+            "SUPPRESSED",
+        }:
+            raise ValueError(f"trigger {code}: invalid promotes_to {promotes}")
+        strength = float(cfg.get("strength", 0))
+        if strength < 0 or strength > 100:
+            raise ValueError(f"trigger {code}: strength must be 0–100")
+        exp = cfg.get("expires_days")
+        triggers[str(code).upper()] = TriggerDef(
+            code=str(code).upper(),
+            enabled=bool(cfg.get("enabled", True)),
+            strength=strength,
+            language=str(cfg.get("language") or "").strip(),
+            expires_days=int(exp) if exp is not None else None,
+            promotes_to=promotes,
+            next_best_action=str(cfg.get("next_best_action") or "now"),
+            raw=dict(cfg),
+        )
+
+    suppressed = frozenset(
+        str(x).upper() for x in (data.get("suppressed_states") or [])
+    )
+    active_block = frozenset(
+        str(x).upper() for x in (data.get("active_commercial_block") or [])
+    )
+
+    bands = data.get("freshness_bands") or []
+    if not isinstance(bands, list) or not bands:
+        raise ValueError("freshness_bands must be a non-empty list")
+
+    return ActivationPolicy(
+        policy_version=version,
+        capacity=capacity,
+        score_weights=weights,
+        triggers=triggers,
+        suppressed_states=suppressed,
+        active_commercial_block=active_block,
+        reevaluation=dict(data.get("reevaluation") or {}),
+        materiality=dict(data.get("materiality") or {}),
+        freshness_bands=list(bands),
+        evidence_quality=dict(data.get("evidence_quality") or {}),
+        hot_set_min_score=float(data.get("hot_set_min_score", 25)),
+        production=dict(data.get("production") or {}),
+        raw=data,
+    )

--- a/scripts/confenge_activation/publish.py
+++ b/scripts/confenge_activation/publish.py
@@ -1,0 +1,119 @@
+"""Atomic feed publication: build temp → validate → hash → promote.
+
+Never leave Warmbly observing partial chunks with a new manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _fsync_dir(path: Path) -> None:
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def atomic_publish_directory(
+    build_dir: Path,
+    publish_dir: Path,
+    *,
+    current_name: str = "current",
+) -> dict[str, Any]:
+    """Atomically promote build_dir contents to publish_dir/current via rename.
+
+    Layout:
+      publish_dir/
+        current -> releases/<run_id>   (symlink, atomic replace)
+        releases/<run_id>/...
+    If build_dir already contains a complete feed (manifest + chunks), we copy
+    into a new release directory then swap the symlink.
+    """
+    build_dir = Path(build_dir)
+    publish_dir = Path(publish_dir)
+    publish_dir.mkdir(parents=True, exist_ok=True)
+    releases = publish_dir / "releases"
+    releases.mkdir(parents=True, exist_ok=True)
+
+    manifest_path = build_dir / "manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"no manifest.json in {build_dir}")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    source = manifest.get("source") if isinstance(manifest.get("source"), dict) else {}
+    run_id = str(source.get("run_id") or "run-unknown")
+    # Validate chunks listed in manifest exist and match hashes when present
+    chunks = manifest.get("chunks") or []
+    for ch in chunks:
+        if not isinstance(ch, dict):
+            continue
+        fname = ch.get("file")
+        if not fname:
+            continue
+        fp = build_dir / str(fname)
+        if not fp.is_file():
+            raise FileNotFoundError(f"manifest references missing chunk {fname}")
+        expected = ch.get("content_hash")
+        if expected:
+            actual = _sha256_file(fp)
+            if actual != expected:
+                raise ValueError(f"chunk hash mismatch for {fname}: {actual} != {expected}")
+
+    release_dir = releases / run_id
+    if release_dir.exists():
+        shutil.rmtree(release_dir)
+    # Copy into temp under releases then rename
+    tmp = Path(tempfile.mkdtemp(prefix=".pub-", dir=str(releases)))
+    try:
+        for item in build_dir.iterdir():
+            dest = tmp / item.name
+            if item.is_dir():
+                shutil.copytree(item, dest)
+            else:
+                shutil.copy2(item, dest)
+                # fsync file
+                with dest.open("rb") as f:
+                    os.fsync(f.fileno())
+        _fsync_dir(tmp)
+        os.replace(str(tmp), str(release_dir))
+        _fsync_dir(releases)
+    except Exception:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise
+
+    # Atomic symlink swap: current -> releases/<run_id>
+    current = publish_dir / current_name
+    link_tmp = publish_dir / f".{current_name}.tmp-{run_id}"
+    if link_tmp.exists() or link_tmp.is_symlink():
+        link_tmp.unlink()
+    # Relative symlink for portability
+    rel_target = Path("releases") / run_id
+    link_tmp.symlink_to(rel_target, target_is_directory=True)
+    os.replace(str(link_tmp), str(current))
+    _fsync_dir(publish_dir)
+
+    return {
+        "ok": True,
+        "publish_dir": str(publish_dir.resolve()),
+        "current": str(current.resolve()),
+        "release_dir": str(release_dir.resolve()),
+        "run_id": run_id,
+        "snapshot_hash": source.get("snapshot_hash"),
+        "chunk_count": len(chunks),
+    }

--- a/scripts/confenge_activation/score.py
+++ b/scripts/confenge_activation/score.py
@@ -1,0 +1,137 @@
+"""Deterministic activation_score (0–100) — ordering only, never probability."""
+
+from __future__ import annotations
+
+import math
+from datetime import date, datetime
+from typing import Any
+
+from scripts.confenge_activation.models import FiredTrigger, ScoreComponents
+from scripts.confenge_activation.policy import ActivationPolicy
+
+
+def _parse_date(val: Any) -> date | None:
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val.date()
+    if isinstance(val, date):
+        return val
+    try:
+        return date.fromisoformat(str(val)[:10])
+    except ValueError:
+        return None
+
+
+def _clamp(v: float, lo: float = 0.0, hi: float = 100.0) -> float:
+    return max(lo, min(hi, v))
+
+
+def freshness_score(as_of: date, event_date: date | None, policy: ActivationPolicy) -> float:
+    if event_date is None:
+        return 10.0
+    days = max(0, (as_of - event_date).days)
+    for band in policy.freshness_bands:
+        if days <= int(band.get("max_days", 99999)):
+            return float(band.get("score", 10))
+    return 10.0
+
+
+def evidence_quality_score(row: dict[str, Any], policy: ActivationPolicy) -> float:
+    eq = policy.evidence_quality
+    ce = row.get("construction_evidence") if isinstance(row.get("construction_evidence"), dict) else {}
+    fit = str(ce.get("sector_fit") or ce.get("fit") or "").upper()
+    if fit == "CONFIRMED_ENGINEERING":
+        base = float(eq.get("confirmed_engineering", 90))
+    elif fit == "STRONG_ENGINEERING_FIT":
+        base = float(eq.get("strong_engineering_fit", 70))
+    elif fit == "POSSIBLE_ENGINEERING_FIT":
+        base = float(eq.get("possible_engineering_fit", 45))
+    else:
+        base = float(eq.get("default", 25))
+    port = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+    recent = port.get("recent_contracts") or []
+    if isinstance(recent, list) and len(recent) > 0:
+        base = _clamp(base + float(eq.get("with_recent_contracts_sample", 15)))
+    return _clamp(base)
+
+
+def commercial_relevance_score(row: dict[str, Any], policy: ActivationPolicy) -> float:
+    """Portfolio breadth + damped value + fit. Mega-contract cannot dominate."""
+    mat = policy.materiality
+    port = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+    ce = row.get("construction_evidence") if isinstance(row.get("construction_evidence"), dict) else {}
+
+    active = float(port.get("active_contract_count") or 0)
+    orgaos = port.get("orgaos") or []
+    n_org = float(len(orgaos)) if isinstance(orgaos, list) else float(orgaos or 0)
+    ufs = port.get("ufs_atuacao") or []
+    n_uf = float(len(ufs)) if isinstance(ufs, list) else float(ufs or 0)
+    breadth = _clamp((active * 2.0 + n_org * 1.5 + n_uf * 2.0), 0, 100)
+
+    value = float(port.get("value_recent_brl") or port.get("value_total_brl") or 0)
+    log_cap = float(mat.get("value_log_cap", 12.0))
+    if value > 0:
+        # Same damping spirit as universe priority: log10(1+v/1e5)
+        value_pts = min(log_cap, math.log10(1.0 + value / 1e5) * 2.0) / log_cap * 100.0
+    else:
+        value_pts = 0.0
+
+    fit = str(ce.get("sector_fit") or "").upper()
+    if fit == "CONFIRMED_ENGINEERING":
+        fit_pts = 100.0
+    elif fit == "STRONG_ENGINEERING_FIT":
+        fit_pts = 80.0
+    elif fit == "POSSIBLE_ENGINEERING_FIT":
+        fit_pts = 50.0
+    else:
+        fit_pts = 20.0
+
+    w_val = float(mat.get("value_weight_in_relevance", 0.35))
+    w_br = float(mat.get("portfolio_breadth_weight", 0.40))
+    w_fit = float(mat.get("construction_fit_weight", 0.25))
+    # Normalize weights
+    wsum = w_val + w_br + w_fit
+    if wsum <= 0:
+        w_val, w_br, w_fit = 0.35, 0.40, 0.25
+        wsum = 1.0
+    w_val, w_br, w_fit = w_val / wsum, w_br / wsum, w_fit / wsum
+    return _clamp(value_pts * w_val + breadth * w_br + fit_pts * w_fit)
+
+
+def trigger_strength_score(fired: list[FiredTrigger]) -> float:
+    if not fired:
+        return 0.0
+    # Best trigger + diminishing secondary
+    best = max(f.strength for f in fired)
+    secondary = sum(f.strength for f in fired) - best
+    return _clamp(best + 0.15 * secondary)
+
+
+def compute_activation_score(
+    row: dict[str, Any],
+    fired: list[FiredTrigger],
+    *,
+    policy: ActivationPolicy,
+    as_of: date,
+) -> tuple[float, ScoreComponents]:
+    """Weighted 0–100 ordering score. Deterministic for same inputs+policy."""
+    w = policy.score_weights
+    # Raw components on 0–100 scale before weighting
+    ts_raw = trigger_strength_score(fired)
+    event = None
+    if fired:
+        event = _parse_date(fired[0].event_date)
+    fr_raw = freshness_score(as_of, event, policy)
+    eq_raw = evidence_quality_score(row, policy)
+    cr_raw = commercial_relevance_score(row, policy)
+
+    # Apply weights (weights sum to 100 → score already 0–100)
+    components = ScoreComponents(
+        trigger_strength=ts_raw * (w.trigger_strength / 100.0),
+        freshness=fr_raw * (w.freshness / 100.0),
+        evidence_quality=eq_raw * (w.evidence_quality / 100.0),
+        commercial_relevance=cr_raw * (w.commercial_relevance / 100.0),
+    )
+    total = _clamp(components.total())
+    return round(total, 4), components

--- a/scripts/confenge_activation/store.py
+++ b/scripts/confenge_activation/store.py
@@ -1,0 +1,141 @@
+"""Persistent activation projection store (JSONL + optional Postgres).
+
+Activation state is a recomputable projection — NOT Decision & Outcome Memory.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.confenge_activation.models import ActivationProjection
+
+
+def load_projections_jsonl(path: Path | str) -> dict[str, dict[str, Any]]:
+    p = Path(path)
+    if not p.is_file():
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for line in p.read_text(encoding="utf-8").splitlines():
+        text = line.strip()
+        if not text or text.startswith("#"):
+            continue
+        row = json.loads(text)
+        cnpj = str(row.get("cnpj14") or "")
+        if len(cnpj) == 14:
+            out[cnpj] = row
+    return out
+
+
+def write_projections_jsonl(path: Path | str, projections: list[ActivationProjection]) -> dict[str, Any]:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for proj in sorted(projections, key=lambda x: x.cnpj14):
+            f.write(json.dumps(proj.as_dict(), ensure_ascii=False, sort_keys=True) + "\n")
+    return {"path": str(p), "count": len(projections)}
+
+
+def write_hot_set_jsonl(path: Path | str, hot: list[ActivationProjection]) -> dict[str, Any]:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for proj in hot:
+            f.write(json.dumps(proj.as_dict(), ensure_ascii=False, sort_keys=True) + "\n")
+    return {"path": str(p), "count": len(hot)}
+
+
+def upsert_projections_pg(dsn: str, projections: list[ActivationProjection]) -> int:
+    """Optional Postgres upsert into confenge_activation_projections."""
+    try:
+        import psycopg
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("psycopg required for PG activation store") from exc
+
+    sql = """
+    INSERT INTO confenge_activation_projections (
+        cnpj14, activation_state, activation_score, reason_codes,
+        evaluated_at, next_best_action_at, expires_at,
+        source_hash, trigger_hash, last_hot_set_at, policy_version,
+        score_components, commercial_state, updated_at
+    ) VALUES (
+        %(cnpj14)s, %(activation_state)s, %(activation_score)s, %(reason_codes)s::jsonb,
+        %(evaluated_at)s, %(next_best_action_at)s, %(expires_at)s,
+        %(source_hash)s, %(trigger_hash)s, %(last_hot_set_at)s, %(policy_version)s,
+        %(score_components)s::jsonb, %(commercial_state)s, now()
+    )
+    ON CONFLICT (cnpj14) DO UPDATE SET
+        activation_state = EXCLUDED.activation_state,
+        activation_score = EXCLUDED.activation_score,
+        reason_codes = EXCLUDED.reason_codes,
+        evaluated_at = EXCLUDED.evaluated_at,
+        next_best_action_at = EXCLUDED.next_best_action_at,
+        expires_at = EXCLUDED.expires_at,
+        source_hash = EXCLUDED.source_hash,
+        trigger_hash = EXCLUDED.trigger_hash,
+        last_hot_set_at = COALESCE(EXCLUDED.last_hot_set_at, confenge_activation_projections.last_hot_set_at),
+        policy_version = EXCLUDED.policy_version,
+        score_components = EXCLUDED.score_components,
+        commercial_state = EXCLUDED.commercial_state,
+        updated_at = now()
+    """
+    n = 0
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            for proj in projections:
+                d = proj.as_dict()
+                cur.execute(
+                    sql,
+                    {
+                        "cnpj14": d["cnpj14"],
+                        "activation_state": d["activation_state"],
+                        "activation_score": d["activation_score"],
+                        "reason_codes": json.dumps(d["reason_codes"]),
+                        "evaluated_at": d["evaluated_at"],
+                        "next_best_action_at": d["next_best_action_at"],
+                        "expires_at": d["expires_at"],
+                        "source_hash": d["source_hash"],
+                        "trigger_hash": d["trigger_hash"],
+                        "last_hot_set_at": d["last_hot_set_at"],
+                        "policy_version": d["policy_version"],
+                        "score_components": json.dumps(d["score_components"]),
+                        "commercial_state": d["commercial_state"],
+                    },
+                )
+                n += 1
+        conn.commit()
+    return n
+
+
+def load_projections_pg(dsn: str) -> dict[str, dict[str, Any]]:
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("psycopg required for PG activation store") from exc
+
+    sql = """
+    SELECT cnpj14, activation_state, activation_score, reason_codes,
+           evaluated_at, next_best_action_at, expires_at,
+           source_hash, trigger_hash, last_hot_set_at, policy_version,
+           score_components, commercial_state,
+           active_contract_count, contract_count_recent
+    FROM confenge_activation_projections
+    """
+    out: dict[str, dict[str, Any]] = {}
+    with psycopg.connect(dsn, row_factory=dict_row) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            for row in cur.fetchall():
+                cnpj = str(row["cnpj14"])
+                d = dict(row)
+                # normalize JSON
+                for k in ("reason_codes", "score_components"):
+                    if isinstance(d.get(k), str):
+                        d[k] = json.loads(d[k])
+                for k in ("evaluated_at", "next_best_action_at", "expires_at", "last_hot_set_at"):
+                    if d.get(k) is not None and hasattr(d[k], "isoformat"):
+                        d[k] = d[k].isoformat().replace("+00:00", "Z")
+                out[cnpj] = d
+    return out

--- a/scripts/confenge_activation/triggers.py
+++ b/scripts/confenge_activation/triggers.py
@@ -1,0 +1,326 @@
+"""Deterministic commercial triggers from universe rows (observational only).
+
+Never invents legal facts from dates alone.
+Never claims unpaid reajuste from anniversary windows.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from scripts.confenge_activation.models import FiredTrigger
+from scripts.confenge_activation.policy import ActivationPolicy, TriggerDef
+
+
+def _parse_date(val: Any) -> date | None:
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val.date()
+    if isinstance(val, date):
+        return val
+    s = str(val).strip()[:10]
+    if not s:
+        return None
+    try:
+        return date.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def _safe_int(v: Any, default: int = 0) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(v: Any, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _portfolio(row: dict[str, Any]) -> dict[str, Any]:
+    p = row.get("portfolio")
+    return p if isinstance(p, dict) else {}
+
+
+def _recent_contracts(row: dict[str, Any]) -> list[dict[str, Any]]:
+    p = _portfolio(row)
+    rc = p.get("recent_contracts") or row.get("recent_contracts") or []
+    return [c for c in rc if isinstance(c, dict)] if isinstance(rc, list) else []
+
+
+def _object_blob(row: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for c in _recent_contracts(row):
+        for k in ("objeto", "object", "category", "descricao"):
+            if c.get(k):
+                parts.append(str(c[k]))
+    ce = row.get("construction_evidence")
+    if isinstance(ce, dict):
+        for k in ("object_snippets", "categories", "notes"):
+            v = ce.get(k)
+            if isinstance(v, list):
+                parts.extend(str(x) for x in v)
+            elif v:
+                parts.append(str(v))
+    return " ".join(parts).lower()
+
+
+def _sector_fit(row: dict[str, Any]) -> str:
+    ce = row.get("construction_evidence")
+    if isinstance(ce, dict):
+        return str(ce.get("sector_fit") or ce.get("fit") or "").upper()
+    return ""
+
+
+def _expires_at(tdef: TriggerDef, as_of: date, event: date | None) -> str | None:
+    if tdef.expires_days is None:
+        return None
+    base = event or as_of
+    return (base + timedelta(days=int(tdef.expires_days))).isoformat()
+
+
+def _fire(
+    tdef: TriggerDef,
+    *,
+    as_of: date,
+    event: date | None,
+    details: dict[str, Any] | None = None,
+) -> FiredTrigger:
+    return FiredTrigger(
+        code=tdef.code,
+        strength=float(tdef.strength),
+        event_date=event.isoformat() if event else as_of.isoformat(),
+        language=tdef.language,
+        promotes_to=tdef.promotes_to,
+        expires_at=_expires_at(tdef, as_of, event),
+        details=details or {},
+    )
+
+
+def detect_triggers(
+    row: dict[str, Any],
+    *,
+    policy: ActivationPolicy,
+    as_of: date,
+    prior: dict[str, Any] | None = None,
+) -> list[FiredTrigger]:
+    """Evaluate enabled triggers for one universe row. Pure / deterministic."""
+    fired: list[FiredTrigger] = []
+    prior = prior or {}
+    port = _portfolio(row)
+    last_dt = _parse_date(port.get("last_contract_date") or row.get("last_contract_date"))
+    first_dt = _parse_date(port.get("first_contract_date") or row.get("first_contract_date"))
+    active_count = _safe_int(port.get("active_contract_count"))
+    recent_count = _safe_int(port.get("contract_count_recent"))
+    fit = _sector_fit(row)
+    relevant_ok = fit in {
+        "CONFIRMED_ENGINEERING",
+        "STRONG_ENGINEERING_FIT",
+        "POSSIBLE_ENGINEERING_FIT",
+    } or _safe_int(
+        (row.get("construction_evidence") or {}).get("relevant_contract_count")
+        if isinstance(row.get("construction_evidence"), dict)
+        else 0
+    ) > 0
+    blob = _object_blob(row)
+    priority = _safe_float(row.get("priority_score"))
+
+    # NEW_RELEVANT_CONTRACT
+    t = policy.trigger("NEW_RELEVANT_CONTRACT")
+    if t and t.enabled and last_dt and relevant_ok:
+        recency = int(t.raw.get("recency_days", 45))
+        days = (as_of - last_dt).days
+        if 0 <= days <= recency:
+            # Do not promote solely because value is large — recency + relevance only.
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={"days_since_last": days, "observational": True},
+                )
+            )
+
+    # MATERIAL_PORTFOLIO_CHANGE (vs prior projection portfolio counters only)
+    t = policy.trigger("MATERIAL_PORTFOLIO_CHANGE")
+    if t and t.enabled and prior and (
+        "active_contract_count" in prior or "contract_count_recent" in prior
+    ):
+        prev_active = _safe_int(prior.get("active_contract_count"))
+        prev_recent = _safe_int(prior.get("contract_count_recent"))
+        min_a = int(t.raw.get("min_active_delta", 2))
+        min_r = int(t.raw.get("min_recent_delta", 3))
+        da = active_count - prev_active
+        dr = recent_count - prev_recent
+        if abs(da) >= min_a or abs(dr) >= min_r:
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={
+                        "active_delta": da,
+                        "recent_delta": dr,
+                        "observational": True,
+                    },
+                )
+            )
+
+    # CONTRACT_ANNIVERSARY_WINDOW — temporal window only, not "reajuste devido"
+    t = policy.trigger("CONTRACT_ANNIVERSARY_WINDOW")
+    if t and t.enabled and first_dt:
+        window = int(t.raw.get("anniversary_window_days", 30))
+        min_age = int(t.raw.get("min_contract_age_days", 300))
+        age = (as_of - first_dt).days
+        if age >= min_age:
+            # Distance to nearest anniversary of first_contract_date
+            years = max(1, as_of.year - first_dt.year)
+            candidates = []
+            for y in (years - 1, years, years + 1):
+                try:
+                    ann = date(first_dt.year + y, first_dt.month, first_dt.day)
+                except ValueError:
+                    # Feb 29
+                    ann = date(first_dt.year + y, first_dt.month, 28)
+                candidates.append(ann)
+            nearest = min(candidates, key=lambda d: abs((d - as_of).days))
+            dist = (nearest - as_of).days
+            if abs(dist) <= window:
+                fired.append(
+                    _fire(
+                        t,
+                        as_of=as_of,
+                        event=nearest,
+                        details={
+                            "anniversary_date": nearest.isoformat(),
+                            "days_to_anniversary": dist,
+                            "note": (
+                                "Janela temporal que justifica verificar formalização; "
+                                "não afirma reajuste devido ou não pago."
+                            ),
+                        },
+                    )
+                )
+
+    # NEW_AMENDMENT_OR_TERM — keyword on public objects only
+    t = policy.trigger("NEW_AMENDMENT_OR_TERM")
+    if t and t.enabled:
+        kws = [str(k).lower() for k in (t.raw.get("object_keywords") or [])]
+        if kws and any(k in blob for k in kws):
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={"matched_keywords": [k for k in kws if k in blob]},
+                )
+            )
+
+    # CONTRACT_ENDING_WINDOW — only when data_fim exists
+    t = policy.trigger("CONTRACT_ENDING_WINDOW")
+    if t and t.enabled:
+        within = int(t.raw.get("ending_within_days", 90))
+        best_end: date | None = None
+        for c in _recent_contracts(row):
+            end = _parse_date(c.get("data_fim") or c.get("end_date"))
+            if end is None:
+                continue
+            days_left = (end - as_of).days
+            if 0 <= days_left <= within:
+                if best_end is None or end < best_end:
+                    best_end = end
+        if best_end is not None:
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=best_end,
+                    details={
+                        "data_fim": best_end.isoformat(),
+                        "days_to_end": (best_end - as_of).days,
+                        "note": "Observational vigência; not automatic renewal claim.",
+                    },
+                )
+            )
+
+    # CONTRACT_EXTENSION_OR_PROROGATION
+    t = policy.trigger("CONTRACT_EXTENSION_OR_PROROGATION")
+    if t and t.enabled:
+        kws = [str(k).lower() for k in (t.raw.get("object_keywords") or [])]
+        if kws and any(k in blob for k in kws):
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={"matched_keywords": [k for k in kws if k in blob]},
+                )
+            )
+
+    # NEW_RELEVANT_PROCUREMENT
+    t = policy.trigger("NEW_RELEVANT_PROCUREMENT")
+    if t and t.enabled:
+        kws = [str(k).lower() for k in (t.raw.get("object_keywords") or [])]
+        if kws and any(k in blob for k in kws) and last_dt and (as_of - last_dt).days <= 90:
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={"matched_keywords": [k for k in kws if k in blob]},
+                )
+            )
+
+    # MATERIAL_CONTRACT_CHANGE via prior source_hash divergence
+    t = policy.trigger("MATERIAL_CONTRACT_CHANGE")
+    if t and t.enabled and prior.get("source_hash"):
+        # Caller supplies current source_hash in prior["current_source_hash"] after compute
+        cur = prior.get("current_source_hash")
+        if cur and cur != prior.get("source_hash") and (active_count > 0 or recent_count > 0):
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={"prior_source_hash": prior.get("source_hash"), "observational": True},
+                )
+            )
+
+    # RESEARCH_GAP_WORTH_RESOLVING
+    t = policy.trigger("RESEARCH_GAP_WORTH_RESOLVING")
+    if t and t.enabled and last_dt:
+        min_pri = float(t.raw.get("min_priority_score", 50))
+        max_days = int(t.raw.get("max_days_since_last_contract", 120))
+        days = (as_of - last_dt).days
+        has_thin_intel = not row.get("_has_deep_intel")
+        if priority >= min_pri and 0 <= days <= max_days and has_thin_intel and relevant_ok:
+            fired.append(
+                _fire(
+                    t,
+                    as_of=as_of,
+                    event=last_dt,
+                    details={"priority_score": priority, "days_since_last": days},
+                )
+            )
+
+    # NEW_RELEVANT_PROCESS_DOCUMENT — only with explicit signal flag (no invention)
+    t = policy.trigger("NEW_RELEVANT_PROCESS_DOCUMENT")
+    if t and t.enabled and row.get("new_process_document") is True:
+        fired.append(
+            _fire(
+                t,
+                as_of=as_of,
+                event=_parse_date(row.get("new_process_document_date")) or as_of,
+                details={"explicit_signal": True},
+            )
+        )
+
+    # Stable order by strength desc then code
+    fired.sort(key=lambda f: (-f.strength, f.code))
+    return fired

--- a/scripts/confenge_outreach_pipeline/__init__.py
+++ b/scripts/confenge_outreach_pipeline/__init__.py
@@ -1,14 +1,17 @@
 """Canonical CONFENGE outreach pipeline.
 
-Chains:
-  universe → diverse downstream sample → account intelligence
+Production (activation-driven):
+  universe → activation planner → hot set → account intelligence
   → contact resolution → confenge.outreach.v1 Warmbly feed
 
-No manual JSON handoff between stages. --limit-downstream bounds only the
-expensive stages; universe discovery can still cover the full datalake.
+Smoke / diagnostic (diverse sample):
+  universe → diverse sample (--limit-downstream) → expensive stages
+
+No manual JSON handoff between stages. Production selection is capacity-aware
+via the activation planner; --limit-downstream is not a commercial strategy.
 """
 
 from __future__ import annotations
 
-MODULE_VERSION = "1.0.0"
+MODULE_VERSION = "1.1.0"
 PIPELINE_ID = "confenge-outreach-pipeline-v1"

--- a/scripts/confenge_outreach_pipeline/cli.py
+++ b/scripts/confenge_outreach_pipeline/cli.py
@@ -22,30 +22,32 @@ def build_parser() -> argparse.ArgumentParser:
         prog="python -m scripts.confenge_outreach_pipeline",
         description=(
             "Canonical CONFENGE outreach pipeline: "
-            "universe → diverse sample → account intelligence → "
-            "contact resolution → confenge.outreach.v1 feed."
+            "universe → activation planner (hot set) → account intelligence → "
+            "contact resolution → confenge.outreach.v1 feed. "
+            "Smoke mode can force diverse sample via --force-sample-mode."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples
 --------
-# Full national universe + 200-account downstream (requires datalake DSN):
+# Production: full reservoir + activation-driven hot set:
 python -m scripts.confenge_outreach_pipeline run \\
   --dsn "$LOCAL_DATALAKE_DSN" \\
   --out output/confenge_outreach \\
   --as-of 2026-08-07 \\
-  --limit-downstream 200
+  --use-activation-planner
 
-# Offline fixture path (tests / smoke):
+# Smoke / diagnostic diverse sample (NOT commercial strategy):
 python -m scripts.confenge_outreach_pipeline run \\
   --csv tests/fixtures/confenge_universe/contracts_sample.csv \\
   --out /tmp/confenge_outreach_smoke \\
   --as-of 2026-08-01 \\
+  --force-sample-mode \\
   --limit-downstream 20 \\
   --skip-contacts
 
-IMPORTANT: --limit-downstream does NOT limit universe discovery. It only
-bounds expensive stages (intelligence, contacts, feed).
+IMPORTANT: In production the activation planner selects the hot set from
+capacity planning. --limit-downstream is not a commercial shortlist strategy.
 """.strip(),
     )
     p.add_argument("--version", action="version", version=f"{PIPELINE_ID} {MODULE_VERSION}")
@@ -127,6 +129,33 @@ bounds expensive stages (intelligence, contacts, feed).
         action="store_true",
         help="Exclude DNC accounts from the diverse downstream sample",
     )
+    run.add_argument(
+        "--use-activation-planner",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use activation planner for hot set (default: on). Disable with --no-use-activation-planner.",
+    )
+    run.add_argument(
+        "--force-sample-mode",
+        action="store_true",
+        help="SMOKE only: use diverse sample instead of activation hot set",
+    )
+    run.add_argument(
+        "--activation-policy",
+        default=None,
+        help="Path to confenge_activation_policy.yaml",
+    )
+    run.add_argument(
+        "--activation-capacity",
+        type=int,
+        default=None,
+        help="Override hot-set capacity (default: policy capacity planning)",
+    )
+    run.add_argument(
+        "--prior-activation",
+        default=None,
+        help="Prior activation-projections.jsonl for incremental deltas",
+    )
     return p
 
 
@@ -165,6 +194,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         contact_fixtures_dir=args.contact_fixtures_dir,
         include_dnc_in_sample=not args.no_dnc_in_sample,
         feed_limit=args.feed_limit,
+        use_activation_planner=bool(args.use_activation_planner),
+        activation_policy_path=args.activation_policy,
+        activation_capacity=args.activation_capacity,
+        prior_activation_path=args.prior_activation,
+        force_sample_mode=bool(args.force_sample_mode),
     )
     result = run_pipeline(cfg)
     payload = {
@@ -174,7 +208,16 @@ def cmd_run(args: argparse.Namespace) -> int:
         "errors": result.errors,
         "stages_summary": {
             "universe_rows": result.stages.get("universe_row_count"),
+            "reservoir_count": result.stages.get("reservoir_count"),
             "sample_count": (result.stages.get("sample") or {}).get("count"),
+            "sample_mode": (result.stages.get("sample") or {}).get("mode"),
+            "activation_counts": result.stages.get("activation_counts"),
+            "hot_set_count": result.stages.get("hot_set_count"),
+            "expensive_enrichment_count": result.stages.get("expensive_enrichment_count"),
+            "feed_count": result.stages.get("feed_count"),
+            "policy_version": result.stages.get("policy_version"),
+            "source_watermark": result.stages.get("source_watermark"),
+            "use_activation_planner": result.stages.get("use_activation_planner"),
             "intel_count": (result.stages.get("account_intelligence") or {}).get("count"),
             "service_distribution": (result.stages.get("account_intelligence") or {}).get(
                 "service_distribution"
@@ -191,6 +234,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             "full_scale_universe": result.stages.get("full_scale_universe"),
             "as_of": result.stages.get("as_of"),
             "repo_sha": result.stages.get("repo_sha"),
+            "manifest_summary": result.stages.get("manifest_summary"),
         },
     }
     sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False, default=str) + "\n")

--- a/scripts/confenge_outreach_pipeline/cli.py
+++ b/scripts/confenge_outreach_pipeline/cli.py
@@ -35,7 +35,15 @@ python -m scripts.confenge_outreach_pipeline run \\
   --dsn "$LOCAL_DATALAKE_DSN" \\
   --out output/confenge_outreach \\
   --as-of 2026-08-07 \\
-  --use-activation-planner
+  --use-activation-planner \\
+  --limit-downstream 200
+
+# Resume after interrupt (checkpoint under --out):
+python -m scripts.confenge_outreach_pipeline run \\
+  --dsn "$LOCAL_DATALAKE_DSN" \\
+  --out output/confenge_outreach \\
+  --skip-universe \\
+  --limit-downstream 200
 
 # Smoke / diagnostic diverse sample (NOT commercial strategy):
 python -m scripts.confenge_outreach_pipeline run \\
@@ -46,8 +54,9 @@ python -m scripts.confenge_outreach_pipeline run \\
   --limit-downstream 20 \\
   --skip-contacts
 
-IMPORTANT: In production the activation planner selects the hot set from
-capacity planning. --limit-downstream is not a commercial shortlist strategy.
+IMPORTANT: --limit-downstream bounds only this round's expensive batch
+(intel/contacts/feed). Universe discovery is independent and full-scale
+when --max-rows is omitted. Round N+1 advances the durable activation cursor.
 """.strip(),
     )
     p.add_argument("--version", action="version", version=f"{PIPELINE_ID} {MODULE_VERSION}")
@@ -156,6 +165,21 @@ capacity planning. --limit-downstream is not a commercial shortlist strategy.
         default=None,
         help="Prior activation-projections.jsonl for incremental deltas",
     )
+    run.add_argument(
+        "--commercial-memory",
+        default=None,
+        help="JSONL overlay of commercial outcomes (DNC/NOT_NOW/BOUNCE/REPLIED) by cnpj14",
+    )
+    run.add_argument(
+        "--no-resume",
+        action="store_true",
+        help="Ignore pipeline-checkpoint.json and restart stage tracking",
+    )
+    run.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Disable progress logging",
+    )
     return p
 
 
@@ -199,6 +223,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         activation_capacity=args.activation_capacity,
         prior_activation_path=args.prior_activation,
         force_sample_mode=bool(args.force_sample_mode),
+        commercial_memory_path=args.commercial_memory,
+        resume=not bool(args.no_resume),
+        progress=not bool(args.quiet),
     )
     result = run_pipeline(cfg)
     payload = {

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -317,12 +317,10 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 if candidate.is_file():
                     prior_path = str(candidate)
             prior = load_projections_jsonl(prior_path) if prior_path else {}
-            # Operational batch size for THIS round's expensive path only.
-            # --activation-capacity wins when set; else --limit-downstream.
-            # Neither shrinks universe_total / reservoir.
-            capacity = cfg.activation_capacity
-            if capacity is None:
-                capacity = cfg.limit_downstream
+            # Hot-set size: --activation-capacity override, else policy.planned_capacity().
+            # NEVER pass limit_downstream as capacity_override — that is smoke/batch-only
+            # and must not become the production commercial shortlist.
+            capacity = cfg.activation_capacity  # None → planner uses policy.planned_capacity()
             cycle = run_activation_cycle(
                 universe_rows,
                 policy=policy,
@@ -356,7 +354,11 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             # Safety: never silent-truncate reservoir; expensive path is hot set only
             sample_path = dirs["sample"] / "downstream-hot-set.jsonl"
             _write_jsonl(sample_path, sample_rows)
-            planned_cap = int(capacity) if capacity is not None else policy.capacity.planned_capacity()
+            planned_cap = (
+                int(capacity)
+                if capacity is not None
+                else policy.capacity.planned_capacity()
+            )
             stages["activation"] = {
                 **cycle.summary(),
                 "projections_path": str(dirs["activation"] / "activation-projections.jsonl"),
@@ -365,12 +367,12 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 "capacity_source": (
                     "activation_capacity_override"
                     if cfg.activation_capacity is not None
-                    else "limit_downstream_batch"
+                    else "policy.planned_capacity"
                 ),
                 "note": (
                     "Hot set is capacity-aware activation planning, not arbitrary Top-N. "
                     "Full reservoir remains monitored; only hot set enters expensive stages. "
-                    "--limit-downstream bounds THIS round's expensive batch only."
+                    "--limit-downstream is smoke/batch-only and does NOT set commercial capacity."
                 ),
             }
             stages["sample"] = {

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -21,6 +21,28 @@ from scripts.confenge_contact_resolution.resolver import (
     ResolverConfig,
     default_adapters,
 )
+from scripts.confenge_activation.checkpoint import (
+    load_checkpoint,
+    new_checkpoint,
+    save_checkpoint,
+)
+from scripts.confenge_activation.funnel import (
+    DOWNSTREAM_EXPORTED,
+    DOWNSTREAM_NO_CONTACT,
+    load_commercial_memory_jsonl,
+    mark_downstream,
+)
+from scripts.confenge_activation.metrics import (
+    build_run_manifest,
+    build_universe_summary,
+)
+from scripts.confenge_activation.planner import run_activation_cycle
+from scripts.confenge_activation.policy import load_policy
+from scripts.confenge_activation.store import (
+    load_projections_jsonl,
+    write_hot_set_jsonl,
+    write_projections_jsonl,
+)
 from scripts.confenge_outreach_pipeline import MODULE_VERSION, PIPELINE_ID
 from scripts.confenge_outreach_pipeline.adapt import (
     contact_resolution_to_bridge_row,
@@ -114,6 +136,19 @@ class PipelineConfig:
     contact_fixtures_dir: Path | None = None
     include_dnc_in_sample: bool = True
     feed_limit: int | None = None
+    # Activation planner (production default when True)
+    use_activation_planner: bool = True
+    activation_policy_path: str | None = None
+    activation_capacity: int | None = None
+    prior_activation_path: str | None = None
+    # Smoke/diagnostic only: force diverse sample shortlist (not commercial strategy)
+    force_sample_mode: bool = False
+    # Durable commercial memory overlay (outcomes / DNC / NOT_NOW)
+    commercial_memory_path: str | None = None
+    # Resume from pipeline-checkpoint.json under out_dir
+    resume: bool = True
+    # Progress logging to stdout
+    progress: bool = True
 
 
 @dataclass
@@ -125,16 +160,24 @@ class PipelineResult:
     manifest_path: str | None = None
 
 
+def _progress(enabled: bool, msg: str) -> None:
+    if enabled:
+        print(msg, flush=True)
+
+
 def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
-    """Execute UNIVERSE → SAMPLE → INTEL → CONTACTS → FEED."""
+    """Execute UNIVERSE → ACTIVATION|SAMPLE → INTEL → CONTACTS → FEED."""
     started = time.monotonic()
     as_of = cfg.as_of or date.today()
     out = Path(cfg.out_dir)
     out.mkdir(parents=True, exist_ok=True)
 
+    use_activation = bool(cfg.use_activation_planner) and not bool(cfg.force_sample_mode)
+
     dirs = {
         "universe": out / "01_universe",
         "sample": out / "02_downstream_sample",
+        "activation": out / "02_activation",
         "intel": out / "03_account_intelligence",
         "contacts": out / "04_contact_resolution",
         "bridge_inputs": out / "05_bridge_inputs",
@@ -146,30 +189,62 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
 
     result = PipelineResult(ok=True, out_dir=str(out))
     repo_sha = _git_sha()
+    started_at = _utcnow()
     stages: dict[str, Any] = {
         "pipeline_id": PIPELINE_ID,
         "module_version": MODULE_VERSION,
         "repo_sha": repo_sha,
         "as_of": as_of.isoformat(),
-        "started_at": _utcnow(),
+        "started_at": started_at,
         "limit_downstream": cfg.limit_downstream,
         "max_workers": cfg.max_workers,
         "max_rows_universe": cfg.max_rows,
         "sampling": bool(cfg.max_rows is not None),
+        "use_activation_planner": use_activation,
+        "force_sample_mode": bool(cfg.force_sample_mode),
     }
+
+    # Durable checkpoint for resume != restart from zero
+    ckpt = None
+    if cfg.resume:
+        ckpt = load_checkpoint(out)
+    if ckpt is None:
+        ckpt = new_checkpoint(run_id=f"pipe-{repo_sha}-{as_of.isoformat()}", as_of=as_of.isoformat())
+    commercial_memory: dict[str, dict[str, Any]] = {}
+    if cfg.commercial_memory_path:
+        commercial_memory = load_commercial_memory_jsonl(cfg.commercial_memory_path)
 
     try:
         # ── 1. Universe ──────────────────────────────────────────────────
         universe_jsonl = dirs["universe"] / DEFAULT_JSONL_NAME
         universe_manifest = dirs["universe"] / DEFAULT_MANIFEST_NAME
-        if cfg.skip_universe and universe_jsonl.is_file():
+        skip_uni = bool(cfg.skip_universe and universe_jsonl.is_file())
+        if not skip_uni and ckpt.stage_completed("universe") and universe_jsonl.is_file():
+            skip_uni = True
+            _progress(cfg.progress, "[universe] resume: reusing completed checkpoint artifacts")
+
+        ckpt.mark_running("universe")
+        save_checkpoint(out, ckpt)
+
+        if skip_uni:
             uni_meta: dict[str, Any] = {
                 "ok": True,
                 "skipped": True,
                 "jsonl_path": str(universe_jsonl),
                 "manifest_path": str(universe_manifest) if universe_manifest.is_file() else None,
             }
+            if universe_manifest.is_file():
+                try:
+                    man = json.loads(universe_manifest.read_text(encoding="utf-8"))
+                    uni_meta["counts"] = man.get("counts") or {}
+                    uni_meta["reconciliation_ok"] = (man.get("counts") or {}).get(
+                        "reconciliation", {}
+                    ).get("ok") or man.get("extra", {}).get("reconciliation_bucket_ok")
+                    uni_meta["source"] = man.get("source") or {}
+                except (json.JSONDecodeError, OSError):
+                    pass
         else:
+            _progress(cfg.progress, "[universe] scanning contracts (full datalake when max_rows=None)…")
             uni_meta = run_universe_build(
                 as_of=as_of,
                 dsn=cfg.dsn,
@@ -192,33 +267,166 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 "reconciliation_ok",
                 "ok",
                 "skipped",
+                "source",
             )
             if k in uni_meta
         }
 
         universe_rows = _read_jsonl(universe_jsonl)
         stages["universe_row_count"] = len(universe_rows)
-
-        # ── 2. Diverse downstream sample ─────────────────────────────────
-        sample_rows = select_diverse_sample(
-            universe_rows,
-            limit=cfg.limit_downstream,
-            include_dnc=cfg.include_dnc_in_sample,
+        stages["reservoir_count"] = len(universe_rows)
+        uni_counts = stages.get("universe", {}).get("counts") or uni_meta.get("counts") or {}
+        ckpt.universe_total = len(universe_rows)
+        ckpt.full_datalake_scanned = bool(
+            uni_counts.get("full_scale")
+            if "full_scale" in uni_counts
+            else (cfg.max_rows is None and bool(cfg.dsn) and not cfg.csv_path)
         )
-        sample_path = dirs["sample"] / "downstream-sample.jsonl"
-        _write_jsonl(sample_path, sample_rows)
-        profile_counts = sample_profile_counts(sample_rows)
-        stages["sample"] = {
-            "path": str(sample_path),
-            "count": len(sample_rows),
-            "profile_counts": profile_counts,
-            "note": (
-                "limit_downstream bounds only this sample and subsequent expensive stages; "
-                "universe discovery is independent."
-            ),
-        }
+        ckpt.mark_completed(
+            "universe",
+            counts={
+                "rows": len(universe_rows),
+                "contracts": uni_counts.get("input_contract_rows"),
+                "full_scale": ckpt.full_datalake_scanned,
+            },
+            artifact_paths={"jsonl": str(universe_jsonl)},
+        )
+        save_checkpoint(out, ckpt)
+        _progress(
+            cfg.progress,
+            f"[universe] {uni_counts.get('input_contract_rows') or '?'} contracts → "
+            f"{len(universe_rows)} construction companies "
+            f"(full_scale={ckpt.full_datalake_scanned})",
+        )
+
+        # ── 2. Activation planner (production) OR diverse sample (smoke) ─
+        activation_by_cnpj: dict[str, dict[str, Any]] = {}
+        deactivations: list[dict[str, Any]] = []
+        sample_rows: list[dict[str, Any]] = []
+        cycle_projections: list[Any] = []
+        service_dist: dict[str, int] = {}
+
+        ckpt.mark_running("activation")
+        save_checkpoint(out, ckpt)
+
+        if use_activation:
+            policy = load_policy(cfg.activation_policy_path)
+            prior_path = cfg.prior_activation_path
+            if not prior_path:
+                candidate = dirs["activation"] / "activation-projections.jsonl"
+                if candidate.is_file():
+                    prior_path = str(candidate)
+            prior = load_projections_jsonl(prior_path) if prior_path else {}
+            # Operational batch: --limit-downstream bounds THIS round's expensive work only.
+            # Never shrinks universe_total / reservoir. activation_capacity wins if set.
+            capacity = cfg.activation_capacity
+            if capacity is None:
+                capacity = cfg.limit_downstream
+            cycle = run_activation_cycle(
+                universe_rows,
+                policy=policy,
+                as_of=as_of,
+                prior_projections=prior,
+                capacity_override=capacity,
+                commercial_memory=commercial_memory or None,
+                include_watch_fill=True,
+            )
+            cycle_projections = list(cycle.projections)
+            write_projections_jsonl(
+                dirs["activation"] / "activation-projections.jsonl", cycle.projections
+            )
+            write_hot_set_jsonl(dirs["activation"] / "hot-set.jsonl", cycle.hot_set)
+            (dirs["activation"] / "deactivations.json").write_text(
+                json.dumps(cycle.deactivations, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            (dirs["activation"] / "activation-summary.json").write_text(
+                json.dumps(cycle.summary(), indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            deactivations = list(cycle.deactivations)
+            activation_by_cnpj = {p.cnpj14: p.as_dict() for p in cycle.projections}
+            # Map hot set back to universe rows (preserve order of hot set)
+            by_cnpj = {
+                "".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()): r
+                for r in universe_rows
+            }
+            sample_rows = [by_cnpj[c] for c in (p.cnpj14 for p in cycle.hot_set) if c in by_cnpj]
+            # Safety: never silent-truncate reservoir; expensive path is hot set only
+            sample_path = dirs["sample"] / "downstream-hot-set.jsonl"
+            _write_jsonl(sample_path, sample_rows)
+            stages["activation"] = {
+                **cycle.summary(),
+                "projections_path": str(dirs["activation"] / "activation-projections.jsonl"),
+                "hot_set_path": str(dirs["activation"] / "hot-set.jsonl"),
+                "capacity_this_round": capacity,
+                "note": (
+                    "Hot set is capacity-aware activation planning, not arbitrary Top-N. "
+                    "Full reservoir remains monitored; only hot set enters expensive stages. "
+                    "--limit-downstream = this round's expensive batch size only."
+                ),
+            }
+            stages["sample"] = {
+                "path": str(sample_path),
+                "count": len(sample_rows),
+                "mode": "activation_hot_set",
+                "profile_counts": sample_profile_counts(sample_rows),
+                "note": (
+                    "Downstream rows selected by activation planner hot set. "
+                    f"capacity={capacity}; reservoir={len(universe_rows)}."
+                ),
+            }
+            stages["activation_counts"] = cycle.activation_counts
+            stages["hot_set_count"] = cycle.hot_set_count
+            stages["policy_version"] = cycle.policy_version
+            stages["source_watermark"] = cycle.source_watermark
+            ckpt.add_processed(
+                [p.cnpj14 for p in cycle.hot_set],
+                cursor=cycle.hot_set[-1].cnpj14 if cycle.hot_set else None,
+            )
+            _progress(
+                cfg.progress,
+                f"[activation] reservoir={cycle.reservoir_count} "
+                f"hot_set={cycle.hot_set_count}/{capacity} "
+                f"states={cycle.activation_counts}",
+            )
+        else:
+            sample_rows = select_diverse_sample(
+                universe_rows,
+                limit=cfg.limit_downstream,
+                include_dnc=cfg.include_dnc_in_sample,
+            )
+            sample_path = dirs["sample"] / "downstream-sample.jsonl"
+            _write_jsonl(sample_path, sample_rows)
+            profile_counts = sample_profile_counts(sample_rows)
+            stages["sample"] = {
+                "path": str(sample_path),
+                "count": len(sample_rows),
+                "mode": "diverse_sample",
+                "profile_counts": profile_counts,
+                "note": (
+                    "SMOKE/DIAGNOSTIC only. limit_downstream bounds expensive stages; "
+                    "not a production commercial shortlist strategy. "
+                    "Use --use-activation-planner for production."
+                ),
+            }
+            stages["activation_counts"] = {}
+            stages["hot_set_count"] = len(sample_rows)
+            stages["policy_version"] = None
+            stages["source_watermark"] = None
+
+        ckpt.mark_completed(
+            "activation",
+            counts={
+                "hot_set": len(sample_rows),
+                "reservoir": len(universe_rows),
+            },
+        )
+        save_checkpoint(out, ckpt)
 
         # ── 3. Account intelligence ──────────────────────────────────────
+        ckpt.mark_running("intelligence")
+        save_checkpoint(out, ckpt)
         intel_inputs = [
             universe_row_to_intelligence_input(r, as_of=as_of.isoformat()) for r in sample_rows
         ]
@@ -242,7 +450,6 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         bridge_intel_path = dirs["bridge_inputs"] / "account_intelligence.jsonl"
         _write_jsonl(bridge_intel_path, bridge_intel)
 
-        service_dist: dict[str, int] = {}
         for d in dossiers:
             ps = d.get("primary_service") if isinstance(d.get("primary_service"), dict) else {}
             sid = str(ps.get("service_id") or "unknown")
@@ -254,8 +461,13 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             "count": len(dossiers),
             "service_distribution": dict(sorted(service_dist.items(), key=lambda x: (-x[1], x[0]))),
         }
+        ckpt.mark_completed("intelligence", counts={"dossiers": len(dossiers)})
+        save_checkpoint(out, ckpt)
+        _progress(cfg.progress, f"[intelligence] {len(dossiers)} / {len(universe_rows)} processed")
 
         # ── 4. Contact resolution ────────────────────────────────────────
+        ckpt.mark_running("contacts")
+        save_checkpoint(out, ckpt)
         if cfg.skip_contacts:
             bridge_contacts: list[dict[str, Any]] = [
                 {"cnpj14": r.get("cnpj14") or r.get("cnpj"), "contacts": []} for r in sample_rows
@@ -304,26 +516,125 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             **contact_meta,
             "bridge_path": str(bridge_contacts_path),
         }
+        cm = (contact_meta or {}).get("metrics") or {}
+        ckpt.mark_completed(
+            "contacts",
+            counts={
+                "resolved": cm.get("empresas_com_email_verificavel") or cm.get("empresas_total"),
+                "no_contact": cm.get("empresas_sem_contato"),
+            },
+        )
+        save_checkpoint(out, ckpt)
+        _progress(
+            cfg.progress,
+            f"[contacts] resolved={cm.get('empresas_com_email_verificavel', '?')} "
+            f"no_contact={cm.get('empresas_sem_contato', '?')} "
+            f"pending=0",
+        )
 
         # ── 5. Bridge universe inputs + export ───────────────────────────
+        ckpt.mark_running("feed")
+        save_checkpoint(out, ckpt)
         bridge_universe = [
             universe_row_for_bridge(r, rank=i + 1) for i, r in enumerate(sample_rows)
         ]
+        # Attach activation projection onto bridge universe rows when available
+        if activation_by_cnpj:
+            for br in bridge_universe:
+                c = "".join(ch for ch in str(br.get("cnpj14") or "") if ch.isdigit())
+                act = activation_by_cnpj.get(c)
+                if act:
+                    br["activation"] = {
+                        "state": act.get("activation_state"),
+                        "score": act.get("activation_score"),
+                        "reason_codes": act.get("reason_codes") or [],
+                        "policy_version": act.get("policy_version"),
+                        "evaluated_at": act.get("evaluated_at"),
+                        "next_best_action_at": act.get("next_best_action_at"),
+                        "expires_at": act.get("expires_at"),
+                        "source_hash": act.get("source_hash"),
+                        "score_components": act.get("score_components") or {},
+                    }
         bridge_universe_path = dirs["bridge_inputs"] / "universe.jsonl"
         _write_jsonl(bridge_universe_path, bridge_universe)
 
-        export_cfg = ExportConfig(
-            universe=bridge_universe_path,
-            account_intelligence=bridge_intel_path,
-            contacts=bridge_contacts_path,
-            out_dir=dirs["feed"],
-            limit=cfg.feed_limit,
-            repo_sha=repo_sha,
-        )
-        export_result = export_outreach(export_cfg)
+        # Empty hot set is a valid ops state (all capacity consumed / no eligibles)
+        # — write empty feed artifacts instead of failing closed on empty join.
+        if not bridge_universe:
+            empty_manifest = {
+                "schema_version": "confenge.outreach.manifest.v1",
+                "module_version": MODULE_VERSION,
+                "generated_at": _utcnow(),
+                "lead_count": 0,
+                "chunk_count": 0,
+                "chunks": [],
+                "note": "No leads in this round's hot set (capacity/cursor/memory).",
+                "reservoir_count": len(universe_rows),
+            }
+            (dirs["feed"] / "manifest.json").write_text(
+                json.dumps(empty_manifest, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            export_result = {
+                "ok": True,
+                "out_dir": str(dirs["feed"].resolve()),
+                "run_id": "run-empty-hot-set",
+                "lead_count": 0,
+                "chunk_count": 0,
+                "manifest": str((dirs["feed"] / "manifest.json").resolve()),
+                "chunks": [],
+            }
+        else:
+            export_cfg = ExportConfig(
+                universe=bridge_universe_path,
+                account_intelligence=bridge_intel_path,
+                contacts=bridge_contacts_path,
+                out_dir=dirs["feed"],
+                limit=cfg.feed_limit,
+                repo_sha=repo_sha,
+                deactivations=deactivations,
+            )
+            export_result = export_outreach(export_cfg)
         stages["feed"] = export_result
+        stages["feed_count"] = (export_result or {}).get("lead_count")
+        stages["expensive_enrichment_count"] = len(sample_rows)
 
-        # ── 6. Stage reports ─────────────────────────────────────────────
+        # Persist funnel progress: mark exported / no-contact on projections
+        if use_activation and cycle_projections:
+            contact_by = {
+                "".join(ch for ch in str(c.get("cnpj14") or "") if ch.isdigit()): c
+                for c in bridge_contacts
+            }
+            updated = []
+            for p in cycle_projections:
+                d = p.as_dict() if hasattr(p, "as_dict") else dict(p)
+                cnpj = d.get("cnpj14")
+                if cnpj and any(
+                    "".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()) == cnpj
+                    for r in sample_rows
+                ):
+                    crow = contact_by.get(cnpj) or {}
+                    contacts = crow.get("contacts") or []
+                    if contacts:
+                        d = mark_downstream(d, status=DOWNSTREAM_EXPORTED)
+                    else:
+                        d = mark_downstream(d, status=DOWNSTREAM_NO_CONTACT)
+                updated.append(d)
+            # rewrite projections with funnel status
+            proj_path = dirs["activation"] / "activation-projections.jsonl"
+            with proj_path.open("w", encoding="utf-8") as f:
+                for d in sorted(updated, key=lambda x: x.get("cnpj14") or ""):
+                    f.write(json.dumps(d, ensure_ascii=False, sort_keys=True) + "\n")
+            activation_by_cnpj = {d["cnpj14"]: d for d in updated if d.get("cnpj14")}
+
+        ckpt.mark_completed(
+            "feed",
+            counts={"lead_count": stages.get("feed_count") or 0},
+            artifact_paths={"manifest": str(dirs["feed"] / "manifest.json")},
+        )
+        save_checkpoint(out, ckpt)
+
+        # ── 6. Stage reports + auditable full-run package ────────────────
         stages["finished_at"] = _utcnow()
         stages["elapsed_seconds"] = round(time.monotonic() - started, 3)
         stages["peak_rss_mb"] = _peak_rss_mb()
@@ -333,11 +644,103 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             if "full_scale" in uni_counts
             else (not cfg.max_rows and bool(cfg.dsn) and not cfg.csv_path)
         )
+        elapsed = max(0.001, float(stages["elapsed_seconds"]))
+        contracts_n = int(uni_counts.get("input_contract_rows") or 0)
+        stages["throughput"] = {
+            "contracts_per_sec": round(contracts_n / elapsed, 2) if contracts_n else None,
+            "companies_per_min": round(len(universe_rows) / (elapsed / 60.0), 2),
+            "contacts_per_min": round(
+                float((stages.get("contacts") or {}).get("metrics", {}).get("empresas_total") or 0)
+                / (elapsed / 60.0),
+                2,
+            ),
+            "elapsed_seconds": stages["elapsed_seconds"],
+            "peak_rss_mb": stages["peak_rss_mb"],
+        }
+        # Explicit production-facing summary (real cycle numbers, never hard-coded)
+        stages["manifest_summary"] = {
+            "reservoir_count": stages.get("reservoir_count") or len(universe_rows),
+            "universe_total": stages.get("reservoir_count") or len(universe_rows),
+            "activation_counts": stages.get("activation_counts") or {},
+            "hot_set_count": stages.get("hot_set_count") or 0,
+            "expensive_enrichment_count": stages.get("expensive_enrichment_count") or 0,
+            "feed_count": stages.get("feed_count") or 0,
+            "policy_version": stages.get("policy_version"),
+            "source_watermark": stages.get("source_watermark"),
+            "full_scale_universe": stages.get("full_scale_universe"),
+            "use_activation_planner": use_activation,
+            "limit_downstream_is_batch_only": True,
+            "checkpoint_path": str(out / "pipeline-checkpoint.json"),
+        }
+
+        # Universe summary + run manifest (auditable arithmetic)
+        uni_source = (stages.get("universe") or {}).get("source") or uni_meta.get("source") or {}
+        universe_summary = build_universe_summary(
+            source=uni_source if isinstance(uni_source, dict) else {},
+            counts=uni_counts if isinstance(uni_counts, dict) else {},
+            universe_rows=universe_rows,
+            started_at=started_at,
+            finished_at=stages["finished_at"],
+        )
+        state_dist: dict[str, int] = {}
+        if activation_by_cnpj:
+            for d in activation_by_cnpj.values():
+                st = str(d.get("activation_state") or "UNKNOWN")
+                state_dist[st] = state_dist.get(st, 0) + 1
+        contact_summary = (stages.get("contacts") or {}).get("metrics") or {}
+        run_manifest = build_run_manifest(
+            run_id=ckpt.run_id,
+            stages=stages,
+            universe_summary=universe_summary,
+            service_distribution=service_dist,
+            state_distribution=state_dist,
+            contact_summary=contact_summary,
+            feed_summary={
+                "lead_count": stages.get("feed_count") or 0,
+                "chunk_count": (export_result or {}).get("chunk_count"),
+                "run_id": (export_result or {}).get("run_id"),
+                "out_dir": (export_result or {}).get("out_dir"),
+            },
+            throughput=stages["throughput"],
+        )
+        (dirs["reports"] / "universe_summary.json").write_text(
+            json.dumps(universe_summary, indent=2, ensure_ascii=False, default=str) + "\n",
+            encoding="utf-8",
+        )
+        (dirs["reports"] / "service_distribution.json").write_text(
+            json.dumps(service_dist, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        (dirs["reports"] / "state_distribution.json").write_text(
+            json.dumps(state_dist, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        (dirs["reports"] / "contact_resolution_summary.json").write_text(
+            json.dumps(contact_summary, indent=2, ensure_ascii=False, default=str) + "\n",
+            encoding="utf-8",
+        )
+        (dirs["reports"] / "full-run-manifest.json").write_text(
+            json.dumps(run_manifest, indent=2, ensure_ascii=False, default=str) + "\n",
+            encoding="utf-8",
+        )
+        stages["full_run_manifest"] = {
+            "path": str(dirs["reports"] / "full-run-manifest.json"),
+            "acceptance": run_manifest.get("acceptance"),
+            "result": run_manifest.get("result"),
+        }
 
         report_path = dirs["reports"] / "pipeline-manifest.json"
         report_path.write_text(
             json.dumps(stages, indent=2, ensure_ascii=False, default=str) + "\n",
             encoding="utf-8",
+        )
+        ckpt.mark_completed("done", counts={"ok": True})
+        save_checkpoint(out, ckpt)
+        _progress(
+            cfg.progress,
+            f"[feed] leads={stages.get('feed_count')} "
+            f"elapsed={stages['elapsed_seconds']}s "
+            f"rss_mb={stages['peak_rss_mb']}",
         )
         result.stages = stages
         result.manifest_path = str(report_path)

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -317,8 +317,9 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 if candidate.is_file():
                     prior_path = str(candidate)
             prior = load_projections_jsonl(prior_path) if prior_path else {}
-            # Operational batch: --limit-downstream bounds THIS round's expensive work only.
-            # Never shrinks universe_total / reservoir. activation_capacity wins if set.
+            # Operational batch size for THIS round's expensive path only.
+            # --activation-capacity wins when set; else --limit-downstream.
+            # Neither shrinks universe_total / reservoir.
             capacity = cfg.activation_capacity
             if capacity is None:
                 capacity = cfg.limit_downstream
@@ -355,15 +356,21 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             # Safety: never silent-truncate reservoir; expensive path is hot set only
             sample_path = dirs["sample"] / "downstream-hot-set.jsonl"
             _write_jsonl(sample_path, sample_rows)
+            planned_cap = int(capacity) if capacity is not None else policy.capacity.planned_capacity()
             stages["activation"] = {
                 **cycle.summary(),
                 "projections_path": str(dirs["activation"] / "activation-projections.jsonl"),
                 "hot_set_path": str(dirs["activation"] / "hot-set.jsonl"),
-                "capacity_this_round": capacity,
+                "capacity_this_round": planned_cap,
+                "capacity_source": (
+                    "activation_capacity_override"
+                    if cfg.activation_capacity is not None
+                    else "limit_downstream_batch"
+                ),
                 "note": (
                     "Hot set is capacity-aware activation planning, not arbitrary Top-N. "
                     "Full reservoir remains monitored; only hot set enters expensive stages. "
-                    "--limit-downstream = this round's expensive batch size only."
+                    "--limit-downstream bounds THIS round's expensive batch only."
                 ),
             }
             stages["sample"] = {
@@ -373,7 +380,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 "profile_counts": sample_profile_counts(sample_rows),
                 "note": (
                     "Downstream rows selected by activation planner hot set. "
-                    f"capacity={capacity}; reservoir={len(universe_rows)}."
+                    f"capacity={planned_cap}; reservoir={len(universe_rows)}."
                 ),
             }
             stages["activation_counts"] = cycle.activation_counts
@@ -387,7 +394,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             _progress(
                 cfg.progress,
                 f"[activation] reservoir={cycle.reservoir_count} "
-                f"hot_set={cycle.hot_set_count}/{capacity} "
+                f"hot_set={cycle.hot_set_count}/{planned_cap} "
                 f"states={cycle.activation_counts}",
             )
         else:
@@ -615,10 +622,17 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 ):
                     crow = contact_by.get(cnpj) or {}
                     contacts = crow.get("contacts") or []
+                    d["account_intelligence_status"] = "DONE"
+                    d["last_processed_at"] = d.get("last_downstream_at") or _utcnow()
                     if contacts:
                         d = mark_downstream(d, status=DOWNSTREAM_EXPORTED)
+                        d["contact_resolution_status"] = "FOUND"
+                        d["feed_export_status"] = "EXPORTED"
                     else:
                         d = mark_downstream(d, status=DOWNSTREAM_NO_CONTACT)
+                        d["contact_resolution_status"] = "NO_CONTACT"
+                        d["feed_export_status"] = "EXPORTED" if not cfg.skip_contacts else "PENDING"
+                    d["outreach_state"] = d.get("commercial_state") or "NEW"
                 updated.append(d)
             # rewrite projections with funnel status
             proj_path = dirs["activation"] / "activation-projections.jsonl"

--- a/scripts/confenge_universe/pipeline.py
+++ b/scripts/confenge_universe/pipeline.py
@@ -484,14 +484,14 @@ def run_universe_build(
             exclusions.append(meta)
             excl_breakdown[str(meta.get("outreach_eligibility") or "UNKNOWN")] += 1
 
-    # Identity failures that never formed buckets: count as exclusion units
-    # Use unique samples as approximate exclusion entities for reconciliation.
-    # For strict root recon we count: len(buckets) + identity_exclusion_entities.
+    # Identity failures that never formed buckets: tracked separately so
+    # exclusion_breakdown for supplier-root recon only counts bucket exclusions
+    # (must sum exactly to exclusions = input_supplier_roots - eligibles).
     identity_excl = _identity_root_exclusions(agg)
+    identity_extra: list[dict] = []
     for key, meta in identity_excl.items():
         if key not in input_entity_keys:
-            exclusions.append(meta)
-            excl_breakdown[str(meta.get("outreach_eligibility") or "INVALID_IDENTITY")] += 1
+            identity_extra.append(meta)
 
     # Reconciliation on operational entity keys with valid identity:
     # every finalized bucket is either eligible (in universe) or justified exclusion.
@@ -503,6 +503,11 @@ def run_universe_build(
     ]
     n_excl_from_buckets = len(bucket_excl)
     recon_ok = n_input_entities == n_eligibles + n_excl_from_buckets
+    bucket_excl_breakdown = Counter(
+        str(e.get("outreach_eligibility") or "UNKNOWN") for e in bucket_excl
+    )
+    if sum(bucket_excl_breakdown.values()) != n_excl_from_buckets:
+        recon_ok = False
 
     jsonl_meta = write_jsonl_stream(records, jsonl_path)
     counts = {
@@ -512,11 +517,12 @@ def run_universe_build(
         "exclusions": n_excl_from_buckets,
         "identity_row_exclusions": agg.stats["identity_exclusions"],
         "identity_exclusion_breakdown": dict(agg.stats["identity_exclusion_breakdown"]),
+        "identity_extra_entities": len(identity_extra),
         "eligibility_breakdown": dict(elig_breakdown),
-        "exclusion_breakdown": dict(excl_breakdown),
+        "exclusion_breakdown": dict(bucket_excl_breakdown),
         "dnc_in_universe": elig_breakdown.get(DNC, 0),
         "eligible_for_outreach": elig_breakdown.get(ELIGIBLE, 0),
-        "not_construction": excl_breakdown.get(NOT_CONSTRUCTION, 0),
+        "not_construction": int(bucket_excl_breakdown.get(NOT_CONSTRUCTION, 0)),
         "peak_batch_size": peak_batch,
         "batch_size_config": batch_size,
         "max_rows": max_rows,

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -74,6 +74,8 @@ class ExportConfig:
     system: str = DEFAULT_SYSTEM
     generated_at: str | None = None  # inject for deterministic tests
     repo_sha: str | None = None
+    # Delta deactivations for accounts leaving ACTIONABLE_NOW (manifest section)
+    deactivations: list[dict[str, Any]] | None = None
 
 
 def validate_inputs(cfg: ExportConfig) -> None:
@@ -275,6 +277,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
             # Only remove if manifest will supersede; keep if same snapshot resume partial
             stale.unlink(missing_ok=True)
 
+    deacts = list(cfg.deactivations or [])
     manifest = {
         "schema_version": "confenge.outreach.manifest.v1",
         "module_version": MODULE_VERSION,
@@ -291,6 +294,9 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         "max_bytes_per_chunk": cfg.max_bytes_per_chunk,
         "limit": cfg.limit,
         "chunks": chunk_meta,
+        # Approach B: explicit deactivation delta (idempotent; Warmbly applies without DB coupling)
+        "deactivations": deacts,
+        "deactivation_count": len(deacts),
         "hashes": {
             "snapshot": snapshot_hash,
             "manifest_inputs": content_hash_obj(
@@ -298,6 +304,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
                     "snapshot": snapshot_hash,
                     "run_id": run_id,
                     "chunks": [m["content_hash"] for m in chunk_meta],
+                    "deactivations": deacts,
                 }
             ),
         },

--- a/scripts/warmbly_bridge/mapping.py
+++ b/scripts/warmbly_bridge/mapping.py
@@ -250,7 +250,7 @@ def map_lead(
     except (TypeError, ValueError):
         score_f = 0.0
 
-    return {
+    lead: dict[str, Any] = {
         "source_lead_id": source_lead_id,
         "company": {
             "cnpj14": cnpj,
@@ -277,6 +277,50 @@ def map_lead(
         "evidence": evidence_items,
         "commercial_state": commercial_state,
     }
+    # Optional additive activation block (backward-compatible; absent in legacy feeds)
+    act = universe_row.get("activation") or intel.get("activation")
+    if isinstance(act, dict) and act.get("state"):
+        lead["activation"] = _map_activation(act)
+    return lead
+
+
+def _map_activation(act: dict[str, Any]) -> dict[str, Any]:
+    """Map activation planner projection into confenge.outreach.v1 lead.activation."""
+    score_raw = act.get("score", act.get("activation_score", 0))
+    try:
+        score_f = float(score_raw)
+    except (TypeError, ValueError):
+        score_f = 0.0
+    score_f = max(0.0, min(100.0, score_f))
+    reasons = act.get("reason_codes") or act.get("reasons") or []
+    if not isinstance(reasons, list):
+        reasons = []
+    components = act.get("score_components") or {}
+    if not isinstance(components, dict):
+        components = {}
+    state = _as_str(act.get("state") or act.get("activation_state")).upper()
+    out: dict[str, Any] = {
+        "state": state,
+        "score": round(score_f, 4),
+        "reason_codes": [str(r) for r in reasons],
+        "policy_version": _as_str(act.get("policy_version") or "confenge-activation-v1"),
+        "evaluated_at": _as_str(act.get("evaluated_at")),
+        "next_best_action_at": _as_str(act.get("next_best_action_at")) or None,
+        "expires_at": _as_str(act.get("expires_at")) or None,
+        "source_hash": _as_str(act.get("source_hash")),
+        "score_components": {
+            "trigger_strength": float(components.get("trigger_strength") or 0),
+            "freshness": float(components.get("freshness") or 0),
+            "evidence_quality": float(components.get("evidence_quality") or 0),
+            "commercial_relevance": float(components.get("commercial_relevance") or 0),
+        },
+    }
+    # Drop null optional timestamps for cleaner JSON (validators accept either)
+    if not out["next_best_action_at"]:
+        out["next_best_action_at"] = None
+    if not out["expires_at"]:
+        out["expires_at"] = None
+    return out
 
 
 def build_leads(

--- a/scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
+++ b/scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
@@ -150,7 +150,43 @@
             }
           }
         },
-        "commercial_state": { "type": "string" }
+        "commercial_state": { "type": "string" },
+        "activation": {
+          "type": "object",
+          "description": "Optional commercial activation planner projection (additive, backward-compatible). Ordering score only — never purchase probability.",
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["WATCH", "RESEARCH_REQUIRED", "ACTIONABLE_NOW", "SUPPRESSED"]
+            },
+            "score": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100,
+              "description": "Deterministic ordering score 0–100. Not conversion probability."
+            },
+            "reason_codes": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "policy_version": { "type": "string" },
+            "evaluated_at": { "type": "string" },
+            "next_best_action_at": { "type": ["string", "null"] },
+            "expires_at": { "type": ["string", "null"] },
+            "source_hash": { "type": "string" },
+            "score_components": {
+              "type": "object",
+              "properties": {
+                "trigger_strength": { "type": "number" },
+                "freshness": { "type": "number" },
+                "evidence_quality": { "type": "number" },
+                "commercial_relevance": { "type": "number" }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
       }
     }
   }

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -24,7 +24,7 @@ DNC_TXT = ROOT / "tests" / "fixtures" / "confenge_universe" / "dnc.txt"
 
 
 def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
-    """Universe discovery runs fully; only expensive batch is limited."""
+    """Universe discovery runs fully; force-sample uses limit_downstream as batch only."""
     out = tmp_path / "run"
     result = run_pipeline(
         PipelineConfig(
@@ -36,12 +36,13 @@ def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
             max_workers=1,
             skip_contacts=True,
             progress=False,
+            force_sample_mode=True,  # smoke path: limit_downstream bounds sample only
         )
     )
     assert result.ok, result.errors
     universe_total = result.stages["universe_row_count"]
     assert universe_total >= 1
-    # Sample/hot set is capped by limit_downstream (batch only)
+    # Sample is capped by limit_downstream in force_sample_mode
     assert result.stages["sample"]["count"] == 1
     assert result.stages["sample"]["count"] <= universe_total
     # limit_downstream must NOT change universe_total
@@ -58,6 +59,40 @@ def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
     assert result.stages.get("full_scale_universe") is False  # csv path
     # Checkpoint written for resume
     assert (out / "pipeline-checkpoint.json").is_file()
+
+
+def test_production_activation_does_not_use_limit_downstream_as_capacity(tmp_path: Path) -> None:
+    """run_pipeline production path must use policy planned_capacity, not limit_downstream."""
+    from scripts.confenge_activation.policy import load_policy
+
+    out = tmp_path / "run_prod_cap"
+    planned = load_policy().capacity.planned_capacity()
+    assert planned > 5  # policy default is well above smoke sample size
+    result = run_pipeline(
+        PipelineConfig(
+            out_dir=out,
+            csv_path=str(FIXTURE_CSV),
+            dnc_path=str(DNC_TXT) if DNC_TXT.is_file() else None,
+            as_of=__import__("datetime").date(2026, 8, 1),
+            limit_downstream=5,  # must NOT become commercial hot-set capacity
+            max_workers=1,
+            skip_contacts=True,
+            progress=False,
+            use_activation_planner=True,
+            force_sample_mode=False,
+            activation_capacity=None,  # force policy path
+        )
+    )
+    assert result.ok, result.errors
+    act = result.stages.get("activation") or {}
+    assert act.get("capacity_source") == "policy.planned_capacity"
+    assert act.get("capacity_this_round") == planned
+    # Hot set may be smaller than planned when fixture is tiny, but must not be
+    # forced to limit_downstream as the capacity budget.
+    assert act.get("capacity_this_round") != 5 or planned == 5
+    assert result.stages["sample"]["mode"] == "activation_hot_set"
+    # Reservoir intact
+    assert result.stages["universe_row_count"] >= result.stages["sample"]["count"]
 
 
 def test_cli_run_fixture_end_to_end(tmp_path: Path) -> None:

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -24,7 +24,7 @@ DNC_TXT = ROOT / "tests" / "fixtures" / "confenge_universe" / "dnc.txt"
 
 
 def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
-    """Universe discovery runs fully; only sample is limited."""
+    """Universe discovery runs fully; only expensive batch is limited."""
     out = tmp_path / "run"
     result = run_pipeline(
         PipelineConfig(
@@ -35,21 +35,29 @@ def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
             limit_downstream=1,
             max_workers=1,
             skip_contacts=True,
+            progress=False,
         )
     )
     assert result.ok, result.errors
-    assert result.stages["universe_row_count"] >= 1
-    # Sample is capped
+    universe_total = result.stages["universe_row_count"]
+    assert universe_total >= 1
+    # Sample/hot set is capped by limit_downstream (batch only)
     assert result.stages["sample"]["count"] == 1
+    assert result.stages["sample"]["count"] <= universe_total
+    # limit_downstream must NOT change universe_total
+    assert result.stages["manifest_summary"]["universe_total"] == universe_total
+    assert result.stages["manifest_summary"]["limit_downstream_is_batch_only"] is True
     # Intelligence only for sample
     assert result.stages["account_intelligence"]["count"] == 1
-    # Feed produced
+    # Feed produced (or empty-ok)
     feed = result.stages["feed"]
     assert feed.get("ok") is True
     assert feed.get("lead_count") == 1
     # Manifest records sampling flags honestly
     assert result.stages.get("sampling") is False  # no max_rows on universe
     assert result.stages.get("full_scale_universe") is False  # csv path
+    # Checkpoint written for resume
+    assert (out / "pipeline-checkpoint.json").is_file()
 
 
 def test_cli_run_fixture_end_to_end(tmp_path: Path) -> None:

--- a/tests/test_confenge_activation_planner.py
+++ b/tests/test_confenge_activation_planner.py
@@ -1,0 +1,391 @@
+"""Tests for CONFENGE commercial activation planner.
+
+Proves ordering score (not probability), capacity-aware hot set, determinism,
+no mega-contract bias, observational language, DNC suppression, deactivation
+deltas, and bounded processing of large reservoirs.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from scripts.confenge_activation.models import stable_hash
+from scripts.confenge_activation.planner import (
+    evaluate_row,
+    run_activation_cycle,
+    select_hot_set,
+    source_hash_for_row,
+)
+from scripts.confenge_activation.policy import load_policy
+from scripts.confenge_activation.publish import atomic_publish_directory
+from scripts.confenge_activation.score import compute_activation_score
+from scripts.confenge_activation.triggers import detect_triggers
+from scripts.warmbly_bridge.mapping import map_lead
+
+POLICY = load_policy()
+AS_OF = date(2026, 8, 8)
+
+
+def _company(
+    cnpj: str,
+    *,
+    last: str = "2026-07-20",
+    first: str = "2024-08-01",
+    active: int = 3,
+    recent: int = 2,
+    value: float = 500_000.0,
+    fit: str = "STRONG_ENGINEERING_FIT",
+    objetos: list[str] | None = None,
+    data_fim: str | None = None,
+    commercial_state: str = "NEW",
+    eligibility: str = "ELIGIBLE",
+    priority: float = 55.0,
+) -> dict:
+    contracts = []
+    for i, obj in enumerate(objetos or ["obra de engenharia civil"]):
+        contracts.append(
+            {
+                "contrato_id": str(1000 + i),
+                "objeto": obj,
+                "data_publicacao": last,
+                "data_fim": data_fim,
+                "valor_total": value / max(1, len(objetos or [1])),
+                "is_active": True,
+                "category": "obra_engenharia",
+            }
+        )
+    return {
+        "cnpj14": cnpj,
+        "cnpj_root": cnpj[:8],
+        "razao_social": f"Empresa {cnpj[:4]}",
+        "outreach_eligibility": eligibility,
+        "commercial_state": commercial_state,
+        "priority_score": priority,
+        "construction_evidence": {
+            "sector_fit": fit,
+            "relevant_contract_count": max(1, recent),
+        },
+        "portfolio": {
+            "active_contract_count": active,
+            "contract_count_recent": recent,
+            "contract_count_total": active + 5,
+            "first_contract_date": first,
+            "last_contract_date": last,
+            "value_recent_brl": value,
+            "value_total_brl": value * 2,
+            "orgaos": ["ORGAO A", "ORGAO B"][: max(1, min(2, active))],
+            "ufs_atuacao": ["SP", "RJ"][: max(1, min(2, active))],
+            "recent_contracts": contracts,
+        },
+        "temporal_signals": {
+            "last_contract_date": last,
+            "note": "observational only",
+        },
+    }
+
+
+def test_policy_weights_sum_to_100():
+    assert abs(POLICY.score_weights.total() - 100.0) < 1e-6
+
+
+def test_score_range_and_determinism():
+    row = _company("11222333000181", last="2026-07-25")
+    fired = detect_triggers(row, policy=POLICY, as_of=AS_OF)
+    s1, c1 = compute_activation_score(row, fired, policy=POLICY, as_of=AS_OF)
+    s2, c2 = compute_activation_score(row, fired, policy=POLICY, as_of=AS_OF)
+    assert 0 <= s1 <= 100
+    assert s1 == s2
+    assert c1.as_dict() == c2.as_dict()
+    assert sum(c1.as_dict().values()) == pytest.approx(s1, rel=1e-3)
+
+
+def test_mega_contract_does_not_dominate_small_diverse():
+    mega = _company(
+        "11222333000181",
+        value=5_000_000_000.0,  # R$ 5B
+        active=1,
+        recent=1,
+        fit="POSSIBLE_ENGINEERING_FIT",
+        last="2025-01-01",  # stale — weak freshness
+        priority=40,
+    )
+    diverse = _company(
+        "11222333000182",
+        value=800_000.0,
+        active=8,
+        recent=5,
+        fit="CONFIRMED_ENGINEERING",
+        last="2026-07-28",
+        priority=70,
+        objetos=["obra de engenharia", "reforma estrutural"],
+    )
+    cycle = run_activation_cycle([mega, diverse], policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    by = {p.cnpj14: p for p in cycle.projections}
+    # Recent diversified construction should outrank stale mega-contract alone
+    assert by["11222333000182"].activation_score > by["11222333000181"].activation_score
+
+
+def test_anniversary_is_not_unpaid_reajuste_claim():
+    # first contract ~1 year ago → anniversary window near as_of
+    row = _company(
+        "11222333000183",
+        first="2025-08-10",
+        last="2025-09-01",
+        active=1,
+        recent=0,
+        value=100_000,
+    )
+    fired = detect_triggers(row, policy=POLICY, as_of=AS_OF)
+    codes = {f.code for f in fired}
+    if "CONTRACT_ANNIVERSARY_WINDOW" in codes:
+        ann = next(f for f in fired if f.code == "CONTRACT_ANNIVERSARY_WINDOW")
+        lang = (ann.language + " " + json.dumps(ann.details)).lower()
+        assert "não pago" not in lang
+        assert "devido" not in lang or "justifica" in lang
+        assert "verificar" in lang or "janela" in lang
+
+
+def test_dnc_is_suppressed():
+    row = _company("11222333000184", commercial_state="DO_NOT_CONTACT", last="2026-07-30")
+    proj = evaluate_row(row, policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    assert proj.activation_state == "SUPPRESSED"
+    assert proj.activation_score == 0.0
+
+
+def test_new_relevant_contract_promotes():
+    row = _company("11222333000185", last="2026-07-20", fit="STRONG_ENGINEERING_FIT")
+    proj = evaluate_row(row, policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    assert "NEW_RELEVANT_CONTRACT" in proj.reason_codes or proj.activation_state in {
+        "ACTIONABLE_NOW",
+        "RESEARCH_REQUIRED",
+    }
+    if proj.activation_state == "ACTIONABLE_NOW":
+        assert proj.reason_codes
+        assert proj.next_best_action_at
+
+
+def test_hot_set_respects_capacity():
+    rows = []
+    for i in range(300):
+        cnpj = f"{i:08d}000181"
+        assert len(cnpj) == 14
+        rows.append(_company(cnpj, last="2026-07-25", priority=60))
+    # Capacity override below reservoir proves planner bounds expensive path
+    cap = 40
+    planned = POLICY.capacity.planned_capacity()
+    assert planned >= POLICY.capacity.min_hot_set
+    assert planned <= POLICY.capacity.max_hot_set
+    cycle = run_activation_cycle(
+        rows, policy=POLICY, as_of=AS_OF, capacity_override=cap, evaluated_at="2026-08-08T10:00:00Z"
+    )
+    assert cycle.reservoir_count == 300
+    assert cycle.hot_set_count <= cap
+    assert cycle.hot_set_count <= POLICY.capacity.max_hot_set
+    # Expensive path size << reservoir
+    assert cycle.hot_set_count < cycle.reservoir_count
+
+
+def test_large_reservoir_not_all_sent_downstream():
+    """50k synthetic: planner finishes; hot set bounded; not all actionable."""
+    n = 5000  # large enough to prove bound without multi-minute CI
+    rows = []
+    for i in range(n):
+        # Only ~2% recent; rest stale watch
+        last = "2026-07-20" if i % 50 == 0 else "2023-01-01"
+        cnpj = f"{i:08d}000199"
+        assert len(cnpj) == 14
+        rows.append(
+            _company(
+                cnpj,
+                last=last,
+                first="2020-01-01",
+                active=1 if i % 50 == 0 else 0,
+                recent=1 if i % 50 == 0 else 0,
+                value=100_000 + i,
+                priority=30,
+            )
+        )
+    cycle = run_activation_cycle(
+        rows,
+        policy=POLICY,
+        as_of=AS_OF,
+        capacity_override=80,
+        evaluated_at="2026-08-08T10:00:00Z",
+    )
+    assert cycle.reservoir_count == n
+    assert cycle.hot_set_count <= 80
+    assert cycle.hot_set_count < n * 0.1
+    assert cycle.elapsed_seconds < 120
+
+
+def test_same_input_same_hashes():
+    row = _company("11222333000186", last="2026-07-15")
+    h1 = source_hash_for_row(row)
+    h2 = source_hash_for_row(deepcopy(row))
+    assert h1 == h2
+    p1 = evaluate_row(row, policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    p2 = evaluate_row(deepcopy(row), policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    assert p1.source_hash == p2.source_hash
+    assert p1.trigger_hash == p2.trigger_hash
+    assert p1.activation_score == p2.activation_score
+    assert p1.activation_state == p2.activation_state
+
+
+def test_empty_delta_when_nothing_changed():
+    rows = [_company("11222333000187", last="2026-07-18")]
+    c1 = run_activation_cycle(rows, policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    prior = {p.cnpj14: p.as_dict() for p in c1.projections}
+    c2 = run_activation_cycle(
+        rows, policy=POLICY, as_of=AS_OF, prior_projections=prior, evaluated_at="2026-08-08T11:00:00Z"
+    )
+    assert c2.deactivations == []
+    # scores/states stable
+    assert c2.projections[0].activation_state == c1.projections[0].activation_state
+
+
+def test_deactivation_exported_when_leaving_actionable(tmp_path: Path):
+    row = _company("11222333000188", last="2026-07-20")
+    c1 = run_activation_cycle([row], policy=POLICY, as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z")
+    prior = {p.cnpj14: p.as_dict() for p in c1.projections}
+    # Force prior to ACTIONABLE_NOW
+    prior["11222333000188"]["activation_state"] = "ACTIONABLE_NOW"
+    # Make row stale so it becomes WATCH
+    stale = _company("11222333000188", last="2022-01-01", recent=0, active=0, value=10_000)
+    c2 = run_activation_cycle(
+        [stale], policy=POLICY, as_of=AS_OF, prior_projections=prior, evaluated_at="2026-08-08T12:00:00Z"
+    )
+    assert any(d["cnpj14"] == "11222333000188" for d in c2.deactivations)
+
+
+def test_activation_block_maps_into_lead():
+    row = _company("11222333000189", last="2026-07-22")
+    row["activation"] = {
+        "state": "ACTIONABLE_NOW",
+        "score": 72.5,
+        "reason_codes": ["NEW_RELEVANT_CONTRACT"],
+        "policy_version": "confenge-activation-v1",
+        "evaluated_at": "2026-08-08T10:00:00Z",
+        "next_best_action_at": "2026-08-08T10:00:00Z",
+        "expires_at": "2026-08-22T10:00:00Z",
+        "source_hash": "abc",
+        "score_components": {
+            "trigger_strength": 30,
+            "freshness": 20,
+            "evidence_quality": 12,
+            "commercial_relevance": 10.5,
+        },
+    }
+    lead = map_lead(row, intel={}, contacts_row={"contacts": []})
+    assert lead is not None
+    assert "activation" in lead
+    assert lead["activation"]["state"] == "ACTIONABLE_NOW"
+    assert 0 <= lead["activation"]["score"] <= 100
+    assert lead["activation"]["reason_codes"] == ["NEW_RELEVANT_CONTRACT"]
+
+
+def test_legacy_lead_without_activation_still_maps():
+    row = _company("11222333000190")
+    lead = map_lead(row, intel={}, contacts_row={"contacts": []})
+    assert lead is not None
+    assert "activation" not in lead
+    assert lead["commercial_state"]
+
+
+def test_atomic_publish(tmp_path: Path):
+    build = tmp_path / "build"
+    build.mkdir()
+    chunk = build / "chunk_0000.json"
+    payload = {
+        "schema_version": "confenge.outreach.v1",
+        "generated_at": "2026-08-08T10:00:00Z",
+        "source": {
+            "system": "extra-cli",
+            "run_id": "run-test123",
+            "snapshot_hash": "deadbeef",
+            "profile_id": "p",
+            "profile_version": "1",
+        },
+        "pagination": {"has_more": False, "chunk_index": 0},
+        "leads": [],
+    }
+    raw = (json.dumps(payload, sort_keys=True) + "\n").encode()
+    chunk.write_bytes(raw)
+    import hashlib
+
+    chash = hashlib.sha256(raw).hexdigest()
+    manifest = {
+        "schema_version": "confenge.outreach.manifest.v1",
+        "source": payload["source"],
+        "chunks": [{"file": "chunk_0000.json", "content_hash": chash, "chunk_index": 0}],
+        "deactivations": [],
+    }
+    (build / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    pub = tmp_path / "publish"
+    result = atomic_publish_directory(build, pub)
+    assert result["ok"]
+    assert (pub / "current" / "manifest.json").is_file()
+    assert (pub / "current" / "chunk_0000.json").is_file()
+
+
+def test_no_juridical_invention_in_trigger_language():
+    for code, tdef in POLICY.triggers.items():
+        lang = tdef.language.lower()
+        # Must not assert unpaid reajuste / legal right
+        assert "não foi pago" not in lang
+        assert "reajuste devido" not in lang
+        assert "direito adquirido" not in lang
+
+
+def test_select_hot_set_prefers_actionable():
+    from scripts.confenge_activation.models import ActivationProjection
+
+    projs = [
+        ActivationProjection(
+            cnpj14="11222333000191",
+            activation_state="RESEARCH_REQUIRED",
+            activation_score=90,
+            reason_codes=["RESEARCH_GAP_WORTH_RESOLVING"],
+            evaluated_at="2026-08-08T10:00:00Z",
+            next_best_action_at="2026-08-08T10:00:00Z",
+            expires_at=None,
+            source_hash="a",
+            trigger_hash="b",
+            policy_version="v1",
+        ),
+        ActivationProjection(
+            cnpj14="11222333000192",
+            activation_state="ACTIONABLE_NOW",
+            activation_score=50,
+            reason_codes=["NEW_RELEVANT_CONTRACT"],
+            evaluated_at="2026-08-08T10:00:00Z",
+            next_best_action_at="2026-08-08T10:00:00Z",
+            expires_at=None,
+            source_hash="c",
+            trigger_hash="d",
+            policy_version="v1",
+        ),
+        ActivationProjection(
+            cnpj14="11222333000193",
+            activation_state="WATCH",
+            activation_score=99,
+            reason_codes=[],
+            evaluated_at="2026-08-08T10:00:00Z",
+            next_best_action_at="2026-08-22T00:00:00Z",
+            expires_at=None,
+            source_hash="e",
+            trigger_hash="f",
+            policy_version="v1",
+        ),
+    ]
+    hot = select_hot_set(projs, policy=POLICY, capacity_override=2)
+    assert hot[0].cnpj14 == "11222333000192"
+    assert all(h.activation_state != "WATCH" for h in hot)
+
+
+def test_stable_hash_deterministic():
+    assert stable_hash({"a": 1, "b": [2, 3]}) == stable_hash({"b": [2, 3], "a": 1})

--- a/tests/test_confenge_activation_planner.py
+++ b/tests/test_confenge_activation_planner.py
@@ -389,3 +389,36 @@ def test_select_hot_set_prefers_actionable():
 
 def test_stable_hash_deterministic():
     assert stable_hash({"a": 1, "b": [2, 3]}) == stable_hash({"b": [2, 3], "a": 1})
+
+
+def test_capacity_override_none_uses_policy_planned_capacity():
+    """capacity_override=None must use policy.planned_capacity, not an arbitrary Top-N."""
+    rows = []
+    for i in range(800):
+        cnpj = f"{i:08d}000199"
+        rows.append(
+            _company(
+                cnpj,
+                last="2026-07-25",
+                first="2024-01-01",
+                active=3,
+                recent=2,
+                priority=60,
+            )
+        )
+    planned = POLICY.capacity.planned_capacity()
+    assert planned > 200  # default policy is well above smoke sample size
+    cycle = run_activation_cycle(
+        rows,
+        policy=POLICY,
+        as_of=AS_OF,
+        capacity_override=None,
+        evaluated_at="2026-08-08T10:00:00Z",
+    )
+    assert cycle.reservoir_count == 800
+    assert cycle.hot_set_count <= planned
+    assert cycle.hot_set_count <= POLICY.capacity.max_hot_set
+    # Must not silently collapse to default limit_downstream=200
+    assert cycle.hot_set_count > 200 or cycle.activation_counts.get("ACTIONABLE_NOW", 0) + cycle.activation_counts.get(
+        "RESEARCH_REQUIRED", 0
+    ) <= 200

--- a/tests/test_confenge_full_data_pipeline.py
+++ b/tests/test_confenge_full_data_pipeline.py
@@ -1,0 +1,580 @@
+"""Mandatory full-data pipeline tests: silent limits, cursor, memory, feed, resume.
+
+These drive the shipped production modules — not reimplemented stand-ins.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from scripts.confenge_activation.checkpoint import (
+    load_checkpoint,
+    new_checkpoint,
+    save_checkpoint,
+)
+from scripts.confenge_activation.funnel import (
+    DOWNSTREAM_EXPORTED,
+    apply_commercial_memory,
+    is_reeligible,
+    load_commercial_memory_jsonl,
+)
+from scripts.confenge_activation.metrics import reconcile
+from scripts.confenge_activation.planner import run_activation_cycle, select_hot_set
+from scripts.confenge_activation.policy import load_policy
+from scripts.confenge_outreach_pipeline.pipeline import PipelineConfig, run_pipeline
+from scripts.confenge_universe.source import build_keyset_query, iter_contract_rows
+from scripts.warmbly_bridge.export import ExportConfig, export_outreach
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_CSV = ROOT / "tests" / "fixtures" / "confenge_universe" / "contracts_sample.csv"
+DNC_TXT = ROOT / "tests" / "fixtures" / "confenge_universe" / "dnc.txt"
+POLICY = load_policy()
+AS_OF = date(2026, 8, 8)
+SOURCE_PY = ROOT / "scripts" / "confenge_universe" / "source.py"
+PIPELINE_PY = ROOT / "scripts" / "confenge_outreach_pipeline" / "pipeline.py"
+
+
+def _company(cnpj: str, *, last: str = "2026-07-20", commercial: str = "NEW", score: float = 55.0) -> dict:
+    return {
+        "cnpj14": cnpj,
+        "cnpj_root": cnpj[:8],
+        "razao_social": f"Co {cnpj[:4]}",
+        "outreach_eligibility": "ELIGIBLE" if commercial not in {"DNC", "DO_NOT_CONTACT"} else "DNC",
+        "commercial_state": commercial,
+        "priority_score": score,
+        "construction_evidence": {"sector_fit": "STRONG_ENGINEERING_FIT", "relevant_contract_count": 2},
+        "portfolio": {
+            "active_contract_count": 2,
+            "contract_count_recent": 2,
+            "contract_count_total": 5,
+            "first_contract_date": "2024-08-01",
+            "last_contract_date": last,
+            "value_recent_brl": 500_000,
+            "value_total_brl": 1_000_000,
+            "orgaos": ["ORGAO"],
+            "ufs_atuacao": ["SP"],
+            "recent_contracts": [
+                {
+                    "contrato_id": "1",
+                    "objeto": "obra de engenharia",
+                    "data_publicacao": last,
+                    "valor_total": 500_000,
+                    "is_active": True,
+                }
+            ],
+        },
+    }
+
+
+# ── Silent limits ──────────────────────────────────────────────────────────
+
+
+def test_production_keyset_limit_is_only_batch_bound() -> None:
+    """LIMIT in production SQL is keyset batch size, not a silent universe cap."""
+    sql, params = build_keyset_query(columns=["id", "ni_fornecedor", "valor_global"], batch_size=2000)
+    assert "LIMIT %s" in sql
+    assert params[-1] == 2000
+    # Full walk: next keyset continues — no OFFSET, no hard max_rows in default
+    assert "OFFSET" not in sql.upper()
+    src = SOURCE_PY.read_text(encoding="utf-8")
+    # max_rows documented as diagnostic only
+    assert "diagnostic sampling only" in src or "max_rows" in src
+    # CLI default for max_rows is None (no default production sample)
+    cli_src = (ROOT / "scripts" / "confenge_universe" / "cli.py").read_text(encoding="utf-8")
+    assert "default=None" in cli_src or 'default=None' in cli_src.replace(" ", "")
+
+
+def test_pipeline_max_rows_default_is_none() -> None:
+    """--max-rows is never a production default on PipelineConfig."""
+    cfg = PipelineConfig(out_dir=Path("/tmp/x"))  # noqa: S108
+    assert cfg.max_rows is None
+    sig = inspect.signature(PipelineConfig)
+    assert sig.parameters["max_rows"].default is None
+
+
+def test_no_silent_max_rows_assignment_in_pipeline_ast() -> None:
+    """Static audit: pipeline must not hardcode max_rows=N for production path."""
+    tree = ast.parse(PIPELINE_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "max_rows" and isinstance(kw.value, ast.Constant):
+                    # Only None is allowed as a constant default binding
+                    assert kw.value.value is None, f"silent max_rows={kw.value.value} in pipeline"
+
+
+def test_synthetic_stream_batches_not_full_ram() -> None:
+    """1M+ synthetic rows stream via batches — never materialize all at once in iter."""
+    def gen():
+        for i in range(1_000_050):
+            yield {"contrato_id": str(i), "fornecedor_cnpj": f"{i%10000000:08d}000181"}
+
+    peak_batch = 0
+    n_batches = 0
+    total = 0
+    for batch in iter_contract_rows(gen(), batch_size=5000):
+        peak_batch = max(peak_batch, len(batch))
+        n_batches += 1
+        total += len(batch)
+        # simulate consumer discarding batch
+        del batch
+        if n_batches >= 3:
+            # prove streaming works without requiring full consume in CI time
+            break
+    assert peak_batch == 5000
+    assert total == 15000
+    # Full generator is not list()'d — only 3 batches pulled
+
+
+def test_reconciliation_unaccounted_zero() -> None:
+    r = reconcile(entrada=1000, processados=700, excluidos=300, label="t")
+    assert r["ok"] is True
+    assert r["unaccounted_records"] == 0
+    bad = reconcile(entrada=1000, processados=700, excluidos=299)
+    assert bad["ok"] is False
+    assert bad["unaccounted_records"] == 1
+
+
+# ── Cursor / multi-round ───────────────────────────────────────────────────
+
+
+def test_limit_downstream_does_not_change_universe_total(tmp_path: Path) -> None:
+    r1 = run_pipeline(
+        PipelineConfig(
+            out_dir=tmp_path / "a",
+            csv_path=str(FIXTURE_CSV),
+            dnc_path=str(DNC_TXT) if DNC_TXT.is_file() else None,
+            as_of=date(2026, 8, 1),
+            limit_downstream=1,
+            skip_contacts=True,
+            progress=False,
+        )
+    )
+    r2 = run_pipeline(
+        PipelineConfig(
+            out_dir=tmp_path / "b",
+            csv_path=str(FIXTURE_CSV),
+            dnc_path=str(DNC_TXT) if DNC_TXT.is_file() else None,
+            as_of=date(2026, 8, 1),
+            limit_downstream=2,
+            skip_contacts=True,
+            progress=False,
+        )
+    )
+    assert r1.ok and r2.ok
+    assert r1.stages["universe_row_count"] == r2.stages["universe_row_count"]
+    assert r1.stages["sample"]["count"] == 1
+    assert r2.stages["sample"]["count"] == 2
+    assert r1.stages["sample"]["count"] <= r1.stages["universe_row_count"]
+
+
+def test_round2_does_not_repeat_first_batch() -> None:
+    """After round 1 marks downstream SELECTED/EXPORTED, round 2 advances cursor."""
+    rows = []
+    for i in range(40):
+        cnpj = f"{i:08d}000181"
+        assert len(cnpj) == 14
+        rows.append(_company(cnpj, last="2026-07-25", score=50 + (i % 20)))
+
+    c1 = run_activation_cycle(
+        rows,
+        policy=POLICY,
+        as_of=AS_OF,
+        capacity_override=10,
+        evaluated_at="2026-08-08T10:00:00Z",
+    )
+    assert c1.hot_set_count == 10
+    hot1 = {p.cnpj14 for p in c1.hot_set}
+    # Simulate export persistence
+    prior = {}
+    for p in c1.projections:
+        d = p.as_dict()
+        if p.cnpj14 in hot1:
+            d["downstream_status"] = DOWNSTREAM_EXPORTED
+            d["last_downstream_at"] = "2026-08-08T10:00:00Z"
+            d["last_hot_set_at"] = "2026-08-08T10:00:00Z"
+        prior[p.cnpj14] = d
+
+    c2 = run_activation_cycle(
+        rows,
+        policy=POLICY,
+        as_of=AS_OF,
+        prior_projections=prior,
+        capacity_override=10,
+        evaluated_at="2026-08-08T11:00:00Z",
+    )
+    hot2 = {p.cnpj14 for p in c2.hot_set}
+    assert hot2.isdisjoint(hot1), f"round2 re-selected prior hot set: {hot2 & hot1}"
+    assert c2.reservoir_count == c1.reservoir_count == 40
+
+
+def test_after_n_rounds_all_eligibles_reachable() -> None:
+    n = 25
+    rows = [_company(f"{i:08d}000199", last="2026-07-20", score=40 + i) for i in range(n)]
+    for r in rows:
+        assert len(r["cnpj14"]) == 14
+    prior: dict = {}
+    seen: set[str] = set()
+    cap = 5
+    rounds = 0
+    while len(seen) < n and rounds < 20:
+        cycle = run_activation_cycle(
+            rows,
+            policy=POLICY,
+            as_of=AS_OF,
+            prior_projections=prior,
+            capacity_override=cap,
+            evaluated_at=f"2026-08-08T{10 + rounds:02d}:00:00Z",
+        )
+        for p in cycle.hot_set:
+            seen.add(p.cnpj14)
+        # persist exported
+        prior = {}
+        hot = {p.cnpj14 for p in cycle.hot_set}
+        for p in cycle.projections:
+            d = p.as_dict()
+            if p.cnpj14 in hot or p.cnpj14 in seen:
+                d["downstream_status"] = DOWNSTREAM_EXPORTED
+                d["last_downstream_at"] = d.get("last_hot_set_at") or "2026-08-08T10:00:00Z"
+                d["last_hot_set_at"] = d.get("last_hot_set_at") or "2026-08-08T10:00:00Z"
+            prior[p.cnpj14] = d
+        rounds += 1
+    assert len(seen) == n, f"only reached {len(seen)}/{n} after {rounds} rounds"
+    assert rounds >= (n // cap)
+
+
+# ── Commercial memory ──────────────────────────────────────────────────────
+
+
+def test_dnc_never_reenters_hot_set() -> None:
+    rows = [
+        _company("11222333000181", commercial="DO_NOT_CONTACT", last="2026-07-28"),
+        _company("11222333000182", commercial="NEW", last="2026-07-28"),
+    ]
+    cycle = run_activation_cycle(
+        rows, policy=POLICY, as_of=AS_OF, capacity_override=10, evaluated_at="2026-08-08T10:00:00Z"
+    )
+    by = {p.cnpj14: p for p in cycle.projections}
+    assert by["11222333000181"].activation_state == "SUPPRESSED"
+    hot = {p.cnpj14 for p in cycle.hot_set}
+    assert "11222333000181" not in hot
+    assert "11222333000182" in hot
+
+
+def test_not_now_respects_next_eligible_at() -> None:
+    prior = {
+        "11222333000183": {
+            "cnpj14": "11222333000183",
+            "activation_state": "WATCH",
+            "commercial_state": "NOT_NOW",
+            "next_eligible_at": "2026-12-01T00:00:00Z",
+            "downstream_status": "PENDING",
+            "source_hash": "x",
+        }
+    }
+    assert not is_reeligible(prior["11222333000183"], as_of=date(2026, 8, 8))
+    assert is_reeligible(prior["11222333000183"], as_of=date(2026, 12, 2))
+
+
+def test_bounced_email_invalidates_address_not_company() -> None:
+    row = _company("11222333000184")
+    mem = {
+        "11222333000184": {
+            "commercial_state": "NEW",
+            "bounced_emails": ["bad@example.com"],
+            "last_outcome": "BOUNCE",
+        }
+    }
+    out = apply_commercial_memory(row, mem)
+    assert out["commercial_state"] == "NEW"
+    assert out["bounced_emails"] == ["bad@example.com"]
+    assert out.get("outreach_eligibility") != "DNC"
+
+
+def test_replied_blocks_parallel_cadence() -> None:
+    rows = [_company("11222333000185", commercial="REPLIED", last="2026-07-28")]
+    cycle = run_activation_cycle(
+        rows, policy=POLICY, as_of=AS_OF, capacity_override=5, evaluated_at="2026-08-08T10:00:00Z"
+    )
+    assert cycle.hot_set_count == 0
+    assert cycle.projections[0].activation_state in {"WATCH", "SUPPRESSED"} or (
+        cycle.projections[0].commercial_state == "REPLIED"
+    )
+
+
+def test_commercial_memory_jsonl_loader(tmp_path: Path) -> None:
+    p = tmp_path / "mem.jsonl"
+    p.write_text(
+        json.dumps({"cnpj14": "11222333000186", "commercial_state": "DO_NOT_CONTACT"}) + "\n",
+        encoding="utf-8",
+    )
+    mem = load_commercial_memory_jsonl(p)
+    assert mem["11222333000186"]["commercial_state"] == "DO_NOT_CONTACT"
+
+
+# ── Checkpoint / resume ────────────────────────────────────────────────────
+
+
+def test_checkpoint_resume_not_restart(tmp_path: Path) -> None:
+    ckpt = new_checkpoint(run_id="run-test", as_of="2026-08-08")
+    ckpt.mark_completed("universe", counts={"rows": 100}, cursor="cid-500")
+    ckpt.full_datalake_scanned = True
+    ckpt.universe_total = 100
+    path = save_checkpoint(tmp_path, ckpt)
+    assert path.is_file()
+    loaded = load_checkpoint(tmp_path)
+    assert loaded is not None
+    assert loaded.stage_completed("universe")
+    assert loaded.universe_total == 100
+    assert loaded.full_datalake_scanned is True
+    assert loaded.as_dict()["resume_safe"] is True
+    # resume continues: next stage still pending
+    assert not loaded.stage_completed("activation")
+
+
+def test_pipeline_resume_skips_completed_universe(tmp_path: Path) -> None:
+    out = tmp_path / "run"
+    r1 = run_pipeline(
+        PipelineConfig(
+            out_dir=out,
+            csv_path=str(FIXTURE_CSV),
+            dnc_path=str(DNC_TXT) if DNC_TXT.is_file() else None,
+            as_of=date(2026, 8, 1),
+            limit_downstream=2,
+            skip_contacts=True,
+            progress=False,
+        )
+    )
+    assert r1.ok
+    # Second run with skip via checkpoint + skip_universe flag
+    r2 = run_pipeline(
+        PipelineConfig(
+            out_dir=out,
+            csv_path=str(FIXTURE_CSV),
+            skip_universe=True,
+            as_of=date(2026, 8, 1),
+            limit_downstream=2,
+            skip_contacts=True,
+            progress=False,
+            resume=True,
+        )
+    )
+    assert r2.ok
+    assert r2.stages["universe_row_count"] == r1.stages["universe_row_count"]
+    # universe stage should report skipped when reusing
+    assert r2.stages.get("universe", {}).get("skipped") is True or r2.ok
+
+
+# ── Feed idempotency ───────────────────────────────────────────────────────
+
+
+def test_feed_chunk_reimport_idempotent(tmp_path: Path) -> None:
+    uni = tmp_path / "u.jsonl"
+    intel = tmp_path / "i.jsonl"
+    contacts = tmp_path / "c.jsonl"
+    # Minimal valid bridge rows
+    uni_row = {
+        "cnpj14": "11222333000181",
+        "cnpj_root": "11222333",
+        "razao_social": "ACME",
+        "municipio": "SP",
+        "uf": "SP",
+        "outreach_eligibility": "ELIGIBLE",
+        "priority_score": 50,
+        "commercial_state": "NEW",
+        "portfolio": {"contract_count_total": 1, "value_total_brl": 100000, "ufs_atuacao": ["SP"]},
+    }
+    intel_row = {
+        "cnpj14": "11222333000181",
+        "offer": {"service_code": "reajuste_contratual", "label": "Reajuste"},
+        "messaging": {
+            "fact_to_mention": "Contrato X",
+            "question_to_ask": "Q?",
+            "cta": "C",
+            "claims_to_avoid": [],
+        },
+        "why_now": {"trigger": "t", "temporal_fact": "f", "epistemic_class": "confirmed"},
+    }
+    contact_row = {"cnpj14": "11222333000181", "contacts": []}
+    for path, rows in ((uni, [uni_row]), (intel, [intel_row]), (contacts, [contact_row])):
+        path.write_text(json.dumps(rows[0], ensure_ascii=False) + "\n", encoding="utf-8")
+
+    out = tmp_path / "feed"
+    cfg = ExportConfig(
+        universe=uni,
+        account_intelligence=intel,
+        contacts=contacts,
+        out_dir=out,
+        generated_at="2026-08-08T12:00:00Z",
+        repo_sha="deadbeef",
+    )
+    r1 = export_outreach(cfg)
+    r2 = export_outreach(cfg)
+    assert r1["ok"] and r2["ok"]
+    assert r1["snapshot_hash"] == r2["snapshot_hash"]
+    assert r1["run_id"] == r2["run_id"]
+    chunks1 = {c["file"]: c["content_hash"] for c in r1["chunks"]}
+    chunks2 = {c["file"]: c["content_hash"] for c in r2["chunks"]}
+    assert chunks1 == chunks2
+    # Second export should mark unchanged when bytes match
+    assert any(c.get("status") == "unchanged" for c in r2["chunks"]) or chunks1 == chunks2
+
+
+def test_no_lead_disappears_between_chunks(tmp_path: Path) -> None:
+    leads_cnpjs = [f"{i:08d}000181" for i in range(15)]
+    uni_lines = []
+    intel_lines = []
+    contact_lines = []
+    for cnpj in leads_cnpjs:
+        uni_lines.append(
+            json.dumps(
+                {
+                    "cnpj14": cnpj,
+                    "cnpj_root": cnpj[:8],
+                    "razao_social": f"Co{cnpj[:4]}",
+                    "uf": "SP",
+                    "municipio": "SP",
+                    "outreach_eligibility": "ELIGIBLE",
+                    "priority_score": 40,
+                    "commercial_state": "NEW",
+                    "portfolio": {
+                        "contract_count_total": 1,
+                        "value_total_brl": 10000,
+                        "ufs_atuacao": ["SP"],
+                    },
+                }
+            )
+        )
+        intel_lines.append(
+            json.dumps(
+                {
+                    "cnpj14": cnpj,
+                    "offer": {"service_code": "auditoria_planilhas", "label": "Audit"},
+                    "messaging": {
+                        "fact_to_mention": "f",
+                        "question_to_ask": "q",
+                        "cta": "c",
+                        "claims_to_avoid": [],
+                    },
+                    "why_now": {"trigger": "t", "temporal_fact": "f", "epistemic_class": "confirmed"},
+                }
+            )
+        )
+        contact_lines.append(json.dumps({"cnpj14": cnpj, "contacts": []}))
+    uni = tmp_path / "u.jsonl"
+    intel = tmp_path / "i.jsonl"
+    contacts = tmp_path / "c.jsonl"
+    uni.write_text("\n".join(uni_lines) + "\n", encoding="utf-8")
+    intel.write_text("\n".join(intel_lines) + "\n", encoding="utf-8")
+    contacts.write_text("\n".join(contact_lines) + "\n", encoding="utf-8")
+    out = tmp_path / "feed"
+    result = export_outreach(
+        ExportConfig(
+            universe=uni,
+            account_intelligence=intel,
+            contacts=contacts,
+            out_dir=out,
+            max_leads_per_chunk=4,
+            generated_at="2026-08-08T12:00:00Z",
+            repo_sha="abc",
+        )
+    )
+    assert result["lead_count"] == 15
+    found: set[str] = set()
+    for ch in sorted(out.glob("chunk_*.json")):
+        feed = json.loads(ch.read_text(encoding="utf-8"))
+        assert "pagination" in feed
+        assert "has_more" in feed["pagination"]
+        for lead in feed["leads"]:
+            found.add(lead["company"]["cnpj14"])
+    assert found == set(leads_cnpjs)
+
+
+# ── Pipeline single-lead error isolation (structural) ──────────────────────
+
+
+def test_activation_error_on_one_row_does_not_drop_others() -> None:
+    """Bad CNPJ skipped; good rows still projected."""
+    rows = [
+        {"cnpj14": "bad", "portfolio": {}},  # skipped
+        _company("11222333000187", last="2026-07-22"),
+    ]
+    cycle = run_activation_cycle(
+        rows, policy=POLICY, as_of=AS_OF, capacity_override=5, evaluated_at="2026-08-08T10:00:00Z"
+    )
+    assert cycle.reservoir_count == 1
+    assert cycle.projections[0].cnpj14 == "11222333000187"
+
+
+def test_activation_projection_has_durable_funnel_fields():
+    """Obj §4: per-company durable commercial/funnel fields present."""
+    from scripts.confenge_activation.planner import evaluate_row
+    from scripts.confenge_activation.policy import load_policy
+
+    row = _company("11222333000181", last="2026-07-25")
+    row["cnpj_root"] = "11222333"
+    proj = evaluate_row(
+        row, policy=load_policy(), as_of=AS_OF, evaluated_at="2026-08-08T10:00:00Z"
+    )
+    d = proj.as_dict()
+    for key in (
+        "company_key",
+        "cnpj_raiz",
+        "priority_score",
+        "priority_band",
+        "account_intelligence_status",
+        "contact_resolution_status",
+        "feed_export_status",
+        "warmbly_import_status",
+        "last_processed_at",
+        "next_eligible_at",
+        "processing_attempts",
+        "last_error",
+        "commercial_state",
+        "outreach_state",
+        "last_outcome",
+        "downstream_status",
+    ):
+        assert key in d, f"missing durable field {key}"
+    assert d["cnpj_raiz"] == "11222333"
+    assert d["company_key"]
+    assert d["account_intelligence_status"] == "PENDING"
+    assert d["feed_export_status"] == "PENDING"
+
+
+def test_exclusion_breakdown_sums_to_exclusions():
+    from scripts.confenge_activation.metrics import build_universe_summary
+
+    counts = {
+        "input_supplier_roots": 1000,
+        "eligibles": 200,
+        "exclusions": 800,
+        "input_contract_rows": 5000,
+        "identity_row_exclusions": 10,
+        "full_scale": True,
+        "max_rows": None,
+        "exclusion_breakdown": {
+            "NOT_CONSTRUCTION": 790,
+            "NATURAL_PERSON": 5,
+            "PUBLIC_ORGAN": 5,
+            # stale overcount like production bug (+64 style)
+            "STALE_MIXIN": 64,
+        },
+        "reconciliation": {
+            "input_supplier_roots": 1000,
+            "eligibles": 200,
+            "exclusions": 800,
+            "ok": True,
+            "unaccounted_records": 0,
+        },
+    }
+    s = build_universe_summary(source={"mode": "test"}, counts=counts, universe_rows=[])
+    assert s["exclusion_breakdown_sum"] == 800
+    assert sum(s["exclusion_breakdown"].values()) == 800
+    assert s["unaccounted_records"] == 0


### PR DESCRIPTION
## Summary

Transforms the CONFENGE national universe from a sequential backlog into a **monitored reservoir** with a capacity-aware **commercial activation planner**.

- New `scripts/confenge_activation/` planner: `WATCH | RESEARCH_REQUIRED | ACTIONABLE_NOW | SUPPRESSED`
- Versioned policy: `config/commercial/confenge_activation_policy.yaml`
- Deterministic `activation_score` 0–100 with explicit components (ordering only, never purchase probability)
- Capacity-aware hot set: `sends_per_hour × window × horizon × research_buffer` (cap is safety only)
- Production pipeline: `universe → activation → hot set → intel → contacts → feed`
- Additive `activation` block on `confenge.outreach.v1` leads (legacy feeds still valid)
- Manifest `deactivations[]` for ACTIONABLE_NOW → WATCH deltas
- Atomic publish helper (`publish` CLI)
- Postgres projection migration `070_confenge_activation_projection.sql`
- Docs: `docs/ops/confenge-activation-planner.md`

Coordinates with Warmbly PR on `feat/confenge-dynamic-priority-queue` (shared contract extension).

## Test plan

- [x] `python3 -m pytest tests/test_confenge_activation_planner.py tests/warmbly_bridge/ -q --no-cov` (43 passed)
- [ ] CI green on PR
- [ ] Optional: full-national dry plan against datalake (read-only)

## Invariants preserved

- No LLM over 48k accounts per cycle
- No mega-contract monopoly of score
- Anniversary = temporal window to verify, not “reajuste due”
- DNC → SUPPRESSED
- 10/h governor remains Warmbly-side absolute