### PR TITLE
test(quality): lint test subpackages

### DIFF
--- a/tests/bid_readiness/test_bid_readiness_core.py
+++ b/tests/bid_readiness/test_bid_readiness_core.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import zipfile
 from pathlib import Path
 

--- a/tests/bid_readiness/test_integration_edital_acervo.py
+++ b/tests/bid_readiness/test_integration_edital_acervo.py
@@ -213,7 +213,8 @@ def test_evaluate_technical_match_uses_acervo():
 
 def test_pipeline_source_imports_integration():
     import inspect
-    from scripts.bid_readiness import pipeline, match
+
+    from scripts.bid_readiness import match, pipeline
 
     assert "integrate_requirements" in inspect.getsource(pipeline)
     assert "match_technical_via_acervo" in inspect.getsource(match)

--- a/tests/commercial_leads/test_end_to_end_reproducibility.py
+++ b/tests/commercial_leads/test_end_to_end_reproducibility.py
@@ -10,7 +10,7 @@ from scripts.commercial_leads.scoring import (
     diagnose_offer_distribution,
     score_supplier,
 )
-from scripts.commercial_leads.signals import SignalResult, SIGNAL_STATUS_FIRED
+from scripts.commercial_leads.signals import SIGNAL_STATUS_FIRED, SignalResult
 
 
 class _Prof:

--- a/tests/commercial_leads/test_persistence_rollback.py
+++ b/tests/commercial_leads/test_persistence_rollback.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from pathlib import Path
 
 import pytest
 
 from scripts.commercial_leads.pipeline import persist_run
 from scripts.commercial_leads.profile import load_profile
-from pathlib import Path
 
 
 class _BoomCursor:

--- a/tests/commercial_leads/test_scoring_and_exports.py
+++ b/tests/commercial_leads/test_scoring_and_exports.py
@@ -150,6 +150,7 @@ def test_profile_rejects_forbidden_language(tmp_path):
     )
     cat.write_text(f"catalog_version: '1'\nsignals:\n{sigs}", encoding="utf-8")
     import pytest
+
     from scripts.commercial_leads.profile import load_profile
 
     with pytest.raises(ValueError, match="forbidden"):

--- a/tests/commercial_leads/test_sector_fit.py
+++ b/tests/commercial_leads/test_sector_fit.py
@@ -4,19 +4,19 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
+from scripts.commercial_leads.commercial_validity import evaluate_supplier_validity
+from scripts.commercial_leads.geography import classify_geography
 from scripts.commercial_leads.sector_fit import (
     CLASS_CONFIRMED,
+    CLASS_CONFLICTING,
     CLASS_OUT,
     CLASS_POSSIBLE,
     CLASS_STRONG,
     CLASS_UNKNOWN,
-    CLASS_CONFLICTING,
     PUBLISHABLE,
     assert_denominator_invariant,
     classify_supplier_sector_fit,
 )
-from scripts.commercial_leads.commercial_validity import evaluate_supplier_validity
-from scripts.commercial_leads.geography import classify_geography
 
 
 def _ctr(

--- a/tests/commercial_leads/test_sector_fit_properties.py
+++ b/tests/commercial_leads/test_sector_fit_properties.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from datetime import date, timedelta
 
 from scripts.commercial_leads.sector_fit import (
-    CLASS_POSSIBLE,
-    CLASS_STRONG,
     CLASS_CONFIRMED,
     CLASS_OUT,
+    CLASS_POSSIBLE,
+    CLASS_STRONG,
     PUBLISHABLE,
-    classify_supplier_sector_fit,
     assert_denominator_invariant,
+    classify_supplier_sector_fit,
 )
 
 

--- a/tests/commercial_leads/test_snapshot.py
+++ b/tests/commercial_leads/test_snapshot.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-from pathlib import Path
 
 from scripts.commercial_leads.snapshot import validate_snapshot_manifest, write_default_manifest
 
@@ -122,7 +121,6 @@ def test_manifest_missing_canonical_hash_blocked_for_independent_anchor(tmp_path
         ),
         encoding="utf-8",
     )
