### PR TITLE
docs(confenge): record authoritative feed publication

### DIFF
--- a/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/HANDOFF.md
+++ b/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/HANDOFF.md
@@ -2,9 +2,10 @@
 
 ## Estado
 
-`IMPLEMENTED_PENDING_MAIN_AND_CI`: o exportador e o pipeline agora distinguem
-hot set de enriquecimento do universo integral de decisões. Nenhum envio,
-import ou habilitação de campanha faz parte desta mudança.
+`OPERATIONALLY_VERIFIED_DOD_ACCEPTANCE_PENDING`: o release integral foi gerado
+pelo extra-cli no `main`, publicado, validado e sincronizado no Warmbly. A
+seleção manual e o envio não foram executados; todos os bloqueios de envio
+continuam ativos. Este estado não marca o item como `ACCEPTED` no `DOD.md`.
 
 ## Contrato operacional
 
@@ -17,6 +18,26 @@ import ou habilitação de campanha faz parte desta mudança.
 - Importação só pode consumir manifest com `coverage_complete=true`,
   `watermarks_monotonic=true` e `omission_preserves_authorization=false`.
 - A seleção strict ESR/piloto isolada é recusada como feed autoritativo.
+- Timestamps de decisão são serializados em UTC RFC 3339 antes de ordenar,
+  calcular hashes e gravar chunks.
+
+## Release operacional
+
+- commit do gerador: `d0ce84741eb12eb115a4bcf73a9fde73d8fd1cfa`;
+- run: `run-0cd4121c646cb6d9`;
+- snapshot: `a6c32643e67bcf2f9a1f3a8147d700a605de5de8934a078ddefb8308e8a03e5f`;
+- manifesto SHA-256: `341052580fe737bb9a70e289825fa56ecd970fefa6c94080ff1332320db2b06a`;
+- universo: 401.923 CNPJs únicos em 402 chunks, sem duplicatas;
+- elegibilidade strict no feed: 32 contas e 32 contatos reais verificáveis;
+- sincronização Warmbly: `completed`, 402/402 chunks e 32 contas elegíveis
+  para seleção manual;
+- manifesto contínuo: `https://159.195.18.88:8443/manifest.json`;
+- release imutável:
+  `https://159.195.18.88:8443/releases/run-0cd4121c646cb6d9-d0ce8474/manifest.json`.
+
+Os 402 hashes de arquivo, os hashes canônicos de `leads+source`, o self-hash
+do manifesto e o schema `confenge.outreach.v1` foram recalculados. Os mesmos
+844.480.022 bytes de chunks foram relidos via HTTPS e comparados ao manifesto.
 
 ## Evidência reproduzível
 
@@ -30,9 +51,11 @@ Os testes comprovam PREVENCAO como `14893700000105`, PREVENCAO e BEBA MAIS
 OUT, SULPEL com evidência insuficiente, DNC/stale/missing inelegíveis e uma
 engenharia `TARGET_CONFIRMED`, fresh e `email_send_ready=true`. Também executam
 as sequências CONFIRMED→OUT e CONFIRMED→omissão, sem ressurreição.
-O resumo carimbado da regeneração, validação do schema e hashes está em
+O resumo sanitizado da regeneração, publicação, sincronização e gates está em
 [`verification.json`](./verification.json).
 
-Chunks operacionais regenerados permanecem fora do Git conforme ADR-020. O
-manifest e os hashes devem corresponder ao mesmo HEAD que passou na CI antes de
-qualquer importação futura.
+Chunks operacionais permanecem fora do Git conforme ADR-020. O release foi
+gerado pelo mesmo `main` que passou na CI. `CONFENGE_AUTO_SEND_ENABLED=false`,
+`CONFENGE_GREEN_AUTORUN_ENABLED=false`, aprovação humana obrigatória,
+`CONFENGE_SENDING_PAUSED=true` e o kill switch durável estavam ativos após o
+sync. Nenhum destinatário foi selecionado e nenhum envio foi disparado.

