### PR TITLE
build(quality): enforce repository-wide Ruff gate

### DIFF
--- a/.agents/skills/reversa-highcharts-visualizer/scripts/sample_data.py
+++ b/.agents/skills/reversa-highcharts-visualizer/scripts/sample_data.py
@@ -17,9 +17,11 @@ Saída:
 
 import argparse
 import json
-import random
 import sys
 from datetime import datetime, timedelta
+from random import SystemRandom
+
+RNG = SystemRandom()
 
 
 def sample_line(months: int = 12, series_count: int = 2) -> dict:
@@ -27,8 +29,8 @@ def sample_line(months: int = 12, series_count: int = 2) -> dict:
     months_list = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"][:months]
     series = []
     for i in range(series_count):
-        base = random.randint(50, 200)
-        data = [round(base + random.gauss(0, 20) + j * random.uniform(-2, 5), 1) for j in range(months)]
+        base = RNG.randint(50, 200)
+        data = [round(base + RNG.gauss(0, 20) + j * RNG.uniform(-2, 5), 1) for j in range(months)]
         series.append({"name": f"Série {chr(65 + i)}", "data": data})
     return {"categories": months_list, "series": series, "suggested_type": "line"}
 
@@ -38,7 +40,7 @@ def sample_column(categories: int = 6, series_count: int = 2) -> dict:
     cats = [f"Categoria {chr(65 + i)}" for i in range(categories)]
     series = []
     for i in range(series_count):
-        data = [random.randint(20, 150) for _ in range(categories)]
+        data = [RNG.randint(20, 150) for _ in range(categories)]
         series.append({"name": f"Grupo {i + 1}", "data": data})
     return {"categories": cats, "series": series, "suggested_type": "column"}
 
@@ -46,7 +48,7 @@ def sample_column(categories: int = 6, series_count: int = 2) -> dict:
 def sample_pie(items: int = 6) -> dict:
     """Dados de exemplo para pie/donut chart."""
     names = ["Tecnologia", "Saúde", "Finanças", "Educação", "Varejo", "Indústria", "Energia", "Transporte"][:items]
-    values = [random.randint(5, 35) for _ in range(items)]
+    values = [RNG.randint(5, 35) for _ in range(items)]
     total = sum(values)
     data = [{"name": n, "y": round(v / total * 100, 1)} for n, v in zip(names, values)]
     # Destacar o maior
@@ -58,8 +60,8 @@ def sample_pie(items: int = 6) -> dict:
 
 def sample_scatter(points: int = 50) -> dict:
     """Dados de exemplo para scatter chart."""
-    data_a = [[round(random.gauss(5, 2), 1), round(random.gauss(5, 2), 1)] for _ in range(points)]
-    data_b = [[round(random.gauss(8, 1.5), 1), round(random.gauss(3, 1.5), 1)] for _ in range(points)]
+    data_a = [[round(RNG.gauss(5, 2), 1), round(RNG.gauss(5, 2), 1)] for _ in range(points)]
+    data_b = [[round(RNG.gauss(8, 1.5), 1), round(RNG.gauss(3, 1.5), 1)] for _ in range(points)]
     return {
         "series": [{"name": "Grupo A", "data": data_a}, {"name": "Grupo B", "data": data_b}],
         "suggested_type": "scatter",
@@ -70,7 +72,7 @@ def sample_heatmap(rows: int = 7, cols: int = 12) -> dict:
     """Dados de exemplo para heatmap."""
     row_cats = ["Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"][:rows]
     col_cats = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"][:cols]
-    data = [[x, y, random.randint(0, 100)] for x in range(cols) for y in range(rows)]
+    data = [[x, y, RNG.randint(0, 100)] for x in range(cols) for y in range(rows)]
     return {"xCategories": col_cats, "yCategories": row_cats, "series": [{"data": data}], "suggested_type": "heatmap"}
 
 
@@ -92,7 +94,7 @@ def sample_sankey() -> dict:
 
 def sample_gauge(value: float = None) -> dict:
     """Dados de exemplo para gauge/solid gauge."""
-    val = value or round(random.uniform(30, 95), 1)
+    val = value or round(RNG.uniform(30, 95), 1)
     return {"series": [{"name": "Performance", "data": [val]}], "suggested_type": "solidgauge", "min": 0, "max": 100}
 
 
@@ -120,13 +122,13 @@ def sample_stock(days: int = 365) -> dict:
         date = start + timedelta(days=i)
         if date.weekday() >= 5:
             continue
-        o = round(price + random.gauss(0, 2), 2)
-        h = round(o + abs(random.gauss(0, 3)), 2)
-        l = round(o - abs(random.gauss(0, 3)), 2)
-        c = round(random.uniform(l, h), 2)
-        price = c
+        open_price = round(price + RNG.gauss(0, 2), 2)
+        high_price = round(open_price + abs(RNG.gauss(0, 3)), 2)
+        low_price = round(open_price - abs(RNG.gauss(0, 3)), 2)
+        close_price = round(RNG.uniform(low_price, high_price), 2)
+        price = close_price
         ts = int(date.timestamp() * 1000)
-        data.append([ts, o, h, l, c])
+        data.append([ts, open_price, high_price, low_price, close_price])
     return {"series": [{"type": "candlestick", "name": "ACME", "data": data}], "suggested_type": "stock"}
 
 

--- a/.agents/skills/reversa-highcharts-visualizer/scripts/sample_data.py
+++ b/.agents/skills/reversa-highcharts-visualizer/scripts/sample_data.py
@@ -18,7 +18,7 @@ Saída:
 import argparse
 import json
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from random import SystemRandom
 
 RNG = SystemRandom()
@@ -94,7 +94,7 @@ def sample_sankey() -> dict:
 
 def sample_gauge(value: float = None) -> dict:
     """Dados de exemplo para gauge/solid gauge."""
-    val = value or round(RNG.uniform(30, 95), 1)
+    val = value if value is not None else round(RNG.uniform(30, 95), 1)
     return {"series": [{"name": "Performance", "data": [val]}], "suggested_type": "solidgauge", "min": 0, "max": 100}
 
 
@@ -115,7 +115,7 @@ def sample_treemap() -> dict:
 
 def sample_stock(days: int = 365) -> dict:
     """Dados de exemplo para stock chart (OHLC)."""
-    start = datetime(2024, 1, 1)
+    start = datetime(2024, 1, 1, tzinfo=UTC)
     price = 150.0
     data = []
     for i in range(days):

--- a/.aiox-core/monitor/hooks/lib/send_event.py
+++ b/.aiox-core/monitor/hooks/lib/send_event.py
@@ -18,9 +18,16 @@ TIMEOUT_MS = int(os.environ.get("AIOX_MONITOR_TIMEOUT_MS", "500"))
 def validated_server_url(value: str) -> str | None:
     """Return a normalized HTTP(S) monitor URL, or None for unsafe input."""
     parsed = urllib.parse.urlsplit(value)
-    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.query
+        or parsed.fragment
+    ):
         return None
-    return value.rstrip("/")
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", "")
+    )
 
 
 def send_event(event_type: str, data: dict[str, Any]) -> bool:

--- a/.aiox-core/monitor/hooks/lib/send_event.py
+++ b/.aiox-core/monitor/hooks/lib/send_event.py
@@ -7,11 +7,20 @@ Non-blocking with short timeout to avoid slowing Claude.
 import json
 import os
 import time
