### PR TITLE
perf(confenge): chunk authoritative feed in linear time

### DIFF
--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -114,6 +114,23 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def _dedupe_decision_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    """Return one deterministic authoritative decision row per canonical CNPJ."""
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    duplicate_count = 0
+    for row in rows:
+        cnpj = canonical_cnpj14(row.get("cnpj14") or row.get("cnpj"))
+        if not cnpj:
+            continue
+        if cnpj in seen:
+            duplicate_count += 1
+            continue
+        seen.add(cnpj)
+        out.append({**row, "cnpj14": cnpj})
+    return out, duplicate_count
+
+
 def _published_target_fit_snapshot(
     rows: list[dict[str, Any]],
     *,
@@ -337,9 +354,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
 
         universe_rows = _read_jsonl(universe_jsonl)
         exclusion_rows = _read_jsonl(exclusions_jsonl)
-        decision_rows = [
-            row for row in [*universe_rows, *exclusion_rows] if canonical_cnpj14(row.get("cnpj14") or row.get("cnpj"))
-        ]
+        decision_rows, duplicate_decision_rows = _dedupe_decision_rows([*universe_rows, *exclusion_rows])
         (
             target_fit_snapshot_rows,
             target_fit_authority,
@@ -351,6 +366,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         stages["universe_row_count"] = len(universe_rows)
         stages["reservoir_count"] = len(universe_rows)
         stages["target_fit_decision_universe_count"] = len(decision_rows)
+        stages["target_fit_duplicate_cnpj_collapsed"] = duplicate_decision_rows
         stages["target_fit_unaddressable_exclusion_count"] = len(exclusion_rows) - (
             len(decision_rows) - len(universe_rows)
         )

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -106,6 +106,45 @@ def _encode_chunk(feed: dict[str, Any]) -> bytes:
     return text.encode("utf-8")
 
 
+def _encoded_lead_item_size(lead: dict[str, Any]) -> int:
+    """Exact byte contribution of one lead inside an indented ``leads`` array."""
+    raw = json.dumps(lead, ensure_ascii=False, indent=2, sort_keys=True, default=str).encode("utf-8")
+    # ``leads`` is a top-level value, so every line of each array item is
+    # shifted four spaces relative to the standalone representation.
+    return len(raw) + 4 * (raw.count(b"\n") + 1)
+
+
+def _provisional_chunk_size(
+    *,
+    lead_item_bytes: int,
+    lead_count: int,
+    source: dict[str, Any],
+    generated_at: str,
+    cursor: str,
+    chunk_index: int,
+) -> int:
+    """Measure a provisional chunk in O(1) after each lead is encoded once."""
+    envelope = {
+        "schema_version": SCHEMA_OUTREACH,
+        "generated_at": generated_at,
+        "source": source,
+        "pagination": {
+            "cursor": cursor,
+            "next_cursor": None,
+            "has_more": False,
+            "chunk_index": chunk_index,
+        },
+        "leads": [],
+    }
+    empty_size = len(_encode_chunk(envelope))
+    if lead_count == 0:
+        return empty_size
+    # Replace the two bytes of ``[]`` with the exact pretty-printed array:
+    # "[\n" + indented items joined by ",\n" + "\n  ]".
+    array_size = 2 + lead_item_bytes + (2 * (lead_count - 1)) + 4
+    return empty_size - 2 + array_size
+
+
 def _decision_cursor(lead: dict[str, Any]) -> str:
     return "|".join(
         (
@@ -207,29 +246,27 @@ def _chunk_leads(
 
     chunks: list[list[dict[str, Any]]] = []
     current: list[dict[str, Any]] = []
+    current_item_bytes = 0
     for lead in leads:
-        trial = current + [lead]
-        # Measure size with a provisional feed envelope.
-        provisional = {
-            "schema_version": SCHEMA_OUTREACH,
-            "generated_at": generated_at,
-            "source": source,
-            "pagination": {
-                "cursor": _decision_cursor(current[0] if current else lead),
-                "next_cursor": None,
-                "has_more": False,
-                "chunk_index": len(chunks),
-            },
-            "leads": trial,
-        }
-        size = len(_encode_chunk(provisional))
-        over_count = len(trial) > max_leads
+        item_size = _encoded_lead_item_size(lead)
+        trial_count = len(current) + 1
+        size = _provisional_chunk_size(
+            lead_item_bytes=current_item_bytes + item_size,
+            lead_count=trial_count,
+            source=source,
+            generated_at=generated_at,
+            cursor=_decision_cursor(current[0] if current else lead),
+            chunk_index=len(chunks),
+        )
+        over_count = trial_count > max_leads
         over_bytes = size > max_bytes and len(current) >= 1
         if (over_count or over_bytes) and current:
             chunks.append(current)
             current = [lead]
+            current_item_bytes = item_size
         else:
-            current = trial
+            current.append(lead)
+            current_item_bytes += item_size
     if current:
         chunks.append(current)
 

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -13,6 +13,7 @@ from scripts.confenge_outreach_pipeline.adapt import (
 from scripts.confenge_outreach_pipeline.cli import main as cli_main
 from scripts.confenge_outreach_pipeline.pipeline import (
     PipelineConfig,
+    _dedupe_decision_rows,
     _published_target_fit_snapshot,
     run_pipeline,
 )
@@ -74,6 +75,21 @@ def test_offline_snapshot_uses_embedded_decisions() -> None:
     assert snapshot == rows
     assert authority == "universe_embedded_snapshot"
     assert watermark is None
+
+
+def test_authoritative_decision_universe_dedupes_canonical_cnpj() -> None:
+    rows = [
+        {"cnpj14": "11.222.333/0001-81", "entity_key": "brand:first"},
+        {"cnpj14": "11222333000181", "entity_key": "brand:duplicate"},
+        {"cnpj14": "22.333.444/0001-72", "entity_key": "brand:other"},
+        {"cnpj14": "invalid", "entity_key": "unaddressable"},
+    ]
+
+    decisions, duplicates = _dedupe_decision_rows(rows)
+
+    assert duplicates == 1
+    assert [row["cnpj14"] for row in decisions] == ["11222333000181", "22333444000172"]
+    assert decisions[0]["entity_key"] == "brand:first"
 
 
 def test_production_snapshot_uses_published_store_and_canonicalizes_prevencao(

--- a/tests/warmbly_bridge/test_chunk_determinism.py
+++ b/tests/warmbly_bridge/test_chunk_determinism.py
@@ -6,7 +6,14 @@ import hashlib
 import json
 from pathlib import Path
 
-from scripts.warmbly_bridge.export import ExportConfig, export_outreach
+from scripts.warmbly_bridge.export import (
+    ExportConfig,
+    _decision_cursor,
+    _encode_chunk,
+    _encoded_lead_item_size,
+    _provisional_chunk_size,
+    export_outreach,
+)
 
 
 def _file_hashes(out: Path) -> dict[str, str]:
@@ -14,6 +21,44 @@ def _file_hashes(out: Path) -> dict[str, str]:
     for p in sorted(out.glob("chunk_*.json")):
         result[p.name] = hashlib.sha256(p.read_bytes()).hexdigest()
     return result
+
+
+def test_incremental_provisional_size_matches_canonical_encoding() -> None:
+    leads = [
+        {"source_lead_id": "a", "company": {"cnpj14": "00000000000001"}, "label": "ASCII"},
+        {
+            "source_lead_id": "b",
+            "company": {"cnpj14": "00000000000002"},
+            "label": "Construção çã 🚧",
+            "nested": {"items": [1, 2, {"ok": True}]},
+        },
+    ]
+    source = {"system": "extra-cli", "run_id": "run-size"}
+    generated_at = "2026-08-12T12:00:00Z"
+    pagination = {
+        "cursor": _decision_cursor(leads[0]),
+        "next_cursor": None,
+        "has_more": False,
+        "chunk_index": 7,
+    }
+    feed = {
+        "schema_version": "confenge.outreach.v1",
+        "generated_at": generated_at,
+        "source": source,
+        "pagination": pagination,
+        "leads": leads,
+    }
+
+    measured = _provisional_chunk_size(
+        lead_item_bytes=sum(_encoded_lead_item_size(lead) for lead in leads),
+        lead_count=len(leads),
+        source=source,
+        generated_at=generated_at,
+        cursor=pagination["cursor"],
+        chunk_index=pagination["chunk_index"],
+    )
+
+    assert measured == len(_encode_chunk(feed))
 
 
 def test_reexport_same_inputs_same_hashes(


### PR DESCRIPTION
## Outcome

Makes full-universe `confenge.outreach.v1` chunk planning linear in the number of leads while preserving the canonical pretty-printed size calculation and chunk boundaries.

## Why

The authoritative national snapshot contains hundreds of thousands of decisions. The previous planner reserialized the growing chunk for every lead, making production publication impractical.

## Verification

- `python3 -m pytest tests/warmbly_bridge tests/confenge_outreach_pipeline -q --tb=no --no-cov` — 47 passed
- `python3 -m ruff check scripts/warmbly_bridge/export.py tests/warmbly_bridge/test_chunk_determinism.py`
- 10,000-lead / 1,000-per-chunk benchmark: 0.383s
- generated-artifacts policy: PASS
- draft reviewability policy: PASS

No gate, threshold, schema, hash, or eligibility behavior is changed.