-    from scripts.commercial_leads.snapshot import bind_snapshot_to_database
 
     r = validate_snapshot_manifest(man, verify_file_hash=True)
     # File hash may validate, but bind without canonical is BLOCKED independent anchor
@@ -240,9 +238,6 @@ def test_post_restore_canonical_mint_not_accepted_as_anchor(tmp_path):
     original = snapmod.compute_canonical_table_hash
     snapmod.compute_canonical_table_hash = fake_compute  # type: ignore[assignment]
     try:
-        # fetch_all will fail without real conn — patch fetch_all too
-        import scripts.commercial_leads.dbutil as dbutil
-
         def fake_fetch(conn, sql, params=None):
             if "COUNT" in sql.upper():
                 return [{"n": 0}]
@@ -250,11 +245,7 @@ def test_post_restore_canonical_mint_not_accepted_as_anchor(tmp_path):
                 return [{"min_d": None, "max_d": None}]
             return []
 
-        orig_fetch = dbutil.fetch_all
-        # bind imports fetch_all inside function from dbutil
-        import scripts.commercial_leads.snapshot as s2
-
-        # Patch at usage site via monkey: replace bind's fetch by wrapping compute only
+        # Patch fetch_all at its usage site and replace bind's compute helper.
         # Use validate path: missing canon → BLOCKED
         class V:
             def as_dict(self):

--- a/tests/commercial_leads/test_validity_gates.py
+++ b/tests/commercial_leads/test_validity_gates.py
@@ -6,8 +6,6 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from scripts.commercial_leads import POPULATION_FULL, POPULATION_SAMPLE, SOURCE_STATE_RESTORED
 from scripts.commercial_leads.isolation import assert_source_state_isolation, mask_dsn
 

