### PR TITLE
refactor(quality): harden DOD controller lint

### DIFF
--- a/squads/extra-dod-roi/scripts/campaign.py
+++ b/squads/extra-dod-roi/scripts/campaign.py
@@ -12,18 +12,21 @@ import argparse
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 SQUAD_DIR = SCRIPT_DIR.parent
+GIT = shutil.which("git")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from dod_ids import normalize_text, stable_dod_id  # noqa: E402
-from parse_dod import parse_dod  # noqa: E402
 from rank_next_cli import run_rank_next  # noqa: E402
 from snapshot_state import repo_root_from  # noqa: E402
 
@@ -32,7 +35,7 @@ DEFAULT_TARGET = 50
 
 
 def utcnow() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def ledger_path(root: Path) -> Path:
@@ -115,15 +118,17 @@ def ensure_baseline(root: Path, target: int) -> dict[str, Any]:
     items = parse_items(text)
     open_items = [x for x in items if not x["checked"]]
     done_items = [x for x in items if x["checked"]]
-    head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    head = subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+        [GIT, "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
     try:
-        main = subprocess.check_output(
-            ["git", "rev-parse", "origin/main"], cwd=root, text=True
+        main = subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+            [GIT, "rev-parse", "origin/main"], cwd=root, text=True
         ).strip()
     except subprocess.CalledProcessError:
         main = None
-    branch = subprocess.check_output(
-        ["git", "branch", "--show-current"], cwd=root, text=True
+    branch = subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+        [GIT, "branch", "--show-current"], cwd=root, text=True
     ).strip()
     ledger = {
         "version": "1.0.0",

--- a/squads/extra-dod-roi/scripts/canonical_count.py
+++ b/squads/extra-dod-roi/scripts/canonical_count.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 import subprocess
+import tempfile
 from collections import Counter
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -29,6 +31,10 @@ from typing import Any
 
 from campaign import parse_items
 from dod_ids import core_requirement_text, normalize_text
+
+GIT = shutil.which("git")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 
 # Evidence types that may support a PASS count
 ACCEPTABLE_EVIDENCE_TYPES = frozenset(
@@ -141,8 +147,8 @@ def utcnow() -> str:
 
 
 def git_head(root: Path) -> str:
-    return subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=root, text=True
+    return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+        [GIT, "rev-parse", "HEAD"], cwd=root, text=True
     ).strip()
 
 
@@ -161,15 +167,15 @@ def _review_head_ok(root: Path, reviewed: str, final_head: str) -> bool:
     if reviewed == final_head:
         return True
     try:
-        merge_base = subprocess.check_output(
-            ["git", "merge-base", reviewed, final_head],
+        merge_base = subprocess.check_output(  # noqa: S603 - git argv, no shell
+            [GIT, "merge-base", reviewed, final_head],
             cwd=root,
             text=True,
         ).strip()
         if merge_base != reviewed:
             return False
-        diff = subprocess.check_output(
-            ["git", "diff", "--name-only", reviewed, final_head],
+        diff = subprocess.check_output(  # noqa: S603 - git argv, no shell
+            [GIT, "diff", "--name-only", reviewed, final_head],
             cwd=root,
             text=True,
         ).strip()
@@ -466,7 +472,13 @@ def validate_row_chain(
     # Artifact existence (repo-relative paths only)
     for ap in item.artifact_paths:
         rel = ap.split(":")[0].strip().strip("`")
-        if not rel or rel.startswith("/tmp") or rel.startswith("/var"):
+        candidate = Path(rel)
+        excluded_roots = (Path(tempfile.gettempdir()).resolve(), Path("/var"))
+        excluded = candidate.is_absolute() and any(
+            candidate == excluded_root or excluded_root in candidate.parents
+            for excluded_root in excluded_roots
+        )
+        if not rel or excluded:
             continue
         if re.match(r"^[\w./-]+$", rel) and ("/" in rel or rel.endswith((".md", ".py", ".json", ".txt", ".sh", ".yml"))):
             p = root / rel

--- a/squads/extra-dod-roi/scripts/cli.py
+++ b/squads/extra-dod-roi/scripts/cli.py
@@ -26,7 +26,7 @@ SQUAD_DIR = SCRIPT_DIR.parent
 
 def run_py(script: str, args: list[str]) -> int:
     cmd = [sys.executable, str(SCRIPT_DIR / script), *args]
-    return subprocess.call(cmd)
+    return subprocess.call(cmd)  # noqa: S603 - sys.executable + in-repo script
 
 
 def cmd_status(_: argparse.Namespace) -> int:

--- a/squads/extra-dod-roi/scripts/cycle_lock.py
+++ b/squads/extra-dod-roi/scripts/cycle_lock.py
@@ -6,8 +6,7 @@ import argparse
 import json
 import os
 import sys
-import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -25,7 +24,7 @@ def acquire(squad_root: Path, owner: str, force: bool = False) -> int:
     payload = {
         "owner": owner,
         "pid": os.getpid(),
-        "acquired_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "acquired_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     lp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     # stderr so force-next --json stays pure on stdout

--- a/squads/extra-dod-roi/scripts/cycle_state.py
+++ b/squads/extra-dod-roi/scripts/cycle_state.py
@@ -7,8 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -66,7 +65,7 @@ ABORT = {
 
 
 def utcnow() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def cycle_path() -> Path:
@@ -153,7 +152,6 @@ def advance(cycle: dict[str, Any], to_phase: str, *, actor: str, evidence: dict[
         )
     cycle["phase"] = to_phase
     # next required
-    idx = PHASES.index(to_phase) if to_phase in PHASES else -1
     if to_phase == "DONE":
         cycle["next_phase_required"] = None
         cycle["status"] = "completed"

--- a/squads/extra-dod-roi/scripts/dod_ids.py
+++ b/squads/extra-dod-roi/scripts/dod_ids.py
@@ -9,7 +9,6 @@ import hashlib
 import re
 from typing import Any
 
-
 _EVIDENCE_SPLIT = re.compile(
     r"\s*(?:Evid[eê]ncia\s*:|Evidence\s*:|`PARTIAL`|PARTIAL\s*[—\-])",
     re.IGNORECASE,
@@ -37,13 +36,13 @@ def normalize_text(body: str) -> str:
 
 def stable_dod_id(section: str, body: str) -> str:
     key = f"{(section or '').strip()}|{normalize_text(body)}"
-    return f"dod:{hashlib.sha1(key.encode('utf-8')).hexdigest()[:12]}"
+    return f"dod:{hashlib.sha1(key.encode('utf-8'), usedforsecurity=False).hexdigest()[:12]}"
 
 
 def slice_id_for_section(section: str, open_ids: list[str]) -> str:
     """Deterministic slice id from section + sorted open item ids."""
     payload = f"{section}|{'|'.join(sorted(open_ids))}"
-    return f"slice:{hashlib.sha1(payload.encode('utf-8')).hexdigest()[:12]}"
+    return f"slice:{hashlib.sha1(payload.encode('utf-8'), usedforsecurity=False).hexdigest()[:12]}"
 
 
 def classify_truth_state(

--- a/squads/extra-dod-roi/scripts/enforce_aiox_path.py
+++ b/squads/extra-dod-roi/scripts/enforce_aiox_path.py
@@ -9,22 +9,26 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import shutil
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 SQUAD_DIR = SCRIPT_DIR.parent
 REPO = SQUAD_DIR.parent.parent  # squads/extra-dod-roi -> repo root
+GIT = shutil.which("git")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 
 sys.path.insert(0, str(SCRIPT_DIR))
 from integration_mode import is_main_direct, load_integration_mode  # noqa: E402
 
 
 def utcnow() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def fail(code: str, message: str, **extra: Any) -> int:
@@ -40,7 +44,9 @@ def ok(message: str, **extra: Any) -> int:
 
 def git(*args: str) -> str:
     try:
-        return subprocess.check_output(["git", *args], cwd=str(REPO), text=True).strip()
+        return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+            [GIT, *args], cwd=str(REPO), text=True
+        ).strip()
     except Exception:
         return ""
 
@@ -73,8 +79,8 @@ def writer_lock_valid() -> tuple[bool, dict[str, Any] | None, str]:
     exp = data.get("expires_at")
     if exp:
         try:
-            dt = datetime.strptime(exp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-            if datetime.now(timezone.utc) > dt:
+            dt = datetime.strptime(exp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+            if datetime.now(UTC) > dt:
                 return False, data, "main-writer.lock expired"
         except ValueError:
             return False, data, "main-writer.lock expires_at invalid"
@@ -98,8 +104,8 @@ def check_stale_rank(rank: dict[str, Any]) -> list[str]:
     if gen:
         try:
             # 2026-07-17T21:34:02Z
-            dt = datetime.strptime(gen, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
-            age_h = (datetime.now(timezone.utc) - dt).total_seconds() / 3600.0
+            dt = datetime.strptime(gen, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+            age_h = (datetime.now(UTC) - dt).total_seconds() / 3600.0
             if age_h > 4:
                 reasons.append(f"ranking age {age_h:.1f}h > 4h")
         except ValueError:

--- a/squads/extra-dod-roi/scripts/force_next.py
+++ b/squads/extra-dod-roi/scripts/force_next.py
@@ -36,13 +36,15 @@ from rank_next_cli import run_rank_next  # noqa: E402
 
 def run(cmd: list[str], *, quiet: bool = False) -> int:
     if quiet:
-        return subprocess.call(
+        return subprocess.call(  # noqa: S603 - internal argv assembled by this CLI
             cmd,
             cwd=str(REPO),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-    return subprocess.call(cmd, cwd=str(REPO))
+    return subprocess.call(  # noqa: S603 - internal argv assembled by this CLI
+        cmd, cwd=str(REPO)
+    )
 
 
 def build_card(

--- a/squads/extra-dod-roi/scripts/graph_build.py
+++ b/squads/extra-dod-roi/scripts/graph_build.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 
@@ -69,7 +69,7 @@ def build_default_graph(context: dict[str, Any] | None = None) -> dict[str, Any]
 
     return {
         "version": "1.0.0",
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "nodes": nodes,
         "edges": edge_objs,
         "critical_path": critical_path,
@@ -84,7 +84,6 @@ def main(argv: list[str] | None = None) -> int:
     graph = build_default_graph()
     text = json.dumps(graph, indent=2, ensure_ascii=False)
     if args.output:
-        Path = __import__("pathlib").Path
         out = Path(args.output)
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(text + "\n", encoding="utf-8")

--- a/squads/extra-dod-roi/scripts/main_writer_lock.py
+++ b/squads/extra-dod-roi/scripts/main_writer_lock.py
@@ -10,7 +10,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +20,7 @@ DEFAULT_TTL_MIN = 120
 
 
 def utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def utcnow_s() -> str:
@@ -33,7 +33,7 @@ def lock_path(squad_root: Path) -> Path:
 
 def _parse_ts(s: str) -> datetime | None:
     try:
-        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
     except (TypeError, ValueError):
         return None
 

--- a/squads/extra-dod-roi/scripts/materialize_aiox_story.py
+++ b/squads/extra-dod-roi/scripts/materialize_aiox_story.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +19,7 @@ REPO = SQUAD_DIR.parent.parent
 
 
 def utcnow() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def slugify(s: str) -> str:
@@ -98,13 +97,13 @@ def build_story_md(
 
     return f"""# Story: {title}
 
-**Story ID:** `{story_id}`  
-**Epic:** EPIC-EXTRA-DOD-ROI (evergreen)  
-**Status:** Draft  
-**Risk level:** **{risk_for_candidate(cand)}**  
-**Source:** squad `extra-dod-roi` force-next (cycle `{cycle_id}`)  
-**Candidate ID:** `{cand.get("id")}`  
-**ROI:** `{cand.get("roi")}`  
+**Story ID:** `{story_id}`<br>
+**Epic:** EPIC-EXTRA-DOD-ROI (evergreen)<br>
+**Status:** Draft<br>
+**Risk level:** **{risk_for_candidate(cand)}**<br>
+**Source:** squad `extra-dod-roi` force-next (cycle `{cycle_id}`)<br>
+**Candidate ID:** `{cand.get("id")}`<br>
+**ROI:** `{cand.get("roi")}`<br>
 **DoD refs:** {dod_refs}
 
 > **FOOL-PROOF BINDING:** This story was materialized exclusively from ranking[0].
@@ -115,8 +114,8 @@ def build_story_md(
 
 ## Story
 
-As **Tiago (operator of Extra Consultoria B2G tooling)**,  
-I want **{cand.get("title")}**,  
+As **Tiago (operator of Extra Consultoria B2G tooling)**,<br>
+I want **{cand.get("title")}**,<br>
 so that **the project advances the highest-ROI unlocked DoD gate without false greens**.
 
 ---

--- a/squads/extra-dod-roi/scripts/parse_dod.py
+++ b/squads/extra-dod-roi/scripts/parse_dod.py
@@ -7,7 +7,7 @@ import hashlib
 import json
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -105,7 +105,7 @@ def parse_dod(path: Path) -> dict[str, Any]:
 
     return {
         "version": "1.0.0",
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "dod_path": str(path),
         "dod_sha256": sha256_file(path),
         "item_count": len(items),

--- a/squads/extra-dod-roi/scripts/rank_next_cli.py
+++ b/squads/extra-dod-roi/scripts/rank_next_cli.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -19,14 +19,14 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 SQUAD_DIR = SCRIPT_DIR.parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from snapshot_state import collect_snapshot, repo_root_from  # noqa: E402
-from parse_dod import parse_dod  # noqa: E402
-from graph_build import build_default_graph  # noqa: E402
-from score_roi import load_weights, rank_candidates  # noqa: E402
 from generate_candidates import (  # noqa: E402
     generate_dynamic_candidates,
     load_campaign_accepted_ids,
 )
+from graph_build import build_default_graph  # noqa: E402
+from parse_dod import parse_dod  # noqa: E402
+from score_roi import load_weights, rank_candidates  # noqa: E402
+from snapshot_state import collect_snapshot, repo_root_from  # noqa: E402
 
 
 def _load_story_state(root: Path, story_id: str) -> dict[str, Any] | None:
@@ -133,7 +133,6 @@ def apply_completion_filters(
             divergences.append(f"Candidate {cand_id} marked COMPLETED: {reason}")
     # Demote dynamic slices whose dod_item_ids are all already accepted/checked
     accepted = load_campaign_accepted_ids(root)
-    matrix_done: set[str] = set()
     # Also demote if every item is already checkbox=true in live matrix (caller may pass)
     for c in candidates:
         if c.get("status") != "UNLOCKED":
@@ -745,7 +744,7 @@ def run_rank_next(
 
     result = {
         "version": "1.0.0",
-        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "mode": "read-only",
         "command": "rank-next",
         "git": snapshot.get("git"),

--- a/squads/extra-dod-roi/scripts/rebuild_campaign_final.py
+++ b/squads/extra-dod-roi/scripts/rebuild_campaign_final.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
 from collections import defaultdict
@@ -18,6 +19,9 @@ from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+GIT = shutil.which("git")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from campaign import load_ledger, parse_items, save_ledger  # noqa: E402
@@ -33,7 +37,7 @@ HEAD: str = ""
 
 
 def run(cmd: list[str], cwd: Path, timeout: int = 120) -> tuple[int, str, str]:
-    p = subprocess.run(
+    p = subprocess.run(  # noqa: S603 - caller supplies controlled argv only
         cmd,
         cwd=cwd,
         capture_output=True,
@@ -44,7 +48,9 @@ def run(cmd: list[str], cwd: Path, timeout: int = 120) -> tuple[int, str, str]:
 
 
 def git_head(root: Path) -> str:
-    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+        [GIT, "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
 
 
 def uncheck_dod(root: Path, item_ids: set[str]) -> int:

--- a/squads/extra-dod-roi/scripts/remediate_skeptic_findings.py
+++ b/squads/extra-dod-roi/scripts/remediate_skeptic_findings.py
@@ -12,14 +12,20 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from collections import Counter, defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+GIT = shutil.which("git")
+GH = shutil.which("gh")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from campaign import load_ledger, parse_items, save_ledger  # noqa: E402
@@ -156,11 +162,13 @@ REPLACEMENTS = [
 
 
 def utcnow() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def git_head(root: Path) -> str:
-    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=root, text=True).strip()
+    return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+        [GIT, "rev-parse", "HEAD"], cwd=root, text=True
+    ).strip()
 
 
 def check_line(root: Path, item_id: str, evidence: str) -> bool:
@@ -179,7 +187,7 @@ def check_line(root: Path, item_id: str, evidence: str) -> bool:
         if not m:
             out.append(line)
             continue
-        indent, mark, body = m.group(1), m.group(2), m.group(3).strip()
+        indent, body = m.group(1), m.group(3).strip()
         sid = stable_dod_id(section, body)
         if sid == item_id:
             core = core_requirement_text(body)
@@ -193,7 +201,10 @@ def check_line(root: Path, item_id: str, evidence: str) -> bool:
 
 
 def run_cmd(cmd: str, root: Path) -> int:
-    r = subprocess.run(cmd, shell=True, cwd=root, capture_output=True, text=True)
+    # Commands are versioned acceptance contracts and intentionally use shell syntax.
+    r = subprocess.run(  # noqa: S602 - intentional versioned command executor
+        cmd, shell=True, cwd=root, capture_output=True, text=True
+    )
     return r.returncode
 
 
@@ -381,16 +392,10 @@ def independent_qa(root: Path, rows: list[dict[str, Any]], head: str) -> dict[st
                 reasons.append("PDF claim proven only via README output/")
         if "constantes de domínio" in text.lower():
             # scan scatter
-            hits = subprocess.run(
-                ["bash", "-lc", "grep -rn 'REQUEST_TIMEOUT\\s*=' scripts/ --include='*.py' | wc -l"],
-                cwd=root,
-                capture_output=True,
-                text=True,
+            n = sum(
+                len(re.findall(r"^\s*REQUEST_TIMEOUT\s*=", path.read_text(encoding="utf-8"), re.MULTILINE))
+                for path in (root / "scripts").rglob("*.py")
             )
-            try:
-                n = int((hits.stdout or "0").strip())
-            except ValueError:
-                n = 0
             if n > 1:
                 verdict = "FAIL"
                 reasons.append(f"REQUEST_TIMEOUT defined in {n} places — not centralized")
@@ -409,7 +414,12 @@ def independent_qa(root: Path, rows: list[dict[str, Any]], head: str) -> dict[st
         # Artifact existence
         for ap in r.get("artifact_paths") or []:
             rel = ap.split(":")[0]
-            if rel and not rel.startswith("/tmp") and "/" in rel:
+            candidate = Path(rel)
+            temp_root = Path(tempfile.gettempdir()).resolve()
+            in_temp = candidate.is_absolute() and (
+                candidate == temp_root or temp_root in candidate.parents
+            )
+            if rel and not in_temp and "/" in rel:
                 if not (root / rel).exists() and not rel.endswith("/"):
                     # dirs may be listed without trailing content
                     if not (root / rel).exists():
@@ -434,8 +444,10 @@ def independent_qa(root: Path, rows: list[dict[str, Any]], head: str) -> dict[st
     # PR body count if available via gh
     pr_body_n = None
     try:
-        out = subprocess.check_output(
-            ["gh", "pr", "view", "24", "--json", "body,title"],
+        if GH is None:
+            raise FileNotFoundError("gh executable not found")
+        out = subprocess.check_output(  # noqa: S603 - fixed resolved gh executable
+            [GH, "pr", "view", "24", "--json", "body,title"],
             cwd=root,
             text=True,
         )
@@ -581,9 +593,6 @@ def main() -> int:
 
     print("== flip replacements ==")
     items = parse_items((root / "DOD.md").read_text(encoding="utf-8"))
-    items_by_norm_section = {
-        (normalize_text(i["text"]), i["section"]): i for i in items
-    }
     new_rows = list(by_id.values())
     existing_ids = {r["dod_item_id"] for r in new_rows}
 

--- a/squads/extra-dod-roi/scripts/snapshot_state.py
+++ b/squads/extra-dod-roi/scripts/snapshot_state.py
@@ -8,10 +8,9 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -30,7 +29,7 @@ def repo_root_from(start: Path | None = None) -> Path:
 
 def run(cmd: list[str], cwd: Path, timeout: int = 60) -> tuple[int, str, str]:
     try:
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: S603 - internal argv, always shell=False
             cmd,
             cwd=str(cwd),
             capture_output=True,
@@ -63,7 +62,7 @@ def list_dir_names(path: Path, limit: int = 200) -> list[str]:
 
 
 def collect_snapshot(root: Path, fetch_remote: bool = False) -> dict[str, Any]:
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     snap: dict[str, Any] = {
         "version": "1.0.0",
         "generated_at": now,

--- a/squads/extra-dod-roi/scripts/stale_detect.py
+++ b/squads/extra-dod-roi/scripts/stale_detect.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import shutil
 import subprocess
-import sys
 from pathlib import Path
+
+GIT = shutil.which("git")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 
 
 def sha256_file(path: Path) -> str | None:
@@ -18,7 +22,9 @@ def sha256_file(path: Path) -> str | None:
 
 def git(root: Path, *args: str) -> str:
     try:
-        return subprocess.check_output(["git", *args], cwd=str(root), text=True).strip()
+        return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+            [GIT, *args], cwd=str(root), text=True
+        ).strip()
     except Exception:
         return ""
 

--- a/squads/extra-dod-roi/scripts/validate_state.py
+++ b/squads/extra-dod-roi/scripts/validate_state.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 
 

--- a/squads/extra-dod-roi/tests/test_audit_matrix.py
+++ b/squads/extra-dod-roi/tests/test_audit_matrix.py
@@ -375,8 +375,8 @@ class SkepticRemediationGuards(unittest.TestCase):
 
     def test_len_gt_100_rejected_for_semantic_claim(self) -> None:
         """validate_row_chain must reject len(t)>100 as sole proof of semantic claim."""
-        from canonical_count import validate_row_chain  # noqa: WPS433
         from campaign import load_ledger  # noqa: WPS433
+        from canonical_count import validate_row_chain  # noqa: WPS433
 
         ledger = load_ledger(ROOT)
         baseline_open = set((ledger.get("baseline") or {}).get("open_ids") or [])

--- a/squads/extra-dod-roi/tests/test_campaign_guards.py
+++ b/squads/extra-dod-roi/tests/test_campaign_guards.py
@@ -7,19 +7,17 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "squads" / "extra-dod-roi" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from campaign import (  # noqa: E402
-    ensure_baseline,
+    parse_items,
     reconstruct_accepted_from_diff,
     register_acceptance,
     validate_evidence_quality,
     validate_guards,
-    parse_items,
 )
 from dod_ids import stable_dod_id  # noqa: E402
 from generate_candidates import generate_dynamic_candidates  # noqa: E402
@@ -125,7 +123,6 @@ class CampaignGuards(unittest.TestCase):
             # broken on purpose: same text can't be both; use proper file
             (root / "DOD.md").write_text("# S\n- [x] Open item one.\n", encoding="utf-8")
             # build ledger manually with open baseline
-            from campaign import save_ledger, utcnow
 
             items = parse_items("# S\n- [ ] Open item one.\n")
             open_id = items[0]["id"]

--- a/squads/extra-dod-roi/tests/test_completion_filter.py
+++ b/squads/extra-dod-roi/tests/test_completion_filter.py
@@ -11,8 +11,8 @@ SCRIPTS = ROOT / "squads" / "extra-dod-roi" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from rank_next_cli import (  # noqa: E402
-    apply_completion_filters,
     _story_done,
+    apply_completion_filters,
 )
 
 

--- a/squads/extra-dod-roi/tests/test_main_direct.py
+++ b/squads/extra-dod-roi/tests/test_main_direct.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -11,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS = ROOT / "squads" / "extra-dod-roi" / "scripts"
 SQUAD = ROOT / "squads" / "extra-dod-roi"
+GIT = shutil.which("git")
 
 
 class MainDirectModeTests(unittest.TestCase):
@@ -26,7 +28,7 @@ class MainDirectModeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             squad = Path(td)
             (squad / "state" / "locks").mkdir(parents=True)
-            proc = subprocess.run(
+            proc = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
                 [
                     sys.executable,
                     str(SCRIPTS / "main_writer_lock.py"),
@@ -48,7 +50,7 @@ class MainDirectModeTests(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
-            st = subprocess.run(
+            st = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
                 [
                     sys.executable,
                     str(SCRIPTS / "main_writer_lock.py"),
@@ -67,7 +69,7 @@ class MainDirectModeTests(unittest.TestCase):
             self.assertEqual(data["lock"]["task"], "test-task")
             self.assertIn("intended_files", data["lock"])
             # second acquire without force fails
-            proc2 = subprocess.run(
+            proc2 = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
                 [
                     sys.executable,
                     str(SCRIPTS / "main_writer_lock.py"),
@@ -87,7 +89,7 @@ class MainDirectModeTests(unittest.TestCase):
             self.assertEqual(proc2.returncode, 1)
             self.assertIn("LOCK_HELD", proc2.stdout)
             # release
-            rel = subprocess.run(
+            rel = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
                 [
                     sys.executable,
                     str(SCRIPTS / "main_writer_lock.py"),
@@ -102,7 +104,7 @@ class MainDirectModeTests(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(rel.returncode, 0, rel.stdout + rel.stderr)
-            st2 = subprocess.run(
+            st2 = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
                 [
                     sys.executable,
                     str(SCRIPTS / "main_writer_lock.py"),
@@ -118,15 +120,17 @@ class MainDirectModeTests(unittest.TestCase):
             self.assertFalse(json.loads(st2.stdout).get("held"))
 
     def test_enforce_implement_on_main_requires_writer_lock(self):
-        branch = subprocess.check_output(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=str(ROOT), text=True
+        if GIT is None:
+            self.skipTest("git executable unavailable")
+        branch = subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+            [GIT, "rev-parse", "--abbrev-ref", "HEAD"], cwd=str(ROOT), text=True
         ).strip()
         if branch != "main":
             self.skipTest("main-direct implement gate tested on main only")
         lock = SQUAD / "state" / "locks" / "main-writer.lock"
         if lock.exists():
             lock.unlink()
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
             [sys.executable, str(SCRIPTS / "enforce_aiox_path.py"), "implement"],
             cwd=str(ROOT),
             capture_output=True,

--- a/squads/extra-dod-roi/tests/test_squad_smoke.py
+++ b/squads/extra-dod-roi/tests/test_squad_smoke.py
@@ -91,7 +91,7 @@ class SquadSmoke(unittest.TestCase):
                 },
             ]
         }
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
             [sys.executable, str(SCRIPTS / "score_roi.py"), "--input", "-", "--weights", str(SQUAD / "data" / "roi-weights.yaml")],
             input=json.dumps(payload),
             text=True,
@@ -105,7 +105,7 @@ class SquadSmoke(unittest.TestCase):
         self.assertGreater(data["candidates"][0]["roi"], data["candidates"][1]["roi"])
 
     def test_parse_dod_summary(self):
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
             [sys.executable, str(SCRIPTS / "parse_dod.py"), "--summary-only"],
             cwd=str(ROOT),
             capture_output=True,
@@ -118,7 +118,7 @@ class SquadSmoke(unittest.TestCase):
         self.assertIn("dod_sha256", data)
 
     def test_snapshot_and_rank(self):
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
             [sys.executable, str(SCRIPTS / "rank_next_cli.py"), "--top", "5", "--json"],
             cwd=str(ROOT),
             capture_output=True,
@@ -149,7 +149,7 @@ class FoolproofEnforcement(unittest.TestCase):
     def test_implement_gate_is_fail_closed_or_allows_active_cycle(self):
         # When a foolproof cycle is STORY_READY/IMPLEMENTING on a non-main branch,
         # implement is allowed. Otherwise the gate must fail closed with a known code.
-        proc = subprocess.run(
+        proc = subprocess.run(  # noqa: S603 - sys.executable + in-repo script
             [sys.executable, str(SCRIPTS / "enforce_aiox_path.py"), "implement"],
             cwd=str(ROOT),
             capture_output=True,
@@ -191,7 +191,8 @@ class FoolproofEnforcement(unittest.TestCase):
         from importlib.util import module_from_spec, spec_from_file_location
 
         spec = spec_from_file_location("cycle_state", SCRIPTS / "cycle_state.py")
-        assert spec and spec.loader
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
         mod = module_from_spec(spec)
         spec.loader.exec_module(mod)
         # INIT cannot jump to IMPLEMENTING

--- a/tools/dod_controller.py
+++ b/tools/dod_controller.py
@@ -13,18 +13,23 @@ import argparse
 import hashlib
 import json
 import re
+import shlex
+import shutil
 import sys
 import unicodedata
 from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 try:
     import yaml
 except ImportError:  # pragma: no cover
     yaml = None  # type: ignore[assignment]
+
+GIT = shutil.which("git")
 
 ROOT = Path(__file__).resolve().parents[1]
 DOD_PATH = ROOT / "DOD.md"
@@ -163,12 +168,12 @@ _FULL_SUITE_HINTS = (
 
 
 def utc_now() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace(
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace(
         "+00:00", "Z"
     )
 
 
-class ControllerExit(Exception):
+class ControllerError(Exception):
     """Controlled non-zero exit for CLI commands (testable without SystemExit)."""
 
     def __init__(self, message: str, code: int = 1) -> None:
@@ -179,7 +184,7 @@ class ControllerExit(Exception):
 
 def die(msg: str, code: int = 1) -> None:
     print(f"ERROR: {msg}", file=sys.stderr)
-    raise ControllerExit(msg, code)
+    raise ControllerError(msg, code)
 
 
 def require_yaml() -> Any:
@@ -1244,6 +1249,10 @@ def cmd_verify(args: argparse.Namespace) -> int:
     if not item:
         die(f"unknown item: {item_id}", 2)
 
+    head = _git_head()
+    if head is None:
+        die("git HEAD unavailable; refusing to write verification evidence")
+
     pack = EVIDENCE_DIR / item_id
     pack.mkdir(parents=True, exist_ok=True)
     criteria_path = pack / "acceptance_criteria.md"
@@ -1254,7 +1263,6 @@ def cmd_verify(args: argparse.Namespace) -> int:
             "acceptance_criteria.md is rejected)"
         )
 
-    head = _git_head()
     results: dict[str, Any] = {
         "item_id": item_id,
         "commands": [],
@@ -1308,7 +1316,8 @@ def cmd_verify(args: argparse.Namespace) -> int:
             continue
         c0 = time.monotonic()
         try:
-            proc = subprocess.run(
+            # Acceptance commands are versioned shell contracts and may use pipes.
+            proc = subprocess.run(  # noqa: S602 - intentional command-contract executor
                 cmd,
                 shell=True,
                 cwd=str(ROOT),
@@ -1352,9 +1361,10 @@ def cmd_verify(args: argparse.Namespace) -> int:
 
     for test in raw_tests:
         c0 = time.monotonic()
+        test_argv = [sys.executable, "-m", "pytest", test, "-q", "--tb=line"]
         try:
-            proc = subprocess.run(
-                ["python3", "-m", "pytest", test, "-q", "--tb=line"],
+            proc = subprocess.run(  # noqa: S603 - fixed interpreter and pytest module
+                test_argv,
                 cwd=str(ROOT),
                 capture_output=True,
                 text=True,
@@ -1364,7 +1374,7 @@ def cmd_verify(args: argparse.Namespace) -> int:
             counts = parse_pytest_counts(proc.stdout, proc.stderr)
             entry = {
                 "test": test,
-                "cmd": f"python3 -m pytest {test} -q --tb=line",
+                "cmd": shlex.join(test_argv),
                 "exit_code": proc.returncode,
                 "duration_s": duration,
                 "stdout_tail": proc.stdout[-500:],
@@ -2070,9 +2080,11 @@ def cmd_report(args: argparse.Namespace) -> int:
 def _git_head() -> str | None:
     import subprocess
 
+    if GIT is None:
+        return None
     try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], cwd=str(ROOT), text=True
+        return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+            [GIT, "rev-parse", "HEAD"], cwd=str(ROOT), text=True
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
@@ -2081,9 +2093,11 @@ def _git_head() -> str | None:
 def _git_branch() -> str:
     import subprocess
 
+    if GIT is None:
+        return "unknown"
     try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=str(ROOT), text=True
+        return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+            [GIT, "rev-parse", "--abbrev-ref", "HEAD"], cwd=str(ROOT), text=True
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return "unknown"
@@ -2239,7 +2253,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         args = parser.parse_args(argv)
         return int(args.func(args))
-    except ControllerExit as exc:
+    except ControllerError as exc:
         return int(exc.code)
 
 


### PR DESCRIPTION
## Summary

Third sequential wave for #327. Eliminates all 93 Ruff findings in the DOD controller and `extra-dod-roi` squad while preserving the two intentional versioned shell command executors with narrow, documented `S602` suppressions. Resolves executables, uses `sys.executable`, replaces the Bash count pipeline with Python traversal, makes temp-root checks portable and component-aware, preserves SHA-1 identifiers with `usedforsecurity=False`, and renames `ControllerExit` to `ControllerError`.

## Validation

- `python3 -m ruff check squads/extra-dod-roi tools/dod_controller.py`: PASS
- controller tests: 19 passed
- remaining squad suite: 79 passed, 1 skipped, excluding two preexisting stale governance assertions (canonical ledger count 50 vs reconstructed 0; historical workflow-dispatch-only assertion after Test All became mandatory)
- CodeRabbit review findings addressed
- generated-artifacts policy: PASS
- PR reviewability policy: PASS

Refs #327