+import urllib.parse
 import urllib.request
 from typing import Any
 
 SERVER_URL = os.environ.get("AIOX_MONITOR_URL", "http://localhost:4001")
 TIMEOUT_MS = int(os.environ.get("AIOX_MONITOR_TIMEOUT_MS", "500"))
+
+
+def validated_server_url(value: str) -> str | None:
+    """Return a normalized HTTP(S) monitor URL, or None for unsafe input."""
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    return value.rstrip("/")
 
 
 def send_event(event_type: str, data: dict[str, Any]) -> bool:
@@ -26,20 +35,25 @@ def send_event(event_type: str, data: dict[str, Any]) -> bool:
         True if sent successfully, False otherwise
     """
     try:
+        server_url = validated_server_url(SERVER_URL)
+        if server_url is None:
+            return False
         payload = json.dumps({
             "type": event_type,
             "timestamp": int(time.time() * 1000),
             "data": data
         }).encode("utf-8")
 
-        req = urllib.request.Request(
-            f"{SERVER_URL}/events",
+        req = urllib.request.Request(  # noqa: S310 - validated HTTP(S) URL with hostname
+            f"{server_url}/events",
             data=payload,
             headers={"Content-Type": "application/json"},
             method="POST"
         )
 
-        urllib.request.urlopen(req, timeout=TIMEOUT_MS / 1000)
+        urllib.request.urlopen(  # noqa: S310 - request URL validated above
+            req, timeout=TIMEOUT_MS / 1000
+        )
         return True
 
     except Exception:

--- a/.aiox-core/monitor/hooks/notification.py
+++ b/.aiox-core/monitor/hooks/notification.py
@@ -4,14 +4,14 @@ Notification hook - captures Claude notifications.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.aiox-core/monitor/hooks/post_tool_use.py
+++ b/.aiox-core/monitor/hooks/post_tool_use.py
@@ -7,14 +7,14 @@ Most important for tracking what actually happened.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.aiox-core/monitor/hooks/pre_compact.py
+++ b/.aiox-core/monitor/hooks/pre_compact.py
@@ -4,14 +4,14 @@ PreCompact hook - captures before context compaction.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.aiox-core/monitor/hooks/pre_tool_use.py
+++ b/.aiox-core/monitor/hooks/pre_tool_use.py
@@ -7,14 +7,14 @@ Use this to see what tools are being invoked and their inputs.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.aiox-core/monitor/hooks/stop.py
+++ b/.aiox-core/monitor/hooks/stop.py
@@ -4,14 +4,14 @@ Stop hook - captures when Claude stops execution.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.aiox-core/monitor/hooks/subagent_stop.py
+++ b/.aiox-core/monitor/hooks/subagent_stop.py
@@ -4,14 +4,14 @@ SubagentStop hook - captures when a subagent (Task tool) stops.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.aiox-core/monitor/hooks/user_prompt_submit.py
+++ b/.aiox-core/monitor/hooks/user_prompt_submit.py
@@ -6,14 +6,14 @@ This is the starting point of each interaction.
 """
 
 import json
-import sys
 import os
+import sys
 
 # Add lib to path
 sys.path.insert(0, os.path.dirname(__file__))
 
-from lib.send_event import send_event
 from lib.enrich import enrich_event
+from lib.send_event import send_event
 
 
 def main():

--- a/.claude/skills/architect-first/scripts/architecture_validator.py
+++ b/.claude/skills/architect-first/scripts/architecture_validator.py
@@ -9,12 +9,10 @@ Usage:
     python architecture_validator.py [--path ARCH_DOC_PATH]
 """
 
-import os
-import sys
 import argparse
 import re
+import sys
 from pathlib import Path
-from typing import List, Dict, Set, Tuple
 
 
 class ValidationIssue:
@@ -38,7 +36,7 @@ class ArchitectureValidator:
     def __init__(self, doc_path: Path):
         self.doc_path = doc_path
         self.content = ""
-        self.issues: List[ValidationIssue] = []
+        self.issues: list[ValidationIssue] = []
 
         # Required sections in architecture doc
         self.required_sections = [
@@ -62,7 +60,7 @@ class ArchitectureValidator:
     def _load_document(self) -> bool:
         """Load architecture document"""
         try:
-            with open(self.doc_path, "r", encoding="utf-8") as f:
+            with open(self.doc_path, encoding="utf-8") as f:
                 self.content = f.read()
             return True
         except Exception as e:
@@ -208,14 +206,6 @@ class ArchitectureValidator:
 
     def _check_integration_points(self):
         """Check integration points documentation"""
-        integration_keywords = [
-            "integration",
-            "api",
-            "interface",
-            "endpoint",
-            "external",
-        ]
-
         integration_match = re.search(
             r"#{1,3}\s+Integration.*?\n(.*?)(?=\n#{1,3}|\Z)",
             self.content,

--- a/.claude/skills/architect-first/scripts/check_coupling.py
+++ b/.claude/skills/architect-first/scripts/check_coupling.py
@@ -11,12 +11,11 @@ Usage:
     python check_coupling.py [--path PROJECT_PATH] [--config CONFIG_FILE]
 """
 
-import os
+import argparse
 import re
 import sys
-import argparse
 from pathlib import Path
-from typing import List, Dict, Set, Tuple
+
 import yaml
 
 
@@ -50,7 +49,7 @@ class CouplingChecker:
 
     def __init__(self, project_path: Path, config_path: Path = None):
         self.project_path = project_path
-        self.violations: List[CouplingViolation] = []
+        self.violations: list[CouplingViolation] = []
         self.config = self._load_config(config_path)
 
         # Modules to check for coupling (from config or defaults)
@@ -81,16 +80,16 @@ class CouplingChecker:
             ],
         )
 
-    def _load_config(self, config_path: Path = None) -> Dict:
+    def _load_config(self, config_path: Path = None) -> dict:
         """Load configuration file if exists"""
         if config_path and config_path.exists():
-            with open(config_path, "r") as f:
+            with open(config_path) as f:
                 return yaml.safe_load(f) or {}
 
         # Try default config location
         default_config = self.project_path / ".coupling-check.yaml"
         if default_config.exists():
-            with open(default_config, "r") as f:
+            with open(default_config) as f:
                 return yaml.safe_load(f) or {}
 
         return {}
@@ -103,7 +102,7 @@ class CouplingChecker:
                 return True
         return False
 
-    def _find_files_to_scan(self) -> List[Path]:
+    def _find_files_to_scan(self) -> list[Path]:
         """Find all files to scan for coupling violations"""
         files = []
         for pattern in self.file_patterns:
@@ -208,7 +207,7 @@ class CouplingChecker:
     def check_file(self, file_path: Path):
         """Check a single file for coupling violations"""
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
+            with open(file_path, encoding="utf-8") as f:
                 content = f.read()
 
             self._check_hardcoded_imports(file_path, content)
@@ -244,7 +243,7 @@ class CouplingChecker:
         print(f"❌ Found {len(self.violations)} coupling violation(s):")
 
         # Group violations by type
-        by_type: Dict[str, List[CouplingViolation]] = {}
+        by_type: dict[str, list[CouplingViolation]] = {}
         for violation in self.violations:
             if violation.violation_type not in by_type:
                 by_type[violation.violation_type] = []