--- a/tests/confenge_activation/test_emit_final_closure_pack_gates.py
+++ b/tests/confenge_activation/test_emit_final_closure_pack_gates.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from scripts.confenge_activation.emit_final_closure_pack import (
     assert_pack_postconditions,
     build_sha_binding,

--- a/tests/confenge_contact_resolution/test_provenance_contamination.py
+++ b/tests/confenge_contact_resolution/test_provenance_contamination.py
@@ -511,8 +511,6 @@ def test_export_mapping_allows_real_provenance(tmp_path: Path) -> None:
     universe = [
         {
             "cnpj14": "12345678000199",
-            "company_name": "EMPRESA TARGET ENGENHARIA LTDA",
-            "official_domain": "empresa-target.com.br",
             "outreach_eligibility": "ELIGIBLE",
             "target_fit_class": "TARGET_CONFIRMED",
             "construction_evidence": {

--- a/tests/confenge_process_enrichment/test_national_confirmed_limits.py
+++ b/tests/confenge_process_enrichment/test_national_confirmed_limits.py
@@ -21,13 +21,13 @@ def test_refuse_pilot_sample_as_max_companies(tmp_path) -> None:  # noqa: ANN001
 
 
 def test_terminal_from_process_result_mapping() -> None:
-    from scripts.confenge_process_enrichment.models import TerminalState
-    from scripts.confenge_process_enrichment.national_confirmed import (
-        _terminal_from_process_result,
-    )
     from scripts.confenge_contact_resolution.discovery_state import (
         CONTACT_EXHAUSTED,
         CONTACT_READY,
+    )
+    from scripts.confenge_process_enrichment.models import TerminalState
+    from scripts.confenge_process_enrichment.national_confirmed import (
+        _terminal_from_process_result,
     )
 
     class _R:

--- a/tests/confenge_target_fit/test_downstream_and_concurrency.py
+++ b/tests/confenge_target_fit/test_downstream_and_concurrency.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import UTC, datetime, timedelta
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import UTC, datetime
 
 import pytest
 
@@ -22,7 +22,7 @@ from scripts.confenge_target_fit.config import TargetFitRefreshConfig
 from scripts.confenge_target_fit.db import connect
 from scripts.confenge_target_fit.feed import assert_warmbly_contract, enrich_outreach_row
 from scripts.confenge_target_fit.loader import company_input_from_dict
-from scripts.confenge_target_fit.models import MaterializedTargetFit, TransitionEvent
+from scripts.confenge_target_fit.models import MaterializedTargetFit
 from scripts.confenge_target_fit.store import (
     claim_batch,
     enqueue_dirty,
@@ -30,7 +30,6 @@ from scripts.confenge_target_fit.store import (
     get_current,
     is_send_suppressed,
     publish_materialization,
-    record_downstream_invalidation_soft,
 )
 from scripts.confenge_target_fit.worker import process_one
 from scripts.warmbly_bridge.mapping import map_lead

--- a/tests/confenge_target_fit/test_live_published_join.py
+++ b/tests/confenge_target_fit/test_live_published_join.py
@@ -385,7 +385,6 @@ def test_published_path_exception_fails_closed_not_rescore():
         ]
     }
 
-    import scripts.warmbly_bridge.mapping as mapping_mod
     import scripts.confenge_target_fit.published as pub_mod
 
     real = pub_mod.published_from_row_or_db

--- a/tests/confenge_target_fit/test_store_idempotency.py
+++ b/tests/confenge_target_fit/test_store_idempotency.py
@@ -24,9 +24,9 @@ pytestmark = [
 
 
 def _apply_migration():
-    from pathlib import Path
     import subprocess
     import sys
+    from pathlib import Path
 
     subprocess.check_call(
         [

--- a/tests/predictive/test_claims_and_leakage.py
+++ b/tests/predictive/test_claims_and_leakage.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from scripts.predictive.claims import ClaimRegistry, load_registry
+from scripts.predictive.backtest import run_classification_backtest
+from scripts.predictive.claims import ClaimRegistry
 from scripts.predictive.dataset import (
     build_competitive_winner_dataset,
     build_demand_dataset,
     build_discount_dataset,
 )
-from scripts.predictive.labels import demand_label, is_aec_object, winning_discount, winner_label
+from scripts.predictive.labels import demand_label, is_aec_object, winner_label, winning_discount
 from scripts.predictive.leakage import assert_no_leakage, audit_examples
 from scripts.predictive.metrics import classification_report, evaluate_classification_gates
-from scripts.predictive.backtest import run_classification_backtest
-from scripts.predictive.profile_calibration import list_missing_critical, load_profile, personalization_blockers
-from scripts.lib.bid_simulator import simulate_bid
+from scripts.predictive.profile_calibration import personalization_blockers
 
 
 def test_claim_registry_seven_claims(tmp_path):
@@ -53,7 +52,7 @@ def test_fully_proven_requires_market_trio_production(tmp_path):
 
 
 def test_invalid_demand_negative_rejected():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     lab = demand_label(
         as_of=as_of,
         horizon_days=30,
@@ -65,7 +64,7 @@ def test_invalid_demand_negative_rejected():
 
 
 def test_valid_demand_negative_with_coverage():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     lab = demand_label(
         as_of=as_of,
         horizon_days=30,
@@ -93,7 +92,7 @@ def test_discount_semantics_reject_paid():
 
 
 def test_leakage_fail_closed_winner_feature():
-    as_of = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 6, 1, tzinfo=UTC)
     bad = {
         "example_id": "x1",
         "as_of_at": as_of.isoformat(),
@@ -107,7 +106,7 @@ def test_leakage_fail_closed_winner_feature():
 
 
 def test_leakage_fail_closed_future_event():
-    as_of = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 6, 1, tzinfo=UTC)
     bad = {
         "example_id": "x2",
         "as_of_at": as_of.isoformat(),
@@ -121,7 +120,7 @@ def test_leakage_fail_closed_future_event():
 
 
 def test_demand_dataset_pit_and_no_leak():
-    base = datetime(2022, 1, 1, tzinfo=timezone.utc)
+    base = datetime(2022, 1, 1, tzinfo=UTC)
     contracts = []
     for i in range(24):
         contracts.append(
@@ -156,7 +155,7 @@ def test_demand_dataset_pit_and_no_leak():
 
 
 def test_competitive_dataset_builds():
-    base = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    base = datetime(2021, 1, 1, tzinfo=UTC)
     contracts = []
     for i in range(40):
         contracts.append(
@@ -183,7 +182,7 @@ def test_discount_dataset_data_blocked_when_empty():
 
 
 def test_backtest_runs_on_synthetic_demand():
-    base = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    base = datetime(2020, 1, 1, tzinfo=UTC)
     contracts = []
     for ente in range(5):
         for i in range(36):

--- a/tests/predictive/test_immutability_and_cli.py
+++ b/tests/predictive/test_immutability_and_cli.py
@@ -7,8 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/predictive/test_metrics_and_deps.py
+++ b/tests/predictive/test_metrics_and_deps.py
@@ -19,7 +19,6 @@ from scripts.predictive.metrics import (
     precision_recall_at_threshold,
 )
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/predictive/test_outcomes_and_drift.py
+++ b/tests/predictive/test_outcomes_and_drift.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import json
-
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from scripts.predictive.claims import ClaimRegistry
@@ -19,7 +18,7 @@ from scripts.predictive.weekly_section import build_weekly_predictive_section
 
 
 def test_resolve_demand_positive_with_event():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     pred = {
         "prediction_id": "pred_test_1",
         "target_name": "demand_30d",
@@ -40,7 +39,7 @@ def test_resolve_demand_positive_with_event():
 
 def test_resolve_demand_negative_requires_coverage():
     """Empty events without coverage must NOT become label 0.0."""
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     pred = {
         "prediction_id": "pred_no_cov",
         "target_name": "demand_30d",
@@ -61,7 +60,7 @@ def test_resolve_demand_negative_requires_coverage():
 
 
 def test_resolve_demand_negative_with_explicit_coverage():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     pred = {
         "prediction_id": "pred_cov",
         "target_name": "demand_30d",
@@ -80,7 +79,7 @@ def test_resolve_demand_negative_with_explicit_coverage():
 
 
 def test_resolve_demand_negative_with_weak_nearby_coverage():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     pred = {
         "prediction_id": "pred_weak",
         "target_name": "demand_30d",
@@ -98,7 +97,7 @@ def test_resolve_demand_negative_with_weak_nearby_coverage():
 
 
 def test_resolve_immature_returns_none():
-    as_of = datetime.now(timezone.utc).replace(microsecond=0)
+    as_of = datetime.now(UTC).replace(microsecond=0)
     pred = {
         "prediction_id": "pred_immature",
         "target_name": "demand_30d",
@@ -113,7 +112,7 @@ def test_resolve_immature_returns_none():
 
 
 def test_p2a_resolve_winner_match():
-    as_of = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 6, 1, tzinfo=UTC)
     pred = {
         "prediction_id": "p2a_1",
         "target_name": "competitive_winner_p2a",
@@ -139,7 +138,7 @@ def test_p2a_resolve_winner_match():
 
 
 def test_p2a_resolve_non_winner():
-    as_of = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 6, 1, tzinfo=UTC)
     pred = {
         "prediction_id": "p2a_2",
         "target_name": "competitive_winner_p2a",
@@ -174,7 +173,7 @@ def test_p2a_immature_no_outcome():
 
 
 def test_p2a_rejects_outcome_before_as_of():
-    as_of = datetime(2024, 6, 10, tzinfo=timezone.utc)
+    as_of = datetime(2024, 6, 10, tzinfo=UTC)
     pred = {
         "prediction_id": "p2a_leak",
         "target_name": "competitive_winner_p2a",
@@ -196,7 +195,7 @@ def test_p2a_rejects_outcome_before_as_of():
 
 
 def test_resolve_predictions_routes_p2a_and_demand():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     preds = [
         {
             "prediction_id": "d1",
@@ -238,7 +237,7 @@ def test_resolve_predictions_routes_p2a_and_demand():
 
 
 def test_build_winners_index():
-    as_of = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    as_of = datetime(2024, 1, 1, tzinfo=UTC)
     contracts = [
         {
             "contrato_id": "X1",

--- a/tests/predictive/test_p2a_no_winner_injection.py
+++ b/tests/predictive/test_p2a_no_winner_injection.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from scripts.predictive.dataset import build_competitive_winner_dataset
 
 
 def test_cold_start_winner_not_injected_and_outcome_dropped():
     """New supplier who never won before must not appear via force-include."""
-    base = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    base = datetime(2021, 1, 1, tzinfo=UTC)
     contracts = []
     # Build history with suppliers 0-2 only
     for i in range(30):
@@ -47,7 +47,7 @@ def test_cold_start_winner_not_injected_and_outcome_dropped():
 
 
 def test_known_winner_in_history_still_labeled():
-    base = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    base = datetime(2021, 1, 1, tzinfo=UTC)
     contracts = []
     for i in range(40):
         contracts.append(

--- a/tests/process_documents/test_entity_source_fair_queue.py
+++ b/tests/process_documents/test_entity_source_fair_queue.py
@@ -10,9 +10,9 @@ import pytest
 from scripts.process_documents.entity_queue import (
     EntityQueueEntry,
     SourceQueueEntry,
+    append_dlq_record,
     apply_multi_source_attempt,
     apply_source_attempt_result,
-    append_dlq_record,
     backpressure_allows,
     compute_backoff_hours,
     ensure_entity_source_pairs,

--- a/tests/production_readiness/test_full_scale_and_queue.py
+++ b/tests/production_readiness/test_full_scale_and_queue.py
@@ -82,8 +82,7 @@ def test_process_stream_resume_midway(tmp_path: Path) -> None:
     assert b_partial["final_offset"] == 300
     # continue remaining
     def rest():
-        for row in stream_synthetic_contracts(n, start_offset=300):
-            yield row
+        yield from stream_synthetic_contracts(n, start_offset=300)
 
     b_full = process_stream(
         rest(),

--- a/tests/production_readiness/test_official_sinapi_and_real_case.py
+++ b/tests/production_readiness/test_official_sinapi_and_real_case.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/crawl/test_transformer_esfera.py
+++ b/tests/unit/crawl/test_transformer_esfera.py
@@ -1,5 +1,6 @@
 from scripts.crawl.transformer import transform_pncp_item
 
+
 def _item(esfera):
     return {
         "numeroControlePNCP": "12345678000199-1-000001/2026",

--- a/tests/unit/ops/test_resolve_cnpj14_matriz.py
+++ b/tests/unit/ops/test_resolve_cnpj14_matriz.py
@@ -1,5 +1,5 @@
 """Unit tests for CNPJ-14 matriz resolution (check digits + soft name)."""
-from scripts.ops.resolve_cnpj14_matriz import cnpj14_matriz, soft_name_match, cnpj_check_digits
+from scripts.ops.resolve_cnpj14_matriz import cnpj14_matriz, cnpj_check_digits, soft_name_match
 
 
 def test_known_public_entity_comcap():

--- a/tests/unit/test_pytest_skip_policy.py
+++ b/tests/unit/test_pytest_skip_policy.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from scripts.ops.check_pytest_skip_policy import main, scan_file
 
 


### PR DESCRIPTION
## Summary
- remove 58 Ruff findings from 26 test files in subpackages
- preserve test behavior while removing dead assignments and duplicate effective keys
- modernize UTC aliases and generator delegation

Refs #327

## Validation
- `python3 -m ruff check tests/*/`
- focused changed-file suite: 195 passed, 17 skipped
- CodeRabbit CLI: 0 findings
- governance policies: PASS
- canonical full-suite blocker is pre-existing flake in `test_concurrent_claim_same_company_single_writer`; clean baseline at d0ce8474 reproduced 4 failures / 100 runs; branch diff in that file is imports only