--- a/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/verification.json
+++ b/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/verification.json
@@ -1,54 +1,69 @@
 {
-  "schema": "confenge.authoritative-outreach-feed-verification.v1",
-  "generated_at": "2026-08-12T12:00:00Z",
-  "generation_scope": "deterministic named-case proof; operational full-universe chunks remain outside Git under ADR-020",
+  "schema": "confenge.authoritative-outreach-feed-verification.v2",
+  "verified_at": "2026-08-13T01:11:56Z",
+  "generation_scope": "operational full-universe release; chunks remain outside Git under ADR-020",
   "source": {
-    "repo_sha": "authoritative-test",
-    "snapshot_hash": "ed7ec4fce6b4d2d89ca1709f891f9f5d6711b5cd1c97b68c4862a2fb90aae3a0"
+    "repo_sha": "d0ce84741eb12eb115a4bcf73a9fde73d8fd1cfa",
+    "run_id": "run-0cd4121c646cb6d9",
+    "snapshot_hash": "a6c32643e67bcf2f9a1f3a8147d700a605de5de8934a078ddefb8308e8a03e5f",
+    "datalake_watermark": "2026-08-12T11:14:38.263297+02:00"
   },
   "manifest": {
-    "manifest_content_hash": "b8b3f41725bbc44b18293a23cac32efaf8c66176b96eb850467349d5687b7f34",
-    "chunk_content_hash": "06c4b59d835b70ab2b3ace604b29b9b5bbe570f4f71bc332280ccfc9c974804c",
-    "declared_universe_count": 4,
-    "full_decision_count": 4,
+    "manifest_sha256": "341052580fe737bb9a70e289825fa56ecd970fefa6c94080ff1332320db2b06a",
+    "manifest_content_hash": "060e1c95c95fd1c1d4dd3dbb604da8c51bc71f35776bad17eeb2b874063300f6",
+    "lead_count": 401923,
+    "unique_cnpj_count": 401923,
+    "duplicate_cnpj_count": 0,
+    "chunk_count": 402,
+    "total_chunk_bytes": 844480022,
+    "declared_universe_count": 401923,
+    "full_decision_count": 401923,
     "coverage_complete": true,
     "watermarks_monotonic": true,
     "omission_preserves_authorization": false,
-    "json_schema_valid": true
+    "manifest_hash_valid": true,
+    "all_chunk_content_hashes_valid": true,
+    "all_chunk_leads_hashes_valid": true,
+    "json_schema_valid": true,
+    "served_https_hashes_valid": true
   },
-  "cases": [
-    {
-      "cnpj14": "14893700000105",
-      "name": "PREVENCAO LABORATORIO DE ANALISES CLINICAS LTDA",
-      "target_fit_class": "TARGET_OUT_OF_SCOPE",
-      "target_fit_fresh": true,
-      "target_fit_send_tier": "OUT_OF_SCOPE",
-      "email_send_ready": false
+  "target_fit": {
+    "required_fields_complete_for_all_leads": true,
+    "class_counts": {
+      "TARGET_CONFIRMED": 8173,
+      "TARGET_FIT_MISSING": 826,
+      "TARGET_INSUFFICIENT_EVIDENCE": 276618,
+      "TARGET_OUT_OF_SCOPE": 92959,
+      "TARGET_PROBABLE_RESEARCH": 23347
     },
-    {
-      "cnpj14": "01607033000167",
-      "name": "BEBA MAIS PIRACICABA DISTRIBUIDORA DE BEBIDAS LTDA",
-      "target_fit_class": "TARGET_OUT_OF_SCOPE",
-      "target_fit_fresh": true,
-      "target_fit_send_tier": "OUT_OF_SCOPE",
-      "email_send_ready": false
-    },
-    {
-      "cnpj14": "01942594000112",
-      "name": "SULPEL INDUSTRIA E COMERCIO DE PAPEIS LTDA",
-      "target_fit_class": "TARGET_INSUFFICIENT_EVIDENCE",
-      "target_fit_fresh": true,
-      "target_fit_send_tier": "RESEARCH_ONLY",
-      "email_send_ready": false
-    },
-    {
-      "cnpj14": "11222333000181",
-      "name": "ALFA CONSTRUTORA E ENGENHARIA LTDA",
-      "target_fit_class": "TARGET_CONFIRMED",
-      "target_fit_fresh": true,
-      "target_fit_send_tier": "A_AUTOMATIC",
-      "email_send_ready": true
-    }
-  ],
-  "dispatch_or_import_performed": false
+    "fresh_count": 4810,
+    "strict_eligible_accounts_in_feed": 32,
+    "strict_ready_contacts_in_feed": 32,
+    "minimum_required": 30
+  },
+  "publication": {
+    "immutable_manifest_url": "https://159.195.18.88:8443/releases/run-0cd4121c646cb6d9-d0ce8474/manifest.json",
+    "continuous_manifest_url": "https://159.195.18.88:8443/manifest.json",
+    "chunks_published_before_manifest": true
+  },
+  "warmbly": {
+    "organization_id": "22222222-0000-0000-0000-000000000001",
+    "sync_status": "completed",
+    "chunks_total": 402,
+    "chunks_imported": 402,
+    "new_run_accounts": 401923,
+    "total_accounts_after_sync": 402012,
+    "strict_eligible_accounts_after_sync": 32,
+    "automatic_worker_noop_verified": true,
+    "last_manifest_uri": "https://159.195.18.88:8443/manifest.json"
+  },
+  "safety": {
+    "auto_send_enabled": false,
+    "green_autorun_enabled": false,
+    "require_human_approval": true,
+    "sending_paused": true,
+    "durable_kill_switch_active": true,
+    "selection_performed": false,
+    "dispatch_performed": false
+  }
 }


### PR DESCRIPTION
## Outcome

Records the sanitized operational proof for the full authoritative CONFENGE outreach feed generated from main, published with valid hashes, and synchronized into Warmbly.

## Evidence captured

- 401,923 unique CNPJs / 402 chunks
- JSON Schema plus manifest, raw chunk, and canonical leads hashes valid
- 32 strictly eligible feed accounts and contacts
- Warmbly sync completed 402/402 and post-sync strict eligibility = 32
- recurring HTTPS worker route verified as same-snapshot noop
- sending remains paused; auto-send and autorun off; human approval and durable kill switch on

No emails, cohort CNPJs, generated chunks, or bulk dumps are committed. The DOD item is not marked accepted.