--- a/.claude/skills/architect-first/scripts/validate_risk_mitigation.py
+++ b/.claude/skills/architect-first/scripts/validate_risk_mitigation.py
@@ -9,12 +9,11 @@ Usage:
     python validate_risk_mitigation.py [--path PROJECT_PATH] [--risks RISKS_FILE]
 """
 
-import os
-import sys
 import argparse
 import re
+import sys
 from pathlib import Path
-from typing import List, Dict, Tuple
+
 import yaml
 
 
@@ -44,10 +43,10 @@ class RiskMitigationValidator:
     def __init__(self, project_path: Path, risks_file: Path = None):
         self.project_path = project_path
         self.risks_file = risks_file
-        self.risks: List[Risk] = []
-        self.mitigation_docs: Dict[str, str] = {}
+        self.risks: list[Risk] = []
+        self.mitigation_docs: dict[str, str] = {}
 
-    def _find_risk_documents(self) -> List[Path]:
+    def _find_risk_documents(self) -> list[Path]:
         """Find all documents that might contain risks"""
         risk_doc_patterns = [
             "**/architecture/*.md",
@@ -66,7 +65,7 @@ class RiskMitigationValidator:
     def _extract_risks_from_doc(self, doc_path: Path):
         """Extract risks from a document"""
         try:
-            with open(doc_path, "r", encoding="utf-8") as f:
+            with open(doc_path, encoding="utf-8") as f:
                 content = f.read()
 
             # Look for risk sections
@@ -91,7 +90,7 @@ class RiskMitigationValidator:
     def _parse_risks_from_text(self, text: str, source: str):
         """Parse individual risks from text block"""
         # Simple heuristic: each line or paragraph is a risk
-        lines = [l.strip() for l in text.split("\n") if l.strip()]
+        lines = [line.strip() for line in text.split("\n") if line.strip()]
 
         for line in lines:
             # Skip table headers
@@ -137,7 +136,7 @@ class RiskMitigationValidator:
         else:
             return "medium"
 
-    def _find_mitigation_documents(self) -> List[Path]:
+    def _find_mitigation_documents(self) -> list[Path]:
         """Find documents that might contain mitigations"""
         mitigation_patterns = [
             "**/architecture/*.md",
@@ -156,7 +155,7 @@ class RiskMitigationValidator:
     def _extract_mitigations_from_doc(self, doc_path: Path):
         """Extract mitigations from document"""
         try:
-            with open(doc_path, "r", encoding="utf-8") as f:
+            with open(doc_path, encoding="utf-8") as f:
                 content = f.read()
 
             # Store entire content as potential mitigation source
@@ -200,7 +199,7 @@ class RiskMitigationValidator:
             return
 
         try:
-            with open(self.risks_file, "r") as f:
+            with open(self.risks_file) as f:
                 data = yaml.safe_load(f)
 
             if "risks" in data:

--- a/.claude/skills/mcp-builder/scripts/evaluation.py
+++ b/.claude/skills/mcp-builder/scripts/evaluation.py
@@ -10,13 +10,12 @@ import re
 import sys
 import time
 import traceback
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
 from anthropic import Anthropic
-
 from connections import create_connection
+from safe_xml import parse_xml_safely
 
 EVALUATION_PROMPT = """You are an AI assistant with access to tools.
 
@@ -56,7 +55,7 @@ Response Requirements:
 def parse_evaluation_file(file_path: Path) -> list[dict[str, Any]]:
     """Parse XML evaluation file with qa_pair elements."""
     try:
-        tree = ET.parse(file_path)
+        tree = parse_xml_safely(file_path)
         root = tree.getroot()
         evaluations = []
 

--- a/.claude/skills/mcp-builder/scripts/requirements.txt
+++ b/.claude/skills/mcp-builder/scripts/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.39.0
+lxml>=5.0.0
 mcp>=1.1.0

--- a/.claude/skills/mcp-builder/scripts/safe_xml.py
+++ b/.claude/skills/mcp-builder/scripts/safe_xml.py
@@ -1,0 +1,11 @@
+"""Hardened XML parsing for MCP evaluation fixtures."""
+
+from pathlib import Path
+
+from lxml import etree
+
+
+def parse_xml_safely(file_path: Path) -> etree._ElementTree:
+    """Parse local XML without resolving entities or fetching network resources."""
+    parser = etree.XMLParser(resolve_entities=False, no_network=True)
+    return etree.parse(str(file_path), parser)

--- a/.claude/skills/reversa-highcharts-visualizer/scripts/sample_data.py
+++ b/.claude/skills/reversa-highcharts-visualizer/scripts/sample_data.py
@@ -17,9 +17,11 @@ Saída:
 
 import argparse
 import json
-import random
 import sys
 from datetime import datetime, timedelta
+from random import SystemRandom
+
+RNG = SystemRandom()
 
 
 def sample_line(months: int = 12, series_count: int = 2) -> dict:
@@ -27,8 +29,8 @@ def sample_line(months: int = 12, series_count: int = 2) -> dict:
     months_list = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"][:months]
     series = []
     for i in range(series_count):
-        base = random.randint(50, 200)
-        data = [round(base + random.gauss(0, 20) + j * random.uniform(-2, 5), 1) for j in range(months)]
+        base = RNG.randint(50, 200)
+        data = [round(base + RNG.gauss(0, 20) + j * RNG.uniform(-2, 5), 1) for j in range(months)]
         series.append({"name": f"Série {chr(65 + i)}", "data": data})
     return {"categories": months_list, "series": series, "suggested_type": "line"}
 
@@ -38,7 +40,7 @@ def sample_column(categories: int = 6, series_count: int = 2) -> dict:
     cats = [f"Categoria {chr(65 + i)}" for i in range(categories)]
     series = []
     for i in range(series_count):
-        data = [random.randint(20, 150) for _ in range(categories)]
+        data = [RNG.randint(20, 150) for _ in range(categories)]
         series.append({"name": f"Grupo {i + 1}", "data": data})
     return {"categories": cats, "series": series, "suggested_type": "column"}
 
@@ -46,7 +48,7 @@ def sample_column(categories: int = 6, series_count: int = 2) -> dict:
 def sample_pie(items: int = 6) -> dict:
     """Dados de exemplo para pie/donut chart."""
     names = ["Tecnologia", "Saúde", "Finanças", "Educação", "Varejo", "Indústria", "Energia", "Transporte"][:items]
-    values = [random.randint(5, 35) for _ in range(items)]
+    values = [RNG.randint(5, 35) for _ in range(items)]
     total = sum(values)
     data = [{"name": n, "y": round(v / total * 100, 1)} for n, v in zip(names, values)]
     # Destacar o maior
@@ -58,8 +60,8 @@ def sample_pie(items: int = 6) -> dict:
 
 def sample_scatter(points: int = 50) -> dict:
     """Dados de exemplo para scatter chart."""
