### PR TITLE
fix(target-fit): serialize company queue claims

### DIFF
--- a/scripts/confenge_target_fit/store.py
+++ b/scripts/confenge_target_fit/store.py
@@ -231,6 +231,9 @@ def claim_batch(
             FROM confenge_target_fit_dirty
             WHERE status IN ('pending', 'retry')
               AND (next_retry_at IS NULL OR next_retry_at <= now())
+              AND pg_try_advisory_xact_lock(
+                    hashtext(confenge_target_fit_dirty.company_key)
+                  )
               AND NOT EXISTS (
                   SELECT 1
                   FROM confenge_target_fit_dirty p
@@ -246,7 +249,10 @@ def claim_batch(
             (max(batch_size * 4, batch_size),),
         )
         candidates = cur.fetchall() or []
-        # Step 2: keep first row per company_key (already priority-ordered)
+        # Step 2: keep first row per company_key (already priority-ordered).
+        # The transaction-scoped advisory lock above closes the cross-row race:
+        # concurrent workers may skip different row locks for the same company,
+        # but only one transaction can claim that company_key.
         seen: set[str] = set()
         selected_ids: list[int] = []
         for row in candidates:


### PR DESCRIPTION
## Summary

- serialize queue claims per `company_key` with a transaction-scoped PostgreSQL advisory lock
- preserve `FOR UPDATE SKIP LOCKED` and the existing one-row-per-company batch filter
- fix the race exposed by the post-merge `Edital Relevance Foundation` run on `main`

Refs #327

## Verification

- 20 consecutive executions of `test_concurrent_claim_same_company_single_writer` against real PostgreSQL
- `tests/confenge_target_fit/test_downstream_and_concurrency.py`: 6 passed
- `python3 -m ruff check scripts/confenge_target_fit/store.py`
- generated-artifacts policy: PASS
- PR reviewability: PASS

Failing main evidence: https://github.com/tjsasakifln/extra-cli/actions/runs/31662991625