### PR TITLE
fix(confenge): publish authoritative target-fit feed

### DIFF
--- a/DOD.md
+++ b/DOD.md
@@ -462,6 +462,7 @@ Um item pode ser marcado como concluído apenas quando pelo menos uma das evidê
 - [ ] “Propensão” ou probabilidade de compra só pode ser publicada depois de amostra suficiente, definição de outcome, separação temporal treino/teste, calibração e validação retrospectiva documentadas.
 - [ ] Resultados de contato real retroalimentam a avaliação e o ajuste de sinais, sem reescrever silenciosamente o histórico.
 - [ ] Não são usados atributos pessoais sensíveis ou proxies discriminatórios; `DO_NOT_CONTACT` e restrições legais/comerciais são respeitados.
+- [ ] O `confenge.outreach.v1` publica uma decisão target-fit completa para todo CNPJ endereçável do universo reconciliado, inclusive OUT, insuficiente, stale, DNC, downgrades e tombstones; omissão nunca preserva autorização anterior.
 - [ ] O primeiro ciclo de uso real registra decisões de Tiago, contatos realizados e resultados observados, inclusive quando não houver conversão.
 
 #### Gate imediato `CONFENGE_COMMERCIAL_READY`
@@ -3118,4 +3119,3 @@ CI (PR #12):
 - [x] Scheduler prefers CIGA/DOM families before PNCP under lag drain — avoids 429 starvation.
 - [x] Queue state repair: SUCCESS_ZERO/NONZERO with `scope_complete≠false` reconciled missing `last_success_at` (inconsistent prior gap-close state).
 - Residual non-claims unchanged: official SINAPI live bulk dump; external https webhook delivery.
-

--- a/docs/architecture/adr/ADR-035-confenge-authoritative-target-fit-feed.md
+++ b/docs/architecture/adr/ADR-035-confenge-authoritative-target-fit-feed.md
@@ -1,0 +1,45 @@
+# ADR-035 — CONFENGE authoritative target-fit feed
+
+**Status:** Proposed
+**Date:** 2026-08-12
+
+## Context
+
+`confenge.outreach.v1` was generated from the send-ready/hot-set cohort. A
+company that later became OUT, insufficient, stale, DNC or absent from the ICP
+could disappear from the next feed. A stateful consumer could then retain the
+older CONFIRMED authorization because it never received a revocation.
+
+## Decision
+
+1. The wire artifact is a full decision snapshot, not a send-ready selection.
+2. Expensive intelligence and contact enrichment may remain hot-set bounded;
+   target-fit decisions may not.
+3. Every addressable supplier root is emitted once with non-null class,
+   freshness, classifier version, computation timestamp, source watermark,
+   evidence IDs, send tier and `email_send_ready`.
+   Production resolves these decisions from the mode-aware published store;
+   embedded universe decisions are restricted to offline fixture runs.
+4. Valid-CNPJ exclusions and DNC remain in the decision universe. An omitted
+   materialization becomes `TARGET_FIT_MISSING`, `target_fit_tombstone=true`
+   and `email_send_ready=false`.
+5. Freshness describes decision currency independently of eligibility. A fresh
+   OUT/INSUFFICIENT decision is fresh but ineligible.
+6. Records and cursors are ordered by source watermark, computation timestamp
+   and CNPJ. Invalid or non-timezoned decision timestamps fail closed.
+7. The manifest declares the reconciled universe cardinality and exposes
+   coverage, monotonicity and omission-safety gates. Partial/smoke exports are
+   not authoritative.
+8. A pilot selection cannot be exported as this schema without also providing
+   the full authoritative universe and target-fit snapshot.
+9. The historical PREVENCAO alias `01489370000105` is emitted canonically as
+   `14893700000105` (`14.893.700/0001-05`) without rewriting raw evidence.
+
+## Consequences
+
+- Feed volume follows decision-universe size rather than send capacity.
+- OUT, insufficient and tombstone rows contain little or no contact/intelligence
+  data but still revoke stale authorization explicitly.
+- Operational raw chunks remain outside Git under ADR-020; small manifests,
+  hashes and reproducible tests are the review evidence.
+- No dispatch or campaign authorization is implied by successful export.

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -16,6 +16,8 @@
 | ADR-028 | Entity freshness by capability (canonical universe) | **Vigente** |
 | ADR-029 | Canonical full suite green | **Accepted** (2026-07-21) |
 | ADR-030 | Dual capability coverage truth | **Accepted** (2026-07-21) |
+| ADR-034 | CONFENGE commercial lead evidence model | **Accepted** (2026-07-25) |
+| ADR-035 | CONFENGE authoritative target-fit feed | **Proposed** (2026-08-12) |
 
 ## ADRs revogadas / supersedidas
 
@@ -33,5 +35,3 @@ Se uma ADR for supersedida, registre aqui com data, ADR substituta e motivo.
 2. Atualizar este `INDEX.md` (vigente ou revogada).
 3. Referenciar no README/PRD apenas ADRs vigentes.
 4. Não inventar selos de gate em texto de ADR sem evidência.
-
-| ADR-034 | CONFENGE commercial lead evidence model | Accepted | 2026-07-25 |

--- a/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
+++ b/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
@@ -103,6 +103,11 @@ python -m scripts.confenge_target_fit requeue --cnpj ...
 python -m scripts.confenge_target_fit worker
 ```
 
+`requeue` copies the canonical `cdc_watermark` into the dirty item and refuses
+the operation when that watermark is empty. A changed watermark is republished
+even when the semantic input fingerprint is unchanged, preserving decision
+provenance instead of silently skipping the refresh.
+
 ### Pause / resume
 
 ```bash

--- a/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
+++ b/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
@@ -140,7 +140,7 @@ CONFIRMED → PROBABLE/OUT (ACTIVE)
 | `scripts/confenge_target_fit/published.py` | Load `confenge_company_target_fit_current`, map class→send tier, evaluate freshness/suppression |
 | `send_readiness.evaluate_email_send_ready` | When published fields present on company row, they are **authoritative** (no local re-triangulation) |
 | `warmbly_bridge.mapping.map_lead` | Prefers published `target_fit_*` fields; never re-scores ICP class when materialization is present |
-| `confenge.outreach.v1` schema | Optional lead fields: class, confidence, version, computed_at, source_watermark, fresh, evidence_ids |
+| `confenge.outreach.v1` schema | Required decision fields: class, version, computed_at, source_watermark, fresh, evidence_ids, send tier and email_send_ready |
 
 Feed fields for `confenge.outreach.v1`:
 
@@ -151,6 +151,15 @@ Feed fields for `confenge.outreach.v1`:
 - `target_fit_source_watermark`
 - `target_fit_fresh`
 - `target_fit_evidence_ids`
+- `target_fit_send_tier`
+- `email_send_ready`
+
+`target_fit_fresh` describes whether the published decision is current; it is
+not a synonym for send eligibility. A fresh OUT/INSUFFICIENT decision remains
+fresh and still has `email_send_ready=false`. Missing materialization is
+published as a non-fresh `TARGET_FIT_MISSING` tombstone. Feed order is
+`source_watermark`, `computed_at`, CNPJ ascending so consumers can apply the
+snapshot deterministically.
 
 Warmbly must **not** rescore. Fail-closed if not `TARGET_CONFIRMED` or not fresh.
 

--- a/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/HANDOFF.md
+++ b/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/HANDOFF.md
@@ -1,0 +1,38 @@
+# HANDOFF — CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01
+
+## Estado
+
+`IMPLEMENTED_PENDING_MAIN_AND_CI`: o exportador e o pipeline agora distinguem
+hot set de enriquecimento do universo integral de decisões. Nenhum envio,
+import ou habilitação de campanha faz parte desta mudança.
+
+## Contrato operacional
+
+- `confenge.outreach.v1` contém uma linha por CNPJ endereçável do universo
+  reconciliado, inclusive exclusões e DNC.
+- Toda linha carrega decisão target-fit completa e não nula.
+- Ausência no snapshot vira `TARGET_FIT_MISSING` + tombstone; downgrade OUT
+  permanece presente; ambos bloqueiam envio e impedem ressurreição.
+- Ordem: source watermark, computed_at e CNPJ, ascendente.
+- Importação só pode consumir manifest com `coverage_complete=true`,
+  `watermarks_monotonic=true` e `omission_preserves_authorization=false`.
+- A seleção strict ESR/piloto isolada é recusada como feed autoritativo.
+
+## Evidência reproduzível
+
+```bash
+python3 -m pytest tests/warmbly_bridge/test_authoritative_target_fit_feed.py -q
+python3 -m pytest tests/confenge_outreach_pipeline/test_pipeline.py -q
+python3 -m json.tool scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
+```
+
+Os testes comprovam PREVENCAO como `14893700000105`, PREVENCAO e BEBA MAIS
+OUT, SULPEL com evidência insuficiente, DNC/stale/missing inelegíveis e uma
+engenharia `TARGET_CONFIRMED`, fresh e `email_send_ready=true`. Também executam
+as sequências CONFIRMED→OUT e CONFIRMED→omissão, sem ressurreição.
+O resumo carimbado da regeneração, validação do schema e hashes está em
+[`verification.json`](./verification.json).
+
+Chunks operacionais regenerados permanecem fora do Git conforme ADR-020. O
+manifest e os hashes devem corresponder ao mesmo HEAD que passou na CI antes de
+qualquer importação futura.

--- a/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/verification.json
+++ b/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/verification.json
@@ -1,0 +1,54 @@
+{
+  "schema": "confenge.authoritative-outreach-feed-verification.v1",
+  "generated_at": "2026-08-12T12:00:00Z",
+  "generation_scope": "deterministic named-case proof; operational full-universe chunks remain outside Git under ADR-020",
+  "source": {
+    "repo_sha": "authoritative-test",
+    "snapshot_hash": "ed7ec4fce6b4d2d89ca1709f891f9f5d6711b5cd1c97b68c4862a2fb90aae3a0"
+  },
+  "manifest": {
+    "manifest_content_hash": "b8b3f41725bbc44b18293a23cac32efaf8c66176b96eb850467349d5687b7f34",
+    "chunk_content_hash": "06c4b59d835b70ab2b3ace604b29b9b5bbe570f4f71bc332280ccfc9c974804c",
+    "declared_universe_count": 4,
+    "full_decision_count": 4,
+    "coverage_complete": true,
+    "watermarks_monotonic": true,
+    "omission_preserves_authorization": false,
+    "json_schema_valid": true
+  },
+  "cases": [
+    {
+      "cnpj14": "14893700000105",
+      "name": "PREVENCAO LABORATORIO DE ANALISES CLINICAS LTDA",
+      "target_fit_class": "TARGET_OUT_OF_SCOPE",
+      "target_fit_fresh": true,
+      "target_fit_send_tier": "OUT_OF_SCOPE",
+      "email_send_ready": false
+    },
+    {
+      "cnpj14": "01607033000167",
+      "name": "BEBA MAIS PIRACICABA DISTRIBUIDORA DE BEBIDAS LTDA",
+      "target_fit_class": "TARGET_OUT_OF_SCOPE",
+      "target_fit_fresh": true,
+      "target_fit_send_tier": "OUT_OF_SCOPE",
+      "email_send_ready": false
+    },
+    {
+      "cnpj14": "01942594000112",
+      "name": "SULPEL INDUSTRIA E COMERCIO DE PAPEIS LTDA",
+      "target_fit_class": "TARGET_INSUFFICIENT_EVIDENCE",
+      "target_fit_fresh": true,
+      "target_fit_send_tier": "RESEARCH_ONLY",
+      "email_send_ready": false
+    },
+    {
+      "cnpj14": "11222333000181",
+      "name": "ALFA CONSTRUTORA E ENGENHARIA LTDA",
+      "target_fit_class": "TARGET_CONFIRMED",
+      "target_fit_fresh": true,
+      "target_fit_send_tier": "A_AUTOMATIC",
+      "email_send_ready": true
+    }
+  ],
+  "dispatch_or_import_performed": false
+}

--- a/docs/ops/campaigns/CONFENGE-PILOT-GO-POLICY-01/HANDOFF.md
+++ b/docs/ops/campaigns/CONFENGE-PILOT-GO-POLICY-01/HANDOFF.md
@@ -8,6 +8,13 @@ revalidada sobre contratos live, traduzida pelo bridge existente para
 `EMAIL_SEND_READY`; nenhuma aprovação humana foi fabricada (`approved=0`) e o
 dispatch permanece pausado.
 
+> **Superado para novas exportações (2026-08-12):** o artefato histórico de 20
+> linhas é uma seleção de piloto, não uma fotografia autoritativa do universo.
+> Ele não deve ser reexportado/importado como `confenge.outreach.v1`, porque a
+> omissão de downgrades poderia preservar autorização anterior. O writer agora
+> recusa coorte send-ready isolada; novas importações exigem o feed integral e
+> os gates descritos no handoff `CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01`.
+
 A amostra strict ESR antiga não é evidência de prontidão: ela produzia CNPJ
 sintético e tratava documento público como autoria da empresa. Com validação
 fail-closed, essa amostra cai de 71 para zero. A coorte do piloto vem da amostra

--- a/docs/ops/confenge-outreach-pipeline.md
+++ b/docs/ops/confenge-outreach-pipeline.md
@@ -3,8 +3,9 @@
 Canonical **production** path (no manual JSON handoff):
 
 ```text
-universe → activation planner → hot set → account intelligence
-  → contact resolution → confenge.outreach.v1
+full supplier decision universe → activation planner → hot set
+  → account intelligence/contact resolution for the hot set
+  → authoritative confenge.outreach.v1 for the full decision universe
 ```
 
 Smoke / diagnostic path (not a commercial shortlist strategy):
@@ -45,22 +46,31 @@ python -m scripts.confenge_outreach_pipeline run \
 | `--force-sample-mode` | Smoke: diverse sample instead of activation |
 | `--activation-capacity` | Override hot-set size (policy capacity by default) |
 | `--limit-downstream` | Smoke sample size only; **not** production commercial strategy |
+| `--feed-limit` | Rejected: truncating an authoritative decision snapshot is unsafe |
 | `--max-workers` | Concurrency for expensive stages |
 | `--max-rows` | **Diagnostic sampling** of universe source; never claim full-scale when set |
 | `--csv` | Offline fixture path |
 | `--skip-contacts` | Empty contacts (offline speed) |
 
-`--limit-downstream` does **not** limit universe discovery.
+`--limit-downstream` does **not** limit universe discovery or feed decisions.
+It limits only expensive intelligence/contact work. The feed also includes
+valid-CNPJ exclusions and DNC. Missing target-fit rows become explicit
+`TARGET_FIT_MISSING` tombstones.
+
+With `--dsn`, decisions come from the mode-aware published target-fit store
+(shadow in SHADOW mode; current in ACTIVE/CANARY). The on-the-fly universe
+classification is used only by offline fixture runs; a production store miss
+does not fall back to an embedded CONFIRMED stamp.
 
 ## Outputs
 
 ```text
-01_universe/          confenge-universe-v1.jsonl + manifest
+01_universe/          included + excluded decision JSONLs + manifest
 02_downstream_sample/ diverse commercial sample
 03_account_intelligence/
 04_contact_resolution/
-05_bridge_inputs/     joined shapes for warmbly_bridge
-06_warmbly_feed/      chunked confenge.outreach.v1
+05_bridge_inputs/     full universe + target-fit snapshot; hot-set intel/contacts
+06_warmbly_feed/      temporally ordered authoritative confenge.outreach.v1
 reports/pipeline-manifest.json
 ```
 

--- a/docs/ops/confenge-warmbly-bridge.md
+++ b/docs/ops/confenge-warmbly-bridge.md
@@ -8,7 +8,7 @@ Native producer of `confenge.outreach.v1` and optional HMAC receptor for
 
 | Is | Is not |
 | --- | --- |
-| Path-based export from universe / account-intelligence / contacts JSONL | A universe ranking engine |
+| Path-based export from the full decision universe, target-fit snapshot, intelligence and contacts JSONL | A send-ready cohort exporter |
 | Chunked feed with cursor, hashes, manifest, resume | One monolithic unusable JSON dump |
 | Messaging **context** for Warmbly to draft copy | Final email/WhatsApp copy |
 | Outcome webhook into Decision & Outcome Memory | A second parallel outcome ledger |
@@ -23,9 +23,12 @@ python3 -m scripts.warmbly_bridge export-outreach \
   --universe scripts/warmbly_bridge/fixtures/universe.jsonl \
   --account-intelligence scripts/warmbly_bridge/fixtures/account_intelligence.jsonl \
   --contacts scripts/warmbly_bridge/fixtures/contacts.jsonl \
+  --target-fit-snapshot /path/to/full-target-fit-snapshot.jsonl \
+  --expected-universe-count 12345 \
   --out /tmp/confenge-outreach-out
 
-# Smoke only (not production — production omits --limit):
+# Smoke only. Its manifest has coverage_complete=false and must not be imported
+# as an authoritative account snapshot:
 python3 -m scripts.warmbly_bridge export-outreach \
   --universe ... --account-intelligence ... --contacts ... \
   --out /tmp/confenge-outreach-out \
@@ -46,11 +49,34 @@ when content hashes match (resume / idempotency).
 Missing any of `--universe`, `--account-intelligence`, or `--contacts`
 exits non-zero with an explicit error — no shallow feed is written.
 
+## Authoritative target-fit snapshot
+
+Production must pass `--target-fit-snapshot` and the reconciled
+`--expected-universe-count`. The universe contains every addressable CONFENGE
+company decision, not only the expensive-enrichment hot set: eligible companies,
+`TARGET_OUT_OF_SCOPE`, `TARGET_INSUFFICIENT_EVIDENCE`, DNC and valid-CNPJ
+exclusions all remain present.
+
+Every lead requires `target_fit_class`, `target_fit_fresh`,
+`target_fit_version`, `target_fit_computed_at`,
+`target_fit_source_watermark`, `target_fit_evidence_ids`,
+`target_fit_send_tier` and `email_send_ready`. A CNPJ omitted from the supplied
+snapshot is emitted as `TARGET_FIT_MISSING` with
+`target_fit_tombstone=true` and `email_send_ready=false`; an older CONFIRMED
+authorization can therefore never survive by omission.
+
+Chunks are ordered ascending by source watermark, computation timestamp and
+CNPJ. Import is authorized only when
+`manifest.authoritative_target_fit.coverage_complete=true`,
+`ordering.watermarks_monotonic=true` and
+`omission_preserves_authorization=false`. A smoke limit or undeclared universe
+produces a visibly partial manifest.
+
 ## Serve / import chunks
 
 ### File import (Warmbly side)
 
-Point Warmbly import at a chunk file or directory of chunks (see Warmbly
+After checking the authoritative manifest gates, point Warmbly import at a chunk file or directory of chunks (see Warmbly
 docs / PR #4 import API). Each `chunk_*.json` is a self-contained feed with
 `schema_version`, `source`, `pagination`, and `leads`.
 

--- a/docs/ops/confenge-warmbly-bridge.md
+++ b/docs/ops/confenge-warmbly-bridge.md
@@ -65,6 +65,11 @@ snapshot is emitted as `TARGET_FIT_MISSING` with
 `target_fit_tombstone=true` and `email_send_ready=false`; an older CONFIRMED
 authorization can therefore never survive by omission.
 
+The production pipeline reads the canonical CDC watermark from the target-fit
+control plane, uses it for freshness evaluation, and records it as
+`manifest.source.datalake_watermark`. An explicit non-tombstone decision with
+an empty version, computation timestamp, or source watermark aborts the export.
+
 Chunks are ordered ascending by source watermark, computation timestamp and
 CNPJ. Import is authorized only when
 `manifest.authoritative_target_fit.coverage_complete=true`,

--- a/docs/ops/confenge-warmbly-bridge.md
+++ b/docs/ops/confenge-warmbly-bridge.md
@@ -69,6 +69,9 @@ The production pipeline reads the canonical CDC watermark from the target-fit
 control plane, uses it for freshness evaluation, and records it as
 `manifest.source.datalake_watermark`. An explicit non-tombstone decision with
 an empty version, computation timestamp, or source watermark aborts the export.
+For a direct `export-outreach` operation, pass the same value with
+`--datalake-watermark`; omitting it conservatively compares against the export
+timestamp.
 
 Chunks are ordered ascending by source watermark, computation timestamp and
 CNPJ. Import is authorized only when

--- a/scripts/confenge_activation/strict_national_esr.py
+++ b/scripts/confenge_activation/strict_national_esr.py
@@ -40,7 +40,6 @@ from scripts.confenge_contact_resolution.send_readiness import evaluate_email_se
 from scripts.confenge_outreach_pipeline.integrity_sample import compose_body, compose_subject
 from scripts.linkage.keys import is_valid_cnpj14
 from scripts.warmbly_bridge.export import ExportConfig, export_outreach
-from scripts.warmbly_bridge.mapping import build_leads
 
 DEFAULT_HARVEST = Path("artifacts/confenge/process-first-national-confirmed")
 DEFAULT_OUT = Path("artifacts/confenge/national-commercial-ready")
@@ -627,9 +626,7 @@ def load_contracts_by_root(
     import psycopg2.extras
 
     out: dict[str, list[dict[str, Any]]] = {root: [] for root in roots}
-    with psycopg2.connect(dsn) as conn, conn.cursor(
-        cursor_factory=psycopg2.extras.RealDictCursor
-    ) as cur:
+    with psycopg2.connect(dsn) as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(
             """
             WITH ranked AS (
@@ -684,10 +681,7 @@ def load_contracts_by_root(
 
 def _primary_contract(dossier: dict[str, Any], contracts: list[dict[str, Any]]) -> dict[str, Any]:
     evidence_ids = list((dossier.get("message_spine") or {}).get("fact_evidence_ids") or [])
-    wanted = {
-        str(value).removeprefix("cf-contract-").removeprefix("ev-contract-")
-        for value in evidence_ids
-    }
+    wanted = {str(value).removeprefix("cf-contract-").removeprefix("ev-contract-") for value in evidence_ids}
     chosen = next(
         (row for row in contracts if str(row.get("contract_id") or "") in wanted),
         contracts[0] if contracts else {},
@@ -815,11 +809,7 @@ def build_pilot_review(
             continue
 
         contracts = contracts_by_root.get(root) or []
-        matching_contracts = [
-            row
-            for row in contracts
-            if _root8(row.get("fornecedor_cnpj")) in {"", root}
-        ]
+        matching_contracts = [row for row in contracts if _root8(row.get("fornecedor_cnpj")) in {"", root}]
         if not matching_contracts:
             reject(seed, "no_current_public_contract_evidence")
             continue
@@ -896,9 +886,7 @@ def build_pilot_review(
             "message": message,
             "draft": message,
             "evidence_ids": list(dossier.get("evidence_ids") or []),
-            "supporting_signal_ids": list(
-                (dossier.get("primary_service") or {}).get("supporting_signal_ids") or []
-            ),
+            "supporting_signal_ids": list((dossier.get("primary_service") or {}).get("supporting_signal_ids") or []),
             "n_contracts": len(matching_contracts),
             "n_agencies": len(agencies - {""}),
             "risks": [],
@@ -927,10 +915,7 @@ def build_pilot_review(
     # Keep very broad/complex accounts in ABM even when a commercial mailbox exists.
     eligible: list[dict[str, Any]] = []
     for row in candidates:
-        if (
-            int(row.get("n_contracts") or 0) >= 30
-            and int(row.get("n_agencies") or 0) >= 18
-        ):
+        if int(row.get("n_contracts") or 0) >= 30 and int(row.get("n_agencies") or 0) >= 18:
             rejected.append(
                 {
                     "cnpj14": row.get("cnpj14"),
@@ -1112,27 +1097,40 @@ def build_pilot_feed_inputs(
     return universe, intelligence, contacts
 
 
-def write_pilot_feed(review: dict[str, Any], out_dir: Path) -> dict[str, Any]:
-    """Emit a standard confenge.outreach.v1 feed; no pilot-only wire format."""
-    universe, intelligence, contacts = build_pilot_feed_inputs(review)
-    if not universe:
+def write_pilot_feed(
+    review: dict[str, Any],
+    out_dir: Path,
+    *,
+    authoritative_universe: list[dict[str, Any]] | None = None,
+    target_fit_snapshot: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Emit confenge.outreach.v1 only with a declared full decision universe.
+
+    A reviewed pilot is a selection overlay, not an authoritative account
+    snapshot.  Exporting only its send-ready rows would let omitted downgrades
+    retain stale authorization at the consumer.
+    """
+    pilot_universe, intelligence, contacts = build_pilot_feed_inputs(review)
+    if not pilot_universe:
         raise ValueError("pilot feed requested for a review with no leads")
-    mapped = build_leads(universe, intelligence, contacts)
-    if len(mapped) != len(review.get("leads") or []) or not all(
-        bool(lead.get("email_send_ready")) for lead in mapped
-    ):
-        raise ValueError("pilot feed mapping did not preserve EMAIL_SEND_READY for every reviewed lead")
+    if authoritative_universe is None or target_fit_snapshot is None:
+        raise ValueError(
+            "refusing send-ready-only confenge.outreach.v1: provide the full "
+            "authoritative_universe and target_fit_snapshot"
+        )
     source_dir = out_dir / "source"
     source_dir.mkdir(parents=True, exist_ok=True)
     paths = {
         "universe": source_dir / "universe.jsonl",
         "intelligence": source_dir / "account-intelligence.jsonl",
         "contacts": source_dir / "contacts.jsonl",
+        "target_fit": source_dir / "target-fit-snapshot.jsonl",
     }
     for key, rows in (
-        ("universe", universe),
+        ("universe", authoritative_universe),
         ("intelligence", intelligence),
         ("contacts", contacts),
+        ("target_fit", target_fit_snapshot),
     ):
         paths[key].write_text(
             "".join(json.dumps(row, ensure_ascii=False, default=str) + "\n" for row in rows),
@@ -1143,8 +1141,10 @@ def write_pilot_feed(review: dict[str, Any], out_dir: Path) -> dict[str, Any]:
             universe=paths["universe"],
             account_intelligence=paths["intelligence"],
             contacts=paths["contacts"],
+            target_fit_snapshot=paths["target_fit"],
+            expected_universe_count=len(authoritative_universe),
             out_dir=out_dir,
-            max_leads_per_chunk=max(1, len(mapped)),
+            max_leads_per_chunk=max(1, len(authoritative_universe)),
             system="extra-cli-confenge-pilot",
         )
     )
@@ -1347,7 +1347,6 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dsn", default=None, help="Canonical datalake DSN (defaults to LOCAL_DATALAKE_DSN)")
     p.add_argument("--pilot-seed-file", type=Path, default=None, help="Verified ESR seed JSON for Top20 review")
     p.add_argument("--pilot-size", type=int, default=20)
-    p.add_argument("--pilot-feed-out", type=Path, default=None, help="Optional standard Warmbly feed directory")
     return p
 
 
@@ -1404,14 +1403,17 @@ def main(argv: list[str] | None = None) -> int:
             target_size=max(0, args.pilot_size),
         )
         write_pilot_review(review, out_dir=args.out_dir)
-        feed_result = write_pilot_feed(review, args.pilot_feed_out) if args.pilot_feed_out else None
         pilot_summary = {
             "n": review["n"],
             "email_send_ready": review["email_send_ready"],
             "approved": review["approved"],
             "service_distribution": review["service_distribution"],
             "rejections": len(review["rejections"]),
-            "warmbly_feed": feed_result,
+            "warmbly_feed": None,
+            "warmbly_feed_note": (
+                "Pilot selection is not an authoritative decision snapshot; "
+                "use scripts.confenge_outreach_pipeline for feed export."
+            ),
         }
     summary = {
         "EMAIL_SEND_READY_DISTINCT_COMPANIES": report["EMAIL_SEND_READY_DISTINCT_COMPANIES"],

--- a/scripts/confenge_outreach_pipeline/adapt.py
+++ b/scripts/confenge_outreach_pipeline/adapt.py
@@ -35,8 +35,7 @@ def universe_row_to_intelligence_input(
         # Absence of reajuste proof is NOT positive economic evidence.
         # Avoid false positives on negated phrases ("sem aditivo").
         _neg = any(
-            p in obj_l
-            for p in ("sem aditiv", "sem glosa", "sem reajuste", "sem reequil", "sem medicao", "sem medição")
+            p in obj_l for p in ("sem aditiv", "sem glosa", "sem reajuste", "sem reequil", "sem medicao", "sem medição")
         )
         has_addendum = bool(c.get("has_addendum")) or (
             not _neg
@@ -183,9 +182,7 @@ def universe_row_to_intelligence_input(
         "construction_evidence": ce,
         "target_fit_class": ce.get("target_fit_class") or row.get("target_fit_class"),
         "target_fit_evidence": ce.get("target_fit_evidence") or row.get("target_fit_evidence") or [],
-        "target_fit_reason_codes": ce.get("target_fit_reason_codes")
-        or row.get("target_fit_reason_codes")
-        or [],
+        "target_fit_reason_codes": ce.get("target_fit_reason_codes") or row.get("target_fit_reason_codes") or [],
         "target_fit_confidence": ce.get("target_fit_confidence") or row.get("target_fit_confidence"),
         "target_fit_version": ce.get("target_fit_version") or row.get("target_fit_version"),
         "portfolio_stats": {
@@ -202,12 +199,7 @@ def universe_row_to_intelligence_input(
 def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any]:
     """Normalize confenge-account-intelligence-v1 dossier for warmbly_bridge join."""
     snap = dossier.get("account_snapshot") if isinstance(dossier.get("account_snapshot"), dict) else {}
-    cnpj = _digits(
-        snap.get("cnpj14")
-        or dossier.get("cnpj14")
-        or dossier.get("cnpj")
-        or ""
-    )
+    cnpj = _digits(snap.get("cnpj14") or dossier.get("cnpj14") or dossier.get("cnpj") or "")
     primary = dossier.get("primary_service") if isinstance(dossier.get("primary_service"), dict) else {}
     why = dossier.get("why_now") if isinstance(dossier.get("why_now"), dict) else {}
     dominant = dossier.get("dominant_state") if isinstance(dossier.get("dominant_state"), dict) else {}
@@ -274,11 +266,7 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
     if not contracts:
         # Intelligence dossier keeps portfolio_summary, not full contracts; carry
         # normalized contracts stashed by the pipeline on the dossier when present.
-        contracts = (
-            dossier.get("_pipeline_contracts")
-            if isinstance(dossier.get("_pipeline_contracts"), list)
-            else []
-        )
+        contracts = dossier.get("_pipeline_contracts") if isinstance(dossier.get("_pipeline_contracts"), list) else []
     # Bridge feed contracts are opaque JSON objects for Warmbly.
     bridge_contracts: list[dict[str, Any]] = []
     for c in contracts:
@@ -322,11 +310,7 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
     razao = snap.get("razao_social") or dossier.get("razao_social") or ""
     why_you = str(
         dossier.get("why_this_account")
-        or (
-            f"empresa com execução pública de engenharia/construção observável: {razao}"
-            if razao
-            else ""
-        )
+        or (f"empresa com execução pública de engenharia/construção observável: {razao}" if razao else "")
     )
 
     return {
@@ -353,9 +337,7 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
             "summary": why_summary,
             "observed_at": str(why.get("observed_at") or dossier.get("as_of") or ""),
             "confidence": _confidence_from_epistemic(why.get("epistemic_class")),
-            "evidence_ids": [
-                e["id"] for e in evidence if e.get("epistemic_class") == "CONFIRMED_FACT"
-            ][:5],
+            "evidence_ids": [e["id"] for e in evidence if e.get("epistemic_class") == "CONFIRMED_FACT"][:5],
         },
         "offer": {
             "service_code": warmbly_service or raw_service,
@@ -363,11 +345,7 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
             "extra_cli_service_id": raw_service,
             "service_name": str(primary.get("label") or primary.get("service_name") or ""),
             "entry_offer": str(primary.get("approach_mode") or ""),
-            "micro_offer_code": str(
-                dossier.get("micro_offer_code")
-                or primary.get("approach_mode")
-                or ""
-            ),
+            "micro_offer_code": str(dossier.get("micro_offer_code") or primary.get("approach_mode") or ""),
             "rationale": str(dossier.get("service_fit_rationale") or ""),
         },
         "service_candidates": list(dossier.get("service_candidates") or []),
@@ -463,17 +441,10 @@ def contact_resolution_to_bridge_row(resolution: dict[str, Any]) -> dict[str, An
         if recommended_id and cand.get("candidate_id") == recommended_id:
             is_rec = True
 
-        phone = (
-            cand.get("phone_e164")
-            or cand.get("phone_raw")
-            or cand.get("phone")
-            or ""
-        )
+        phone = cand.get("phone_e164") or cand.get("phone_raw") or cand.get("phone") or ""
         contacts.append(
             {
-                "source_contact_id": str(
-                    cand.get("candidate_id") or cand.get("source_contact_id") or f"ct-{cnpj}-{i}"
-                ),
+                "source_contact_id": str(cand.get("candidate_id") or cand.get("source_contact_id") or f"ct-{cnpj}-{i}"),
                 "name": str(cand.get("name") or ""),
                 "role": str(cand.get("cargo") or cand.get("role") or ""),
                 "email": str(cand.get("email") or cand.get("email_display") or ""),
@@ -514,6 +485,7 @@ def universe_row_for_bridge(row: dict[str, Any], *, rank: int) -> dict[str, Any]
     if str(row.get("outreach_eligibility") or "").upper() == "DNC":
         commercial_state = "DO_NOT_CONTACT"
 
+    construction = row.get("construction_evidence") if isinstance(row.get("construction_evidence"), dict) else {}
     return {
         "cnpj14": cnpj,
         "cnpj_root": _digits(row.get("cnpj_root") or cnpj[:8]),
@@ -532,4 +504,14 @@ def universe_row_for_bridge(row: dict[str, Any], *, rank: int) -> dict[str, Any]
         "priority_score": score_f,
         "priority_reason": row.get("priority_reason"),
         "outreach_eligibility": row.get("outreach_eligibility"),
+        "construction_evidence": construction,
+        "target_fit_class": row.get("target_fit_class") or construction.get("target_fit_class"),
+        "target_fit_confidence": row.get("target_fit_confidence")
+        if row.get("target_fit_confidence") is not None
+        else construction.get("target_fit_confidence"),
+        "target_fit_version": row.get("target_fit_version") or construction.get("target_fit_version"),
+        "target_fit_evidence": row.get("target_fit_evidence") or construction.get("target_fit_evidence") or [],
+        "target_fit_reason_codes": row.get("target_fit_reason_codes")
+        or construction.get("target_fit_reason_codes")
+        or [],
     }

--- a/scripts/confenge_outreach_pipeline/cli.py
+++ b/scripts/confenge_outreach_pipeline/cli.py
@@ -184,7 +184,10 @@ when --max-rows is omitted. Round N+1 advances the durable activation cursor.
 
 
 def cmd_run(args: argparse.Namespace) -> int:
-    dsn = args.dsn or os.environ.get("LOCAL_DATALAKE_DSN")
+    # An explicit CSV is an offline source and must not silently inherit a live
+    # target-fit store from the operator environment. Combining CSV + store is
+    # still available, but only through an explicit --dsn.
+    dsn = args.dsn or (None if args.csv else os.environ.get("LOCAL_DATALAKE_DSN"))
     if not dsn and not args.csv and not args.skip_universe:
         sys.stderr.write(
             "error: provide --dsn / LOCAL_DATALAKE_DSN, --csv, or --skip-universe\n"

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -53,6 +53,7 @@ from scripts.confenge_outreach_pipeline.adapt import (
 from scripts.confenge_outreach_pipeline.sample import sample_profile_counts, select_diverse_sample
 from scripts.confenge_target_fit.company_key import canonical_cnpj14
 from scripts.confenge_target_fit.published import load_published_index
+from scripts.confenge_target_fit.store import get_control
 from scripts.confenge_universe import (
     DEFAULT_EXCLUSIONS_JSONL_NAME,
     DEFAULT_JSONL_NAME,
@@ -117,14 +118,14 @@ def _published_target_fit_snapshot(
     rows: list[dict[str, Any]],
     *,
     dsn: str | None,
-) -> tuple[list[dict[str, Any]], str]:
+) -> tuple[list[dict[str, Any]], str, str | None]:
     """Resolve production decisions from the mode-aware published store.
 
     Offline fixtures retain embedded decisions. With a production DSN, store
     misses stay omitted here so the exporter emits explicit missing tombstones.
     """
     if not dsn:
-        return list(rows), "universe_embedded_snapshot"
+        return list(rows), "universe_embedded_snapshot", None
 
     from scripts.confenge_target_fit.db import connect
 
@@ -133,6 +134,8 @@ def _published_target_fit_snapshot(
     conn = connect(dsn, readonly=True)
     try:
         published = load_published_index(conn, cnpj14s=lookup_cnpjs)
+        control = get_control(conn, "cdc_watermark")
+        datalake_watermark = str(control.get("watermark") or "").strip() or None
     finally:
         conn.close()
 
@@ -152,7 +155,7 @@ def _published_target_fit_snapshot(
                 "company_key": f"cnpj_root:{canonical[:8]}",
             }
         )
-    return snapshot, "published_target_fit_store"
+    return snapshot, "published_target_fit_store", datalake_watermark
 
 
 def _service_context_from_primary(service_id: str | None) -> str:
@@ -337,7 +340,11 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         decision_rows = [
             row for row in [*universe_rows, *exclusion_rows] if canonical_cnpj14(row.get("cnpj14") or row.get("cnpj"))
         ]
-        target_fit_snapshot_rows, target_fit_authority = _published_target_fit_snapshot(
+        (
+            target_fit_snapshot_rows,
+            target_fit_authority,
+            target_fit_datalake_watermark,
+        ) = _published_target_fit_snapshot(
             decision_rows,
             dsn=cfg.dsn,
         )
@@ -661,6 +668,8 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 target_fit_snapshot=target_fit_snapshot_path,
                 expected_universe_count=len(bridge_universe),
                 out_dir=dirs["feed"],
+                datalake_watermark=target_fit_datalake_watermark,
+                require_authoritative_target_fit_metadata=bool(cfg.dsn),
                 repo_sha=repo_sha,
                 deactivations=deactivations,
             )

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -51,7 +51,13 @@ from scripts.confenge_outreach_pipeline.adapt import (
     universe_row_to_intelligence_input,
 )
 from scripts.confenge_outreach_pipeline.sample import sample_profile_counts, select_diverse_sample
-from scripts.confenge_universe import DEFAULT_JSONL_NAME, DEFAULT_MANIFEST_NAME
+from scripts.confenge_target_fit.company_key import canonical_cnpj14
+from scripts.confenge_target_fit.published import load_published_index
+from scripts.confenge_universe import (
+    DEFAULT_EXCLUSIONS_JSONL_NAME,
+    DEFAULT_JSONL_NAME,
+    DEFAULT_MANIFEST_NAME,
+)
 from scripts.confenge_universe.pipeline import run_universe_build
 from scripts.warmbly_bridge.export import ExportConfig, export_outreach
 
@@ -105,6 +111,48 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
             continue
         rows.append(json.loads(text))
     return rows
+
+
+def _published_target_fit_snapshot(
+    rows: list[dict[str, Any]],
+    *,
+    dsn: str | None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Resolve production decisions from the mode-aware published store.
+
+    Offline fixtures retain embedded decisions. With a production DSN, store
+    misses stay omitted here so the exporter emits explicit missing tombstones.
+    """
+    if not dsn:
+        return list(rows), "universe_embedded_snapshot"
+
+    from scripts.confenge_target_fit.db import connect
+
+    raw_cnpjs = [str(row.get("cnpj14") or row.get("cnpj") or "") for row in rows]
+    lookup_cnpjs = sorted({cnpj for raw in raw_cnpjs for cnpj in (raw, canonical_cnpj14(raw)) if cnpj})
+    conn = connect(dsn, readonly=True)
+    try:
+        published = load_published_index(conn, cnpj14s=lookup_cnpjs)
+    finally:
+        conn.close()
+
+    snapshot: list[dict[str, Any]] = []
+    for raw in raw_cnpjs:
+        canonical = canonical_cnpj14(raw)
+        if not canonical:
+            continue
+        decision = published.get(canonical[:8]) or published.get(raw[:8])
+        if not decision:
+            continue
+        snapshot.append(
+            {
+                **decision,
+                "cnpj14": canonical,
+                "cnpj_raiz": canonical[:8],
+                "company_key": f"cnpj_root:{canonical[:8]}",
+            }
+        )
+    return snapshot, "published_target_fit_store"
 
 
 def _service_context_from_primary(service_id: str | None) -> str:
@@ -173,6 +221,11 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
     out.mkdir(parents=True, exist_ok=True)
 
     use_activation = bool(cfg.use_activation_planner) and not bool(cfg.force_sample_mode)
+    if cfg.feed_limit is not None:
+        raise ValueError(
+            "feed_limit is incompatible with the authoritative CONFENGE decision feed; "
+            "limit expensive enrichment with limit_downstream instead"
+        )
 
     dirs = {
         "universe": out / "01_universe",
@@ -217,9 +270,15 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
     try:
         # ── 1. Universe ──────────────────────────────────────────────────
         universe_jsonl = dirs["universe"] / DEFAULT_JSONL_NAME
+        exclusions_jsonl = dirs["universe"] / DEFAULT_EXCLUSIONS_JSONL_NAME
         universe_manifest = dirs["universe"] / DEFAULT_MANIFEST_NAME
-        skip_uni = bool(cfg.skip_universe and universe_jsonl.is_file())
-        if not skip_uni and ckpt.stage_completed("universe") and universe_jsonl.is_file():
+        skip_uni = bool(cfg.skip_universe and universe_jsonl.is_file() and exclusions_jsonl.is_file())
+        if (
+            not skip_uni
+            and ckpt.stage_completed("universe")
+            and universe_jsonl.is_file()
+            and exclusions_jsonl.is_file()
+        ):
             skip_uni = True
             _progress(cfg.progress, "[universe] resume: reusing completed checkpoint artifacts")
 
@@ -237,9 +296,9 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 try:
                     man = json.loads(universe_manifest.read_text(encoding="utf-8"))
                     uni_meta["counts"] = man.get("counts") or {}
-                    uni_meta["reconciliation_ok"] = (man.get("counts") or {}).get(
-                        "reconciliation", {}
-                    ).get("ok") or man.get("extra", {}).get("reconciliation_bucket_ok")
+                    uni_meta["reconciliation_ok"] = (man.get("counts") or {}).get("reconciliation", {}).get(
+                        "ok"
+                    ) or man.get("extra", {}).get("reconciliation_bucket_ok")
                     uni_meta["source"] = man.get("source") or {}
                 except (json.JSONDecodeError, OSError):
                     pass
@@ -254,6 +313,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 dnc_path=cfg.dnc_path,
             )
             universe_jsonl = Path(uni_meta.get("jsonl_path") or universe_jsonl)
+            exclusions_jsonl = Path(uni_meta.get("exclusions_jsonl_path") or exclusions_jsonl)
             universe_manifest = Path(uni_meta.get("manifest_path") or universe_manifest)
         stages["universe"] = {
             k: uni_meta.get(k)
@@ -273,8 +333,22 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         }
 
         universe_rows = _read_jsonl(universe_jsonl)
+        exclusion_rows = _read_jsonl(exclusions_jsonl)
+        decision_rows = [
+            row for row in [*universe_rows, *exclusion_rows] if canonical_cnpj14(row.get("cnpj14") or row.get("cnpj"))
+        ]
+        target_fit_snapshot_rows, target_fit_authority = _published_target_fit_snapshot(
+            decision_rows,
+            dsn=cfg.dsn,
+        )
         stages["universe_row_count"] = len(universe_rows)
         stages["reservoir_count"] = len(universe_rows)
+        stages["target_fit_decision_universe_count"] = len(decision_rows)
+        stages["target_fit_unaddressable_exclusion_count"] = len(exclusion_rows) - (
+            len(decision_rows) - len(universe_rows)
+        )
+        stages["target_fit_snapshot_count"] = len(target_fit_snapshot_rows)
+        stages["target_fit_authority"] = target_fit_authority
         uni_counts = stages.get("universe", {}).get("counts") or uni_meta.get("counts") or {}
         ckpt.universe_total = len(universe_rows)
         ckpt.full_datalake_scanned = bool(
@@ -331,9 +405,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 include_watch_fill=True,
             )
             cycle_projections = list(cycle.projections)
-            write_projections_jsonl(
-                dirs["activation"] / "activation-projections.jsonl", cycle.projections
-            )
+            write_projections_jsonl(dirs["activation"] / "activation-projections.jsonl", cycle.projections)
             write_hot_set_jsonl(dirs["activation"] / "hot-set.jsonl", cycle.hot_set)
             (dirs["activation"] / "deactivations.json").write_text(
                 json.dumps(cycle.deactivations, indent=2, ensure_ascii=False) + "\n",
@@ -346,28 +418,19 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             deactivations = list(cycle.deactivations)
             activation_by_cnpj = {p.cnpj14: p.as_dict() for p in cycle.projections}
             # Map hot set back to universe rows (preserve order of hot set)
-            by_cnpj = {
-                "".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()): r
-                for r in universe_rows
-            }
+            by_cnpj = {"".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()): r for r in universe_rows}
             sample_rows = [by_cnpj[c] for c in (p.cnpj14 for p in cycle.hot_set) if c in by_cnpj]
             # Safety: never silent-truncate reservoir; expensive path is hot set only
             sample_path = dirs["sample"] / "downstream-hot-set.jsonl"
             _write_jsonl(sample_path, sample_rows)
-            planned_cap = (
-                int(capacity)
-                if capacity is not None
-                else policy.capacity.planned_capacity()
-            )
+            planned_cap = int(capacity) if capacity is not None else policy.capacity.planned_capacity()
             stages["activation"] = {
                 **cycle.summary(),
                 "projections_path": str(dirs["activation"] / "activation-projections.jsonl"),
                 "hot_set_path": str(dirs["activation"] / "hot-set.jsonl"),
                 "capacity_this_round": planned_cap,
                 "capacity_source": (
-                    "activation_capacity_override"
-                    if cfg.activation_capacity is not None
-                    else "policy.planned_capacity"
+                    "activation_capacity_override" if cfg.activation_capacity is not None else "policy.planned_capacity"
                 ),
                 "note": (
                     "Hot set is capacity-aware activation planning, not arbitrary Top-N. "
@@ -436,9 +499,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         # ── 3. Account intelligence ──────────────────────────────────────
         ckpt.mark_running("intelligence")
         save_checkpoint(out, ckpt)
-        intel_inputs = [
-            universe_row_to_intelligence_input(r, as_of=as_of.isoformat()) for r in sample_rows
-        ]
+        intel_inputs = [universe_row_to_intelligence_input(r, as_of=as_of.isoformat()) for r in sample_rows]
         intel_input_path = dirs["intel"] / "intelligence-inputs.jsonl"
         _write_jsonl(intel_input_path, intel_inputs)
 
@@ -502,8 +563,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 )
             )
             cnpjs = [
-                "".join(ch for ch in str(r.get("cnpj14") or r.get("cnpj") or "") if ch.isdigit())
-                for r in sample_rows
+                "".join(ch for ch in str(r.get("cnpj14") or r.get("cnpj") or "") if ch.isdigit()) for r in sample_rows
             ]
             cnpjs = [c for c in cnpjs if c]
             resolutions = resolver.resolve_batch(cnpjs, max_workers=cfg.max_workers)
@@ -544,9 +604,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         # ── 5. Bridge universe inputs + export ───────────────────────────
         ckpt.mark_running("feed")
         save_checkpoint(out, ckpt)
-        bridge_universe = [
-            universe_row_for_bridge(r, rank=i + 1) for i, r in enumerate(sample_rows)
-        ]
+        bridge_universe = [universe_row_for_bridge(r, rank=i + 1) for i, r in enumerate(decision_rows)]
         # Attach activation projection onto bridge universe rows when available
         if activation_by_cnpj:
             for br in bridge_universe:
@@ -566,6 +624,8 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                     }
         bridge_universe_path = dirs["bridge_inputs"] / "universe.jsonl"
         _write_jsonl(bridge_universe_path, bridge_universe)
+        target_fit_snapshot_path = dirs["bridge_inputs"] / "target-fit-snapshot.jsonl"
+        _write_jsonl(target_fit_snapshot_path, target_fit_snapshot_rows)
 
         # Empty hot set is a valid ops state (all capacity consumed / no eligibles)
         # — write empty feed artifacts instead of failing closed on empty join.
@@ -598,8 +658,9 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 universe=bridge_universe_path,
                 account_intelligence=bridge_intel_path,
                 contacts=bridge_contacts_path,
+                target_fit_snapshot=target_fit_snapshot_path,
+                expected_universe_count=len(bridge_universe),
                 out_dir=dirs["feed"],
-                limit=cfg.feed_limit,
                 repo_sha=repo_sha,
                 deactivations=deactivations,
             )
@@ -610,17 +671,13 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
 
         # Persist funnel progress: mark exported / no-contact on projections
         if use_activation and cycle_projections:
-            contact_by = {
-                "".join(ch for ch in str(c.get("cnpj14") or "") if ch.isdigit()): c
-                for c in bridge_contacts
-            }
+            contact_by = {"".join(ch for ch in str(c.get("cnpj14") or "") if ch.isdigit()): c for c in bridge_contacts}
             updated = []
             for p in cycle_projections:
                 d = p.as_dict() if hasattr(p, "as_dict") else dict(p)
                 cnpj = d.get("cnpj14")
                 if cnpj and any(
-                    "".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()) == cnpj
-                    for r in sample_rows
+                    "".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()) == cnpj for r in sample_rows
                 ):
                     crow = contact_by.get(cnpj) or {}
                     contacts = crow.get("contacts") or []
@@ -666,8 +723,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             "contracts_per_sec": round(contracts_n / elapsed, 2) if contracts_n else None,
             "companies_per_min": round(len(universe_rows) / (elapsed / 60.0), 2),
             "contacts_per_min": round(
-                float((stages.get("contacts") or {}).get("metrics", {}).get("empresas_total") or 0)
-                / (elapsed / 60.0),
+                float((stages.get("contacts") or {}).get("metrics", {}).get("empresas_total") or 0) / (elapsed / 60.0),
                 2,
             ),
             "elapsed_seconds": stages["elapsed_seconds"],

--- a/scripts/confenge_target_fit/company_key.py
+++ b/scripts/confenge_target_fit/company_key.py
@@ -5,13 +5,27 @@ from __future__ import annotations
 import re
 from typing import Any
 
+# Curated corrections are applied at the commercial-feed boundary as identity
+# aliases.  Keep the raw source evidence unchanged; every emitted decision uses
+# the corrected canonical CNPJ.
+_CNPJ14_CORRECTIONS = {
+    "01489370000105": "14893700000105",  # PREVENCAO LABORATORIO
+}
+
 
 def digits_only(value: Any) -> str:
     return re.sub(r"\D", "", str(value or ""))
 
 
+def canonical_cnpj14(value: Any) -> str:
+    digits = digits_only(value)
+    if len(digits) != 14:
+        return ""
+    return _CNPJ14_CORRECTIONS.get(digits, digits)
+
+
 def cnpj_raiz_from_cnpj14(cnpj: str | None) -> str | None:
-    d = digits_only(cnpj)
+    d = canonical_cnpj14(cnpj) or digits_only(cnpj)
     if len(d) >= 8:
         return d[:8]
     return None
@@ -50,19 +64,10 @@ def resolve_company_from_contract(contract: dict[str, Any]) -> tuple[str, str] |
 
 
 def is_consortium_contract(contract: dict[str, Any]) -> bool:
-    if contract.get("is_consortium") or contract.get("consorcio") or contract.get(
-        "consortium"
-    ):
+    if contract.get("is_consortium") or contract.get("consorcio") or contract.get("consortium"):
         return True
-    obj = str(
-        contract.get("objeto_contrato")
-        or contract.get("objeto")
-        or contract.get("object")
-        or ""
-    ).lower()
-    nome = str(
-        contract.get("fornecedor_nome") or contract.get("nome_fornecedor") or ""
-    ).lower()
+    obj = str(contract.get("objeto_contrato") or contract.get("objeto") or contract.get("object") or "").lower()
+    nome = str(contract.get("fornecedor_nome") or contract.get("nome_fornecedor") or "").lower()
     markers = ("consórcio", "consorcio", " em consorcio", " em consórcio")
     return any(m in obj or m in nome for m in markers)
 

--- a/scripts/confenge_target_fit/compute.py
+++ b/scripts/confenge_target_fit/compute.py
@@ -71,6 +71,8 @@ def compute_materialization(
     prev_ver = (previous or {}).get("target_fit_version")
     prev_class = (previous or {}).get("target_fit_class")
     prev_conf = (previous or {}).get("target_fit_confidence")
+    prev_watermark = str((previous or {}).get("source_watermark") or "")
+    incoming_watermark = str(company.source_watermark or "")
 
     if (
         previous
@@ -78,6 +80,10 @@ def compute_materialization(
         and prev_ver == target_fit_version
         and prev_class
         and prev_class not in {REFRESH_FAILED, "RECOMPUTE_REQUIRED"}
+        # A newer canonical watermark is provenance work even when semantic
+        # inputs are unchanged. Recompute/publish so the durable snapshot can
+        # prove which datalake state the decision observed.
+        and (not incoming_watermark or incoming_watermark == prev_watermark)
     ):
         meta["skipped_fingerprint"] = True
         mat = MaterializedTargetFit(

--- a/scripts/confenge_target_fit/freshness.py
+++ b/scripts/confenge_target_fit/freshness.py
@@ -70,6 +70,30 @@ def evaluate_freshness(
             blocks_send=True,
         )
 
+    if op == "missing" or cls == "TARGET_FIT_MISSING":
+        return FreshnessDecision(
+            company_key=company_key,
+            target_fit_fresh=False,
+            target_fit_age_seconds=age,
+            target_fit_computed_at=computed if isinstance(computed, datetime) else None,
+            target_fit_source_watermark=tf_wm,
+            datalake_watermark=datalake_watermark or "",
+            reason="TARGET_FIT_MISSING",
+            blocks_send=True,
+        )
+
+    if op == "stale":
+        return FreshnessDecision(
+            company_key=company_key,
+            target_fit_fresh=False,
+            target_fit_age_seconds=age,
+            target_fit_computed_at=computed if isinstance(computed, datetime) else None,
+            target_fit_source_watermark=tf_wm,
+            datalake_watermark=datalake_watermark or "",
+            reason="TARGET_FIT_STALE",
+            blocks_send=True,
+        )
+
     if op in {"recompute_required"} or cls == "RECOMPUTE_REQUIRED":
         return FreshnessDecision(
             company_key=company_key,
@@ -184,7 +208,7 @@ def feed_fields_from_current(
         "target_fit_version": current.get("target_fit_version"),
         "target_fit_computed_at": computed,
         "target_fit_source_watermark": current.get("source_watermark"),
-        "target_fit_fresh": freshness.target_fit_fresh and not freshness.blocks_send,
+        "target_fit_fresh": freshness.target_fit_fresh,
         "target_fit_evidence_ids": ids,
         "target_fit_freshness_reason": freshness.reason,
     }

--- a/scripts/confenge_target_fit/published.py
+++ b/scripts/confenge_target_fit/published.py
@@ -9,10 +9,13 @@ from typing import Any
 
 from scripts.confenge_target_fit import (
     TARGET_CONFIRMED,
+    TARGET_FIT_VERSION,
+    TARGET_INSUFFICIENT_EVIDENCE,
     TARGET_OUT_OF_SCOPE,
     TARGET_PROBABLE_RESEARCH,
 )
 from scripts.confenge_target_fit.company_key import (
+    canonical_cnpj14,
     cnpj_raiz_from_cnpj14,
     company_key_from_raiz,
     digits_only,
@@ -27,15 +30,97 @@ from scripts.confenge_target_fit.store import (
     is_send_suppressed,
 )
 
+TARGET_FIT_MISSING = "TARGET_FIT_MISSING"
+
+
+def _row_target_fit_payload(row: dict[str, Any]) -> dict[str, Any]:
+    embedded = row.get("published_target_fit") or row.get("target_fit_materialization")
+    if isinstance(embedded, dict):
+        return dict(embedded)
+    construction = row.get("construction_evidence")
+    if not isinstance(construction, dict):
+        construction = {}
+    return {
+        "target_fit_class": row.get("target_fit_class") or construction.get("target_fit_class"),
+        "target_fit_confidence": row.get("target_fit_confidence")
+        if row.get("target_fit_confidence") is not None
+        else construction.get("target_fit_confidence"),
+        "target_fit_version": row.get("target_fit_version") or construction.get("target_fit_version"),
+        "target_fit_evidence": row.get("target_fit_evidence") or construction.get("target_fit_evidence") or [],
+        "target_fit_reason_codes": row.get("target_fit_reason_codes")
+        or construction.get("target_fit_reason_codes")
+        or [],
+        "computed_at": row.get("target_fit_computed_at") or row.get("computed_at"),
+        "source_watermark": row.get("target_fit_source_watermark") or row.get("source_watermark"),
+        "operational_status": row.get("target_fit_operational_status") or row.get("operational_status"),
+    }
+
+
+def complete_published_decision(
+    row: dict[str, Any],
+    *,
+    computed_at: str,
+    source_watermark: str,
+) -> dict[str, Any] | None:
+    """Return a complete authoritative decision, including an explicit miss tombstone."""
+    company = row.get("company") if isinstance(row.get("company"), dict) else {}
+    cnpj = canonical_cnpj14(row.get("cnpj14") or row.get("cnpj") or company.get("cnpj14"))
+    if not cnpj:
+        return None
+    raiz = cnpj[:8]
+    payload = _row_target_fit_payload(row)
+    target_class = str(payload.get("target_fit_class") or TARGET_FIT_MISSING).upper()
+    missing = target_class == TARGET_FIT_MISSING
+    evidence = payload.get("target_fit_evidence") or []
+    if not isinstance(evidence, list):
+        evidence = []
+    reasons = payload.get("target_fit_reason_codes") or []
+    if not isinstance(reasons, list):
+        reasons = []
+    if missing and TARGET_FIT_MISSING not in reasons:
+        reasons = [*reasons, TARGET_FIT_MISSING]
+    return {
+        **payload,
+        "company_key": company_key_from_raiz(raiz),
+        "cnpj_raiz": raiz,
+        "target_fit_class": target_class,
+        "target_fit_confidence": payload.get("target_fit_confidence"),
+        "target_fit_version": str(payload.get("target_fit_version") or TARGET_FIT_VERSION),
+        "target_fit_evidence": evidence,
+        "target_fit_reason_codes": [str(reason) for reason in reasons],
+        "computed_at": str(payload.get("computed_at") or computed_at),
+        "source_watermark": str(payload.get("source_watermark") or source_watermark),
+        "operational_status": str(payload.get("operational_status") or ("missing" if missing else "ok")).lower(),
+        "target_fit_tombstone": missing,
+    }
+
+
+def build_published_index_from_rows(
+    rows: list[dict[str, Any]],
+    *,
+    computed_at: str,
+    source_watermark: str,
+) -> dict[str, dict[str, Any]]:
+    """Build a full snapshot index; later rows supersede earlier ones deterministically."""
+    out: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        decision = complete_published_decision(row, computed_at=computed_at, source_watermark=source_watermark)
+        if decision is None:
+            continue
+        raiz = str(decision["cnpj_raiz"])
+        key = str(decision["company_key"])
+        out[key] = decision
+        out[raiz] = decision
+        out[f"cnpj_root:{raiz}"] = decision
+    return out
+
 
 def company_key_from_row(row: dict[str, Any] | None) -> str | None:
     if not row:
         return None
     if row.get("company_key"):
         return str(row["company_key"])
-    cnpj: Any = row.get("cnpj14") or row.get("cnpj") or row.get("cnpj_root") or row.get(
-        "cnpj_raiz"
-    )
+    cnpj: Any = row.get("cnpj14") or row.get("cnpj") or row.get("cnpj_root") or row.get("cnpj_raiz")
     company = row.get("company")
     if isinstance(company, dict):
         cnpj = cnpj or company.get("cnpj14") or company.get("cnpj_root")
@@ -318,11 +403,8 @@ def _embed_from_row(row: dict[str, Any]) -> dict[str, Any] | None:
             "target_fit_reason_codes": row.get("target_fit_reason_codes") or [],
             "target_fit_evidence": row.get("target_fit_evidence") or [],
             "computed_at": row.get("target_fit_computed_at") or row.get("computed_at"),
-            "source_watermark": row.get("target_fit_source_watermark")
-            or row.get("source_watermark"),
-            "operational_status": row.get("target_fit_operational_status")
-            or row.get("operational_status")
-            or "ok",
+            "source_watermark": row.get("target_fit_source_watermark") or row.get("source_watermark"),
+            "operational_status": row.get("target_fit_operational_status") or row.get("operational_status") or "ok",
             "input_fingerprint": row.get("input_fingerprint"),
         }
     return None
@@ -398,9 +480,14 @@ def map_class_to_send_tier(target_fit_class: str | None) -> str:
     cls = (target_fit_class or "").strip().upper()
     if cls == TARGET_CONFIRMED:
         return "A_AUTOMATIC"
-    if cls == TARGET_PROBABLE_RESEARCH:
+    if cls in {TARGET_PROBABLE_RESEARCH, TARGET_INSUFFICIENT_EVIDENCE}:
         return "RESEARCH_ONLY"
-    if cls in {TARGET_OUT_OF_SCOPE, "REFRESH_FAILED", "RECOMPUTE_REQUIRED"}:
+    if cls in {
+        TARGET_OUT_OF_SCOPE,
+        TARGET_FIT_MISSING,
+        "REFRESH_FAILED",
+        "RECOMPUTE_REQUIRED",
+    }:
         return "OUT_OF_SCOPE"
     return "OUT_OF_SCOPE"
 
@@ -471,7 +558,7 @@ def attach_published_fields(
     computed = published.get("computed_at") or published.get("target_fit_computed_at")
     if hasattr(computed, "isoformat"):
         computed = computed.isoformat()
-    fresh_ok = bool(freshness and freshness.target_fit_fresh and not freshness.blocks_send)
+    fresh_ok = bool(freshness and freshness.target_fit_fresh)
     out.update(
         {
             "target_fit_class": published.get("target_fit_class"),
@@ -483,6 +570,8 @@ def attach_published_fields(
             "target_fit_fresh": fresh_ok,
             "target_fit_evidence_ids": ids,
             "target_fit_freshness_reason": (freshness.reason if freshness else None),
+            "target_fit_reason_codes": list(published.get("target_fit_reason_codes") or []),
+            "target_fit_tombstone": bool(published.get("target_fit_tombstone")),
         }
     )
     return out
@@ -514,7 +603,5 @@ def resolve_gate_from_conn(
         "blocks_send": blocks,
         "reasons": reasons,
         "freshness": fresh,
-        "send_tier": map_class_to_send_tier(
-            (published or {}).get("target_fit_class") if published else None
-        ),
+        "send_tier": map_class_to_send_tier((published or {}).get("target_fit_class") if published else None),
     }

--- a/scripts/confenge_target_fit/published.py
+++ b/scripts/confenge_target_fit/published.py
@@ -61,6 +61,7 @@ def complete_published_decision(
     *,
     computed_at: str,
     source_watermark: str,
+    require_authoritative_metadata: bool = False,
 ) -> dict[str, Any] | None:
     """Return a complete authoritative decision, including an explicit miss tombstone."""
     company = row.get("company") if isinstance(row.get("company"), dict) else {}
@@ -71,6 +72,15 @@ def complete_published_decision(
     payload = _row_target_fit_payload(row)
     target_class = str(payload.get("target_fit_class") or TARGET_FIT_MISSING).upper()
     missing = target_class == TARGET_FIT_MISSING
+    if require_authoritative_metadata and not missing:
+        required = {
+            "target_fit_version": payload.get("target_fit_version"),
+            "computed_at": payload.get("computed_at"),
+            "source_watermark": payload.get("source_watermark"),
+        }
+        absent = [name for name, value in required.items() if not str(value or "").strip()]
+        if absent:
+            raise ValueError(f"published target-fit decision incomplete for {cnpj}: {', '.join(absent)}")
     evidence = payload.get("target_fit_evidence") or []
     if not isinstance(evidence, list):
         evidence = []
@@ -100,11 +110,17 @@ def build_published_index_from_rows(
     *,
     computed_at: str,
     source_watermark: str,
+    require_authoritative_metadata: bool = False,
 ) -> dict[str, dict[str, Any]]:
     """Build a full snapshot index; later rows supersede earlier ones deterministically."""
     out: dict[str, dict[str, Any]] = {}
     for row in rows:
-        decision = complete_published_decision(row, computed_at=computed_at, source_watermark=source_watermark)
+        decision = complete_published_decision(
+            row,
+            computed_at=computed_at,
+            source_watermark=source_watermark,
+            require_authoritative_metadata=require_authoritative_metadata,
+        )
         if decision is None:
             continue
         raiz = str(decision["cnpj_raiz"])

--- a/scripts/confenge_target_fit/store.py
+++ b/scripts/confenge_target_fit/store.py
@@ -157,8 +157,13 @@ def requeue_company(
     cnpj_raiz: str,
     reason: str = "manual_requeue",
     priority: int = 90,
-    source_watermark: str = "",
+    source_watermark: str | None = None,
 ) -> str:
+    resolved_watermark = str(source_watermark or "").strip()
+    if not resolved_watermark:
+        resolved_watermark = str(get_control(conn, "cdc_watermark").get("watermark") or "").strip()
+    if not resolved_watermark:
+        raise ValueError("manual requeue requires a non-empty canonical CDC source watermark")
     key = f"requeue:{company_key}:{uuid.uuid4().hex[:12]}"
     enqueue_dirty(
         conn,
@@ -168,7 +173,7 @@ def requeue_company(
         source_entity="manual",
         source_id=None,
         source_updated_at=_utcnow(),
-        source_watermark=source_watermark,
+        source_watermark=resolved_watermark,
         priority=priority,
         idempotency_key=key,
     )

--- a/scripts/confenge_universe/__init__.py
+++ b/scripts/confenge_universe/__init__.py
@@ -37,6 +37,7 @@ OUTREACH_ELIGIBILITY_STATES = frozenset(
 UNIVERSE_MEMBER_STATES = frozenset({ELIGIBLE, DNC})
 
 DEFAULT_JSONL_NAME = "confenge-universe-v1.jsonl"
+DEFAULT_EXCLUSIONS_JSONL_NAME = "confenge-universe-exclusions-v1.jsonl"
 DEFAULT_MANIFEST_NAME = "confenge-universe-manifest-v1.json"
 
 __all__ = [
@@ -54,5 +55,6 @@ __all__ = [
     "OUTREACH_ELIGIBILITY_STATES",
     "UNIVERSE_MEMBER_STATES",
     "DEFAULT_JSONL_NAME",
+    "DEFAULT_EXCLUSIONS_JSONL_NAME",
     "DEFAULT_MANIFEST_NAME",
 ]

--- a/scripts/confenge_universe/pipeline.py
+++ b/scripts/confenge_universe/pipeline.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from scripts.commercial_leads.contract_relevance import classify_contract_relevance
 from scripts.confenge_universe import (
+    DEFAULT_EXCLUSIONS_JSONL_NAME,
     DNC,
     ELIGIBLE,
     MODULE_VERSION,
@@ -161,9 +162,7 @@ def load_dnc_from_commercial_state(dsn: str) -> set[str]:
     return out
 
 
-def load_registry_from_dsn(
-    dsn: str, cnpjs: list[str]
-) -> dict[str, dict[str, Any]]:
+def load_registry_from_dsn(dsn: str, cnpjs: list[str]) -> dict[str, dict[str, Any]]:
     """Load supplier_registry cadastral rows for representative CNPJs. Fail-soft."""
     if not cnpjs:
         return {}
@@ -396,9 +395,7 @@ def run_universe_build(
     resolved_csv = csv_path
 
     if row_iter is not None:
-        batches: Iterator[list[dict[str, Any]]] = iter_contract_rows(
-            row_iter, batch_size=batch_size
-        )
+        batches: Iterator[list[dict[str, Any]]] = iter_contract_rows(row_iter, batch_size=batch_size)
         source_meta = {
             "mode": "iterator",
             "as_of": as_of_d.isoformat(),
@@ -440,9 +437,7 @@ def run_universe_build(
         source_meta = {**source_meta, **source_meta_extra}
     source_meta["dnc_sources"] = dnc_sources
 
-    agg = UniverseAggregator(
-        as_of=as_of_d, enable_independent_brand=enable_independent_brand
-    )
+    agg = UniverseAggregator(as_of=as_of_d, enable_independent_brand=enable_independent_brand)
 
     peak_batch = 0
     for batch in batches:
@@ -474,9 +469,7 @@ def run_universe_build(
     input_entity_keys = set(agg.buckets.keys())
 
     for bucket in agg.all_buckets():
-        rec, meta = finalize_bucket(
-            bucket, as_of=as_of_d, dnc_set=dnc, registry=reg_map
-        )
+        rec, meta = finalize_bucket(bucket, as_of=as_of_d, dnc_set=dnc, registry=reg_map)
         if rec is not None:
             records.append(rec)
             elig_breakdown[str(rec["outreach_eligibility"])] += 1
@@ -498,18 +491,16 @@ def run_universe_build(
     n_input_entities = len(input_entity_keys)
     n_eligibles = len(records)
     # Prefer exact: eligibles + exclusions that came from buckets
-    bucket_excl = [
-        e for e in exclusions if not str(e.get("entity_key", "")).startswith("identity:")
-    ]
+    bucket_excl = [e for e in exclusions if not str(e.get("entity_key", "")).startswith("identity:")]
     n_excl_from_buckets = len(bucket_excl)
     recon_ok = n_input_entities == n_eligibles + n_excl_from_buckets
-    bucket_excl_breakdown = Counter(
-        str(e.get("outreach_eligibility") or "UNKNOWN") for e in bucket_excl
-    )
+    bucket_excl_breakdown = Counter(str(e.get("outreach_eligibility") or "UNKNOWN") for e in bucket_excl)
     if sum(bucket_excl_breakdown.values()) != n_excl_from_buckets:
         recon_ok = False
 
     jsonl_meta = write_jsonl_stream(records, jsonl_path)
+    exclusions_path = out / DEFAULT_EXCLUSIONS_JSONL_NAME
+    exclusions_meta = write_jsonl_stream(exclusions, exclusions_path)
     counts = {
         "input_contract_rows": agg.stats["input_contract_rows"],
         "input_supplier_roots": n_input_entities,
@@ -550,7 +541,7 @@ def run_universe_build(
             "full_scale_command": (
                 "python3 -m scripts.confenge_universe build "
                 "--out output/confenge_universe "
-                "--dsn \"$LOCAL_DATALAKE_DSN\" "
+                '--dsn "$LOCAL_DATALAKE_DSN" '
                 "# omit --max-rows for full national scan"
             ),
         },
@@ -563,6 +554,11 @@ def run_universe_build(
         "exclusions": n_excl_from_buckets,
         "ok": recon_ok,
     }
+    manifest["outputs"]["exclusions_jsonl"] = {
+        "filename": exclusions_path.name,
+        "lines": exclusions_meta["lines"],
+        "sha256": exclusions_meta["sha256"],
+    }
     write_manifest(manifest, manifest_path)
 
     return {
@@ -571,6 +567,7 @@ def run_universe_build(
         "repo_sha": sha,
         "jsonl_path": str(jsonl_path),
         "manifest_path": str(manifest_path),
+        "exclusions_jsonl_path": str(exclusions_path),
         "counts": counts,
         "records": records,
         "exclusions": exclusions,

--- a/scripts/warmbly_bridge/cli.py
+++ b/scripts/warmbly_bridge/cli.py
@@ -59,6 +59,7 @@ def cmd_export(args: argparse.Namespace) -> int:
         profile_version=args.profile_version,
         system=args.system,
         generated_at=args.generated_at,
+        datalake_watermark=args.datalake_watermark,
         repo_sha=args.repo_sha,
     )
     try:
@@ -199,6 +200,11 @@ def build_parser() -> argparse.ArgumentParser:
     e.add_argument("--profile-version", default=DEFAULT_PROFILE_VERSION)
     e.add_argument("--system", default="extra-cli")
     e.add_argument("--generated-at", default=None, help="Override generated_at (tests)")
+    e.add_argument(
+        "--datalake-watermark",
+        default=None,
+        help="Canonical CDC watermark used to evaluate target-fit freshness",
+    )
     e.add_argument("--repo-sha", default=None, help="Override repo_sha (tests)")
     e.set_defaults(func=cmd_export)
 

--- a/scripts/warmbly_bridge/cli.py
+++ b/scripts/warmbly_bridge/cli.py
@@ -49,6 +49,8 @@ def cmd_export(args: argparse.Namespace) -> int:
         universe=Path(args.universe),
         account_intelligence=Path(args.account_intelligence),
         contacts=Path(args.contacts),
+        target_fit_snapshot=(Path(args.target_fit_snapshot) if args.target_fit_snapshot else None),
+        expected_universe_count=args.expected_universe_count,
         out_dir=Path(args.out),
         limit=args.limit,
         max_leads_per_chunk=args.max_leads_per_chunk,
@@ -76,10 +78,7 @@ def _build_store(args: argparse.Namespace) -> Any:
         return InMemoryOutcomeStore()
     dsn = getattr(args, "dsn", None) or os.environ.get("LOCAL_DATALAKE_DSN")
     if not dsn:
-        raise ValueError(
-            "no outcome store DSN: pass --dsn, set LOCAL_DATALAKE_DSN, "
-            "or explicitly pass --memory-store"
-        )
+        raise ValueError("no outcome store DSN: pass --dsn, set LOCAL_DATALAKE_DSN, or explicitly pass --memory-store")
     from scripts.decision_memory.db import connect
     from scripts.decision_memory.repository import DecisionMemoryRepository
 
@@ -181,6 +180,17 @@ def build_parser() -> argparse.ArgumentParser:
     e.add_argument("--universe", required=True, help="Universe JSONL path")
     e.add_argument("--account-intelligence", required=True, help="Account intelligence JSONL path")
     e.add_argument("--contacts", required=True, help="Contacts JSONL path")
+    e.add_argument(
+        "--target-fit-snapshot",
+        default=None,
+        help="Authoritative full target-fit snapshot JSONL; defaults to embedded universe decisions",
+    )
+    e.add_argument(
+        "--expected-universe-count",
+        type=int,
+        default=None,
+        help="Declared authoritative universe cardinality; required for coverage_complete=true",
+    )
     e.add_argument("--out", required=True, help="Output directory for chunks + manifest")
     e.add_argument("--limit", type=int, default=None, help="Smoke limit (Top N); omit in production")
     e.add_argument("--max-leads-per-chunk", type=int, default=DEFAULT_MAX_LEADS_PER_CHUNK)

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.confenge_target_fit.published import build_published_index_from_rows
 from scripts.warmbly_bridge import (
     DEFAULT_MAX_BYTES_PER_CHUNK,
     DEFAULT_MAX_LEADS_PER_CHUNK,
@@ -45,9 +46,11 @@ def _git_sha() -> str:
         return "unknown"
 
 
-def _snapshot_hash(universe: Path, intel: Path, contacts: Path) -> str:
+def _snapshot_hash(universe: Path, intel: Path, contacts: Path, target_fit: Path | None) -> str:
     h = hashlib.sha256()
-    for p in (universe, intel, contacts):
+    for p in (universe, intel, contacts, target_fit):
+        if p is None:
+            continue
         h.update(p.name.encode())
         h.update(b"\0")
         h.update(p.read_bytes())
@@ -66,6 +69,8 @@ class ExportConfig:
     account_intelligence: Path
     contacts: Path
     out_dir: Path
+    target_fit_snapshot: Path | None = None
+    expected_universe_count: int | None = None
     limit: int | None = None
     max_leads_per_chunk: int = DEFAULT_MAX_LEADS_PER_CHUNK
     max_bytes_per_chunk: int = DEFAULT_MAX_BYTES_PER_CHUNK
@@ -83,16 +88,107 @@ def validate_inputs(cfg: ExportConfig) -> None:
     require_readable_file(cfg.universe, label="--universe")
     require_readable_file(cfg.account_intelligence, label="--account-intelligence")
     require_readable_file(cfg.contacts, label="--contacts")
+    if cfg.target_fit_snapshot is not None:
+        require_readable_file(cfg.target_fit_snapshot, label="--target-fit-snapshot")
     if cfg.max_leads_per_chunk < 1:
         raise InputError("--max-leads-per-chunk must be >= 1")
     if cfg.max_bytes_per_chunk < 1024:
         raise InputError("--max-bytes-per-chunk must be >= 1024")
+    if cfg.expected_universe_count is not None and cfg.expected_universe_count < 1:
+        raise InputError("--expected-universe-count must be >= 1")
 
 
 def _encode_chunk(feed: dict[str, Any]) -> bytes:
     # Canonical serialization for stable content hashes (resume/idempotency).
     text = json.dumps(feed, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n"
     return text.encode("utf-8")
+
+
+def _decision_cursor(lead: dict[str, Any]) -> str:
+    return "|".join(
+        (
+            str(lead.get("target_fit_source_watermark") or ""),
+            str(lead.get("target_fit_computed_at") or ""),
+            str((lead.get("company") or {}).get("cnpj14") or ""),
+        )
+    )
+
+
+def _parse_timestamp(value: Any, *, field: str, cnpj: str) -> datetime:
+    text = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise InputError(f"invalid {field} timestamp for {cnpj}: {text!r}") from exc
+    if parsed.tzinfo is None:
+        raise InputError(f"timezone required in {field} for {cnpj}: {text!r}")
+    return parsed.astimezone(UTC)
+
+
+def _decision_order_key(lead: dict[str, Any]) -> tuple[datetime, datetime, str, str]:
+    cnpj = str((lead.get("company") or {}).get("cnpj14") or "")
+    return (
+        _parse_timestamp(
+            lead.get("target_fit_source_watermark"),
+            field="target_fit_source_watermark",
+            cnpj=cnpj,
+        ),
+        _parse_timestamp(
+            lead.get("target_fit_computed_at"),
+            field="target_fit_computed_at",
+            cnpj=cnpj,
+        ),
+        cnpj,
+        str(lead.get("source_lead_id") or ""),
+    )
+
+
+def _assert_authoritative_leads(leads: list[dict[str, Any]]) -> dict[str, Any]:
+    required = (
+        "target_fit_class",
+        "target_fit_fresh",
+        "target_fit_version",
+        "target_fit_computed_at",
+        "target_fit_source_watermark",
+        "target_fit_evidence_ids",
+        "target_fit_send_tier",
+        "email_send_ready",
+    )
+    cursors: list[str] = []
+    order_keys: list[tuple[datetime, datetime, str, str]] = []
+    seen: set[str] = set()
+    for lead in leads:
+        cnpj = str((lead.get("company") or {}).get("cnpj14") or "")
+        missing = [field for field in required if field not in lead or lead[field] is None]
+        if missing:
+            raise InputError(f"authoritative target-fit decision incomplete for {cnpj}: {missing}")
+        if not str(lead["target_fit_class"]):
+            raise InputError(f"authoritative target-fit class empty for {cnpj}")
+        if not str(lead["target_fit_version"]):
+            raise InputError(f"authoritative target-fit version empty for {cnpj}")
+        if not str(lead["target_fit_computed_at"]):
+            raise InputError(f"authoritative target-fit computed_at empty for {cnpj}")
+        if not str(lead["target_fit_source_watermark"]):
+            raise InputError(f"authoritative target-fit watermark empty for {cnpj}")
+        if cnpj in seen:
+            raise InputError(f"duplicate authoritative decision for CNPJ {cnpj}")
+        seen.add(cnpj)
+        cursors.append(_decision_cursor(lead))
+        order_keys.append(_decision_order_key(lead))
+    monotonic = all(a <= b for a, b in zip(order_keys, order_keys[1:]))
+    if not monotonic:
+        raise InputError("target-fit source watermarks are not monotonically ordered")
+    return {
+        "key": [
+            "target_fit_source_watermark",
+            "target_fit_computed_at",
+            "company.cnpj14",
+        ],
+        "direction": "ascending",
+        "watermarks_monotonic": True,
+        "first_cursor": cursors[0] if cursors else None,
+        "last_cursor": cursors[-1] if cursors else None,
+    }
 
 
 def _chunk_leads(
@@ -117,7 +213,7 @@ def _chunk_leads(
             "generated_at": generated_at,
             "source": source,
             "pagination": {
-                "cursor": current[0]["company"]["cnpj14"] if current else lead["company"]["cnpj14"],
+                "cursor": _decision_cursor(current[0] if current else lead),
                 "next_cursor": None,
                 "has_more": False,
                 "chunk_index": len(chunks),
@@ -137,9 +233,9 @@ def _chunk_leads(
 
     result: list[tuple[list[dict[str, Any]], dict[str, Any]]] = []
     for idx, slice_leads in enumerate(chunks):
-        cursor = slice_leads[0]["company"]["cnpj14"] if slice_leads else None
+        cursor = _decision_cursor(slice_leads[0]) if slice_leads else None
         has_more = idx < len(chunks) - 1
-        next_cursor = chunks[idx + 1][0]["company"]["cnpj14"] if has_more else None
+        next_cursor = _decision_cursor(chunks[idx + 1][0]) if has_more else None
         pagination = {
             "cursor": cursor,
             "next_cursor": next_cursor,
@@ -163,13 +259,15 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
     if not universe_rows:
         raise InputError("--universe has no records; refusing empty shallow export")
 
-    leads = build_leads(universe_rows, intel_rows, contact_rows)
-    if cfg.limit is not None:
-        if cfg.limit < 0:
-            raise InputError("--limit must be >= 0")
-        leads = leads[: cfg.limit]
+    if cfg.limit is not None and cfg.limit < 0:
+        raise InputError("--limit must be >= 0")
 
-    snapshot_hash = _snapshot_hash(cfg.universe, cfg.account_intelligence, cfg.contacts)
+    snapshot_hash = _snapshot_hash(
+        cfg.universe,
+        cfg.account_intelligence,
+        cfg.contacts,
+        cfg.target_fit_snapshot,
+    )
     run_id = _run_id(snapshot_hash, cfg.profile_id, cfg.profile_version)
     # Deterministic resume: reuse generated_at/repo_sha from prior manifest when
     # snapshot_hash matches so re-export yields identical chunk hashes.
@@ -194,6 +292,42 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         repo_sha = str(prior_source["repo_sha"])
     else:
         repo_sha = _git_sha()
+
+    if cfg.target_fit_snapshot is not None:
+        target_fit_rows = read_jsonl(cfg.target_fit_snapshot, label="--target-fit-snapshot")
+        # Seed every addressable company as an explicit missing tombstone.  The
+        # authoritative snapshot then overwrites the companies it contains;
+        # omission can never preserve a CONFIRMED decision from an older feed.
+        published_index = build_published_index_from_rows(
+            [{"cnpj14": row.get("cnpj14") or row.get("cnpj")} for row in universe_rows],
+            computed_at=generated_at,
+            source_watermark=generated_at,
+        )
+        published_index.update(
+            build_published_index_from_rows(
+                target_fit_rows,
+                computed_at=generated_at,
+                source_watermark=generated_at,
+            )
+        )
+    else:
+        target_fit_rows = universe_rows
+        published_index = build_published_index_from_rows(
+            target_fit_rows,
+            computed_at=generated_at,
+            source_watermark=generated_at,
+        )
+    leads = build_leads(
+        universe_rows,
+        intel_rows,
+        contact_rows,
+        published_index=published_index,
+        datalake_watermark=generated_at,
+    )
+    leads.sort(key=_decision_order_key)
+    if cfg.limit is not None:
+        leads = leads[: cfg.limit]
+    ordering = _assert_authoritative_leads(leads)
 
     source = {
         "system": cfg.system,
@@ -278,6 +412,11 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
             stale.unlink(missing_ok=True)
 
     deacts = list(cfg.deactivations or [])
+    coverage_complete = bool(
+        cfg.expected_universe_count is not None
+        and cfg.limit is None
+        and len(leads) == len(universe_rows) == cfg.expected_universe_count
+    )
     manifest = {
         "schema_version": "confenge.outreach.manifest.v1",
         "module_version": MODULE_VERSION,
@@ -287,12 +426,26 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
             "universe": str(cfg.universe.resolve()),
             "account_intelligence": str(cfg.account_intelligence.resolve()),
             "contacts": str(cfg.contacts.resolve()),
+            "target_fit_snapshot": (
+                str(cfg.target_fit_snapshot.resolve())
+                if cfg.target_fit_snapshot is not None
+                else str(cfg.universe.resolve())
+            ),
         },
         "lead_count": len(leads),
         "chunk_count": len(chunk_meta),
         "max_leads_per_chunk": cfg.max_leads_per_chunk,
         "max_bytes_per_chunk": cfg.max_bytes_per_chunk,
         "limit": cfg.limit,
+        "authoritative_target_fit": {
+            "source": "target_fit_snapshot" if cfg.target_fit_snapshot is not None else "universe_embedded_snapshot",
+            "full_decision_count": len(leads),
+            "universe_count": len(universe_rows),
+            "declared_universe_count": cfg.expected_universe_count,
+            "coverage_complete": coverage_complete,
+            "omission_preserves_authorization": not coverage_complete,
+            "ordering": ordering,
+        },
         "chunks": chunk_meta,
         # Approach B: explicit deactivation delta (idempotent; Warmbly applies without DB coupling)
         "deactivations": deacts,
@@ -310,15 +463,15 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         },
     }
     manifest_path = out / "manifest.json"
-    manifest_bytes = (
-        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n"
-    ).encode("utf-8")
+    manifest_bytes = (json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n").encode(
+        "utf-8"
+    )
     manifest_path.write_bytes(manifest_bytes)
     manifest["manifest_content_hash"] = hashlib.sha256(manifest_bytes).hexdigest()
     # rewrite with self hash
-    manifest_bytes = (
-        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n"
-    ).encode("utf-8")
+    manifest_bytes = (json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n").encode(
+        "utf-8"
+    )
     manifest_path.write_bytes(manifest_bytes)
 
     return {

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -78,6 +78,8 @@ class ExportConfig:
     profile_version: str = DEFAULT_PROFILE_VERSION
     system: str = DEFAULT_SYSTEM
     generated_at: str | None = None  # inject for deterministic tests
+    datalake_watermark: str | None = None
+    require_authoritative_target_fit_metadata: bool = True
     repo_sha: str | None = None
     # Delta deactivations for accounts leaving ACTIONABLE_NOW (manifest section)
     deactivations: list[dict[str, Any]] | None = None
@@ -286,6 +288,12 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         generated_at = str(prior["generated_at"])
     else:
         generated_at = _utcnow()
+    datalake_watermark = str(cfg.datalake_watermark or generated_at)
+    _parse_timestamp(
+        datalake_watermark,
+        field="datalake_watermark",
+        cnpj="authoritative-snapshot",
+    )
     if cfg.repo_sha is not None:
         repo_sha = cfg.repo_sha
     elif same_snapshot and prior_source.get("repo_sha"):
@@ -303,26 +311,34 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
             computed_at=generated_at,
             source_watermark=generated_at,
         )
-        published_index.update(
-            build_published_index_from_rows(
+        try:
+            published_index.update(
+                build_published_index_from_rows(
+                    target_fit_rows,
+                    computed_at=generated_at,
+                    source_watermark=generated_at,
+                    require_authoritative_metadata=cfg.require_authoritative_target_fit_metadata,
+                )
+            )
+        except ValueError as exc:
+            raise InputError(str(exc)) from exc
+    else:
+        target_fit_rows = universe_rows
+        try:
+            published_index = build_published_index_from_rows(
                 target_fit_rows,
                 computed_at=generated_at,
                 source_watermark=generated_at,
+                require_authoritative_metadata=cfg.require_authoritative_target_fit_metadata,
             )
-        )
-    else:
-        target_fit_rows = universe_rows
-        published_index = build_published_index_from_rows(
-            target_fit_rows,
-            computed_at=generated_at,
-            source_watermark=generated_at,
-        )
+        except ValueError as exc:
+            raise InputError(str(exc)) from exc
     leads = build_leads(
         universe_rows,
         intel_rows,
         contact_rows,
         published_index=published_index,
-        datalake_watermark=generated_at,
+        datalake_watermark=datalake_watermark,
     )
     leads.sort(key=_decision_order_key)
     if cfg.limit is not None:
@@ -336,6 +352,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         "repo_sha": repo_sha,
         "profile_id": cfg.profile_id,
         "profile_version": cfg.profile_version,
+        "datalake_watermark": datalake_watermark,
     }
 
     chunk_specs = _chunk_leads(

--- a/scripts/warmbly_bridge/mapping.py
+++ b/scripts/warmbly_bridge/mapping.py
@@ -13,6 +13,7 @@ from scripts.confenge_contact_resolution.send_readiness import (
     classify_target_fit_send_tier,
     evaluate_email_send_ready,
 )
+from scripts.confenge_target_fit.company_key import canonical_cnpj14
 from scripts.warmbly_bridge import EPISTEMIC_CLASSES, VERIFICATION_STATUSES
 from scripts.warmbly_bridge.constants import DEFAULT_CLAIMS_TO_AVOID, DOMINANT_COMMERCIAL_STATES
 
@@ -34,7 +35,7 @@ def digits_only(value: str | None) -> str:
 
 
 def normalize_cnpj14(value: str | None) -> str:
-    d = digits_only(value)
+    d = canonical_cnpj14(value)
     return d if _CNPJ_RE.match(d) else ""
 
 
@@ -395,10 +396,7 @@ def map_lead(
         "why_this_account": intel.get("why_this_account")
         or intel_msg.get("why_this_account")
         or msg_ctx.get("why_this_account"),
-        "why_now": intel.get("why_now")
-        or intel_msg.get("why_now")
-        or msg_ctx.get("why_now")
-        or moment.get("summary"),
+        "why_now": intel.get("why_now") or intel_msg.get("why_now") or msg_ctx.get("why_now") or moment.get("summary"),
         "micro_offer_code": lead["offer"].get("micro_offer_code")
         or lead["offer"].get("entry_offer")
         or intel.get("micro_offer_code"),
@@ -407,9 +405,7 @@ def map_lead(
         or intel.get("evidence_ids")
         or [e.get("id") for e in evidence_items if isinstance(e, dict)],
         "canonical_universe_member": universe_row.get("canonical_universe_member", True),
-        "construction_evidence": universe_row.get("construction_evidence")
-        or intel.get("construction_evidence")
-        or {},
+        "construction_evidence": universe_row.get("construction_evidence") or intel.get("construction_evidence") or {},
         "portfolio": universe_row.get("portfolio")
         if isinstance(universe_row.get("portfolio"), dict)
         else (intel.get("portfolio") if isinstance(intel.get("portfolio"), dict) else {}),
@@ -452,18 +448,12 @@ def map_lead(
             resolve_suppressed,
         )
 
-        pub = published_from_row_or_db(
-            company_ctx, conn=conn, published_index=published_index
-        )
+        pub = published_from_row_or_db(company_ctx, conn=conn, published_index=published_index)
         if pub is not None:
             ck = (pub or {}).get("company_key") or company_key_from_row(company_ctx)
             suppressed = resolve_suppressed(conn, company_key=ck, row=company_ctx)
-            dl_wm = str(
-                company_ctx.get("datalake_watermark") or datalake_watermark or ""
-            )
-            company_ctx = enrich_row_with_published(
-                company_ctx, pub, suppressed=suppressed, datalake_watermark=dl_wm
-            )
+            dl_wm = str(company_ctx.get("datalake_watermark") or datalake_watermark or "")
+            company_ctx = enrich_row_with_published(company_ctx, pub, suppressed=suppressed, datalake_watermark=dl_wm)
             blocks, pub_reasons, fresh = evaluate_published_send_gate(
                 published=pub,
                 datalake_watermark=dl_wm,
@@ -479,9 +469,7 @@ def map_lead(
             lead = attach_published_fields(lead, published=pub, freshness=fresh)
             if blocks:
                 company_ctx["target_fit_send_suppressed"] = True
-            company_ctx["target_fit_fresh"] = bool(
-                fresh and fresh.target_fit_fresh and not fresh.blocks_send
-            )
+            company_ctx["target_fit_fresh"] = bool(fresh and fresh.target_fit_fresh)
         elif live_open:
             # Live path open but no store hit: fail closed (no sticky embed).
             fit = TargetFitResult(
@@ -679,5 +667,12 @@ def build_leads(
         )
         if lead is not None:
             leads.append(lead)
-    leads.sort(key=lambda lead: (lead["company"]["cnpj14"], lead["source_lead_id"]))
+    leads.sort(
+        key=lambda lead: (
+            str(lead.get("target_fit_source_watermark") or ""),
+            str(lead.get("target_fit_computed_at") or ""),
+            lead["company"]["cnpj14"],
+            lead["source_lead_id"],
+        )
+    )
     return leads

--- a/scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
+++ b/scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
@@ -60,7 +60,15 @@
         "contacts",
         "contracts",
         "evidence",
-        "commercial_state"
+        "commercial_state",
+        "target_fit_class",
+        "target_fit_fresh",
+        "target_fit_version",
+        "target_fit_computed_at",
+        "target_fit_source_watermark",
+        "target_fit_evidence_ids",
+        "target_fit_send_tier",
+        "email_send_ready"
       ],
       "properties": {
         "source_lead_id": { "type": "string", "minLength": 1 },
@@ -152,8 +160,17 @@
         },
         "commercial_state": { "type": "string" },
         "target_fit_class": {
-          "type": ["string", "null"],
-          "description": "Published ICP class from extra-cli continuous refresh (TARGET_CONFIRMED|TARGET_PROBABLE_RESEARCH|TARGET_OUT_OF_SCOPE). Warmbly must not re-score."
+          "type": "string",
+          "enum": [
+            "TARGET_CONFIRMED",
+            "TARGET_PROBABLE_RESEARCH",
+            "TARGET_INSUFFICIENT_EVIDENCE",
+            "TARGET_OUT_OF_SCOPE",
+            "TARGET_FIT_MISSING",
+            "REFRESH_FAILED",
+            "RECOMPUTE_REQUIRED"
+          ],
+          "description": "Authoritative published ICP decision. TARGET_FIT_MISSING is an explicit fail-closed tombstone; Warmbly must not re-score or retain an older authorization."
         },
         "target_fit_confidence": {
           "type": ["number", "null"],
@@ -161,19 +178,24 @@
           "maximum": 1
         },
         "target_fit_version": {
-          "type": ["string", "null"],
+          "type": "string",
+          "minLength": 1,
           "description": "Classifier version that produced the published decision."
         },
         "target_fit_computed_at": {
-          "type": ["string", "null"],
+          "type": "string",
+          "minLength": 1,
+          "format": "date-time",
           "description": "ISO timestamp when target-fit was materialised."
         },
         "target_fit_source_watermark": {
-          "type": ["string", "null"],
+          "type": "string",
+          "minLength": 1,
+          "format": "date-time",
           "description": "Datalake watermark observed when target-fit was computed."
         },
         "target_fit_fresh": {
-          "type": ["boolean", "null"],
+          "type": "boolean",
           "description": "False when stale/missing/failed relative to datalake watermark policy."
         },
         "target_fit_evidence_ids": {
@@ -182,12 +204,21 @@
           "description": "Provenance ids only — full evidence stays in extra-cli materialization."
         },
         "target_fit_send_tier": {
-          "type": ["string", "null"],
+          "type": "string",
+          "enum": ["A_AUTOMATIC", "B_EVIDENCE_SUPPORTED", "RESEARCH_ONLY", "OUT_OF_SCOPE"],
           "description": "Legacy send tier mapped from published class (A_AUTOMATIC|B_EVIDENCE_SUPPORTED|RESEARCH_ONLY|OUT_OF_SCOPE)."
         },
         "email_send_ready": {
-          "type": ["boolean", "null"],
+          "type": "boolean",
           "description": "EMAIL_SEND_READY after all gates including published target-fit freshness. Never true if target_fit_class != TARGET_CONFIRMED or not fresh."
+        },
+        "target_fit_reason_codes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "target_fit_tombstone": {
+          "type": "boolean",
+          "description": "True only for an explicit missing-decision revocation record."
         },
         "activation": {
           "type": "object",

--- a/tests/confenge_activation/test_strict_national_esr_and_service_ontology.py
+++ b/tests/confenge_activation/test_strict_national_esr_and_service_ontology.py
@@ -11,6 +11,8 @@ from argparse import Namespace
 from datetime import date, timedelta
 from pathlib import Path
 
+import pytest
+
 from scripts.confenge_account_intelligence.catalog import load_catalog
 from scripts.confenge_account_intelligence.pipeline import build_dossier
 from scripts.confenge_activation.strict_national_esr import (
@@ -224,9 +226,7 @@ def test_jsonl_public_document_does_not_invent_company_authorship(tmp_path: Path
 
 def test_pilot_does_not_describe_future_start_as_recent_event() -> None:
     future = (date.today() + timedelta(days=90)).isoformat()
-    sanitized = _sanitize_pilot_contract_dates(
-        [{"data_inicio": future, "data_publicacao": future, "data_fim": future}]
-    )
+    sanitized = _sanitize_pilot_contract_dates([{"data_inicio": future, "data_publicacao": future, "data_fim": future}])
     assert sanitized[0]["data_inicio"] is None
     assert sanitized[0]["data_publicacao"] is None
     assert sanitized[0]["data_fim"] == future
@@ -276,16 +276,11 @@ def test_pilot_review_has_full_identity_evidence_message_and_human_gate(tmp_path
     assert lead["review_status"] == "HUMAN_REVIEW_PENDING"
     assert lead["review_decision"] is None
     assert review["approved"] == 0
-    feed = write_pilot_feed(review, tmp_path / "feed")
-    assert feed["lead_count"] == 1
-    chunk = json.loads((tmp_path / "feed" / "chunk_0000.json").read_text(encoding="utf-8"))
-    assert chunk["leads"][0]["email_send_ready"] is True
-    assert chunk["leads"][0]["offer"]["service_code"] == lead["recommended_service"]
+    with pytest.raises(ValueError, match="send-ready-only"):
+        write_pilot_feed(review, tmp_path / "feed")
 
 
 def test_empty_pilot_review_cannot_emit_feed(tmp_path: Path) -> None:
-    import pytest
-
     with pytest.raises(ValueError, match="no leads"):
         write_pilot_feed({"leads": []}, tmp_path / "empty-feed")
 

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -11,7 +11,11 @@ from scripts.confenge_outreach_pipeline.adapt import (
     universe_row_to_intelligence_input,
 )
 from scripts.confenge_outreach_pipeline.cli import main as cli_main
-from scripts.confenge_outreach_pipeline.pipeline import PipelineConfig, run_pipeline
+from scripts.confenge_outreach_pipeline.pipeline import (
+    PipelineConfig,
+    _published_target_fit_snapshot,
+    run_pipeline,
+)
 from scripts.confenge_outreach_pipeline.sample import classify_profile, select_diverse_sample
 from scripts.warmbly_bridge.mapping import build_leads
 
@@ -47,15 +51,71 @@ def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
     assert result.stages["manifest_summary"]["limit_downstream_is_batch_only"] is True
     # Intelligence only for sample
     assert result.stages["account_intelligence"]["count"] == 1
-    # Feed produced (or empty-ok)
+    # Feed is the complete decision universe; only expensive stages use the sample.
     feed = result.stages["feed"]
     assert feed.get("ok") is True
-    assert feed.get("lead_count") == 1
+    assert feed.get("lead_count") == result.stages["target_fit_decision_universe_count"]
+    assert feed.get("lead_count") > result.stages["sample"]["count"]
+    feed_manifest = json.loads((out / "06_warmbly_feed" / "manifest.json").read_text(encoding="utf-8"))
+    authority = feed_manifest["authoritative_target_fit"]
+    assert authority["coverage_complete"] is True
+    assert authority["omission_preserves_authorization"] is False
+    assert authority["ordering"]["watermarks_monotonic"] is True
     # Manifest records sampling flags honestly
     assert result.stages.get("sampling") is False  # no max_rows on universe
     assert result.stages.get("full_scale_universe") is False  # csv path
     # Checkpoint written for resume
     assert (out / "pipeline-checkpoint.json").is_file()
+
+
+def test_offline_snapshot_uses_embedded_decisions() -> None:
+    rows = [{"cnpj14": "11222333000181", "target_fit_class": "TARGET_CONFIRMED"}]
+    snapshot, authority = _published_target_fit_snapshot(rows, dsn=None)
+    assert snapshot == rows
+    assert authority == "universe_embedded_snapshot"
+
+
+def test_production_snapshot_uses_published_store_and_canonicalizes_prevencao(
+    monkeypatch,
+) -> None:
+    import scripts.confenge_outreach_pipeline.pipeline as pipeline
+    import scripts.confenge_target_fit.db as target_fit_db
+
+    class FakeConnection:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FakeConnection()
+    monkeypatch.setattr(target_fit_db, "connect", lambda dsn, readonly: conn)
+    monkeypatch.setattr(
+        pipeline,
+        "load_published_index",
+        lambda connection, cnpj14s: {
+            "01489370": {
+                "cnpj_raiz": "01489370",
+                "company_key": "cnpj_root:01489370",
+                "target_fit_class": "TARGET_OUT_OF_SCOPE",
+            }
+        },
+    )
+
+    snapshot, authority = _published_target_fit_snapshot(
+        [{"cnpj14": "01489370000105"}],
+        dsn="postgresql://unused",
+    )
+
+    assert conn.closed is True
+    assert authority == "published_target_fit_store"
+    assert snapshot == [
+        {
+            "cnpj14": "14893700000105",
+            "cnpj_raiz": "14893700",
+            "company_key": "cnpj_root:14893700",
+            "target_fit_class": "TARGET_OUT_OF_SCOPE",
+        }
+    ]
 
 
 def test_production_activation_does_not_use_limit_downstream_as_capacity(tmp_path: Path) -> None:
@@ -287,9 +347,7 @@ def test_adapt_intelligence_and_contacts_join() -> None:
 
 def test_contract_schema_matches_warmbly_constants() -> None:
     """Producer schema_version equals Warmbly consumer constant."""
-    schema_path = (
-        ROOT / "scripts" / "warmbly_bridge" / "schemas" / "confenge.outreach.v1.json"
-    )
+    schema_path = ROOT / "scripts" / "warmbly_bridge" / "schemas" / "confenge.outreach.v1.json"
     assert schema_path.is_file()
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
     # schema file may use $id; constant in package is authoritative

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -159,7 +159,13 @@ def test_production_activation_does_not_use_limit_downstream_as_capacity(tmp_pat
     assert result.stages["universe_row_count"] >= result.stages["sample"]["count"]
 
 
-def test_cli_run_fixture_end_to_end(tmp_path: Path) -> None:
+def test_cli_run_fixture_end_to_end(tmp_path: Path, monkeypatch) -> None:
+    # Full CI exposes a real datalake DSN. CSV fixture mode must remain offline
+    # unless the operator explicitly combines it with --dsn.
+    monkeypatch.setenv(
+        "LOCAL_DATALAKE_DSN",
+        "postgresql://ambient:ambient@127.0.0.1:1/must_not_be_used",
+    )
     out = tmp_path / "cli_out"
     code = cli_main(
         [

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -70,9 +70,10 @@ def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
 
 def test_offline_snapshot_uses_embedded_decisions() -> None:
     rows = [{"cnpj14": "11222333000181", "target_fit_class": "TARGET_CONFIRMED"}]
-    snapshot, authority = _published_target_fit_snapshot(rows, dsn=None)
+    snapshot, authority, watermark = _published_target_fit_snapshot(rows, dsn=None)
     assert snapshot == rows
     assert authority == "universe_embedded_snapshot"
+    assert watermark is None
 
 
 def test_production_snapshot_uses_published_store_and_canonicalizes_prevencao(
@@ -100,14 +101,20 @@ def test_production_snapshot_uses_published_store_and_canonicalizes_prevencao(
             }
         },
     )
+    monkeypatch.setattr(
+        pipeline,
+        "get_control",
+        lambda connection, key: {"watermark": "2026-08-12T08:00:00Z"},
+    )
 
-    snapshot, authority = _published_target_fit_snapshot(
+    snapshot, authority, watermark = _published_target_fit_snapshot(
         [{"cnpj14": "01489370000105"}],
         dsn="postgresql://unused",
     )
 
     assert conn.closed is True
     assert authority == "published_target_fit_store"
+    assert watermark == "2026-08-12T08:00:00Z"
     assert snapshot == [
         {
             "cnpj14": "14893700000105",

--- a/tests/confenge_target_fit/test_cli_and_invariants.py
+++ b/tests/confenge_target_fit/test_cli_and_invariants.py
@@ -14,7 +14,6 @@ from scripts.confenge_target_fit.company_key import (
 from scripts.confenge_target_fit.config import TargetFitRefreshConfig
 from scripts.confenge_target_fit.transitions import classify_event_type
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -177,3 +176,29 @@ def test_target_fit_module_exports_pr211_contract():
     assert tf.TARGET_OUT_OF_SCOPE == "TARGET_OUT_OF_SCOPE"
     assert hasattr(tf, "classify_target_fit")
     assert hasattr(tf, "TARGET_FIT_VERSION")
+
+
+def test_manual_requeue_inherits_canonical_cdc_watermark(monkeypatch):
+    from scripts.confenge_target_fit import store
+
+    captured = {}
+    monkeypatch.setattr(
+        store,
+        "get_control",
+        lambda _conn, key: {"watermark": "2026-08-12T10:00:00Z"} if key == "cdc_watermark" else {},
+    )
+    monkeypatch.setattr(store, "enqueue_dirty", lambda _conn, **kwargs: captured.update(kwargs) or True)
+
+    store.requeue_company(object(), company_key="cnpj_root:12345678", cnpj_raiz="12345678")
+
+    assert captured["source_watermark"] == "2026-08-12T10:00:00Z"
+
+
+def test_manual_requeue_refuses_missing_cdc_watermark(monkeypatch):
+    import pytest
+
+    from scripts.confenge_target_fit import store
+
+    monkeypatch.setattr(store, "get_control", lambda _conn, _key: {})
+    with pytest.raises(ValueError, match="canonical CDC source watermark"):
+        store.requeue_company(object(), company_key="cnpj_root:12345678", cnpj_raiz="12345678")

--- a/tests/confenge_target_fit/test_fingerprint_and_compute.py
+++ b/tests/confenge_target_fit/test_fingerprint_and_compute.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-import pytest
-
 from scripts.confenge_target_fit import (
     TARGET_CONFIRMED,
     TARGET_FIT_VERSION,
@@ -119,6 +117,21 @@ def test_same_event_twice_same_effective_state():
     assert evt2 is None
     assert mat2.target_fit_class == mat1.target_fit_class
     assert mat2.input_fingerprint == mat1.input_fingerprint
+
+
+def test_new_source_watermark_is_republished_even_when_inputs_are_unchanged():
+    first = _construction_company(source_watermark="2026-08-12T09:00:00Z")
+    mat1, _, _ = compute_materialization(first, previous=None, mode="ACTIVE")
+    refreshed = _construction_company(source_watermark="2026-08-12T10:00:00Z")
+
+    mat2, _, meta2 = compute_materialization(
+        refreshed,
+        previous=mat1.as_dict(),
+        mode="ACTIVE",
+    )
+
+    assert meta2["skipped_fingerprint"] is False
+    assert mat2.source_watermark == "2026-08-12T10:00:00Z"
 
 
 def test_supply_only_never_confirms():

--- a/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
+++ b/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
@@ -271,3 +271,25 @@ def test_freshness_uses_canonical_datalake_watermark_not_export_clock(tmp_path: 
     assert leads[0]["email_send_ready"] is True
     manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
     assert manifest["source"]["datalake_watermark"] == source_watermark
+
+
+def test_cli_exposes_canonical_datalake_watermark() -> None:
+    from scripts.warmbly_bridge.cli import build_parser
+
+    args = build_parser().parse_args(
+        [
+            "export-outreach",
+            "--universe",
+            "universe.jsonl",
+            "--account-intelligence",
+            "intelligence.jsonl",
+            "--contacts",
+            "contacts.jsonl",
+            "--out",
+            "feed",
+            "--datalake-watermark",
+            "2026-08-12T08:00:00Z",
+        ]
+    )
+
+    assert args.datalake_watermark == "2026-08-12T08:00:00Z"

--- a/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
+++ b/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
@@ -1,0 +1,233 @@
+"""Authoritative full-snapshot and revocation semantics for confenge.outreach.v1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.warmbly_bridge.export import ExportConfig, export_outreach
+
+NOW = "2026-08-12T12:00:00Z"
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> Path:
+    path.write_text(
+        "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _decision(
+    cnpj14: str,
+    target_class: str,
+    *,
+    watermark: str = NOW,
+    evidence_ids: list[str] | None = None,
+    operational_status: str = "ok",
+) -> dict[str, Any]:
+    return {
+        "cnpj14": cnpj14,
+        "target_fit_class": target_class,
+        "target_fit_confidence": 0.95,
+        "target_fit_version": "confenge-target-fit-v2",
+        "target_fit_computed_at": watermark,
+        "target_fit_source_watermark": watermark,
+        "target_fit_evidence": [
+            {"id": evidence_id, "type": "CONTRACT_EXECUTION"} for evidence_id in (evidence_ids or [])
+        ],
+        "target_fit_reason_codes": [target_class.lower()],
+        "target_fit_operational_status": operational_status,
+    }
+
+
+def _read_leads(out: Path) -> list[dict[str, Any]]:
+    leads: list[dict[str, Any]] = []
+    for path in sorted(out.glob("chunk_*.json")):
+        leads.extend(json.loads(path.read_text(encoding="utf-8"))["leads"])
+    return leads
+
+
+def _export(
+    tmp_path: Path,
+    *,
+    universe: list[dict[str, Any]],
+    target_fit: list[dict[str, Any]],
+    suffix: str,
+) -> tuple[Path, list[dict[str, Any]]]:
+    source = tmp_path / suffix
+    source.mkdir()
+    domains = [f"{str(row['razao_social']).split()[0].lower()}.com.br" for row in universe]
+    feed_universe = [{**row, "official_domain": domains[index]} for index, row in enumerate(universe)]
+    universe_path = _write_jsonl(source / "universe.jsonl", feed_universe)
+    target_fit_path = _write_jsonl(source / "target-fit.jsonl", target_fit)
+    intelligence = [
+        {
+            "cnpj14": row["cnpj14"],
+            "offer": {"service_code": "REAJUSTE"},
+            "primary_service": {
+                "service_id": "REAJUSTE",
+                "service_code": "REAJUSTE",
+                "supporting_signal_ids": [f"signal-{row['cnpj14']}"],
+                "evidence_ids": [f"contract-{row['cnpj14']}"],
+            },
+            "messaging": {
+                "fact_to_mention": (
+                    f"{row['razao_social']} consta no objeto: pavimentacao asfaltica "
+                    "de vias urbanas; orgao: Prefeitura de Coxilha."
+                ),
+                "question_to_ask": "Quem acompanha os contratos publicos?",
+                "cta": "Posso enviar o recorte publico?",
+                "claims_to_avoid": [],
+            },
+            "why_this_account": (
+                f"{row['razao_social']} executa objeto: pavimentacao asfaltica "
+                "de vias urbanas; orgao: Prefeitura de Coxilha."
+            ),
+            "why_now": (
+                f"Aditivo recente de {row['razao_social']} no objeto: pavimentacao "
+                "asfaltica; orgao: Prefeitura de Coxilha."
+            ),
+            "observed_fact": (f"{row['razao_social']}; objeto: pavimentacao asfaltica; orgao: Prefeitura de Coxilha."),
+            "micro_offer_code": "REAJUSTE_CHECK",
+            "evidence": [
+                {
+                    "id": f"contract-{row['cnpj14']}",
+                    "type": "PNCP_CONTRACT",
+                    "epistemic_class": "CONFIRMED_FACT",
+                }
+            ],
+        }
+        for row in universe
+    ]
+    contacts = [
+        {
+            "cnpj14": row["cnpj14"],
+            "contacts": [
+                {
+                    "email": f"engenharia@{domains[index]}",
+                    "ownership_status": "COMPANY_OWNED",
+                    "verification_status": "OBSERVED",
+                    "provenance": {
+                        "source_type": "site",
+                        "source_url": f"https://{domains[index]}/contato",
+                    },
+                }
+            ],
+        }
+        for index, row in enumerate(universe)
+    ]
+    intel_path = _write_jsonl(source / "intelligence.jsonl", intelligence)
+    contacts_path = _write_jsonl(source / "contacts.jsonl", contacts)
+    out = source / "feed"
+    result = export_outreach(
+        ExportConfig(
+            universe=universe_path,
+            account_intelligence=intel_path,
+            contacts=contacts_path,
+            target_fit_snapshot=target_fit_path,
+            expected_universe_count=len(universe),
+            out_dir=out,
+            generated_at=NOW,
+            repo_sha="authoritative-test",
+            max_leads_per_chunk=3,
+        )
+    )
+    assert result["lead_count"] == len(universe)
+    return out, _read_leads(out)
+
+
+def test_full_snapshot_publishes_negative_decisions_and_temporal_order(tmp_path: Path) -> None:
+    universe = [
+        {"cnpj14": "01489370000105", "razao_social": "PREVENCAO LABORATORIO", "commercial_state": "NEW"},
+        {"cnpj14": "01607033000167", "razao_social": "BEBA MAIS", "commercial_state": "NEW"},
+        {"cnpj14": "01942594000112", "razao_social": "SULPEL PAPEIS", "commercial_state": "NEW"},
+        {"cnpj14": "11222333000181", "razao_social": "ALFA ENGENHARIA", "commercial_state": "NEW"},
+        {"cnpj14": "22333444000155", "razao_social": "ENGENHARIA DNC", "commercial_state": "DO_NOT_CONTACT"},
+        {"cnpj14": "33444555000166", "razao_social": "ENGENHARIA STALE", "commercial_state": "NEW"},
+        {"cnpj14": "44555666000177", "razao_social": "SEM ICP PUBLICADO", "commercial_state": "NEW"},
+    ]
+    snapshot = [
+        _decision("01489370000105", "TARGET_OUT_OF_SCOPE"),
+        _decision("01607033000167", "TARGET_OUT_OF_SCOPE"),
+        _decision("01942594000112", "TARGET_INSUFFICIENT_EVIDENCE"),
+        _decision("11222333000181", "TARGET_CONFIRMED", evidence_ids=["eng-contract"]),
+        _decision("22333444000155", "TARGET_CONFIRMED", evidence_ids=["dnc-contract"]),
+        _decision(
+            "33444555000166",
+            "TARGET_CONFIRMED",
+            evidence_ids=["stale-contract"],
+            operational_status="stale",
+        ),
+        # Deliberately omit 44555666: exporter must emit a revocation tombstone.
+    ]
+    out, leads = _export(tmp_path, universe=universe, target_fit=snapshot, suffix="full")
+    by_cnpj = {lead["company"]["cnpj14"]: lead for lead in leads}
+
+    assert "14893700000105" in by_cnpj
+    assert "01489370000105" not in by_cnpj
+    for cnpj in ("14893700000105", "01607033000167", "01942594000112"):
+        assert by_cnpj[cnpj]["email_send_ready"] is False
+    assert by_cnpj["11222333000181"]["target_fit_class"] == "TARGET_CONFIRMED"
+    assert by_cnpj["11222333000181"]["target_fit_fresh"] is True
+    assert by_cnpj["11222333000181"]["email_send_ready"] is True
+    assert by_cnpj["22333444000155"]["email_send_ready"] is False
+    assert by_cnpj["33444555000166"]["target_fit_fresh"] is False
+    assert by_cnpj["33444555000166"]["email_send_ready"] is False
+    missing = by_cnpj["44555666000177"]
+    assert missing["target_fit_class"] == "TARGET_FIT_MISSING"
+    assert missing["target_fit_tombstone"] is True
+    assert missing["email_send_ready"] is False
+
+    required = {
+        "target_fit_class",
+        "target_fit_fresh",
+        "target_fit_version",
+        "target_fit_computed_at",
+        "target_fit_source_watermark",
+        "target_fit_evidence_ids",
+        "target_fit_send_tier",
+        "email_send_ready",
+    }
+    assert all(required <= set(lead) for lead in leads)
+    watermarks = [lead["target_fit_source_watermark"] for lead in leads]
+    assert watermarks == sorted(watermarks)
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    authority = manifest["authoritative_target_fit"]
+    assert authority["coverage_complete"] is True
+    assert authority["full_decision_count"] == len(universe)
+    assert authority["ordering"]["watermarks_monotonic"] is True
+    assert authority["omission_preserves_authorization"] is False
+
+
+def test_downgrade_and_missing_snapshot_cannot_resurrect_prior_authorization(
+    tmp_path: Path,
+) -> None:
+    universe = [{"cnpj14": "11222333000181", "razao_social": "ALFA ENGENHARIA", "commercial_state": "NEW"}]
+    _, initial = _export(
+        tmp_path,
+        universe=universe,
+        target_fit=[_decision("11222333000181", "TARGET_CONFIRMED", evidence_ids=["e1"])],
+        suffix="initial",
+    )
+    assert initial[0]["email_send_ready"] is True
+
+    _, downgraded = _export(
+        tmp_path,
+        universe=universe,
+        target_fit=[_decision("11222333000181", "TARGET_OUT_OF_SCOPE")],
+        suffix="downgraded",
+    )
+    assert downgraded[0]["target_fit_class"] == "TARGET_OUT_OF_SCOPE"
+    assert downgraded[0]["email_send_ready"] is False
+
+    _, tombstoned = _export(
+        tmp_path,
+        universe=universe,
+        target_fit=[],
+        suffix="tombstoned",
+    )
+    assert tombstoned[0]["target_fit_class"] == "TARGET_FIT_MISSING"
+    assert tombstoned[0]["target_fit_tombstone"] is True
+    assert tombstoned[0]["email_send_ready"] is False

--- a/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
+++ b/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
@@ -6,7 +6,10 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from scripts.warmbly_bridge.export import ExportConfig, export_outreach
+from scripts.warmbly_bridge.io_jsonl import InputError
 
 NOW = "2026-08-12T12:00:00Z"
 
@@ -55,6 +58,7 @@ def _export(
     universe: list[dict[str, Any]],
     target_fit: list[dict[str, Any]],
     suffix: str,
+    datalake_watermark: str | None = None,
 ) -> tuple[Path, list[dict[str, Any]]]:
     source = tmp_path / suffix
     source.mkdir()
@@ -130,6 +134,7 @@ def _export(
             expected_universe_count=len(universe),
             out_dir=out,
             generated_at=NOW,
+            datalake_watermark=datalake_watermark,
             repo_sha="authoritative-test",
             max_leads_per_chunk=3,
         )
@@ -231,3 +236,38 @@ def test_downgrade_and_missing_snapshot_cannot_resurrect_prior_authorization(
     assert tombstoned[0]["target_fit_class"] == "TARGET_FIT_MISSING"
     assert tombstoned[0]["target_fit_tombstone"] is True
     assert tombstoned[0]["email_send_ready"] is False
+
+
+def test_explicit_decision_without_source_watermark_fails_closed(tmp_path: Path) -> None:
+    universe = [{"cnpj14": "11222333000181", "razao_social": "ALFA ENGENHARIA", "commercial_state": "NEW"}]
+    incomplete = _decision("11222333000181", "TARGET_CONFIRMED", evidence_ids=["e1"])
+    incomplete.pop("target_fit_source_watermark")
+
+    with pytest.raises(InputError, match="source_watermark"):
+        _export(tmp_path, universe=universe, target_fit=[incomplete], suffix="incomplete")
+
+
+def test_freshness_uses_canonical_datalake_watermark_not_export_clock(tmp_path: Path) -> None:
+    source_watermark = "2026-08-12T08:00:00Z"
+    universe = [
+        {"cnpj14": "11222333000181", "razao_social": "ALFA ENGENHARIA", "commercial_state": "NEW"}
+    ]
+    decision = _decision(
+        "11222333000181",
+        "TARGET_CONFIRMED",
+        watermark=source_watermark,
+        evidence_ids=["e1"],
+    )
+
+    out, leads = _export(
+        tmp_path,
+        universe=universe,
+        target_fit=[decision],
+        suffix="canonical-watermark",
+        datalake_watermark=source_watermark,
+    )
+
+    assert leads[0]["target_fit_fresh"] is True
+    assert leads[0]["email_send_ready"] is True
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["source"]["datalake_watermark"] == source_watermark


### PR DESCRIPTION
## Summary

- publish `confenge.outreach.v1` as an authoritative, complete target-fit decision feed for the full CONFENGE universe
- emit explicit ineligible decisions/tombstones for OUT, stale, insufficient, DNC and missing-ICP cases so omission cannot preserve prior authorization
- enforce temporal ordering, complete coverage metadata and non-resurrection semantics
- correct PREVENCAO's CNPJ to `14.893.700/0001-05`
- document the contract in ADR-035 and record the deterministic proof; no campaign send/import was executed

## Verification

- `python3 -m ruff check ...` — pass
- focused target-fit/outreach/activation suite — 25 passed
- broader focused suite — 136 passed, 17 skipped, 1 deselected
- production-store join regression — 12 passed
- scale regression — 1 passed
- JSON Schema Draft 2020-12 validation and deterministic feed proof — pass
- generated-artifacts policy — pass (24 files, 0 violations)
- PR reviewability policy — pass (24 files, 1,293 textual lines, 0 violations)

Named proof cases: PREVENCAO, BEBA MAIS and SULPEL are explicitly ineligible; the confirmed engineering fixture is eligible. The manifest declares 4/4 authoritative coverage, monotonic ordering and `omission_preserves_authorization=false`.

## Local environment observations

- canonical full suite reached 2,864 passed / 98 skipped before an unrelated concurrent-report test hit the repository's real-DB opt-in fixture interaction; that module passes 3/3 with `REQUIRE_REAL_DB=1`
- golden path returned PARTIAL because the local PNCP runtime pointed at unavailable `127.0.0.1:54399` and its freshness input was stale
- CodeRabbit local review could not connect (`WebSocket closed`); no review findings were produced

CI on this exact HEAD is the merge gate.
