### PR TITLE
fix(confenge): serialize target-fit timestamps as RFC 3339

### DIFF
--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -166,6 +166,19 @@ def _parse_timestamp(value: Any, *, field: str, cnpj: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
+def _rfc3339_timestamp(value: Any, *, field: str, cnpj: str) -> str:
+    """Return the contract timestamp in canonical UTC RFC 3339 form."""
+    return _parse_timestamp(value, field=field, cnpj=cnpj).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_authoritative_timestamps(leads: list[dict[str, Any]]) -> None:
+    """Normalize database datetime strings before schema serialization and hashing."""
+    for lead in leads:
+        cnpj = str((lead.get("company") or {}).get("cnpj14") or "")
+        for field in ("target_fit_source_watermark", "target_fit_computed_at"):
+            lead[field] = _rfc3339_timestamp(lead.get(field), field=field, cnpj=cnpj)
+
+
 def _decision_order_key(lead: dict[str, Any]) -> tuple[datetime, datetime, str, str]:
     cnpj = str((lead.get("company") or {}).get("cnpj14") or "")
     return (
@@ -377,6 +390,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         published_index=published_index,
         datalake_watermark=datalake_watermark,
     )
+    _normalize_authoritative_timestamps(leads)
     leads.sort(key=_decision_order_key)
     if cfg.limit is not None:
         leads = leads[: cfg.limit]

--- a/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
+++ b/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
@@ -273,6 +273,30 @@ def test_freshness_uses_canonical_datalake_watermark_not_export_clock(tmp_path: 
     assert manifest["source"]["datalake_watermark"] == source_watermark
 
 
+def test_database_datetime_strings_are_serialized_as_rfc3339(tmp_path: Path) -> None:
+    database_timestamp = "2026-08-12 12:00:00.123456+00:00"
+    universe = [
+        {"cnpj14": "11222333000181", "razao_social": "ALFA ENGENHARIA", "commercial_state": "NEW"}
+    ]
+    decision = _decision(
+        "11222333000181",
+        "TARGET_CONFIRMED",
+        watermark=database_timestamp,
+        evidence_ids=["e1"],
+    )
+
+    _, leads = _export(
+        tmp_path,
+        universe=universe,
+        target_fit=[decision],
+        suffix="rfc3339-database-timestamp",
+        datalake_watermark=database_timestamp,
+    )
+
+    assert leads[0]["target_fit_computed_at"] == "2026-08-12T12:00:00.123456Z"
+    assert leads[0]["target_fit_source_watermark"] == "2026-08-12T12:00:00.123456Z"
+
+
 def test_cli_exposes_canonical_datalake_watermark() -> None:
     from scripts.warmbly_bridge.cli import build_parser
 


### PR DESCRIPTION
## Outcome

Normalizes authoritative target-fit database timestamps to canonical UTC RFC 3339 before ordering, hashing, and serializing `confenge.outreach.v1` chunks.

## Why

The production PostgreSQL snapshot emits valid timezone-aware timestamps with a space separator. Python accepted them for ordering, but the outreach JSON Schema correctly rejected them as non-RFC-3339. This keeps the feed fail-closed and schema-valid without weakening validation.

## Verification

- `python3 -m pytest tests/warmbly_bridge/test_authoritative_target_fit_feed.py -q` (6 passed)
- `ruff check scripts/warmbly_bridge/export.py tests/warmbly_bridge/test_authoritative_target_fit_feed.py`
- generated-artifacts policy: PASS
- PR reviewability: PASS

No generated production feed data or contact PII is committed.