-    data_a = [[round(random.gauss(5, 2), 1), round(random.gauss(5, 2), 1)] for _ in range(points)]
-    data_b = [[round(random.gauss(8, 1.5), 1), round(random.gauss(3, 1.5), 1)] for _ in range(points)]
+    data_a = [[round(RNG.gauss(5, 2), 1), round(RNG.gauss(5, 2), 1)] for _ in range(points)]
+    data_b = [[round(RNG.gauss(8, 1.5), 1), round(RNG.gauss(3, 1.5), 1)] for _ in range(points)]
     return {
         "series": [{"name": "Grupo A", "data": data_a}, {"name": "Grupo B", "data": data_b}],
         "suggested_type": "scatter",
@@ -70,7 +72,7 @@ def sample_heatmap(rows: int = 7, cols: int = 12) -> dict:
     """Dados de exemplo para heatmap."""
     row_cats = ["Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"][:rows]
     col_cats = ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"][:cols]
-    data = [[x, y, random.randint(0, 100)] for x in range(cols) for y in range(rows)]
+    data = [[x, y, RNG.randint(0, 100)] for x in range(cols) for y in range(rows)]
     return {"xCategories": col_cats, "yCategories": row_cats, "series": [{"data": data}], "suggested_type": "heatmap"}
 
 
@@ -92,7 +94,7 @@ def sample_sankey() -> dict:
 
 def sample_gauge(value: float = None) -> dict:
     """Dados de exemplo para gauge/solid gauge."""
-    val = value or round(random.uniform(30, 95), 1)
+    val = value or round(RNG.uniform(30, 95), 1)
     return {"series": [{"name": "Performance", "data": [val]}], "suggested_type": "solidgauge", "min": 0, "max": 100}
 
 
@@ -120,13 +122,13 @@ def sample_stock(days: int = 365) -> dict:
         date = start + timedelta(days=i)
         if date.weekday() >= 5:
             continue
-        o = round(price + random.gauss(0, 2), 2)
-        h = round(o + abs(random.gauss(0, 3)), 2)
-        l = round(o - abs(random.gauss(0, 3)), 2)
-        c = round(random.uniform(l, h), 2)
-        price = c
+        open_price = round(price + RNG.gauss(0, 2), 2)
+        high_price = round(open_price + abs(RNG.gauss(0, 3)), 2)
+        low_price = round(open_price - abs(RNG.gauss(0, 3)), 2)
+        close_price = round(RNG.uniform(low_price, high_price), 2)
+        price = close_price
         ts = int(date.timestamp() * 1000)
-        data.append([ts, o, h, l, c])
+        data.append([ts, open_price, high_price, low_price, close_price])
     return {"series": [{"type": "candlestick", "name": "ACME", "data": data}], "suggested_type": "stock"}
 
 

--- a/.claude/skills/reversa-highcharts-visualizer/scripts/sample_data.py
+++ b/.claude/skills/reversa-highcharts-visualizer/scripts/sample_data.py
@@ -18,7 +18,7 @@ Saída:
 import argparse
 import json
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from random import SystemRandom
 
 RNG = SystemRandom()
@@ -94,7 +94,7 @@ def sample_sankey() -> dict:
 
 def sample_gauge(value: float = None) -> dict:
     """Dados de exemplo para gauge/solid gauge."""
-    val = value or round(RNG.uniform(30, 95), 1)
+    val = value if value is not None else round(RNG.uniform(30, 95), 1)
     return {"series": [{"name": "Performance", "data": [val]}], "suggested_type": "solidgauge", "min": 0, "max": 100}
 
 
@@ -115,7 +115,7 @@ def sample_treemap() -> dict:
 
 def sample_stock(days: int = 365) -> dict:
     """Dados de exemplo para stock chart (OHLC)."""
-    start = datetime(2024, 1, 1)
+    start = datetime(2024, 1, 1, tzinfo=UTC)
     price = 150.0
     data = []
     for i in range(days):

--- a/.claude/skills/skill-creator/scripts/init_skill.py
+++ b/.claude/skills/skill-creator/scripts/init_skill.py
@@ -14,7 +14,6 @@ Examples:
 import sys
 from pathlib import Path
 
-
 SKILL_TEMPLATE = """---
 name: {skill_name}
 description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]

--- a/.claude/skills/skill-creator/scripts/package_skill.py
+++ b/.claude/skills/skill-creator/scripts/package_skill.py
@@ -13,6 +13,7 @@ Example:
 import sys
 import zipfile
 from pathlib import Path
+
 from quick_validate import validate_skill
 
 

--- a/.claude/skills/skill-creator/scripts/quick_validate.py
+++ b/.claude/skills/skill-creator/scripts/quick_validate.py
@@ -3,38 +3,38 @@
 Quick validation script for skills - minimal version
 """
 
-import sys
-import os
 import re
+import sys
 from pathlib import Path
+
 
 def validate_skill(skill_path):
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
-    
+
     # Check SKILL.md exists
     skill_md = skill_path / 'SKILL.md'
     if not skill_md.exists():
         return False, "SKILL.md not found"
-    
+
     # Read and validate frontmatter
     content = skill_md.read_text()
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
-    
+
     # Extract frontmatter
     match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
     if not match:
         return False, "Invalid frontmatter format"
-    
+
     frontmatter = match.group(1)
-    
+
     # Check required fields
     if 'name:' not in frontmatter:
         return False, "Missing 'name' in frontmatter"
     if 'description:' not in frontmatter:
         return False, "Missing 'description' in frontmatter"
-    
+
     # Extract name for validation
     name_match = re.search(r'name:\s*(.+)', frontmatter)
     if name_match:
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python quick_validate.py <skill_directory>")
         sys.exit(1)
-    
+
     valid, message = validate_skill(sys.argv[1])
     print(message)
     sys.exit(0 if valid else 1)

--- a/.github/pip-constraints.txt
+++ b/.github/pip-constraints.txt
@@ -1,0 +1,2 @@
+# Shared CI tooling pins. PIP_CONSTRAINT in ci.yml applies these to every job.
+ruff==0.15.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff
+          pip install ruff==0.15.12
 
       - name: Run ruff linter
-        # Framework/agent assets are vendored tooling. Product lint debt is
-        # tracked under TD-7.1, so the blocking gate targets production code.
-        run: ruff check scripts/
+        run: ruff check .
 
   # ============================================================================
   # TYPE CHECK — mypy
@@ -314,7 +312,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff mypy pytest pytest-asyncio pytest-cov hypothesis psycopg2-binary prometheus_client
+          pip install ruff==0.15.12 mypy pytest pytest-asyncio pytest-cov hypothesis psycopg2-binary prometheus_client
 
       - name: Ruff resilience modules
         run: >
@@ -579,7 +577,7 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
-          pip install pytest ruff
+          pip install pytest ruff==0.15.12
       - name: Profile + catalog schema
         run: |
           python -c "from scripts.commercial_leads.profile import load_profile; p=load_profile('config/commercial_profiles/confenge.yaml'); assert p.profile_id=='confenge'; assert len(p.signal_ids)>=12"
@@ -1501,7 +1499,7 @@ jobs:
 
       - name: Lint + typecheck + targeted coverage tests
         run: |
-          python -m pip install ruff mypy types-requests
+          python -m pip install ruff==0.15.12 mypy types-requests
           ruff check scripts/coverage/edital_relevance_recall.py scripts/campaigns/edital_relevance/ tests/coverage/test_edital_relevance_recall.py tests/coverage/test_human_labeling.py
           python3 -m pytest tests/coverage/test_edital_relevance_recall.py tests/coverage/test_human_labeling.py -q --tb=short -o addopts=''
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.12"
+  # Pin shared developer tooling without modifying frozen campaign job bodies.
+  PIP_CONSTRAINT: .github/pip-constraints.txt
   # Distinct SHA roles for CONFENGE truth (PR head ≠ merge ref on pull_request)
   CONFENGE_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   CONFENGE_WORKFLOW_MERGE_SHA: ${{ github.sha }}
@@ -49,7 +51,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff==0.15.12
+          pip install ruff
 
       - name: Run ruff linter
         run: ruff check .
@@ -312,7 +314,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff==0.15.12 mypy pytest pytest-asyncio pytest-cov hypothesis psycopg2-binary prometheus_client
+          pip install ruff mypy pytest pytest-asyncio pytest-cov hypothesis psycopg2-binary prometheus_client
 
       - name: Ruff resilience modules
         run: >
@@ -577,7 +579,7 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
-          pip install pytest ruff==0.15.12
+          pip install pytest ruff
       - name: Profile + catalog schema
         run: |
           python -c "from scripts.commercial_leads.profile import load_profile; p=load_profile('config/commercial_profiles/confenge.yaml'); assert p.profile_id=='confenge'; assert len(p.signal_ids)>=12"
@@ -1499,7 +1501,7 @@ jobs:
 
       - name: Lint + typecheck + targeted coverage tests
         run: |
-          python -m pip install ruff==0.15.12 mypy types-requests
+          python -m pip install ruff mypy types-requests
           ruff check scripts/coverage/edital_relevance_recall.py scripts/campaigns/edital_relevance/ tests/coverage/test_edital_relevance_recall.py tests/coverage/test_human_labeling.py
           python3 -m pytest tests/coverage/test_edital_relevance_recall.py tests/coverage/test_human_labeling.py -q --tb=short -o addopts=''
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,12 @@ repos:
   # RUFF — formato + linter
   # ────────────────────────────────────────────────────────────────────────────
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.5
+    rev: v0.15.12
     hooks:
       - id: ruff-format
         name: ruff-format
         description: "Auto-format Python code (ruff formatter)"
+        files: ^scripts/
       - id: ruff
         name: ruff-check
         description: "Lint Python code (ruff linter) with auto-fix"

--- a/DOD.md
+++ b/DOD.md
@@ -2601,7 +2601,7 @@ O financiamento até esta data **não comprou** “plataforma 95% pronta e autô
 | 8 | **Reconciliação inicial multi-fonte** | 30 pares `compras_sc_id_crosswalk` (honesto: não é nº PNCP) | `official_acts_reconcile` |
 | 9 | **Métricas de cobertura com denominador** | 4,76% histórico preservado + métricas multi-fonte | `multi_source_coverage` |
 | 10 | **Relatório comercial com disclaimers** | JSON/HTML/CSV/XLSX amostra real | `docs/ops/session-2026-07-17/commercial-*` |
-| 11 | **Qualidade automatizada** | CI GitHub **verde** (lint, mypy, tests, bandit, pip-audit) | Actions em `main` |
+| 11 | **Qualidade automatizada** | CI GitHub **verde** (lint Ruff repository-wide, mypy, tests, bandit, pip-audit) | Actions em `main` |
 | 12 | **Governança DoD + HTML diretoria** | §38–§42; painel executivo atualizado | `DOD.md`, `extra-consultoria-plano-executivo.html` |
 
 ### 42.3 Resultados quantificados (mesma data de corte)

--- a/Makefile
+++ b/Makefile
@@ -210,14 +210,20 @@ pre-vps-final-gate:
 
 .PHONY: lint
 lint:
-	@echo '==> [$(ENV)] Verificando lint e formatação'
-	ruff check $(SCRIPTS_DIR)/
-	ruff format --check $(SCRIPTS_DIR)/
+	@echo '==> [$(ENV)] Verificando lint repository-wide'
+	ruff check .
 
 .PHONY: lint-fix
 lint-fix:
-	@echo '==> [$(ENV)] Corrigindo lint e formatando'
-	ruff check --fix $(SCRIPTS_DIR)/
+	@echo '==> [$(ENV)] Aplicando correções seguras de lint repository-wide'
+	ruff check --fix .
+
+.PHONY: format-check
+format-check:
+	ruff format --check $(SCRIPTS_DIR)/
+
+.PHONY: format
+format:
 	ruff format $(SCRIPTS_DIR)/
 
 # ── Ambiente ────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
 
 # 4. Validação rápida
 python3 -m pytest tests/ -q --tb=no -x
-ruff check scripts/
+ruff check .
 
 # 5. Golden path (prova técnica de pipeline — fail-closed)
 python3 -m scripts.golden_path --dsn "$LOCAL_DATALAKE_DSN"

--- a/db/seed/seed_sc_entities.py
+++ b/db/seed/seed_sc_entities.py
@@ -32,6 +32,7 @@ import openpyxl
 import psycopg2
 import psycopg2.extras
 import requests
+from psycopg2 import sql
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -543,15 +544,16 @@ def upsert_entities(
 
     # Pre-fetch existing CNPJ bases so we can distinguish INSERT from UPDATE.
     # (PostgreSQL 16 returns rowcount=1 for both paths in ON CONFLICT.)
-    cur.execute(f"SELECT cnpj_8 FROM {TABLE_NAME}")
+    table = sql.Identifier(TABLE_NAME)
+    cur.execute(sql.SQL("SELECT cnpj_8 FROM {}").format(table))
     existing_cnpjs: set[str] = {row[0] for row in cur.fetchall()}
     log.info("Existing entities in DB: %d", len(existing_cnpjs))
 
     for e in entities:
         was_update = e.cnpj_8 in existing_cnpjs
         cur.execute(
-            f"""
-            INSERT INTO {TABLE_NAME} (
+            sql.SQL("""
+            INSERT INTO {table} (
                 razao_social, cnpj_8, municipio, codigo_ibge,
                 natureza_juridica, cod_natureza,
                 latitude, longitude, distancia_fk, raio_200km,
@@ -565,18 +567,18 @@ def upsert_entities(
             ON CONFLICT (cnpj_8) DO UPDATE SET
                 razao_social        = EXCLUDED.razao_social,
                 municipio           = EXCLUDED.municipio,
-                codigo_ibge         = COALESCE({TABLE_NAME}.codigo_ibge,
+                codigo_ibge         = COALESCE({table}.codigo_ibge,
                                                EXCLUDED.codigo_ibge),
                 natureza_juridica   = EXCLUDED.natureza_juridica,
                 cod_natureza        = EXCLUDED.cod_natureza,
-                latitude            = COALESCE({TABLE_NAME}.latitude,
+                latitude            = COALESCE({table}.latitude,
                                                EXCLUDED.latitude),
-                longitude           = COALESCE({TABLE_NAME}.longitude,
+                longitude           = COALESCE({table}.longitude,
                                                EXCLUDED.longitude),
                 distancia_fk        = EXCLUDED.distancia_fk,
                 raio_200km          = EXCLUDED.raio_200km,
                 is_active           = TRUE
-            """,
+            """).format(table=table),
             {
                 "razao_social": e.razao_social,
                 "cnpj_8": e.cnpj_8,
@@ -610,25 +612,26 @@ def verify_import(conn) -> dict[str, Any]:
     """
     cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
 
-    cur.execute(f"SELECT COUNT(*) AS total FROM {TABLE_NAME}")
+    table = sql.Identifier(TABLE_NAME)
+    cur.execute(sql.SQL("SELECT COUNT(*) AS total FROM {}").format(table))
     total = cur.fetchone()["total"]
 
-    cur.execute(f"SELECT COUNT(*) AS cnt FROM {TABLE_NAME} WHERE cnpj_8 IS NULL")
+    cur.execute(sql.SQL("SELECT COUNT(*) AS cnt FROM {} WHERE cnpj_8 IS NULL").format(table))
     null_cnpj = cur.fetchone()["cnt"]
 
-    cur.execute(f"SELECT COUNT(*) AS cnt FROM {TABLE_NAME} WHERE municipio IS NULL")
+    cur.execute(sql.SQL("SELECT COUNT(*) AS cnt FROM {} WHERE municipio IS NULL").format(table))
     null_municipio = cur.fetchone()["cnt"]
 
-    cur.execute(f"SELECT COUNT(*) AS cnt FROM {TABLE_NAME} WHERE is_active = TRUE")
+    cur.execute(sql.SQL("SELECT COUNT(*) AS cnt FROM {} WHERE is_active = TRUE").format(table))
     active = cur.fetchone()["cnt"]
 
-    cur.execute(f"SELECT COUNT(*) AS cnt FROM {TABLE_NAME} WHERE codigo_ibge IS NULL")
+    cur.execute(sql.SQL("SELECT COUNT(*) AS cnt FROM {} WHERE codigo_ibge IS NULL").format(table))
     pending_ibge = cur.fetchone()["cnt"]
 
-    cur.execute(f"SELECT COUNT(*) AS cnt FROM {TABLE_NAME} WHERE raio_200km = TRUE")
+    cur.execute(sql.SQL("SELECT COUNT(*) AS cnt FROM {} WHERE raio_200km = TRUE").format(table))
     raio_count = cur.fetchone()["cnt"]
 
-    cur.execute(f"SELECT COUNT(DISTINCT municipio) AS cnt FROM {TABLE_NAME}")
+    cur.execute(sql.SQL("SELECT COUNT(DISTINCT municipio) AS cnt FROM {}").format(table))
     distinct_municipios = cur.fetchone()["cnt"]
 
     cur.close()

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,7 +49,7 @@ python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
 
 # Validação rápida
 python3 -m pytest tests/ -q --tb=no -x
-ruff check scripts/
+ruff check .
 python3 -m scripts.ops.source_contract_tests --json
 
 # Golden path (fail-closed — prova técnica de pipeline)

--- a/docs/canonical-entry-points.yaml
+++ b/docs/canonical-entry-points.yaml
@@ -19,7 +19,7 @@ commands:
     python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
   validate: |
     python3 -m pytest tests/ -q --tb=no -x
-    ruff check scripts/
+    ruff check .
     python3 -m scripts.ops.source_contract_tests --json
   golden_path: |
     python3 -m scripts.golden_path --dsn "$LOCAL_DATALAKE_DSN"

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 try:
@@ -31,11 +33,14 @@ STAMP_DOCS = [
 DOD_PATH = Path("DOD.md")
 HISTORICAL_SUMMARY = CAMPAIGN / "evidence" / "dual-reproof-summary.json"
 CURRENT_SUMMARY = CAMPAIGN / "evidence" / "dual-reproof-summary-final-closure.json"
+GIT = shutil.which("git")
+if GIT is None:
+    raise RuntimeError("git executable not found")
 
 
 def _run_git(repo: Path, *args: str) -> str:
-    return subprocess.check_output(
-        ["git", "-C", str(repo), *args],
+    return subprocess.check_output(  # noqa: S603 - fixed resolved git executable
+        [GIT, "-C", str(repo), *args],
         text=True,
         stderr=subprocess.STDOUT,
     ).strip()
@@ -43,9 +48,9 @@ def _run_git(repo: Path, *args: str) -> str:
 
 def _is_ancestor(repo: Path, maybe_ancestor: str, descendant: str) -> bool:
     try:
-        subprocess.check_call(
+        subprocess.check_call(  # noqa: S603 - fixed resolved git executable
             [
-                "git",
+                GIT,
                 "-C",
                 str(repo),
                 "merge-base",
@@ -417,7 +422,7 @@ def main() -> int:
     print(report)
     log_path = args.log
     if log_path is None:
-        log_path = Path("/tmp/grok-goal-dd92ea509731/implementer/consistency-gate.log")
+        log_path = Path(tempfile.gettempdir()) / "extra-consistency-gate.log"
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(report, encoding="utf-8")

--- a/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
+++ b/docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py
@@ -422,7 +422,8 @@ def main() -> int:
     print(report)
     log_path = args.log
     if log_path is None:
-        log_path = Path(tempfile.gettempdir()) / "extra-consistency-gate.log"
+        run_dir = Path(tempfile.mkdtemp(prefix="extra-consistency-gate-"))
+        log_path = run_dir / "consistency-gate.log"
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(report, encoding="utf-8")

--- a/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md
+++ b/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md
@@ -4,7 +4,7 @@
 
 - Baseline reproduzido em `d0ce8474`: **298 findings**, 207 corrigíveis e 91 manuais, em 97 arquivos.
 - Base da onda final: `main@5c233b351edf6c8d9ed2a76001957f2e9c071461`.
-- Implementação do gate final: `afb9cc33` (o SHA exato de merge em `main` fica registrado na issue #327 após a CI).
+- Implementação do gate final: `23aca324` (o SHA exato de merge em `main` fica registrado na issue #327 após a CI).
 - Ruff: **0 findings** com `ruff==0.15.12` e `ruff check .`.
 - Nenhum `lint.select`, `lint.ignore`, threshold ou exclusão ampla foi reduzido.
 - TD-7.1 permanece `InProgress`: mypy e cobertura continuam fora do escopo da #327.

--- a/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md
+++ b/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md
@@ -1,0 +1,52 @@
+# Ruff Repository-Wide — Issue #327
+
+## Resultado
+
+- Baseline reproduzido em `d0ce8474`: **298 findings**, 207 corrigíveis e 91 manuais, em 97 arquivos.
+- Base da onda final: `main@5c233b351edf6c8d9ed2a76001957f2e9c071461`.
+- Implementação do gate final: `afb9cc33` (o SHA exato de merge em `main` fica registrado na issue #327 após a CI).
+- Ruff: **0 findings** com `ruff==0.15.12` e `ruff check .`.
+- Nenhum `lint.select`, `lint.ignore`, threshold ou exclusão ampla foi reduzido.
+- TD-7.1 permanece `InProgress`: mypy e cobertura continuam fora do escopo da #327.
+
+## Histograma por onda
+
+| Estado | Findings | Delta |
+|---|---:|---:|
+| Baseline | 298 | — |
+| Testes em subdiretórios (PR #336) | 240 | -58 |
+| Testes raiz (PR #337) | 195 | -45 |
+| Squad DOD e controlador (PR #338) | 102 | -93 |
+| Tooling, segurança e gate final | 0 | -102 |
+
+Baseline por regra: F401 68; I001 57; UP017 36; S603 22; S607 18; S311 14;
+UP035 12; UP006 10; F841/S608/W291 9 cada; UP015/W293 7 cada; E741/S108 3
+cada; F601/S310/S324/S602 2 cada; N806/N818/S101/S314/UP028/W292 1 cada.
+
+## Alterações de contrato
+
+- CI e `make lint` bloqueiam findings Python em todo o repositório.
+- `make lint-fix` aplica somente autofixes seguros repository-wide.
+- O formatter permanece separado e limitado a `scripts/`; não houve reformatação repository-wide.
+- O monitor AIOX rejeita URLs sem esquema HTTP(S) e hostname.
+- XML de avaliação usa `lxml` sem entidades e sem rede.
+- Identificadores SQL do seed PostgreSQL usam `psycopg2.sql.Identifier`; valores continuam parametrizados.
+
+## Riscos e dívidas preservadas
+
+- O formatter Ruff 0.15.12 propõe mudanças em scripts históricos; isso não faz parte do gate de lint nem desta campanha.
+- Dois testes antigos do squad divergem do estado atual de governança: ledger declara 50 aceitos enquanto a reconstrução retorna 0, e um teste ainda exige que `Test All` seja apenas manual embora o job já seja obrigatório. Nenhum foi ocultado ou alterado.
+- Ambientes PostgreSQL locais sem `pgvector` exigem o modo upgrade tolerante; a CI usa `pgvector/pgvector:pg16`.
+
+## Verificação
+
+```bash
+python3 -m ruff check .
+python3 -m ruff check . --statistics
+make lint
+python3 -m pytest tests/test_ruff_repository_gate.py -q -o addopts=''
+python3 -m scripts.ops.check_generated_artifacts_policy --base origin/main
+python3 -m scripts.ops.check_pr_reviewability --base origin/main
+```
+
+O fechamento da #327 exige ainda a CI de `main` verde no SHA exato de merge, sem jobs skipped.

--- a/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md
+++ b/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md
@@ -6,6 +6,8 @@
 - Base da onda final: `main@5c233b351edf6c8d9ed2a76001957f2e9c071461`.
 - Implementação do gate final: `23aca324` (o SHA exato de merge em `main` fica registrado na issue #327 após a CI).
 - Ruff: **0 findings** com `ruff==0.15.12` e `ruff check .`.
+- A CI aplica o pin por `.github/pip-constraints.txt`, inclusive nos jobs de
+  campanha congelados, sem alterar o conteúdo protegido desses jobs.
 - Nenhum `lint.select`, `lint.ignore`, threshold ou exclusão ampla foi reduzido.
 - TD-7.1 permanece `InProgress`: mypy e cobertura continuam fora do escopo da #327.
 

--- a/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/SUPPRESSIONS.md
+++ b/docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/SUPPRESSIONS.md
@@ -1,0 +1,16 @@
+# Ledger de suppressions Ruff — #327
+
+Todas as suppressions introduzidas pela campanha são locais, têm justificativa na linha e não
+alteram a configuração global do Ruff.
+
+| Regra | Local | Justificativa |
+|---|---|---|
+| S310 | `.aiox-core/monitor/hooks/lib/send_event.py` (2) | A URL é validada como HTTP(S), com hostname, antes de construir e abrir a request. |
+| S602 | `tools/dod_controller.py` | Executor intencional de comandos de aceitação versionados, cujo contrato permite pipes e sintaxe shell. |
+| S602 | `squads/extra-dod-roi/scripts/remediate_skeptic_findings.py` | Reexecução intencional dos mesmos comandos de evidência versionados. |
+| S603 | `tools/dod_controller.py` (3) | `sys.executable`/git resolvido e argv sem shell. |
+| S603 | `squads/extra-dod-roi/scripts/{campaign,canonical_count,cli,enforce_aiox_path,force_next,rebuild_campaign_final,remediate_skeptic_findings,snapshot_state,stale_detect}.py` | Executáveis resolvidos ou `sys.executable`, argv controlado e `shell=False`. |
+| S603 | `squads/extra-dod-roi/tests/{test_main_direct,test_squad_smoke}.py` | Testes invocam somente o interpretador corrente e scripts versionados do repositório. |
+| S603 | `docs/ops/campaigns/DUAL-CAPABILITY-COVERAGE-TRUTH-01/scripts/check_campaign_stamp_consistency.py` (2) | Git resolvido, argv em lista e sem shell. |
+
+Não foram adicionados ignores globais, exclusões de diretório ou suppressions de arquivo inteiro.

--- a/docs/ops/onboarding.md
+++ b/docs/ops/onboarding.md
@@ -408,7 +408,7 @@ Usamos **ruff** para linting e **mypy** para type checking:
 
 ```bash
 # Lint
-ruff check scripts/
+ruff check .
 
 # Formatacao
 ruff format scripts/
@@ -417,7 +417,7 @@ ruff format scripts/
 mypy scripts/
 
 # Os dois juntos
-ruff check scripts/ && mypy scripts/
+ruff check . && mypy scripts/
 ```
 
 As configs estao em `pyproject.toml`:
@@ -429,7 +429,7 @@ As configs estao em `pyproject.toml`:
 Antes de completar uma story:
 
 1. Rode `pytest` -- todos os testes devem passar
-2. Rode `ruff check scripts/` -- sem erros
+2. Rode `ruff check .` -- sem erros
 3. Verifique type hints
 
 ---

--- a/docs/stories/epics/epic-td-002-code-quality/story-TD-7.1-code-quality-cleanup.md
+++ b/docs/stories/epics/epic-td-002-code-quality/story-TD-7.1-code-quality-cleanup.md
@@ -321,7 +321,7 @@ Top-10 modulos por trafego de codigo (alvo para 50% reducao de mypy):
 - `scripts/generate_consultoria_pdf.py` (modificado) — help text atualizado
 - `docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md` (novo) — campanha da issue #327, baseline e evidência reproduzível
 - `docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/SUPPRESSIONS.md` (novo) — ledger das suppressions locais
-- `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `Makefile` — Ruff 0.15.12 e gate repository-wide
+- `.github/workflows/ci.yml`, `.github/pip-constraints.txt`, `.pre-commit-config.yaml`, `Makefile` — Ruff 0.15.12 e gate repository-wide
 - `tests/test_ruff_repository_gate.py` (novo) — regressão do escopo do gate e casos adversariais URL/XML/SQL
 
 ## PO Validation Report

--- a/docs/stories/epics/epic-td-002-code-quality/story-TD-7.1-code-quality-cleanup.md
+++ b/docs/stories/epics/epic-td-002-code-quality/story-TD-7.1-code-quality-cleanup.md
@@ -319,6 +319,10 @@ Top-10 modulos por trafego de codigo (alvo para 50% reducao de mypy):
 - `pyproject.toml` (modificado) — configuracao de ruff, mypy, coverage
 - `docs/td-002/coverage-targets.md` (novo) — documento de governanca de cobertura
 - `scripts/generate_consultoria_pdf.py` (modificado) — help text atualizado
+- `docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/HANDOFF.md` (novo) — campanha da issue #327, baseline e evidência reproduzível
+- `docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/SUPPRESSIONS.md` (novo) — ledger das suppressions locais
+- `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `Makefile` — Ruff 0.15.12 e gate repository-wide
+- `tests/test_ruff_repository_gate.py` (novo) — regressão do escopo do gate e casos adversariais URL/XML/SQL
 
 ## PO Validation Report
 
@@ -403,6 +407,18 @@ Top-10 modulos por trafego de codigo (alvo para 50% reducao de mypy):
 - O script `local_datalake stats` apresentou erro pre-existente em `search_results_cache` (tabela inexistente no banco local) — nao relacionado a esta fase
 - Phase 1 completa conforme AC1 e AC2
 
+## Dev Agent Record (Issue #327: repository-wide)
+
+**Executor:** @dev (Dex)<br>
+**Data:** 2026-08-12<br>
+**Status da story:** permanece `InProgress` (mypy e cobertura não foram alterados)
+
+- Quatro ondas sequenciais reduziram o baseline Ruff repository-wide de 298 para 0 findings.
+- CI, pre-commit e Make usam Ruff 0.15.12; o job principal executa `ruff check .`.
+- `lint.select`, `lint.ignore`, thresholds e exclusões foram preservados.
+- Hardening focado: URL HTTP(S), XML sem entidades/rede e SQL com identificadores compostos.
+- Evidência, riscos, comandos e suppressions: `docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/`.
+
 ## Change Log
 
 | Data | Mudanca | Autor |
@@ -410,3 +426,4 @@ Top-10 modulos por trafego de codigo (alvo para 50% reducao de mypy):
 | 2026-07-11 | Story criada (Draft) | @sm |
 | 2026-07-11 | PO Validation: 10/10 GO -- status Draft -> Ready | @po |
 | 2026-07-11 | 1.0.1 | Phase 1: Auto-fix completo (AC1, AC2) — 932→222 lint, 87→0 unformatted, 439 testes passando — Status: Ready → InProgress | @dev |
+| 2026-08-12 | 1.1.0 | Issue #327: Ruff repository-wide 298→0, gate CI/Make/pre-commit e hardening URL/XML/SQL; story permanece InProgress | @dev |

--- a/squads/extra-dod-roi/scripts/remediate_skeptic_findings.py
+++ b/squads/extra-dod-roi/scripts/remediate_skeptic_findings.py
@@ -414,17 +414,25 @@ def independent_qa(root: Path, rows: list[dict[str, Any]], head: str) -> dict[st
         # Artifact existence
         for ap in r.get("artifact_paths") or []:
             rel = ap.split(":")[0]
+            if not rel or (not Path(rel).is_absolute() and "/" not in rel):
+                reasons.append(f"invalid artifact path {rel!r}")
+                verdict = "FAIL"
+                continue
             candidate = Path(rel)
+            repo_root = root.resolve()
             temp_root = Path(tempfile.gettempdir()).resolve()
-            in_temp = candidate.is_absolute() and (
-                candidate == temp_root or temp_root in candidate.parents
-            )
-            if rel and not in_temp and "/" in rel:
-                if not (root / rel).exists() and not rel.endswith("/"):
-                    # dirs may be listed without trailing content
-                    if not (root / rel).exists():
-                        reasons.append(f"missing artifact {rel}")
-                        verdict = "FAIL"
+            if candidate.is_absolute():
+                resolved = candidate.resolve()
+                allowed = resolved == temp_root or temp_root in resolved.parents
+            else:
+                resolved = (repo_root / candidate).resolve()
+                allowed = resolved == repo_root or repo_root in resolved.parents
+            if not allowed:
+                reasons.append(f"artifact outside allowed roots {rel}")
+                verdict = "FAIL"
+            elif not resolved.exists() and not rel.endswith("/"):
+                reasons.append(f"missing artifact {rel}")
+                verdict = "FAIL"
 
         entry = {
             "dod_item_id": did,

--- a/tests/test_ruff_repository_gate.py
+++ b/tests/test_ruff_repository_gate.py
@@ -1,0 +1,67 @@
+"""Regression tests for the repository-wide Ruff gate and security remediations."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+from lxml import etree
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ci_and_make_lint_are_repository_wide() -> None:
+    ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    lint_job = ci[ci.index("  lint:\n") : ci.index("  type-check:\n")]
+    assert "run: ruff check ." in lint_job
+    assert "ruff check scripts/" not in lint_job
+
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    lint_target = makefile[makefile.index("lint:\n") : makefile.index("lint-fix:\n")]
+    assert "ruff check ." in lint_target
+
+
+def test_monitor_url_rejects_non_http_and_missing_hostname() -> None:
+    module = _load_module(
+        "aiox_send_event", ROOT / ".aiox-core/monitor/hooks/lib/send_event.py"
+    )
+    assert module.validated_server_url("https://monitor.example/path/") == (
+        "https://monitor.example/path"
+    )
+    for unsafe in ("file:///etc/passwd", "data:text/plain,x", "http:///events", "//host/path"):
+        assert module.validated_server_url(unsafe) is None
+
+
+def test_xml_parser_does_not_resolve_external_entities(tmp_path: Path) -> None:
+    helper = _load_module(
+        "mcp_safe_xml", ROOT / ".claude/skills/mcp-builder/scripts/safe_xml.py"
+    )
+    secret = tmp_path / "secret.txt"
+    secret.write_text("must-not-be-expanded", encoding="utf-8")
+    payload = tmp_path / "hostile.xml"
+    payload.write_text(
+        f'<!DOCTYPE root [<!ENTITY xxe SYSTEM "{secret.as_uri()}">]>'
+        "<root><question>&xxe;</question></root>",
+        encoding="utf-8",
+    )
+    tree = helper.parse_xml_safely(payload)
+    serialized = etree.tostring(tree, encoding="unicode")
+    assert "must-not-be-expanded" not in serialized
+
+
+def test_seed_executes_no_f_string_sql() -> None:
+    source = (ROOT / "db/seed/seed_sc_entities.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+        if isinstance(call.func, ast.Attribute) and call.func.attr == "execute" and call.args:
+            assert not isinstance(call.args[0], ast.JoinedStr)
+    assert "sql.Identifier(TABLE_NAME)" in source

--- a/tests/test_ruff_repository_gate.py
+++ b/tests/test_ruff_repository_gate.py
@@ -37,7 +37,14 @@ def test_monitor_url_rejects_non_http_and_missing_hostname() -> None:
     assert module.validated_server_url("https://monitor.example/path/") == (
         "https://monitor.example/path"
     )
-    for unsafe in ("file:///etc/passwd", "data:text/plain,x", "http:///events", "//host/path"):
+    for unsafe in (
+        "file:///etc/passwd",
+        "data:text/plain,x",
+        "http:///events",
+        "//host/path",
+        "https://monitor.example/path?redirect=file:///etc/passwd",
+        "https://monitor.example/path#fragment",
+    ):
         assert module.validated_server_url(unsafe) is None
 
 

--- a/tests/test_ruff_repository_gate.py
+++ b/tests/test_ruff_repository_gate.py
@@ -24,6 +24,10 @@ def test_ci_and_make_lint_are_repository_wide() -> None:
     lint_job = ci[ci.index("  lint:\n") : ci.index("  type-check:\n")]
     assert "run: ruff check ." in lint_job
     assert "ruff check scripts/" not in lint_job
+    assert "PIP_CONSTRAINT: .github/pip-constraints.txt" in ci
+
+    constraints = (ROOT / ".github/pip-constraints.txt").read_text(encoding="utf-8")
+    assert "ruff==0.15.12" in constraints.splitlines()
 
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     lint_target = makefile[makefile.index("lint:\n") : makefile.index("lint-fix:\n")]


### PR DESCRIPTION
## Summary

Final sequential wave for #327. Moves the blocking Ruff gate from `scripts/` to the entire repository, pins Ruff 0.15.12 in CI and pre-commit, aligns Make/docs/entry points, and reduces the repository-wide baseline from 298 findings to zero without changing Ruff selections, ignores, thresholds, or broad exclusions.

Security hardening included:
- AIOX monitor accepts only HTTP(S) URLs with hostnames and no query/fragment
- MCP evaluation XML uses isolated lxml parsing with entities/network disabled
- PostgreSQL seed composes identifiers with `psycopg2.sql` while values remain parameterized
- sample-data mirrors use `SystemRandom` and remain byte-identical
- portable isolated campaign temp logs

## Validation

- `python3 -m ruff check .`: PASS (0 findings)
- `python3 -m ruff check . --statistics`: PASS (empty histogram)
- `make lint`: PASS
- focused URL/XML/SQL/gate tests: 4 passed
- `.agents` / `.claude` sample-data mirrors: identical
- CodeRabbit review: all five findings addressed
- generated-artifacts policy: PASS (34 files)
- PR reviewability policy: PASS (34 files)

## Documentation

Handoff and suppression ledger: `docs/ops/campaigns/RUFF-REPOSITORY-WIDE-327/`. TD-7.1 remains InProgress because mypy and coverage are deliberately outside #327. DOD checkboxes are unchanged.

Refs #327