### PR TITLE
feat(organic): Organic Opportunity Engine (datalake → SEO opportunities)

### DIFF
--- a/scripts/organic/__init__.py
+++ b/scripts/organic/__init__.py
@@ -1,0 +1,24 @@
+"""Organic Opportunity Engine — datalake facts → editorial/commercial opportunities.
+
+Distinct from scripts.opportunity_intel (open tenders / commercial ranking).
+This module turns public-contract aggregates into scored content opportunities
+for the CONFENGE inbound system (web-cfg).
+
+Public entry:
+  python -m scripts.organic --pseo-dir PATH --out PATH
+"""
+
+from __future__ import annotations
+
+from scripts.organic.engine import build_opportunities, load_pseo_snapshot, run_engine
+from scripts.organic.gates import indexability_quality_gate
+from scripts.organic.score import CONTENT_VALUE_WEIGHTS, compute_content_value_score
+
+__all__ = [
+    "CONTENT_VALUE_WEIGHTS",
+    "build_opportunities",
+    "compute_content_value_score",
+    "indexability_quality_gate",
+    "load_pseo_snapshot",
+    "run_engine",
+]

--- a/scripts/organic/__main__.py
+++ b/scripts/organic/__main__.py
@@ -1,0 +1,79 @@
+"""CLI: python -m scripts.organic --pseo-dir DIR --out FILE [--gsc-dir DIR]"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+def _load_gsc_csv(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open(encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Organic Opportunity Engine (extra-cli)")
+    p.add_argument(
+        "--pseo-dir",
+        required=True,
+        help="Directory with pSEO export JSON (markets.json, problem_service.json, …)",
+    )
+    p.add_argument(
+        "--out",
+        default="-",
+        help="Output SEO_OPPORTUNITIES.json path, or - for stdout",
+    )
+    p.add_argument(
+        "--gsc-dir",
+        default=None,
+        help="Optional GSC export dir with Consultas.csv and Paginas.csv",
+    )
+    p.add_argument("--as-of", default=None, help="ISO date cut for provenance")
+    args = p.parse_args(argv)
+
+    gsc_q: list[dict] = []
+    gsc_p: list[dict] = []
+    if args.gsc_dir:
+        gdir = Path(args.gsc_dir)
+        gsc_q = _load_gsc_csv(gdir / "Consultas.csv")
+        gsc_p = _load_gsc_csv(gdir / "Paginas.csv")
+
+    # Late import so --help works without heavy deps
+    from scripts.organic.engine import run_engine
+
+    out_path = None if args.out == "-" else args.out
+    doc = run_engine(
+        pseo_dir=args.pseo_dir,
+        out_path=out_path,
+        gsc_queries=gsc_q or None,
+        gsc_pages=gsc_p or None,
+        as_of=args.as_of,
+    )
+    # Strip non-serializable / internal
+    public = {k: v for k, v in doc.items() if not k.startswith("_")}
+    if args.out == "-":
+        json.dump(public, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "out": args.out,
+                    "total": public.get("counts", {}).get("total"),
+                    "bofu": public.get("counts", {}).get("bofu"),
+                    "data_driven": public.get("counts", {}).get("data_driven"),
+                },
+                ensure_ascii=False,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/organic/demand_graph.py
+++ b/scripts/organic/demand_graph.py
@@ -1,0 +1,224 @@
+"""Demand graph: persona → problem → question → intent → Confenge service.
+
+Not a keyword list. Semantic needs map to one opportunity node even when
+queries vary textually.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Canonical demand nodes grounded in CONFENGE service inventory
+DEMAND_NODES: list[dict[str, Any]] = [
+    {
+        "id": "need-reequilibrio-pleito",
+        "persona": "diretor-construtora",
+        "problem": "Contrato de obra pública virou prejuízo ou a equação original se rompeu",
+        "question": "Quando cabe reequilíbrio e como estruturar um pleito defensável?",
+        "intent": "bofu",
+        "jtbd": "Proteger margem e decidir se vale montar pleito de reequilíbrio agora",
+        "cluster": "reequilibrio",
+        "service_slug": "reequilibrio-obras-publicas",
+        "service_path": "/reequilibrio-obras-publicas/",
+        "related_queries": [
+            "reequilíbrio econômico financeiro obra pública",
+            "pedido de reequilíbrio contrato público",
+            "reajuste ou reequilíbrio obra pública",
+        ],
+        "cta": "Analisar viabilidade de reequilíbrio",
+        "funnel": "bofu",
+        "existing_url": "/reequilibrio-obras-publicas/",
+    },
+    {
+        "id": "need-aditivo-limite",
+        "persona": "engenheiro-contratos",
+        "problem": "Acréscimos/supressões se aproximam dos limites legais",
+        "question": "Como contar o limite de 25%/50% e o que documentar no aditivo?",
+        "intent": "mofu",
+        "jtbd": "Calcular saldo de aditivo e evitar pedido sem base",
+        "cluster": "aditivos",
+        "service_slug": "aditivos-obras-publicas",
+        "service_path": "/aditivos-obras-publicas/",
+        "related_queries": [
+            "aditivos obra pública",
+            "limite aditivo 25 50 obra pública",
+            "acréscimo e supressão contrato público",
+        ],
+        "cta": "Revisar estratégia de aditivo",
+        "funnel": "mofu",
+        "tool_path": "/ferramentas/limite-acrescimos-supressoes/",
+        "existing_url": "/aditivos-obras-publicas/",
+    },
+    {
+        "id": "need-medicao-glosa",
+        "persona": "engenheiro-obra",
+        "problem": "Medição glosada, critério inventado ou parcela retida",
+        "question": "Como contestar glosa e proteger o fluxo de caixa?",
+        "intent": "bofu",
+        "jtbd": "Recuperar medição e documentar nexo com o contrato",
+        "cluster": "medicoes-pagamentos",
+        "service_slug": "medicoes-glosas-obras-publicas",
+        "service_path": "/medicoes-glosas-obras-publicas/",
+        "related_queries": [
+            "glosa de medição obra pública",
+            "medição de obra pública rejeitada",
+            "parcela incontroversa medição",
+        ],
+        "cta": "Revisar medição e glosa",
+        "funnel": "bofu",
+        "existing_url": "/medicoes-glosas-obras-publicas/",
+    },
+    {
+        "id": "need-sinapi-desonerado",
+        "persona": "orcamentista",
+        "problem": "Dúvida sobre base SINAPI desonerada vs não desonerada no edital",
+        "question": "Qual base usar e como alinhar BDI e encargos?",
+        "intent": "mofu",
+        "jtbd": "Evitar erro de base que destrói margem na proposta",
+        "cluster": "orcamento-bdi",
+        "service_slug": "auditoria-orcamento-licitacao",
+        "service_path": "/auditoria-orcamento-licitacao/",
+        "related_queries": [
+            "desonerado e não desonerado",
+            "sinapi desonerado ou não desonerado",
+            "desonerado ou não desonerado",
+        ],
+        "cta": "Auditar orçamento e BDI do edital",
+        "funnel": "mofu",
+        "existing_url": "/conteudos/sinapi-desonerado-nao-desonerado/",
+    },
+    {
+        "id": "need-atraso-prorrogacao",
+        "persona": "gerente-contratos",
+        "problem": "Atraso imputável à Administração ou risco de notificação",
+        "question": "Como documentar prorrogação e responder notificação?",
+        "intent": "mofu",
+        "jtbd": "Proteger prazo e evitar sanção indevida",
+        "cluster": "atrasos-prorrogacao",
+        "service_slug": "atrasos-prorrogacao-obras-publicas",
+        "service_path": "/atrasos-prorrogacao-obras-publicas/",
+        "related_queries": [
+            "prorrogação prazo obra pública",
+            "notificação atraso obra pública",
+            "atraso imputável administração",
+        ],
+        "cta": "Montar defesa de prazo",
+        "funnel": "mofu",
+        "tool_path": "/ferramentas/matriz-atraso-obra/",
+        "existing_url": "/atrasos-prorrogacao-obras-publicas/",
+    },
+    {
+        "id": "need-edital-orcamento",
+        "persona": "licitacoes",
+        "problem": "Edital com orçamento inconsistente ou referência duvidosa",
+        "question": "Participar, impugnar ou auditar a planilha antes da proposta?",
+        "intent": "bofu",
+        "jtbd": "Decidir se a licitação é economicamente segura",
+        "cluster": "edital-proposta",
+        "service_slug": "auditoria-orcamento-licitacao",
+        "service_path": "/auditoria-orcamento-licitacao/",
+        "related_queries": [
+            "orçamento incompleto edital obra pública",
+            "auditoria orçamento licitação",
+            "sinapi ou sicro obra pública",
+        ],
+        "cta": "Auditar edital e orçamento",
+        "funnel": "bofu",
+        "existing_url": "/auditoria-orcamento-licitacao/",
+    },
+    {
+        "id": "need-benchmark-mercado",
+        "persona": "diretor-construtora",
+        "problem": "Não sabe se valor/duração/alterações do contrato são 'normais'",
+        "question": "Isso é normal no mercado público de obras?",
+        "intent": "tofu",
+        "jtbd": "Comparar o próprio caso com evidência agregada do mercado",
+        "cluster": "inteligencia-mercado",
+        "service_slug": "metodologia-inteligencia",
+        "service_path": "/metodologia-inteligencia/",
+        "related_queries": [
+            "benchmark contratos obras públicas",
+            "mediana valor contrato obra pública",
+        ],
+        "cta": "Entender como a inteligência de mercado apoia decisões",
+        "funnel": "tofu",
+        "requires_data_moat": True,
+    },
+    {
+        "id": "need-gestao-contratual",
+        "persona": "proprietario-construtora",
+        "problem": "Contratos públicos sem rotina de gestão geram prejuízo silencioso",
+        "question": "Quando vale consultoria de acompanhamento contratual vs equipe própria?",
+        "intent": "bofu",
+        "jtbd": "Decidir se contrata apoio externo para gestão B2G",
+        "cluster": "gestao-contratual",
+        "service_slug": "acompanhamento-contratos-obras",
+        "service_path": "/acompanhamento-contratos-obras/",
+        "related_queries": [
+            "consultoria B2G engenharia construtora",
+            "gestão de contratos de obras públicas",
+        ],
+        "cta": "Diagnosticar gestão contratual B2G",
+        "funnel": "bofu",
+        "existing_url": "/acompanhamento-contratos-obras/",
+    },
+]
+
+
+def demand_map() -> dict[str, Any]:
+    """Export demand graph as versioned artifact structure."""
+    by_cluster: dict[str, list[str]] = {}
+    by_intent: dict[str, list[str]] = {}
+    for n in DEMAND_NODES:
+        by_cluster.setdefault(n["cluster"], []).append(n["id"])
+        by_intent.setdefault(n["intent"], []).append(n["id"])
+    return {
+        "schema_version": "organic-demand-v1",
+        "model": "persona → problem → question → intent → service",
+        "nodes": DEMAND_NODES,
+        "by_cluster": by_cluster,
+        "by_intent": by_intent,
+        "principle": (
+            "Agrupar variantes textuais da mesma necessidade em um único nó. "
+            "Não criar uma página por keyword."
+        ),
+    }
+
+
+def match_queries_to_nodes(queries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Attach GSC query rows to demand nodes by substring overlap."""
+    matches: list[dict[str, Any]] = []
+    for qrow in queries:
+        q = str(qrow.get("query") or qrow.get("Top consultas") or "").lower()
+        if not q:
+            continue
+        best = None
+        best_hits = 0
+        for node in DEMAND_NODES:
+            hits = 0
+            for rq in node.get("related_queries") or []:
+                tokens = [t for t in rq.lower().split() if len(t) > 3]
+                if sum(1 for t in tokens if t in q) >= max(2, len(tokens) // 2):
+                    hits += 1
+                if rq.lower() in q or q in rq.lower():
+                    hits += 2
+            # cluster token hits
+            for tok in node["cluster"].replace("-", " ").split():
+                if len(tok) > 3 and tok in q:
+                    hits += 1
+            if hits > best_hits:
+                best_hits = hits
+                best = node
+        if best and best_hits > 0:
+            matches.append(
+                {
+                    "query": q,
+                    "node_id": best["id"],
+                    "hits": best_hits,
+                    "impressions": float(qrow.get("impressions") or qrow.get("Impressões") or 0),
+                    "clicks": float(qrow.get("clicks") or qrow.get("Cliques") or 0),
+                    "position": float(qrow.get("position") or qrow.get("Posição") or 0),
+                    "ctr": float(qrow.get("ctr") or 0),
+                }
+            )
+    return matches

--- a/scripts/organic/engine.py
+++ b/scripts/organic/engine.py
@@ -341,6 +341,9 @@ def opportunities_from_markets(markets: list[dict[str, Any]], *, as_of: str) -> 
                     "confidence": insight["confidence"],
                     "result": insight["result"],
                     "insight_id": insight["insight_id"],
+                    "evidence_kind": "market_benchmark",
+                    "is_contract_aggregate": n >= 8,
+                    "public_label": "contract_aggregate" if n >= 8 else "thin_sample",
                 },
                 demand_strength=0.35,
                 data_moat=data_moat,
@@ -355,6 +358,51 @@ def opportunities_from_markets(markets: list[dict[str, Any]], *, as_of: str) -> 
     return out
 
 
+def _is_contract_aggregate_evidence(
+    *,
+    evidence_kind: str | None = None,
+    dataset: str | None = None,
+    sources: list[str] | None = None,
+) -> bool:
+    """True only for real public-contract aggregates (content moat).
+
+    Normative/editorial evidence counts (guides, site docs) are valuable but
+    must NOT be labeled as 'we analyzed N contracts' or unique_data_available.
+    """
+    kind = (evidence_kind or "").strip().lower()
+    if kind in {
+        "normative_editorial",
+        "editorial",
+        "normative",
+        "guide",
+        "jurisprudence",
+        "problem_service_pattern",
+    }:
+        return False
+    ds = (dataset or "").lower()
+    srcs = " ".join(str(s).lower() for s in (sources or []))
+    blob = f"{ds} {srcs}"
+    has_pncp = any(
+        t in blob
+        for t in (
+            "pncp_supplier_contracts",
+            "pncp_raw",
+            "pncp_open",
+            "pncp_contracts",
+            "supplier_contracts",
+            "pncp",
+        )
+    )
+    has_only_site = "site-confenge" in blob and not has_pncp
+    if has_only_site:
+        return False
+    return has_pncp or "contract_aggregate" in blob or kind in {
+        "market_benchmark",
+        "open_opportunity_radar",
+        "contract_aggregate",
+    }
+
+
 def opportunities_from_problem_service(
     items: list[dict[str, Any]], *, as_of: str
 ) -> list[dict[str, Any]]:
@@ -365,6 +413,15 @@ def opportunities_from_problem_service(
         guides = list(ps.get("technical_guide_paths") or [])
         existing = guides[0] if guides else (f"/{service}/" if service else None)
         evidence = int(ps.get("evidence_count") or 0)
+        evidence_kind = str(ps.get("evidence_kind") or insight.get("result", {}).get("evidence_kind") or "")
+        sources = list(ps.get("sources") or insight.get("sources") or [])
+        is_contract = _is_contract_aggregate_evidence(
+            evidence_kind=evidence_kind,
+            dataset=str(insight.get("dataset") or ""),
+            sources=sources,
+        )
+        # unique_data / content moat only for genuine contract aggregates
+        unique = is_contract and evidence >= 15
         out.append(
             _base_opportunity(
                 oid=f"opp-ps-{ps.get('id') or ps.get('slug')}",
@@ -381,7 +438,7 @@ def opportunities_from_problem_service(
                 existing_url=existing,
                 suggested_cta=f"Ver serviço: {service}" if service else "Falar com a CONFENGE",
                 suggested_internal_links=guides[:5] + ([f"/{service}/"] if service else []),
-                unique_data=evidence >= 15,
+                unique_data=unique,
                 datalake_evidence={
                     "dataset": insight["dataset"],
                     "as_of": insight["data_as_of"],
@@ -392,9 +449,15 @@ def opportunities_from_problem_service(
                     "confidence": insight["confidence"],
                     "result": insight["result"],
                     "insight_id": insight["insight_id"],
+                    "evidence_kind": evidence_kind or "unknown",
+                    "is_contract_aggregate": is_contract,
+                    "public_label": (
+                        "contract_aggregate" if is_contract else "editorial_pattern"
+                    ),
                 },
                 demand_strength=0.45,
-                data_moat=0.55 if evidence >= 20 else 0.35,
+                # Editorial patterns have topical value but low data moat
+                data_moat=0.55 if unique else (0.25 if evidence >= 15 else 0.15),
                 topical=0.8,
                 freshness=0.5,
                 competitive=0.5,
@@ -448,13 +511,19 @@ def opportunities_from_radar(
                     "as_of": as_of,
                     "record_count": open_n,
                     "historical_count": hist,
-                    "methodology": "Open-status filter on bids; never treat history as open",
+                    "methodology": (
+                        "Filtro de status aberto sobre editais/compras do PNCP; "
+                        "histórico encerrado nunca é tratado como oportunidade vigente."
+                    ),
                     "limitations": [
                         "Status pode mudar após o corte; sempre verificar fonte oficial."
                     ],
                     "sources": ["pncp"],
                     "confidence": 0.65 if open_n >= 3 else 0.3,
                     "freshness": freshness,
+                    "evidence_kind": "open_opportunity_radar",
+                    "is_contract_aggregate": open_n >= 3,
+                    "public_label": "open_radar" if open_n >= 3 else "thin_radar",
                 },
                 demand_strength=0.3,
                 data_moat=0.5 if open_n >= 3 else 0.15,

--- a/scripts/organic/engine.py
+++ b/scripts/organic/engine.py
@@ -8,7 +8,7 @@ Output: SEO_OPPORTUNITIES document ordered by commercial Content Value Score.
 from __future__ import annotations
 
 import json
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -285,7 +285,6 @@ def opportunities_from_markets(markets: list[dict[str, Any]], *, as_of: str) -> 
         insight = insight_from_market(m, as_of=as_of)
         n = int(insight["record_count"] or 0)
         region = (m.get("region") or "") or ""
-        segment = m.get("archetype_id") or m.get("segment") or ""
         slug = m.get("slug") or m.get("id") or "market"
         # Prefer existing inteligencia/radar paths when shape matches
         proposed = f"/inteligencia/mercados/{slug}/" if not str(slug).startswith("market-") else (
@@ -581,7 +580,7 @@ def build_opportunities(
 
     return {
         "schema_version": SCHEMA_VERSION,
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "as_of": as_of,
         "north_star": "receita_esperada_atribuivel_ao_inbound_organico",
         "scoring": {

--- a/scripts/organic/engine.py
+++ b/scripts/organic/engine.py
@@ -1,0 +1,657 @@
+"""Organic Opportunity Engine — facts + demand graph → scored SEO opportunities.
+
+Input: pSEO export snapshot (markets, problem_service, opportunities, agencies…)
+       optional GSC query/page signals (list of dicts)
+Output: SEO_OPPORTUNITIES document ordered by commercial Content Value Score.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.organic.demand_graph import DEMAND_NODES, demand_map, match_queries_to_nodes
+from scripts.organic.gates import gate_from_opportunity
+from scripts.organic.insights import insight_from_market, insight_from_problem_service
+from scripts.organic.score import compute_content_value_score
+
+SCHEMA_VERSION = "seo-opportunities-v1"
+
+
+def load_pseo_snapshot(pseo_dir: Path | str) -> dict[str, Any]:
+    """Load pSEO JSON bodies from a directory (web-cfg data/pseo or fixture)."""
+    root = Path(pseo_dir)
+    out: dict[str, Any] = {"_dir": str(root)}
+    for name in (
+        "markets",
+        "problem_service",
+        "opportunities",
+        "agencies",
+        "prices",
+        "competition",
+        "archetypes",
+        "manifest",
+        "registry",
+    ):
+        path = root / f"{name}.json"
+        if path.exists():
+            out[name] = json.loads(path.read_text(encoding="utf-8"))
+        else:
+            out[name] = [] if name != "manifest" and name != "registry" else {}
+    return out
+
+
+def _as_list(payload: Any, keys: tuple[str, ...] = ()) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [x for x in payload if isinstance(x, dict)]
+    if isinstance(payload, dict):
+        for k in keys:
+            if isinstance(payload.get(k), list):
+                return [x for x in payload[k] if isinstance(x, dict)]
+    return []
+
+
+def _service_fit_for_slug(slug: str | None) -> float:
+    if not slug:
+        return 0.2
+    # Direct service pages = high fit
+    high = {
+        "reequilibrio-obras-publicas",
+        "aditivos-obras-publicas",
+        "medicoes-glosas-obras-publicas",
+        "auditoria-orcamento-licitacao",
+        "atrasos-prorrogacao-obras-publicas",
+        "defesa-margem-contratos-publicos",
+        "bid-room-licitacoes-obras",
+        "acompanhamento-contratos-obras",
+        "diretoria-b2g",
+    }
+    mid = {"metodologia-inteligencia", "diagnostico-pre-licitacao", "diagnostico-b2g-360"}
+    if slug in high:
+        return 0.95
+    if slug in mid:
+        return 0.7
+    return 0.45
+
+
+def _gsc_demand_strength(impressions: float, clicks: float, position: float) -> float:
+    """Map sparse GSC signals to 0–1. High intent position beats raw volume."""
+    if impressions <= 0 and clicks <= 0:
+        return 0.15
+    # Striking distance bonus
+    pos_score = 0.0
+    if 4 <= position <= 15:
+        pos_score = 0.55
+    elif 1 <= position < 4:
+        pos_score = 0.7
+    elif position > 15:
+        pos_score = 0.25
+    imp_score = min(1.0, impressions / 50.0) * 0.35
+    click_score = min(1.0, clicks / 5.0) * 0.35
+    ctr = (clicks / impressions) if impressions else 0
+    ctr_penalty = 0.15 if impressions >= 20 and ctr < 0.02 else 0.0
+    return max(0.0, min(1.0, pos_score + imp_score + click_score + ctr_penalty))
+
+
+def _base_opportunity(
+    *,
+    oid: str,
+    topic: str,
+    cluster: str,
+    intent: str,
+    persona: str,
+    jtbd: str,
+    service_slug: str | None,
+    service_path: str | None,
+    action: str,
+    rationale: str,
+    proposed_url: str | None = None,
+    existing_url: str | None = None,
+    suggested_cta: str | None = None,
+    suggested_internal_links: list[str] | None = None,
+    unique_data: bool = False,
+    datalake_evidence: dict[str, Any] | None = None,
+    gsc_evidence: dict[str, Any] | None = None,
+    demand_strength: float = 0.2,
+    data_moat: float = 0.2,
+    topical: float = 0.5,
+    freshness: float = 0.3,
+    competitive: float = 0.4,
+    penalties: list[str] | None = None,
+    confidence: float = 0.6,
+    source: str = "demand_graph",
+) -> dict[str, Any]:
+    service_fit = _service_fit_for_slug(service_slug)
+    scored = compute_content_value_score(
+        intent_stage=intent,
+        service_fit=service_fit,
+        data_moat=data_moat,
+        demand_evidence=demand_strength,
+        topical_authority=topical,
+        freshness_trigger=freshness,
+        competitive_opportunity=competitive,
+        penalties=penalties,
+    )
+    opp: dict[str, Any] = {
+        "id": oid,
+        "topic": topic,
+        "cluster": cluster,
+        "intent": intent,
+        "persona": persona,
+        "jtbd": jtbd,
+        "commercial_fit": round(service_fit, 3),
+        "service_fit": service_slug,
+        "service_path": service_path,
+        "demand_signal": {
+            "strength": round(demand_strength, 3),
+            "source": "gsc" if gsc_evidence else "inferred",
+        },
+        "search_console_evidence": gsc_evidence or {},
+        "datalake_evidence": datalake_evidence or {},
+        "unique_data_available": unique_data,
+        "freshness": {"score": freshness},
+        "competition": {"score": competitive},
+        "cannibalization": {"risk": "cannibalization" in (penalties or []), "urls": []},
+        "proposed_url": proposed_url,
+        "existing_url": existing_url,
+        "action": action,
+        "score": scored["score"],
+        "score_breakdown": scored["breakdown"],
+        "score_penalties": scored["penalties"],
+        "rationale": rationale,
+        "suggested_cta": suggested_cta,
+        "suggested_internal_links": suggested_internal_links or [],
+        "confidence": confidence,
+        "source": source,
+        "service_fit_score": service_fit,
+        "data_moat_score": data_moat,
+        "demand_strength": demand_strength,
+        "topical_authority_score": topical,
+        "freshness_score": freshness,
+        "competitive_score": competitive,
+        "penalties": list(penalties or []),
+    }
+    gate = gate_from_opportunity(opp)
+    opp["indexability_gate"] = {
+        "indexable": gate["indexable"],
+        "decision": gate["decision"],
+        "fails": gate["fails"],
+        "warnings": gate["warnings"],
+    }
+    if gate["indexable"] and action in {"create", "improve", "keep"}:
+        opp["publishability"] = "indexable_candidate"
+    elif action == "noindex":
+        opp["publishability"] = "noindex"
+    elif not gate["indexable"]:
+        opp["publishability"] = "blocked_by_gate"
+    else:
+        opp["publishability"] = "needs_human"
+    return opp
+
+
+def opportunities_from_demand_nodes(
+    *,
+    gsc_by_node: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Seed opportunities from the demand graph, enriched by GSC if present."""
+    gsc_by_node = gsc_by_node or {}
+    out: list[dict[str, Any]] = []
+    for node in DEMAND_NODES:
+        g = gsc_by_node.get(node["id"]) or {}
+        impressions = float(g.get("impressions") or 0)
+        clicks = float(g.get("clicks") or 0)
+        position = float(g.get("position") or 0)
+        demand = _gsc_demand_strength(impressions, clicks, position)
+        existing = node.get("existing_url") or node.get("service_path")
+        action = "improve" if existing and (impressions > 0 or clicks > 0) else (
+            "keep" if existing else "create"
+        )
+        if existing and impressions >= 20 and clicks == 0:
+            action = "improve"
+        penalties: list[str] = []
+        if node.get("requires_data_moat") and not g.get("has_data"):
+            # still create as tofu candidate; data market opps will fill moat
+            pass
+        if node["intent"] == "tofu" and demand < 0.2:
+            penalties.append("commodity_content")
+
+        # Existing service/editorial URLs carry site provenance (not thin pSEO)
+        editorial_provenance = {
+            "dataset": "web-cfg-editorial",
+            "as_of": "site",
+            "record_count": 1,
+            "methodology": "Página de serviço/editorial já publicada no site Confenge",
+            "limitations": ["Não é agregação do datalake; autoridade editorial + serviço."],
+            "sources": ["site-confenge"],
+            "confidence": 0.8,
+        } if existing else {}
+
+        out.append(
+            _base_opportunity(
+                oid=f"opp-{node['id']}",
+                topic=node["question"],
+                cluster=node["cluster"],
+                intent=node["intent"],
+                persona=node["persona"],
+                jtbd=node["jtbd"],
+                service_slug=node.get("service_slug"),
+                service_path=node.get("service_path"),
+                action=action,
+                rationale=(
+                    f"Necessidade canônica do grafo de demanda ({node['id']}): "
+                    f"{node['problem']}"
+                ),
+                proposed_url=existing,
+                existing_url=existing,
+                suggested_cta=node.get("cta"),
+                suggested_internal_links=[
+                    p
+                    for p in [
+                        node.get("service_path"),
+                        node.get("tool_path"),
+                        existing,
+                    ]
+                    if p
+                ],
+                unique_data=False,
+                datalake_evidence=editorial_provenance,
+                gsc_evidence={
+                    "impressions": impressions,
+                    "clicks": clicks,
+                    "position": position,
+                    "matched_queries": g.get("queries") or [],
+                }
+                if g
+                else {},
+                demand_strength=max(demand, 0.35 if node["intent"] == "bofu" else 0.2),
+                data_moat=0.15,
+                topical=0.75 if node["intent"] != "tofu" else 0.55,
+                freshness=0.4,
+                competitive=0.55 if impressions > 0 else 0.35,
+                penalties=penalties,
+                confidence=0.75 if g else 0.55,
+                source="demand_graph",
+            )
+        )
+    return out
+
+
+def opportunities_from_markets(markets: list[dict[str, Any]], *, as_of: str) -> list[dict[str, Any]]:
+    """Data-driven market/benchmark opportunities (content moat)."""
+    out: list[dict[str, Any]] = []
+    for m in markets:
+        insight = insight_from_market(m, as_of=as_of)
+        n = int(insight["record_count"] or 0)
+        region = (m.get("region") or "") or ""
+        segment = m.get("archetype_id") or m.get("segment") or ""
+        slug = m.get("slug") or m.get("id") or "market"
+        # Prefer existing inteligencia/radar paths when shape matches
+        proposed = f"/inteligencia/mercados/{slug}/" if not str(slug).startswith("market-") else (
+            f"/inteligencia/mercados/{str(slug).replace('market-', '')}/"
+        )
+        # Known radar pattern: archetype-uf
+        if m.get("archetype_id") and region and len(str(region)) == 2:
+            proposed = f"/radar/{m['archetype_id']}-{str(region).lower()}/"
+
+        data_moat = min(1.0, 0.4 + n / 40.0)
+        penalties: list[str] = []
+        if n < 8:
+            penalties.append("thin_content")
+            penalties.append("missing_evidence")
+        if n < 5:
+            penalties.append("low_differentiation")
+
+        action = "create" if n >= 8 else "do_not_create"
+        if n < 8:
+            action = "noindex"
+
+        out.append(
+            _base_opportunity(
+                oid=f"opp-market-{slug}",
+                topic=insight["headline"],
+                cluster="inteligencia-mercado",
+                intent="tofu",
+                persona="diretor-construtora",
+                jtbd="Comparar o próprio mercado com evidência agregada proprietária",
+                service_slug="metodologia-inteligencia",
+                service_path="/metodologia-inteligencia/",
+                action=action if action != "do_not_create" else "noindex",
+                rationale=(
+                    "Benchmark proprietário a partir do datalake; information gain "
+                    "que LLM genérico não reproduz sem os mesmos dados e corte."
+                ),
+                proposed_url=proposed,
+                existing_url=None,
+                suggested_cta="Ver metodologia e limites da inteligência de mercado",
+                suggested_internal_links=[
+                    "/metodologia-inteligencia/",
+                    "/radar/",
+                    "/inteligencia/",
+                    "/auditoria-orcamento-licitacao/",
+                ],
+                unique_data=n >= 8,
+                datalake_evidence={
+                    "dataset": insight["dataset"],
+                    "as_of": insight["data_as_of"],
+                    "record_count": n,
+                    "methodology": insight["methodology"],
+                    "limitations": insight["limitations"],
+                    "sources": insight["sources"],
+                    "confidence": insight["confidence"],
+                    "result": insight["result"],
+                    "insight_id": insight["insight_id"],
+                },
+                demand_strength=0.35,
+                data_moat=data_moat,
+                topical=0.7,
+                freshness=0.8,
+                competitive=0.65,
+                penalties=penalties,
+                confidence=float(insight["confidence"]),
+                source="datalake_market",
+            )
+        )
+    return out
+
+
+def opportunities_from_problem_service(
+    items: list[dict[str, Any]], *, as_of: str
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for ps in items:
+        insight = insight_from_problem_service(ps, as_of=as_of)
+        service = ps.get("confenge_service_slug") or ps.get("service")
+        guides = list(ps.get("technical_guide_paths") or [])
+        existing = guides[0] if guides else (f"/{service}/" if service else None)
+        evidence = int(ps.get("evidence_count") or 0)
+        out.append(
+            _base_opportunity(
+                oid=f"opp-ps-{ps.get('id') or ps.get('slug')}",
+                topic=str(ps.get("problem_label") or ps.get("problem") or "problema-serviço"),
+                cluster=str(ps.get("theme") or "gestao-contratual"),
+                intent="mofu",
+                persona="gerente-contratos",
+                jtbd="Enquadrar o problema no serviço Confenge certo com evidência",
+                service_slug=service,
+                service_path=f"/{service}/" if service else None,
+                action="improve" if existing else "create",
+                rationale=str(ps.get("observed_pattern") or "")[:400],
+                proposed_url=existing,
+                existing_url=existing,
+                suggested_cta=f"Ver serviço: {service}" if service else "Falar com a CONFENGE",
+                suggested_internal_links=guides[:5] + ([f"/{service}/"] if service else []),
+                unique_data=evidence >= 15,
+                datalake_evidence={
+                    "dataset": insight["dataset"],
+                    "as_of": insight["data_as_of"],
+                    "record_count": evidence,
+                    "methodology": insight["methodology"],
+                    "limitations": insight["limitations"],
+                    "sources": insight["sources"],
+                    "confidence": insight["confidence"],
+                    "result": insight["result"],
+                    "insight_id": insight["insight_id"],
+                },
+                demand_strength=0.45,
+                data_moat=0.55 if evidence >= 20 else 0.35,
+                topical=0.8,
+                freshness=0.5,
+                competitive=0.5,
+                penalties=[] if evidence >= 15 else ["missing_evidence"],
+                confidence=float(insight["confidence"]),
+                source="datalake_problem_service",
+            )
+        )
+    return out
+
+
+def opportunities_from_radar(
+    opps_payload: list[dict[str, Any]], *, as_of: str
+) -> list[dict[str, Any]]:
+    """Radar clusters with open items → freshness-triggered content refresh."""
+    out: list[dict[str, Any]] = []
+    for row in opps_payload:
+        rid = str(row.get("id") or row.get("slug") or "radar")
+        items = row.get("items") or []
+        open_n = len(items) if isinstance(items, list) else int(row.get("open_count") or 0)
+        hist = int(row.get("historical_count") or row.get("closed_recent_count") or 0)
+        freshness = row.get("freshness") or {}
+        age = float(freshness.get("age_hours") or 48)
+        fresh_score = 0.9 if age <= 24 else 0.6 if age <= 72 else 0.25
+        action = "improve" if open_n >= 3 else "noindex"
+        penalties = []
+        if open_n < 3:
+            penalties.append("thin_content")
+        out.append(
+            _base_opportunity(
+                oid=f"opp-radar-{rid}",
+                topic=f"Radar: {rid} ({open_n} abertas)",
+                cluster="radar-oportunidades",
+                intent="tofu",
+                persona="licitacoes",
+                jtbd="Monitorar editais/contratos abertos no recorte com evidência fresca",
+                service_slug="bid-room-licitacoes-obras",
+                service_path="/bid-room-licitacoes-obras/",
+                action=action,
+                rationale=(
+                    "Radar data-driven; só indexável com volume mínimo de itens abertos, "
+                    "freshness e interpretação — não template por UF."
+                ),
+                proposed_url=f"/radar/{rid.replace('radar-', '')}/",
+                existing_url=f"/radar/{rid.replace('radar-', '')}/",
+                suggested_cta="Avaliar se a licitação cabe no perfil da construtora",
+                suggested_internal_links=["/radar/", "/bid-room-licitacoes-obras/", "/diagnostico-pre-licitacao/"],
+                unique_data=open_n >= 3,
+                datalake_evidence={
+                    "dataset": "pncp_open_opportunities",
+                    "as_of": as_of,
+                    "record_count": open_n,
+                    "historical_count": hist,
+                    "methodology": "Open-status filter on bids; never treat history as open",
+                    "limitations": [
+                        "Status pode mudar após o corte; sempre verificar fonte oficial."
+                    ],
+                    "sources": ["pncp"],
+                    "confidence": 0.65 if open_n >= 3 else 0.3,
+                    "freshness": freshness,
+                },
+                demand_strength=0.3,
+                data_moat=0.5 if open_n >= 3 else 0.15,
+                topical=0.5,
+                freshness=fresh_score,
+                competitive=0.45,
+                penalties=penalties,
+                confidence=0.65 if open_n >= 3 else 0.35,
+                source="datalake_radar",
+            )
+        )
+    return out
+
+
+def build_opportunities(
+    snapshot: dict[str, Any],
+    *,
+    gsc_queries: list[dict[str, Any]] | None = None,
+    gsc_pages: list[dict[str, Any]] | None = None,
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    """Core pure entry: snapshot + optional GSC → ranked SEO_OPPORTUNITIES doc."""
+    as_of = as_of or date.today().isoformat()
+    markets = _as_list(snapshot.get("markets"), ("markets", "items"))
+    problems = _as_list(snapshot.get("problem_service"), ("items", "problems"))
+    radar = _as_list(snapshot.get("opportunities"), ("items", "opportunities"))
+
+    gsc_by_node: dict[str, dict[str, Any]] = {}
+    if gsc_queries:
+        for m in match_queries_to_nodes(gsc_queries):
+            bucket = gsc_by_node.setdefault(
+                m["node_id"],
+                {"impressions": 0.0, "clicks": 0.0, "position": 0.0, "queries": [], "pos_w": 0.0},
+            )
+            bucket["impressions"] += m["impressions"]
+            bucket["clicks"] += m["clicks"]
+            if m["position"] > 0:
+                bucket["pos_w"] += m["position"] * max(m["impressions"], 1)
+                bucket["queries"].append(m["query"])
+        for nid, b in gsc_by_node.items():
+            imp = b["impressions"] or 1
+            b["position"] = b["pos_w"] / imp if b["pos_w"] else 0
+
+    # Enrich GSC pages into demand (path → cluster heuristics)
+    page_signals: list[dict[str, Any]] = []
+    for p in gsc_pages or []:
+        url = str(p.get("page") or p.get("Páginas principais") or "")
+        page_signals.append(
+            {
+                "url": url,
+                "clicks": float(p.get("clicks") or p.get("Cliques") or 0),
+                "impressions": float(p.get("impressions") or p.get("Impressões") or 0),
+                "position": float(p.get("position") or p.get("Posição") or 0),
+            }
+        )
+
+    opps: list[dict[str, Any]] = []
+    opps.extend(opportunities_from_demand_nodes(gsc_by_node=gsc_by_node))
+    opps.extend(opportunities_from_markets(markets, as_of=as_of))
+    opps.extend(opportunities_from_problem_service(problems, as_of=as_of))
+    opps.extend(opportunities_from_radar(radar, as_of=as_of))
+
+    # Attach page-level improve actions for high-impression low-CTR URLs
+    for ps in page_signals:
+        if ps["impressions"] >= 15 and ps["clicks"] <= 0 and ps["url"]:
+            path = ps["url"].replace("https://confenge.com.br", "").replace("http://confenge.com.br", "")
+            if not path.startswith("/"):
+                path = "/" + path
+            # Map path fragment → service for contextual CTA
+            svc_slug, svc_path, cluster = _service_from_path(path)
+            opps.append(
+                _base_opportunity(
+                    oid=f"opp-gsc-ctr-{abs(hash(path)) % 10_000_000}",
+                    topic=f"CTR opportunity: {path}",
+                    cluster=cluster or "gsc-feedback",
+                    intent="mofu",
+                    persona="orcamentista",
+                    jtbd="Corrigir título/meta para capturar impressões existentes",
+                    service_slug=svc_slug,
+                    service_path=svc_path,
+                    action="improve",
+                    rationale=(
+                        f"Muitas impressões ({ps['impressions']}) e CTR ~0 na posição "
+                        f"{ps['position']:.1f} — reescrever title/meta e reforçar CTA."
+                    ),
+                    proposed_url=path,
+                    existing_url=path,
+                    suggested_cta=(
+                        "Auditar orçamento e BDI do edital"
+                        if "sinapi" in path or "bdi" in path or "orcamento" in path
+                        else "Analisar meu caso com a CONFENGE"
+                    ),
+                    suggested_internal_links=[p for p in [path, svc_path] if p],
+                    unique_data=False,
+                    datalake_evidence={
+                        "dataset": "web-cfg-editorial",
+                        "as_of": "gsc",
+                        "record_count": 1,
+                        "methodology": "GSC page-level striking distance / CTR signal",
+                        "limitations": ["Amostra GSC limitada no export disponível."],
+                        "sources": ["google-search-console"],
+                        "confidence": 0.75,
+                    },
+                    gsc_evidence=ps,
+                    demand_strength=_gsc_demand_strength(ps["impressions"], ps["clicks"], ps["position"]),
+                    data_moat=0.1,
+                    topical=0.6,
+                    freshness=0.7,
+                    competitive=0.6,
+                    penalties=[],
+                    confidence=0.8,
+                    source="gsc_page",
+                )
+            )
+
+    # Dedupe by id, keep highest score
+    by_id: dict[str, dict[str, Any]] = {}
+    for o in opps:
+        prev = by_id.get(o["id"])
+        if not prev or o["score"] > prev["score"]:
+            by_id[o["id"]] = o
+    ranked = sorted(by_id.values(), key=lambda x: (-int(x["score"]), x["id"]))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "as_of": as_of,
+        "north_star": "receita_esperada_atribuivel_ao_inbound_organico",
+        "scoring": {
+            "model": "content_value_score",
+            "weights": {
+                "commercial_intent": 25,
+                "service_fit": 20,
+                "data_moat": 20,
+                "demand_evidence": 15,
+                "topical_authority": 10,
+                "freshness_trigger": 5,
+                "competitive_opportunity": 5,
+            },
+        },
+        "counts": {
+            "total": len(ranked),
+            "by_action": _count_by(ranked, "action"),
+            "by_intent": _count_by(ranked, "intent"),
+            "by_publishability": _count_by(ranked, "publishability"),
+            "bofu": sum(1 for o in ranked if o["intent"] == "bofu"),
+            "data_driven": sum(1 for o in ranked if o.get("unique_data_available")),
+        },
+        "demand_map_ref": "persona → problem → question → intent → service",
+        "opportunities": ranked,
+    }
+
+
+def _count_by(rows: list[dict[str, Any]], key: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for r in rows:
+        k = str(r.get(key) or "?")
+        out[k] = out.get(k, 0) + 1
+    return out
+
+
+def _service_from_path(path: str) -> tuple[str | None, str | None, str | None]:
+    p = path.lower()
+    rules = [
+        (("reequil", "reajuste", "repactua"), "reequilibrio-obras-publicas", "/reequilibrio-obras-publicas/", "reequilibrio"),
+        (("aditivo", "acréscimo", "acrescimo", "supress"), "aditivos-obras-publicas", "/aditivos-obras-publicas/", "aditivos"),
+        (("medicao", "medição", "glosa", "pagamento"), "medicoes-glosas-obras-publicas", "/medicoes-glosas-obras-publicas/", "medicoes-pagamentos"),
+        (("atraso", "prorroga", "notificacao", "notificação"), "atrasos-prorrogacao-obras-publicas", "/atrasos-prorrogacao-obras-publicas/", "atrasos-prorrogacao"),
+        (("sinapi", "sicro", "bdi", "orcamento", "orçamento", "desonerad"), "auditoria-orcamento-licitacao", "/auditoria-orcamento-licitacao/", "orcamento-bdi"),
+        (("edital", "licita", "proposta"), "bid-room-licitacoes-obras", "/bid-room-licitacoes-obras/", "edital-proposta"),
+    ]
+    for keys, slug, spath, cluster in rules:
+        if any(k in p for k in keys):
+            return slug, spath, cluster
+    return None, None, None
+
+
+def run_engine(
+    *,
+    pseo_dir: Path | str,
+    out_path: Path | str | None = None,
+    gsc_queries: list[dict[str, Any]] | None = None,
+    gsc_pages: list[dict[str, Any]] | None = None,
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    """CLI-friendly: load snapshot, build, optionally write JSON."""
+    snap = load_pseo_snapshot(pseo_dir)
+    doc = build_opportunities(
+        snap, gsc_queries=gsc_queries, gsc_pages=gsc_pages, as_of=as_of
+    )
+    doc["demand_map"] = demand_map()
+    if out_path:
+        path = Path(out_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(doc, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        doc["_written"] = str(path)
+    return doc

--- a/scripts/organic/fixtures/markets.json
+++ b/scripts/organic/fixtures/markets.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "market-edificacoes-publicas-sc",
+    "slug": "edificacoes-publicas-sc",
+    "archetype_id": "edificacoes-publicas",
+    "region": "SC",
+    "segment": "edificacoes-publicas",
+    "contract_count": 24,
+    "buyer_count": 9,
+    "supplier_count": 12,
+    "median_value": 420000.0,
+    "p25_value": 180000.0,
+    "p75_value": 910000.0,
+    "open_opportunity_count": 4,
+    "period_start": "2024-01-01",
+    "period_end": "2026-07-01",
+    "interpretation_hooks": [
+      "9 órgãos compradores distintos no recorte SC."
+    ],
+    "limitations": [
+      "Amostra regional; não é censo nacional."
+    ],
+    "sources": ["pncp_supplier_contracts"]
+  },
+  {
+    "id": "market-thin-demo",
+    "slug": "thin-demo-xx",
+    "archetype_id": "saneamento-hidraulica",
+    "region": "XX",
+    "segment": "saneamento",
+    "contract_count": 2,
+    "buyer_count": 1,
+    "supplier_count": 1,
+    "median_value": 50000.0,
+    "period_end": "2026-07-01",
+    "limitations": ["Amostra insuficiente"],
+    "sources": ["pncp_supplier_contracts"]
+  }
+]

--- a/scripts/organic/fixtures/opportunities.json
+++ b/scripts/organic/fixtures/opportunities.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "radar-edificacoes-publicas-sc",
+    "historical_count": 40,
+    "closed_recent_count": 10,
+    "freshness": {
+      "age_hours": 12.0,
+      "data_as_of": "2026-08-01",
+      "status": "ok"
+    },
+    "items": [
+      {"objeto": "Reforma de escola", "uf": "SC", "status_bucket": "aberta"},
+      {"objeto": "Construção de UBS", "uf": "SC", "status_bucket": "aberta"},
+      {"objeto": "Ampliação de prédio", "uf": "SC", "status_bucket": "aberta"},
+      {"objeto": "Cobertura de quadra", "uf": "SC", "status_bucket": "aberta"}
+    ]
+  }
+]

--- a/scripts/organic/fixtures/problem_service.json
+++ b/scripts/organic/fixtures/problem_service.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "prob-reequilibrio",
+    "slug": "reequilibrio-dispersao-precos",
+    "problem_label": "Reequilíbrio diante de dispersão de preços e insumos",
+    "confenge_service_slug": "reequilibrio-obras-publicas",
+    "theme": "reequilibrio",
+    "evidence_count": 28,
+    "evidence_kind": "normative_editorial",
+    "observed_pattern": "Alta dispersão em benchmarks regionais sinaliza sensibilidade a insumos.",
+    "limitations": ["Não recomenda pleito sem dossiê do contrato concreto."],
+    "sources": ["pncp_supplier_contracts", "site-confenge-guides"],
+    "technical_guide_paths": [
+      "/conteudos/reequilibrio-economico-financeiro-obra-publica/",
+      "/reequilibrio-obras-publicas/"
+    ],
+    "related_archetypes": ["edificacoes-publicas"]
+  }
+]

--- a/scripts/organic/gates.py
+++ b/scripts/organic/gates.py
@@ -1,0 +1,190 @@
+"""Indexability Quality Gate for organic / programmatic / data-driven pages.
+
+HTML generation ≠ permission to index. This gate is mandatory and fail-closed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Minimum thresholds (parametrizable via kwargs)
+DEFAULT_MIN_SAMPLE = 8
+DEFAULT_MIN_SCORE = 55
+DEFAULT_MIN_DIFFERENTIATION = 0.35
+
+
+def indexability_quality_gate(
+    *,
+    distinct_intent: bool,
+    own_information: bool,
+    sample_size: int = 0,
+    semantic_differentiation: float = 0.0,
+    independent_utility: bool,
+    data_confidence: float = 0.0,
+    non_redundant: bool,
+    no_cannibalization: bool,
+    has_context_interpretation: bool,
+    identifiable_update: bool,
+    useful_internal_links: bool,
+    contextual_cta: bool,
+    has_provenance: bool,
+    min_sample: int = DEFAULT_MIN_SAMPLE,
+    min_score: int = DEFAULT_MIN_SCORE,
+    content_value_score: int = 0,
+    legal_safe: bool = True,
+) -> dict[str, Any]:
+    """Return gate decision. indexable only if all mandatory criteria pass."""
+    fails: list[str] = []
+    warnings: list[str] = []
+
+    checks = {
+        "distinct_intent": distinct_intent,
+        "own_information": own_information,
+        "sample_sufficient": int(sample_size) >= int(min_sample),
+        "semantic_differentiation": float(semantic_differentiation) >= DEFAULT_MIN_DIFFERENTIATION,
+        "independent_utility": independent_utility,
+        "data_confidence": float(data_confidence) >= 0.45,
+        "non_redundant": non_redundant,
+        "no_cannibalization": no_cannibalization,
+        "has_context_interpretation": has_context_interpretation,
+        "identifiable_update": identifiable_update,
+        "useful_internal_links": useful_internal_links,
+        "contextual_cta": contextual_cta,
+        "has_provenance": has_provenance,
+        "legal_safe": legal_safe,
+        "content_value_floor": int(content_value_score) >= int(min_score),
+    }
+
+    labels = {
+        "distinct_intent": "intent_not_distinct",
+        "own_information": "no_own_information",
+        "sample_sufficient": f"sample<{min_sample}",
+        "semantic_differentiation": "low_semantic_differentiation",
+        "independent_utility": "no_independent_utility",
+        "data_confidence": "low_data_confidence",
+        "non_redundant": "redundant_content",
+        "no_cannibalization": "cannibalization_risk",
+        "has_context_interpretation": "missing_interpretation",
+        "identifiable_update": "no_identifiable_update",
+        "useful_internal_links": "missing_internal_links",
+        "contextual_cta": "missing_contextual_cta",
+        "has_provenance": "missing_provenance",
+        "legal_safe": "legal_risk",
+        "content_value_floor": f"score<{min_score}",
+    }
+
+    for key, ok in checks.items():
+        if not ok:
+            fails.append(labels[key])
+
+    # Soft warnings (do not block alone)
+    if int(sample_size) < min_sample * 2:
+        warnings.append("sample_thin_margin")
+    if float(semantic_differentiation) < 0.55:
+        warnings.append("differentiation_marginal")
+
+    indexable = len(fails) == 0
+    if not indexable:
+        decision = "noindex"
+        if "cannibalization_risk" in fails or "redundant_content" in fails:
+            decision = "merge_or_canonical"
+        if "sample<" in " ".join(fails) or "no_own_information" in fails:
+            decision = "do_not_create"
+    else:
+        decision = "indexable_candidate"
+
+    return {
+        "indexable": indexable,
+        "decision": decision,
+        "fails": fails,
+        "warnings": warnings,
+        "checks": checks,
+        "note": (
+            "Indexability Quality Gate is mandatory. Score cannot compensate "
+            "for failed criteria. Generated HTML is not index permission."
+        ),
+    }
+
+
+def gate_from_opportunity(opp: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """Apply gate using fields commonly present on opportunity dicts.
+
+    Existing service/editorial improves use a lighter sample floor (min_sample=1)
+    because the asset already exists; new programmatic/data pages stay strict.
+    """
+    dl = opp.get("datalake_evidence") or {}
+    sample = int(
+        overrides.get(
+            "sample_size",
+            dl.get("record_count")
+            or dl.get("contract_count")
+            or opp.get("sample_size")
+            or 0,
+        )
+    )
+    unique = bool(opp.get("unique_data_available"))
+    action = str(opp.get("action") or "")
+    source = str(opp.get("source") or "")
+    cannibal = opp.get("cannibalization") or {}
+    score = int((opp.get("score") if opp.get("score") is not None else 0) or 0)
+    existing = bool(opp.get("existing_url"))
+    is_existing_editorial = existing and action in {"improve", "keep"} and (
+        source in {"demand_graph", "gsc_page", "datalake_problem_service"}
+        or str(dl.get("dataset") or "") == "web-cfg-editorial"
+    )
+
+    # New programmatic pages need real sample; existing pages are not "created"
+    min_sample = 1 if is_existing_editorial else DEFAULT_MIN_SAMPLE
+    min_score = 40 if is_existing_editorial else DEFAULT_MIN_SCORE
+    if is_existing_editorial and sample < 1:
+        sample = 1
+
+    kwargs = {
+        "distinct_intent": bool(opp.get("distinct_intent", True)),
+        "own_information": unique
+        or bool(opp.get("own_information"))
+        or is_existing_editorial,
+        "sample_size": sample,
+        "semantic_differentiation": float(
+            opp.get("semantic_differentiation")
+            or (0.7 if unique else 0.55 if is_existing_editorial else 0.25)
+        ),
+        "independent_utility": bool(
+            opp.get("independent_utility", unique or action in {"improve", "keep"})
+        ),
+        "data_confidence": float(opp.get("confidence") or dl.get("confidence") or 0.5),
+        "non_redundant": not bool(cannibal.get("risk") or cannibal.get("urls")),
+        "no_cannibalization": not bool(cannibal.get("risk")),
+        "has_context_interpretation": bool(
+            opp.get("has_interpretation")
+            or (opp.get("rationale") and len(str(opp.get("rationale"))) > 40)
+        ),
+        "identifiable_update": bool(
+            opp.get("freshness") or dl.get("as_of") or dl.get("data_as_of") or is_existing_editorial
+        ),
+        "useful_internal_links": bool(opp.get("suggested_internal_links")),
+        "contextual_cta": bool(opp.get("suggested_cta") or opp.get("service_fit")),
+        "has_provenance": bool(
+            dl.get("dataset") or dl.get("sources") or opp.get("provenance") or is_existing_editorial
+        ),
+        "content_value_score": score,
+        "legal_safe": "legal_risk" not in (opp.get("penalties") or []),
+        "min_sample": min_sample,
+        "min_score": min_score,
+    }
+    kwargs.update(
+        {
+            k: v
+            for k, v in overrides.items()
+            if k
+            in kwargs
+            or k
+            in {
+                "min_sample",
+                "min_score",
+                "legal_safe",
+                "content_value_score",
+            }
+        }
+    )
+    return indexability_quality_gate(**kwargs)

--- a/scripts/organic/insights.py
+++ b/scripts/organic/insights.py
@@ -77,7 +77,7 @@ def insight_from_problem_service(ps: dict[str, Any], *, as_of: str | None = None
     return {
         "insight_id": f"insight-prob-{slug}",
         "kind": "problem_service_pattern",
-        "dataset": ",".join(ps.get("sources") or ["pncp_supplier_contracts", "site-confenge-guides"]),
+        "dataset": ",".join(ps.get("sources") or ["site-confenge-guides"]),
         "data_as_of": as_of,
         "filters": {
             "theme": ps.get("theme"),
@@ -85,8 +85,9 @@ def insight_from_problem_service(ps: dict[str, Any], *, as_of: str | None = None
         },
         "record_count": evidence,
         "methodology": (
-            "Padrão editorial-normativo ancorado em contagem de evidências e "
-            "arquétipos recorrentes no datalake; não é ranking comercial."
+            "Padrão editorial-normativo: enquadramento problema→serviço com base em "
+            "guias técnicos e arquétipos recorrentes. Não é contagem de contratos "
+            "agregados nem ranking comercial."
         ),
         "limitations": list(ps.get("limitations") or []),
         "sources": list(ps.get("sources") or []),

--- a/scripts/organic/insights.py
+++ b/scripts/organic/insights.py
@@ -1,0 +1,114 @@
+"""Reusable data-insight records from pSEO export / datalake aggregates.
+
+Each insight carries provenance so pages can cite:
+
+  “Analisamos X contratos públicos de obras no recorte Y e encontramos Z.”
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+
+def insight_from_market(market: dict[str, Any], *, as_of: str | None = None) -> dict[str, Any]:
+    """Build a data-insight from a market aggregate row."""
+    contract_count = int(market.get("contract_count") or 0)
+    buyer_count = int(market.get("buyer_count") or 0)
+    supplier_count = int(market.get("supplier_count") or 0)
+    median = market.get("median_value")
+    region = market.get("region") or market.get("region_label") or ""
+    segment = market.get("segment") or market.get("archetype_id") or ""
+    mid = str(market.get("id") or market.get("slug") or "market")
+    as_of = as_of or str(market.get("period_end") or date.today().isoformat())
+
+    result = {
+        "contract_count": contract_count,
+        "buyer_count": buyer_count,
+        "supplier_count": supplier_count,
+        "median_value": median,
+        "p25_value": market.get("p25_value"),
+        "p75_value": market.get("p75_value"),
+        "open_opportunity_count": market.get("open_opportunity_count"),
+        "region": region,
+        "segment": segment,
+        "interpretation_hooks": list(market.get("interpretation_hooks") or []),
+    }
+
+    conf = 0.85 if contract_count >= 15 and buyer_count >= 3 else 0.55 if contract_count >= 8 else 0.3
+
+    return {
+        "insight_id": f"insight-{mid}",
+        "kind": "market_benchmark",
+        "dataset": "pncp_supplier_contracts",
+        "data_as_of": as_of,
+        "period_start": market.get("period_start"),
+        "period_end": market.get("period_end"),
+        "filters": {
+            "archetype_id": market.get("archetype_id"),
+            "region": region,
+            "segment": segment,
+        },
+        "record_count": contract_count,
+        "methodology": (
+            "Agregação de contratos com valor_total > 0 e arquétipo AEC primário "
+            "confirmado/probable no export pSEO; mediana e percentis no recorte."
+        ),
+        "limitations": list(market.get("limitations") or [])
+        + [
+            "Não afirma irregularidade, crédito devido ou erro de órgão/fornecedor.",
+            "Valores nominais; objetos heterogêneos — mediana não é preço unitário.",
+        ],
+        "sources": list(market.get("sources") or ["pncp_supplier_contracts"]),
+        "calculation": "median/p25/p75 over contract valor_total in filtered set",
+        "result": result,
+        "confidence": conf,
+        "updated_at": as_of,
+        "pages_using": [],
+        "headline": _market_headline(result, region, segment),
+    }
+
+
+def insight_from_problem_service(ps: dict[str, Any], *, as_of: str | None = None) -> dict[str, Any]:
+    """Insight linking observed problem pattern to a Confenge service."""
+    evidence = int(ps.get("evidence_count") or 0)
+    as_of = as_of or date.today().isoformat()
+    slug = str(ps.get("slug") or ps.get("id") or "problem")
+    return {
+        "insight_id": f"insight-prob-{slug}",
+        "kind": "problem_service_pattern",
+        "dataset": ",".join(ps.get("sources") or ["pncp_supplier_contracts", "site-confenge-guides"]),
+        "data_as_of": as_of,
+        "filters": {
+            "theme": ps.get("theme"),
+            "related_archetypes": ps.get("related_archetypes") or [],
+        },
+        "record_count": evidence,
+        "methodology": (
+            "Padrão editorial-normativo ancorado em contagem de evidências e "
+            "arquétipos recorrentes no datalake; não é ranking comercial."
+        ),
+        "limitations": list(ps.get("limitations") or []),
+        "sources": list(ps.get("sources") or []),
+        "calculation": "evidence_count + observed_pattern narrative",
+        "result": {
+            "problem_label": ps.get("problem_label") or ps.get("problem"),
+            "service_slug": ps.get("confenge_service_slug") or ps.get("service"),
+            "observed_pattern": ps.get("observed_pattern"),
+            "evidence_kind": ps.get("evidence_kind"),
+            "technical_guide_paths": ps.get("technical_guide_paths") or [],
+        },
+        "confidence": 0.7 if evidence >= 20 else 0.45,
+        "updated_at": as_of,
+        "pages_using": list(ps.get("technical_guide_paths") or []),
+        "headline": str(ps.get("problem_label") or ps.get("problem") or slug),
+    }
+
+
+def _market_headline(result: dict[str, Any], region: str, segment: str) -> str:
+    n = result.get("contract_count") or 0
+    med = result.get("median_value")
+    med_s = f" mediana R$ {med:,.0f}".replace(",", ".") if isinstance(med, (int, float)) else ""
+    reg = f" em {region}" if region else ""
+    seg = f" ({segment})" if segment else ""
+    return f"Analisamos {n} contratos públicos de obras{reg}{seg}{med_s}."

--- a/scripts/organic/score.py
+++ b/scripts/organic/score.py
@@ -1,0 +1,142 @@
+"""Content Value Score — commercial impact, not keyword volume.
+
+Default weights (sum 100) match the organic inbound objective:
+
+  commercial_intent          25
+  service_fit                20
+  data_moat                  20
+  demand_evidence            15
+  topical_authority          10
+  freshness_trigger           5
+  competitive_opportunity     5
+
+Score is advisory for ranking. Mandatory indexability gates still block publish.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CONTENT_VALUE_WEIGHTS: dict[str, int] = {
+    "commercial_intent": 25,
+    "service_fit": 20,
+    "data_moat": 20,
+    "demand_evidence": 15,
+    "topical_authority": 10,
+    "freshness_trigger": 5,
+    "competitive_opportunity": 5,
+}
+
+# Penalty magnitudes subtracted after weighted sum (clamped 0–100)
+PENALTY_MAGNITUDES: dict[str, int] = {
+    "commodity_content": 15,
+    "serp_incompatible": 12,
+    "missing_evidence": 18,
+    "low_confidence": 10,
+    "cannibalization": 14,
+    "thin_content": 20,
+    "low_differentiation": 12,
+    "off_positioning": 25,
+    "legal_risk": 30,
+    "purely_speculative": 22,
+}
+
+INTENT_COMMERCIAL = {
+    "bofu": 1.0,
+    "mofu": 0.72,
+    "tofu": 0.38,
+}
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, float(x)))
+
+
+def _clamp100(x: float) -> int:
+    return int(max(0, min(100, round(x))))
+
+
+def compute_content_value_score(
+    *,
+    intent_stage: str = "mofu",
+    service_fit: float = 0.0,
+    data_moat: float = 0.0,
+    demand_evidence: float = 0.0,
+    topical_authority: float = 0.5,
+    freshness_trigger: float = 0.3,
+    competitive_opportunity: float = 0.4,
+    penalties: list[str] | None = None,
+    weights: dict[str, int] | None = None,
+    penalty_magnitudes: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Return 0–100 score + breakdown. Parametrizable weights and penalties.
+
+    All component inputs are expected on 0–1 (higher is better), except
+    penalties which are string codes from PENALTY_MAGNITUDES.
+    """
+    w = dict(weights or CONTENT_VALUE_WEIGHTS)
+    # Normalize if custom weights don't sum to 100
+    wsum = sum(w.values()) or 1
+    scale = 100.0 / wsum
+
+    intent_key = (intent_stage or "mofu").strip().lower()
+    commercial = INTENT_COMMERCIAL.get(intent_key, 0.5)
+
+    comps = {
+        "commercial_intent": _clamp01(commercial),
+        "service_fit": _clamp01(service_fit),
+        "data_moat": _clamp01(data_moat),
+        "demand_evidence": _clamp01(demand_evidence),
+        "topical_authority": _clamp01(topical_authority),
+        "freshness_trigger": _clamp01(freshness_trigger),
+        "competitive_opportunity": _clamp01(competitive_opportunity),
+    }
+
+    # Weighted contribution = component_0_1 * weight * (100/sum_weights)
+    breakdown = {
+        k: int(round(_clamp01(comps[k]) * w.get(k, 0) * scale))
+        for k in w
+        if k in comps
+    }
+    raw_total = sum(breakdown.values())
+
+    pens = list(penalties or [])
+    mag = dict(penalty_magnitudes or PENALTY_MAGNITUDES)
+    penalty_applied: dict[str, int] = {}
+    penalty_sum = 0
+    for p in pens:
+        amount = int(mag.get(p, 0))
+        if amount > 0:
+            penalty_applied[p] = amount
+            penalty_sum += amount
+
+    total = _clamp100(raw_total - penalty_sum)
+
+    return {
+        "score": total,
+        "raw_score": _clamp100(raw_total),
+        "breakdown": breakdown,
+        "weights": {k: int(round(v * scale)) for k, v in w.items()},
+        "penalties": penalty_applied,
+        "penalty_total": penalty_sum,
+        "components_0_1": comps,
+        "note": (
+            "Content Value Score ranks opportunities by expected commercial "
+            "impact; it never overrides mandatory indexability gates."
+        ),
+    }
+
+
+def score_opportunity_dict(opp: dict[str, Any], weights: dict[str, int] | None = None) -> dict[str, Any]:
+    """Score from a partially filled opportunity dict."""
+    return compute_content_value_score(
+        intent_stage=str(opp.get("intent") or opp.get("intent_stage") or "mofu"),
+        service_fit=float(opp.get("service_fit_score") or opp.get("commercial_fit") or 0),
+        data_moat=float(opp.get("data_moat_score") or (1.0 if opp.get("unique_data_available") else 0.2)),
+        demand_evidence=float(opp.get("demand_strength") or 0),
+        topical_authority=float(opp.get("topical_authority_score") or 0.5),
+        freshness_trigger=float(opp.get("freshness_score") or 0.3),
+        competitive_opportunity=float(opp.get("competitive_score") or 0.4),
+        penalties=list(opp.get("penalties") or []),
+        weights=weights,
+    )

--- a/tests/organic/__init__.py
+++ b/tests/organic/__init__.py
@@ -1,0 +1,1 @@
+# Organic opportunity engine tests

--- a/tests/organic/test_engine.py
+++ b/tests/organic/test_engine.py
@@ -6,8 +6,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))

--- a/tests/organic/test_engine.py
+++ b/tests/organic/test_engine.py
@@ -1,0 +1,221 @@
+"""Organic Opportunity Engine — real entry path tests (no mocked score logic)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+FIXTURES = ROOT / "scripts" / "organic" / "fixtures"
+
+from scripts.organic.engine import build_opportunities, load_pseo_snapshot, run_engine
+from scripts.organic.gates import indexability_quality_gate
+from scripts.organic.score import CONTENT_VALUE_WEIGHTS, compute_content_value_score
+
+
+def test_content_value_weights_sum_100():
+    assert sum(CONTENT_VALUE_WEIGHTS.values()) == 100
+
+
+def test_bofu_scores_higher_than_tofu_all_else_equal():
+    bofu = compute_content_value_score(
+        intent_stage="bofu",
+        service_fit=0.9,
+        data_moat=0.5,
+        demand_evidence=0.5,
+        topical_authority=0.5,
+        freshness_trigger=0.5,
+        competitive_opportunity=0.5,
+    )
+    tofu = compute_content_value_score(
+        intent_stage="tofu",
+        service_fit=0.9,
+        data_moat=0.5,
+        demand_evidence=0.5,
+        topical_authority=0.5,
+        freshness_trigger=0.5,
+        competitive_opportunity=0.5,
+    )
+    assert bofu["score"] > tofu["score"]
+    assert bofu["breakdown"]["commercial_intent"] > tofu["breakdown"]["commercial_intent"]
+
+
+def test_penalties_reduce_score():
+    clean = compute_content_value_score(
+        intent_stage="bofu",
+        service_fit=1.0,
+        data_moat=1.0,
+        demand_evidence=1.0,
+        topical_authority=1.0,
+        freshness_trigger=1.0,
+        competitive_opportunity=1.0,
+    )
+    dirty = compute_content_value_score(
+        intent_stage="bofu",
+        service_fit=1.0,
+        data_moat=1.0,
+        demand_evidence=1.0,
+        topical_authority=1.0,
+        freshness_trigger=1.0,
+        competitive_opportunity=1.0,
+        penalties=["thin_content", "cannibalization"],
+    )
+    assert dirty["score"] < clean["score"]
+    assert dirty["penalty_total"] >= 20
+
+
+def test_indexability_gate_blocks_thin_without_provenance():
+    gate = indexability_quality_gate(
+        distinct_intent=True,
+        own_information=False,
+        sample_size=2,
+        semantic_differentiation=0.1,
+        independent_utility=False,
+        data_confidence=0.2,
+        non_redundant=True,
+        no_cannibalization=True,
+        has_context_interpretation=False,
+        identifiable_update=False,
+        useful_internal_links=False,
+        contextual_cta=False,
+        has_provenance=False,
+        content_value_score=99,  # score cannot compensate
+    )
+    assert gate["indexable"] is False
+    assert "no_own_information" in gate["fails"]
+    assert "missing_provenance" in gate["fails"]
+    assert gate["decision"] in {"noindex", "do_not_create", "merge_or_canonical"}
+
+
+def test_indexability_gate_passes_rich_data_page():
+    gate = indexability_quality_gate(
+        distinct_intent=True,
+        own_information=True,
+        sample_size=24,
+        semantic_differentiation=0.7,
+        independent_utility=True,
+        data_confidence=0.8,
+        non_redundant=True,
+        no_cannibalization=True,
+        has_context_interpretation=True,
+        identifiable_update=True,
+        useful_internal_links=True,
+        contextual_cta=True,
+        has_provenance=True,
+        content_value_score=70,
+    )
+    assert gate["indexable"] is True
+    assert gate["decision"] == "indexable_candidate"
+
+
+def test_engine_from_fixtures_produces_ranked_opportunities():
+    snap = load_pseo_snapshot(FIXTURES)
+    assert len(snap["markets"]) == 2
+    doc = build_opportunities(
+        snap,
+        gsc_queries=[
+            {
+                "query": "desonerado e não desonerado",
+                "impressions": 10,
+                "clicks": 0,
+                "position": 9.2,
+            },
+            {
+                "query": "aditivos obra pública",
+                "impressions": 5,
+                "clicks": 0,
+                "position": 66,
+            },
+        ],
+        gsc_pages=[
+            {
+                "page": "https://confenge.com.br/conteudos/sinapi-desonerado-nao-desonerado/",
+                "impressions": 88,
+                "clicks": 0,
+                "position": 7.75,
+            }
+        ],
+        as_of="2026-08-01",
+    )
+    assert doc["schema_version"] == "seo-opportunities-v1"
+    assert doc["counts"]["total"] >= 5
+    assert doc["counts"]["bofu"] >= 1
+    assert doc["counts"]["data_driven"] >= 1
+
+    opps = doc["opportunities"]
+    assert opps == sorted(opps, key=lambda x: (-x["score"], x["id"]))
+
+    required = {
+        "id",
+        "topic",
+        "cluster",
+        "intent",
+        "persona",
+        "jtbd",
+        "commercial_fit",
+        "service_fit",
+        "demand_signal",
+        "search_console_evidence",
+        "datalake_evidence",
+        "unique_data_available",
+        "action",
+        "score",
+        "rationale",
+        "suggested_cta",
+        "suggested_internal_links",
+        "confidence",
+        "publishability",
+    }
+    for o in opps:
+        missing = required - set(o)
+        assert not missing, f"{o['id']} missing {missing}"
+        assert isinstance(o["score"], int)
+        assert 0 <= o["score"] <= 100
+        assert o["intent"] in {"bofu", "mofu", "tofu"}
+        assert o["action"] in {
+            "create",
+            "improve",
+            "merge",
+            "noindex",
+            "keep",
+            "do_not_create",
+        }
+
+    # Thin market must not be indexable candidate
+    thin = next(o for o in opps if "thin-demo" in o["id"] or o["id"].endswith("thin-demo-xx"))
+    assert thin["unique_data_available"] is False or thin["publishability"] != "indexable_candidate"
+    assert thin["action"] in {"noindex", "do_not_create"} or not thin["indexability_gate"]["indexable"]
+
+    # Rich market should have data moat
+    rich = next(o for o in opps if "edificacoes-publicas-sc" in o["id"])
+    assert rich["unique_data_available"] is True
+    assert rich["datalake_evidence"].get("record_count", 0) >= 8
+    assert rich["datalake_evidence"].get("methodology")
+
+
+def test_run_engine_writes_file(tmp_path: Path):
+    out = tmp_path / "SEO_OPPORTUNITIES.json"
+    doc = run_engine(pseo_dir=FIXTURES, out_path=out, as_of="2026-08-01")
+    assert out.exists()
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded["counts"]["total"] == doc["counts"]["total"]
+    assert "demand_map" in loaded
+    assert loaded["demand_map"]["model"].startswith("persona")
+
+
+def test_cli_main_fixture(tmp_path: Path):
+    from scripts.organic.__main__ import main
+
+    out = tmp_path / "out.json"
+    code = main(["--pseo-dir", str(FIXTURES), "--out", str(out), "--as-of", "2026-08-01"])
+    assert code == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["counts"]["total"] > 0
+    assert any(o["intent"] == "bofu" for o in data["opportunities"])
+    assert any(o.get("unique_data_available") for o in data["opportunities"])

--- a/tests/organic/test_engine.py
+++ b/tests/organic/test_engine.py
@@ -217,3 +217,75 @@ def test_cli_main_fixture(tmp_path: Path):
     assert data["counts"]["total"] > 0
     assert any(o["intent"] == "bofu" for o in data["opportunities"])
     assert any(o.get("unique_data_available") for o in data["opportunities"])
+
+
+def test_normative_editorial_problem_service_is_not_unique_data():
+    """Normative/editorial evidence must NOT claim content moat / N contracts."""
+    from scripts.organic.engine import (
+        _is_contract_aggregate_evidence,
+        opportunities_from_problem_service,
+    )
+
+    assert not _is_contract_aggregate_evidence(
+        evidence_kind="normative_editorial",
+        dataset="pncp_supplier_contracts,site-confenge-guides",
+        sources=["pncp_supplier_contracts", "site-confenge-guides"],
+    )
+    # Pure site guides
+    assert not _is_contract_aggregate_evidence(
+        evidence_kind="normative_editorial",
+        dataset="site-confenge-guides",
+        sources=["site-confenge-guides"],
+    )
+    # Real market aggregate still true
+    assert _is_contract_aggregate_evidence(
+        evidence_kind="market_benchmark",
+        dataset="pncp_supplier_contracts",
+        sources=["pncp_supplier_contracts"],
+    )
+
+    rows = opportunities_from_problem_service(
+        [
+            {
+                "id": "prob-fake-normative",
+                "slug": "fake-normative",
+                "problem_label": "Padrão editorial",
+                "confenge_service_slug": "reequilibrio-obras-publicas",
+                "theme": "reequilibrio",
+                "evidence_count": 48,
+                "evidence_kind": "normative_editorial",
+                "observed_pattern": "Padrão qualitativo.",
+                "sources": ["pncp_supplier_contracts", "site-confenge-guides"],
+                "technical_guide_paths": ["/conteudos/x/"],
+                "limitations": ["Não é contagem de contratos."],
+            }
+        ],
+        as_of="2026-08-01",
+    )
+    assert len(rows) == 1
+    opp = rows[0]
+    assert opp["unique_data_available"] is False
+    assert (opp.get("datalake_evidence") or {}).get("public_label") == "editorial_pattern"
+    assert (opp.get("datalake_evidence") or {}).get("is_contract_aggregate") is False
+    # data moat must be low for editorial (not 0.55+ from fake contract signal)
+    assert float(opp.get("data_moat_score") or 0) < 0.4
+
+
+def test_radar_methodology_is_portuguese_client_facing():
+    from scripts.organic.engine import opportunities_from_radar
+
+    rows = opportunities_from_radar(
+        [
+            {
+                "id": "radar-edificacoes-publicas-pr",
+                "historical_count": 10,
+                "items": [{"x": 1}, {"x": 2}, {"x": 3}, {"x": 4}],
+                "freshness": {"age_hours": 12},
+            }
+        ],
+        as_of="2026-08-01",
+    )
+    meth = (rows[0].get("datalake_evidence") or {}).get("methodology") or ""
+    assert "Open-status" not in meth
+    assert "never treat" not in meth.lower()
+    assert "Filtro de status aberto" in meth or "status aberto" in meth.lower()


### PR DESCRIPTION
## Summary
- New `scripts/organic` module (distinct from `opportunity_intel` commercial ranking).
- Demand graph `persona → problem → question → intent → service`.
- Content Value Score (parametrizable weights) + Indexability Quality Gate.
- Data insights from pSEO markets / problem_service / radar with provenance.
- CLI: `python3 -m scripts.organic --pseo-dir … --out SEO_OPPORTUNITIES.json`
- Tests: `tests/organic/test_engine.py` (8 passed).

## Companion
- web-cfg: `feat/organic-inbound-engine` (consumer + site pilot)

## Test plan
- [x] `python3 -m pytest tests/organic/test_engine.py -q -o addopts=`
- [ ] CI green on PR