### PR TITLE
fix(lineage): fail closed on terminal persistence

### DIFF
--- a/docs/ops/provenance-terminal-persistence-342.md
+++ b/docs/ops/provenance-terminal-persistence-342.md
@@ -1,0 +1,40 @@
+# Provenance terminal persistence contract (#342)
+
+**Scope:** `pipeline_runs` terminality for the synchronous crawl adapters.  This
+is a correction of the existing API, not a second provenance framework or a
+change to CONFENGE feed semantics.
+
+## Contract
+
+- `provenance_start`, `provenance_complete`, and `provenance_fail` are
+  keyword-only at the synchronous boundary.  A persistence error raises to the
+  caller; there is no boolean soft-fail or synthetic fallback `run_id`.
+- `source` is part of terminal run identity.  Terminal updates atomically match
+  `run_id`, `source`, and `status = 'running'`.
+- Unknown `run_id`, mismatched `source`, and a repeated terminal transition are
+  distinct observable errors.  A run can leave `running` exactly once.
+- Complete and fail persist the schema counters by their canonical names:
+  fetched, deduplicated, upserted, DLQ, failed, pages planned/completed,
+  watermarks committed, and duration.  Fail additionally persists the error
+  message.
+- PCP, DOM-SC, DOE-SC, TCE-SC, and CIGA reuse the `run_id` returned by the
+  successful start write.  Failure of a terminal write is never converted to a
+  successful crawler return.
+
+## Reproducible validation
+
+```bash
+export LOCAL_DATALAKE_DSN="${LOCAL_DATALAKE_DSN:-postgresql://test:test@127.0.0.1:5433/extra_test}"
+python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
+REQUIRE_REAL_DB=1 TEST_DSN="$LOCAL_DATALAKE_DSN" \
+  python3 -m pytest tests/integration/test_provenance_terminal_persistence.py -q
+python3 -m pytest tests/test_provenance.py tests/test_provenance_sync.py \
+  tests/test_provenance_crawler_contract.py -q
+```
+
+The PostgreSQL test asserts stored column values, not merely that a function
+was called.  Branch/PR evidence remains `VERIFIED`; DOD acceptance still
+requires the exact merged `main` SHA and green canonical CI.
+
+No ADR is added: the change stays inside the existing `ProvenanceTracker` and
+its current `pipeline_runs` schema.

--- a/scripts/crawl/ciga_ckan_crawler.py
+++ b/scripts/crawl/ciga_ckan_crawler.py
@@ -723,28 +723,42 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     Returns:
         List of raw publication dicts from CKAN.
     """
-    from scripts.crawl.provenance_sync import provenance_complete, provenance_start
+    from scripts.crawl.provenance_sync import provenance_complete, provenance_fail, provenance_start
 
-    months = list_domsc_months()
-    if not months:
-        _logger.error("No DOM-SC datasets found on CKAN")
-        return []
-
-    if mode == "incremental":
-        target_months = [months[-1]]
-    else:
-        target_months = months
-
-    run_id = f"ciga_ckan-{int(time.time())}"
-    provenance_start(source="ciga_ckan", mode=mode, params={"months": len(target_months)})
-
+    provenance_started_at = time.monotonic()
+    run_id = provenance_start(source="ciga_ckan", mode=mode)
     all_publications: list[dict] = []
-    for m in target_months:
-        _logger.info("Crawling %s", m)
-        pubs = download_month(m)
-        all_publications.extend(pubs)
+    try:
+        months = list_domsc_months()
+        if not months:
+            raise RuntimeError("No DOM-SC datasets found on CKAN")
 
-    provenance_complete(run_id, "ciga_ckan", records_fetched=len(all_publications))
+        if mode == "incremental":
+            target_months = [months[-1]]
+        else:
+            target_months = months
+
+        for month in target_months:
+            _logger.info("Crawling %s", month)
+            publications = download_month(month)
+            all_publications.extend(publications)
+
+        provenance_complete(
+            run_id=run_id,
+            source="ciga_ckan",
+            records_fetched=len(all_publications),
+            duration_ms=int((time.monotonic() - provenance_started_at) * 1000),
+        )
+    except Exception as exc:
+        provenance_fail(
+            run_id=run_id,
+            source="ciga_ckan",
+            error_message=str(exc),
+            records_fetched=len(all_publications),
+            records_failed=1,
+            duration_ms=int((time.monotonic() - provenance_started_at) * 1000),
+        )
+        raise
 
     _logger.info("Total procurement publications: %d", len(all_publications))
     return all_publications

--- a/scripts/crawl/doe_sc_crawler.py
+++ b/scripts/crawl/doe_sc_crawler.py
@@ -528,8 +528,6 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     days = DOE_SC_FULL_DAYS if mode == "full" else DOE_SC_INCREMENTAL_DAYS
     data_final = date.today()
     data_inicial = data_final - timedelta(days=days)
-    run_id = f"doe_sc-{int(time.time())}"
-
     _logger.info(
         "[DOE-SC] Crawling %s mode: %s to %s (%d days)",
         mode,
@@ -539,7 +537,12 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     )
 
     # Provenance: start run
-    provenance_start(source="doe_sc", mode=mode, params={"data_inicial": str(data_inicial), "data_final": str(data_final)})
+    provenance_started_at = time.monotonic()
+    run_id = provenance_start(
+        source="doe_sc",
+        mode=mode,
+        params={"data_inicial": str(data_inicial), "data_final": str(data_final)},
+    )
 
     # Ensure categories are loaded for filtering
     _load_categories()
@@ -547,13 +550,6 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     try:
         raw_records = _fetch_materias(data_inicial, data_final)
         _logger.info("[DOE-SC] Fetched %d raw records", len(raw_records))
-
-        # Provenance: complete run
-        provenance_complete(run_id, "doe_sc", records_fetched=len(raw_records))
-
-        # Watermark: commit date range
-        if resume:
-            watermark_commit(source="doe_sc", scope_key="date", value=str(data_final), run_id=run_id)
     except Exception as e:
         _logger.error("[DOE-SC] Crawl failed: %s", e)
         dlq_write(
@@ -564,8 +560,28 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
             error_message=str(e)[:2000],
             payload={"mode": mode, "data_inicial": str(data_inicial), "data_final": str(data_final)},
         )
-        provenance_fail(run_id, "doe_sc", error_message=str(e))
+        provenance_fail(
+            run_id=run_id,
+            source="doe_sc",
+            error_message=str(e),
+            records_failed=1,
+            records_dlq=1,
+            duration_ms=int((time.monotonic() - provenance_started_at) * 1000),
+        )
         return []
+
+    # Terminal persistence is deliberately outside the collection handler:
+    # failure here must remain observable to the caller.
+    provenance_complete(
+        run_id=run_id,
+        source="doe_sc",
+        records_fetched=len(raw_records),
+        duration_ms=int((time.monotonic() - provenance_started_at) * 1000),
+    )
+
+    # Watermark: commit date range
+    if resume:
+        watermark_commit(source="doe_sc", scope_key="date", value=str(data_final), run_id=run_id)
 
     return raw_records
 

--- a/scripts/crawl/dom_sc_crawler.py
+++ b/scripts/crawl/dom_sc_crawler.py
@@ -436,8 +436,6 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     days = DOM_SC_FULL_DAYS if mode == "full" else DOM_SC_INCREMENTAL_DAYS
     data_final = date.today()
     data_inicial = data_final - timedelta(days=days)
-    run_id = f"dom_sc-{int(time.time())}"
-
     _logger.info(
         "[DOM-SC] Crawling %s mode: %s to %s (%d days)",
         mode,
@@ -447,18 +445,16 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     )
 
     # Provenance: start run
-    provenance_start(source="dom_sc", mode=mode, params={"data_inicial": str(data_inicial), "data_final": str(data_final)})
+    provenance_started_at = time.monotonic()
+    run_id = provenance_start(
+        source="dom_sc",
+        mode=mode,
+        params={"data_inicial": str(data_inicial), "data_final": str(data_final)},
+    )
 
     try:
         raw_records = _fetch_publications(data_inicial, data_final)
         _logger.info("[DOM-SC] Fetched %d raw records", len(raw_records))
-
-        # Provenance: complete run
-        provenance_complete(run_id, "dom_sc", records_fetched=len(raw_records))
-
-        # Watermark: commit date range
-        if resume:
-            watermark_commit(source="dom_sc", scope_key="date", value=str(data_final), run_id=run_id)
     except Exception as e:
         _logger.error("[DOM-SC] Crawl failed: %s", e)
         dlq_write(
@@ -469,8 +465,28 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
             error_message=str(e)[:2000],
             payload={"mode": mode, "data_inicial": str(data_inicial), "data_final": str(data_final)},
         )
-        provenance_fail(run_id, "dom_sc", error_message=str(e))
+        provenance_fail(
+            run_id=run_id,
+            source="dom_sc",
+            error_message=str(e),
+            records_failed=1,
+            records_dlq=1,
+            duration_ms=int((time.monotonic() - provenance_started_at) * 1000),
+        )
         return []
+
+    # Terminal persistence is deliberately outside the collection handler:
+    # failure here must remain observable to the caller.
+    provenance_complete(
+        run_id=run_id,
+        source="dom_sc",
+        records_fetched=len(raw_records),
+        duration_ms=int((time.monotonic() - provenance_started_at) * 1000),
+    )
+
+    # Watermark: commit date range
+    if resume:
+        watermark_commit(source="dom_sc", scope_key="date", value=str(data_final), run_id=run_id)
 
     return raw_records
 

--- a/scripts/crawl/pcp_crawler.py
+++ b/scripts/crawl/pcp_crawler.py
@@ -428,9 +428,8 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     server_side_uf = codigo_uf is not None
 
     # Provenance: start run
+    provenance_started_at = time.monotonic()
     run_id = provenance_start(source="pcp", mode=mode, params={"data_inicial": data_inicial_str, "data_final": data_final_str})
-    if run_id is None:
-        run_id = f"pcp-{int(time.time())}"
 
     # Watermark: determine starting page
     start_page = 1
@@ -516,10 +515,24 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     _logger.info("[PCP] Crawl complete: %d records (%d pages)", len(all_records), pagina)
 
     # Provenance: complete or fail
+    duration_ms = int((time.monotonic() - provenance_started_at) * 1000)
     if dlq_errors > 0:
-        provenance_fail(run_id, "pcp", error_message=f"{dlq_errors} DLQ errors", records_fetched=len(all_records))
+        provenance_fail(
+            run_id=run_id,
+            source="pcp",
+            error_message=f"{dlq_errors} DLQ errors",
+            records_fetched=len(all_records),
+            records_dlq=dlq_errors,
+            records_failed=dlq_errors,
+            duration_ms=duration_ms,
+        )
     else:
-        provenance_complete(run_id, "pcp", records_fetched=len(all_records))
+        provenance_complete(
+            run_id=run_id,
+            source="pcp",
+            records_fetched=len(all_records),
+            duration_ms=duration_ms,
+        )
 
     return all_records
 

--- a/scripts/crawl/provenance.py
+++ b/scripts/crawl/provenance.py
@@ -36,6 +36,22 @@ SOURCE_SLA: dict[str, int] = {
 }
 
 
+class ProvenanceTerminalPersistenceError(RuntimeError):
+    """Base error for a terminal provenance transition that was not persisted."""
+
+
+class ProvenanceRunNotFoundError(ProvenanceTerminalPersistenceError):
+    """Raised when a terminal transition targets an unknown run."""
+
+
+class ProvenanceSourceMismatchError(ProvenanceTerminalPersistenceError):
+    """Raised when a run exists but belongs to another source."""
+
+
+class ProvenanceRunStateError(ProvenanceTerminalPersistenceError):
+    """Raised when a run has already left the running state."""
+
+
 class ProvenanceTracker:
     """Tracks crawl pipeline runs with full provenance.
 
@@ -65,6 +81,27 @@ class ProvenanceTracker:
             self._pool.putconn(conn)
         else:
             conn.close()
+
+    @staticmethod
+    def _raise_terminal_transition_error(cur, run_id: str, source: str) -> None:
+        """Classify a failed terminal update without weakening its atomic guard."""
+        cur.execute(
+            "SELECT source, status FROM pipeline_runs WHERE run_id = %s",
+            (run_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise ProvenanceRunNotFoundError(f"provenance run not found: run_id={run_id}")
+
+        actual_source, status = row
+        if actual_source != source:
+            raise ProvenanceSourceMismatchError(
+                "provenance source mismatch: "
+                f"run_id={run_id} expected={source} actual={actual_source}"
+            )
+        raise ProvenanceRunStateError(
+            f"provenance run is not running: run_id={run_id} source={source} status={status}"
+        )
 
     async def start_run(
         self,
@@ -106,6 +143,8 @@ class ProvenanceTracker:
     async def complete_run(
         self,
         run_id: str,
+        *,
+        source: str,
         records_fetched: int = 0,
         records_deduplicated: int = 0,
         records_upserted: int = 0,
@@ -135,6 +174,9 @@ class ProvenanceTracker:
                         watermarks_committed = %s,
                         duration_ms = %s
                     WHERE run_id = %s
+                      AND source = %s
+                      AND status = 'running'
+                    RETURNING run_id
                     """,
                     (
                         records_fetched,
@@ -147,8 +189,11 @@ class ProvenanceTracker:
                         watermarks_committed,
                         duration_ms,
                         run_id,
+                        source,
                     ),
                 )
+                if cur.fetchone() is None:
+                    self._raise_terminal_transition_error(cur, run_id, source)
             conn.commit()
             logger.info(
                 "Run completed: %s fetched=%d upserted=%d dlq=%d in %dms",
@@ -164,8 +209,17 @@ class ProvenanceTracker:
     async def fail_run(
         self,
         run_id: str,
+        *,
+        source: str,
         error_message: str,
         records_fetched: int = 0,
+        records_deduplicated: int = 0,
+        records_upserted: int = 0,
+        records_dlq: int = 0,
+        records_failed: int = 0,
+        pages_planned: int = 0,
+        pages_completed: int = 0,
+        watermarks_committed: int = 0,
         duration_ms: int = 0,
     ) -> None:
         """Mark a pipeline run as failed."""
@@ -179,11 +233,36 @@ class ProvenanceTracker:
                         completed_at = NOW(),
                         error_message = %s,
                         records_fetched = %s,
+                        records_deduplicated = %s,
+                        records_upserted = %s,
+                        records_dlq = %s,
+                        records_failed = %s,
+                        pages_planned = %s,
+                        pages_completed = %s,
+                        watermarks_committed = %s,
                         duration_ms = %s
                     WHERE run_id = %s
+                      AND source = %s
+                      AND status = 'running'
+                    RETURNING run_id
                     """,
-                    (error_message[:2000], records_fetched, duration_ms, run_id),
+                    (
+                        error_message[:2000],
+                        records_fetched,
+                        records_deduplicated,
+                        records_upserted,
+                        records_dlq,
+                        records_failed,
+                        pages_planned,
+                        pages_completed,
+                        watermarks_committed,
+                        duration_ms,
+                        run_id,
+                        source,
+                    ),
                 )
+                if cur.fetchone() is None:
+                    self._raise_terminal_transition_error(cur, run_id, source)
             conn.commit()
             logger.error("Run failed: %s — %s", run_id, error_message[:200])
         except Exception as e:

--- a/scripts/crawl/provenance_sync.py
+++ b/scripts/crawl/provenance_sync.py
@@ -2,9 +2,9 @@
 
 Provides sync entry points:
 
-    provenance_start(source, mode, params=None)
-    provenance_complete(run_id, records_fetched, records_upserted, error_count)
-    provenance_fail(run_id, error_message)
+    provenance_start(source=source, mode=mode, params=None)
+    provenance_complete(run_id=run_id, source=source, records_fetched=count)
+    provenance_fail(run_id=run_id, source=source, error_message=message)
 
 Uses ``config.settings.DEFAULT_DSN`` for DB connection.
 """
@@ -63,50 +63,82 @@ def _run_async(coro):
 
 
 def provenance_start(
+    *,
     source: str,
     mode: str = "full",
     params: dict[str, Any] | None = None,
-) -> str | None:
-    """Start a provenance run. Returns run_id string or None on failure."""
-    try:
-        tracker = _get_tracker()
-        run_id = f"{source}-{int(time.time())}"
-        _run_async(tracker.start_run(run_id, source, mode=mode, params=params))
-        logger.debug("provenance started: source=%s run_id=%s", source, run_id)
-        return run_id
-    except Exception as e:
-        logger.error("provenance_start failed for source=%s: %s", source, e)
-        return None
+) -> str:
+    """Start a provenance run or raise if the running row cannot be persisted."""
+    tracker = _get_tracker()
+    run_id = f"{source}-{time.time_ns()}"
+    _run_async(tracker.start_run(run_id, source, mode=mode, params=params))
+    logger.debug("provenance started: source=%s run_id=%s", source, run_id)
+    return run_id
 
 
 def provenance_complete(
+    *,
     run_id: str,
     source: str,
     records_fetched: int = 0,
+    records_deduplicated: int = 0,
     records_upserted: int = 0,
-    error_count: int = 0,
-) -> bool:
-    """Mark a provenance run as completed successfully."""
-    try:
-        tracker = _get_tracker()
-        _run_async(tracker.complete_run(run_id, source, records_fetched, records_upserted, error_count))
-        return True
-    except Exception as e:
-        logger.error("provenance_complete failed for run=%s: %s", run_id, e)
-        return False
+    records_dlq: int = 0,
+    records_failed: int = 0,
+    pages_planned: int = 0,
+    pages_completed: int = 0,
+    watermarks_committed: int = 0,
+    duration_ms: int = 0,
+) -> None:
+    """Persist a successful terminal state or propagate the persistence error."""
+    tracker = _get_tracker()
+    _run_async(
+        tracker.complete_run(
+            run_id,
+            source=source,
+            records_fetched=records_fetched,
+            records_deduplicated=records_deduplicated,
+            records_upserted=records_upserted,
+            records_dlq=records_dlq,
+            records_failed=records_failed,
+            pages_planned=pages_planned,
+            pages_completed=pages_completed,
+            watermarks_committed=watermarks_committed,
+            duration_ms=duration_ms,
+        )
+    )
 
 
 def provenance_fail(
+    *,
     run_id: str,
     source: str,
-    error_message: str = "",
+    error_message: str,
     records_fetched: int = 0,
-) -> bool:
-    """Mark a provenance run as failed."""
-    try:
-        tracker = _get_tracker()
-        _run_async(tracker.fail_run(run_id, source, error_message, records_fetched))
-        return True
-    except Exception as e:
-        logger.error("provenance_fail failed for run=%s: %s", run_id, e)
-        return False
+    records_deduplicated: int = 0,
+    records_upserted: int = 0,
+    records_dlq: int = 0,
+    records_failed: int = 0,
+    pages_planned: int = 0,
+    pages_completed: int = 0,
+    watermarks_committed: int = 0,
+    duration_ms: int = 0,
+) -> None:
+    """Persist a failed terminal state or propagate the persistence error."""
+    tracker = _get_tracker()
+    _run_async(
+        tracker.fail_run(
+            run_id,
+            source=source,
+            error_message=error_message,
+            records_fetched=records_fetched,
+            records_deduplicated=records_deduplicated,
+            records_upserted=records_upserted,
+            records_dlq=records_dlq,
+            records_failed=records_failed,
+            pages_planned=pages_planned,
+            pages_completed=pages_completed,
+            watermarks_committed=watermarks_committed,
+            duration_ms=duration_ms,
+        )
+    )

--- a/scripts/crawl/tce_sc_crawler.py
+++ b/scripts/crawl/tce_sc_crawler.py
@@ -487,8 +487,6 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     days = TCE_SC_FULL_DAYS if mode == "full" else TCE_SC_INCREMENTAL_DAYS
     data_final = date.today()
     data_inicial = data_final - timedelta(days=days)
-    run_id = f"tce_sc-{int(time.time())}"
-
     _logger.info(
         "[TCE-SC] Crawling %s mode: %s to %s (%d days)",
         mode,
@@ -498,7 +496,12 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     )
 
     # Provenance: start run
-    provenance_start(source="tce_sc", mode=mode, params={"data_inicial": str(data_inicial), "data_final": str(data_final)})
+    provenance_started_at = time.monotonic()
+    run_id = provenance_start(
+        source="tce_sc",
+        mode=mode,
+        params={"data_inicial": str(data_inicial), "data_final": str(data_final)},
+    )
 
     all_records: list[dict] = []
     errors = 0
@@ -546,14 +549,27 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
         errors += 1
 
     # Provenance: complete or fail
+    duration_ms = int((time.monotonic() - provenance_started_at) * 1000)
     if errors > 0:
-        provenance_fail(run_id, "tce_sc", error_message=f"{errors} phases failed", records_fetched=len(all_records))
+        provenance_fail(
+            run_id=run_id,
+            source="tce_sc",
+            error_message=f"{errors} phases failed",
+            records_fetched=len(all_records),
+            records_dlq=errors,
+            records_failed=errors,
+            duration_ms=duration_ms,
+        )
     else:
-        provenance_complete(run_id, "tce_sc", records_fetched=len(all_records))
-
-    # Watermark: commit date range
-    if resume:
-        watermark_commit(source="tce_sc", scope_key="date", value=str(data_final), run_id=run_id)
+        provenance_complete(
+            run_id=run_id,
+            source="tce_sc",
+            records_fetched=len(all_records),
+            duration_ms=duration_ms,
+        )
+        # Watermark: only a successful terminal run may advance the date range.
+        if resume:
+            watermark_commit(source="tce_sc", scope_key="date", value=str(data_final), run_id=run_id)
 
     _logger.info("[TCE-SC] Crawl complete: %d total records", len(all_records))
     return all_records

--- a/tests/integration/test_provenance_terminal_persistence.py
+++ b/tests/integration/test_provenance_terminal_persistence.py
@@ -1,0 +1,181 @@
+"""Real-PostgreSQL regression proof for provenance terminal persistence (#342)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from collections.abc import Iterator
+
+import psycopg2
+import psycopg2.extras
+import pytest
+
+from scripts.crawl import provenance_sync
+from scripts.crawl.provenance import (
+    ProvenanceRunNotFoundError,
+    ProvenanceRunStateError,
+    ProvenanceSourceMismatchError,
+    ProvenanceTracker,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def real_tracker(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[ProvenanceTracker, str, list[str]]]:
+    if os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"}:
+        pytest.skip("REQUIRE_REAL_DB=1 is required for the PostgreSQL provenance proof")
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("TEST_DSN")
+    if not dsn:
+        pytest.fail("REQUIRE_REAL_DB=1 but LOCAL_DATALAKE_DSN/TEST_DSN is unset")
+
+    try:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM pipeline_runs LIMIT 1")
+    except Exception as exc:
+        pytest.fail(f"real PostgreSQL pipeline_runs is unavailable: {exc}")
+
+    tracker = ProvenanceTracker(conn_string=dsn)
+    monkeypatch.setattr(provenance_sync, "_tracker", tracker)
+    run_ids: list[str] = []
+    yield tracker, dsn, run_ids
+
+    if run_ids:
+        with psycopg2.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute("DELETE FROM pipeline_runs WHERE run_id = ANY(%s)", (run_ids,))
+
+
+def _new_run_id(run_ids: list[str], label: str) -> str:
+    run_id = f"issue-342-{label}-{uuid.uuid4().hex}"
+    run_ids.append(run_id)
+    return run_id
+
+
+def _start(tracker: ProvenanceTracker, run_id: str, source: str) -> None:
+    asyncio.run(tracker.start_run(run_id, source, mode="incremental"))
+
+
+def _get_run(dsn: str, run_id: str) -> dict:
+    with psycopg2.connect(dsn) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT * FROM pipeline_runs WHERE run_id = %s", (run_id,))
+            row = cur.fetchone()
+    assert row is not None
+    return dict(row)
+
+
+def test_complete_persists_every_count_in_its_schema_column(real_tracker) -> None:
+    tracker, dsn, run_ids = real_tracker
+    run_id = _new_run_id(run_ids, "complete")
+    _start(tracker, run_id, "pcp")
+
+    provenance_sync.provenance_complete(
+        run_id=run_id,
+        source="pcp",
+        records_fetched=101,
+        records_deduplicated=11,
+        records_upserted=89,
+        records_dlq=3,
+        records_failed=2,
+        pages_planned=9,
+        pages_completed=8,
+        watermarks_committed=7,
+        duration_ms=6543,
+    )
+
+    row = _get_run(dsn, run_id)
+    assert row["source"] == "pcp"
+    assert row["status"] == "completed"
+    assert row["completed_at"] is not None
+    assert row["records_fetched"] == 101
+    assert row["records_deduplicated"] == 11
+    assert row["records_upserted"] == 89
+    assert row["records_dlq"] == 3
+    assert row["records_failed"] == 2
+    assert row["pages_planned"] == 9
+    assert row["pages_completed"] == 8
+    assert row["watermarks_committed"] == 7
+    assert row["duration_ms"] == 6543
+
+
+def test_fail_persists_error_counts_and_duration(real_tracker) -> None:
+    tracker, dsn, run_ids = real_tracker
+    run_id = _new_run_id(run_ids, "fail")
+    _start(tracker, run_id, "dom_sc")
+
+    provenance_sync.provenance_fail(
+        run_id=run_id,
+        source="dom_sc",
+        error_message="upstream timed out",
+        records_fetched=13,
+        records_deduplicated=2,
+        records_upserted=8,
+        records_dlq=1,
+        records_failed=1,
+        pages_planned=5,
+        pages_completed=4,
+        watermarks_committed=3,
+        duration_ms=4321,
+    )
+
+    row = _get_run(dsn, run_id)
+    assert row["source"] == "dom_sc"
+    assert row["status"] == "failed"
+    assert row["completed_at"] is not None
+    assert row["error_message"] == "upstream timed out"
+    assert row["records_fetched"] == 13
+    assert row["records_deduplicated"] == 2
+    assert row["records_upserted"] == 8
+    assert row["records_dlq"] == 1
+    assert row["records_failed"] == 1
+    assert row["pages_planned"] == 5
+    assert row["pages_completed"] == 4
+    assert row["watermarks_committed"] == 3
+    assert row["duration_ms"] == 4321
+
+
+def test_wrong_source_and_missing_run_fail_closed(real_tracker) -> None:
+    tracker, dsn, run_ids = real_tracker
+    run_id = _new_run_id(run_ids, "identity")
+    _start(tracker, run_id, "pcp")
+
+    with pytest.raises(ProvenanceSourceMismatchError, match="expected=doe_sc actual=pcp"):
+        provenance_sync.provenance_complete(run_id=run_id, source="doe_sc")
+
+    row = _get_run(dsn, run_id)
+    assert row["status"] == "running"
+    assert row["records_fetched"] == 0
+
+    with pytest.raises(ProvenanceRunNotFoundError, match="not found"):
+        provenance_sync.provenance_fail(
+            run_id=f"missing-{uuid.uuid4().hex}",
+            source="pcp",
+            error_message="cannot persist",
+        )
+
+
+def test_terminal_transition_is_single_use_and_does_not_overwrite_counts(real_tracker) -> None:
+    tracker, dsn, run_ids = real_tracker
+    run_id = _new_run_id(run_ids, "terminal")
+    _start(tracker, run_id, "tce_sc")
+    provenance_sync.provenance_complete(
+        run_id=run_id,
+        source="tce_sc",
+        records_fetched=17,
+        duration_ms=25,
+    )
+
+    with pytest.raises(ProvenanceRunStateError, match="status=completed"):
+        provenance_sync.provenance_fail(
+            run_id=run_id,
+            source="tce_sc",
+            error_message="late failure",
+            records_fetched=999,
+        )
+
+    row = _get_run(dsn, run_id)
+    assert row["status"] == "completed"
+    assert row["records_fetched"] == 17
+    assert row["duration_ms"] == 25

--- a/tests/test_ciga_ckan_crawler.py
+++ b/tests/test_ciga_ckan_crawler.py
@@ -773,9 +773,10 @@ class TestCrawl:
 
     @patch("scripts.crawl.ciga_ckan_crawler.list_domsc_months")
     def test_crawl_no_data(self, mock_list):
-        """No datasets returns empty list."""
+        """Missing source datasets is observable, not implicit success_zero."""
         mock_list.return_value = []
-        assert ciga.crawl() == []
+        with pytest.raises(RuntimeError, match="No DOM-SC datasets"):
+            ciga.crawl()
 
 
 class TestTransform:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -80,8 +80,10 @@ class TestProvenanceTracker:
     @pytest.mark.asyncio
     async def test_complete_run(self, tracker, mock_cur):
         """Given complete_run called, UPDATE with stats."""
+        mock_cur.fetchone.return_value = ("run-001",)
         await tracker.complete_run(
             "run-001",
+            source="pncp",
             records_fetched=100,
             records_upserted=95,
             records_dlq=3,
@@ -95,7 +97,12 @@ class TestProvenanceTracker:
     @pytest.mark.asyncio
     async def test_fail_run(self, tracker, mock_cur):
         """Given fail_run called, UPDATE with error."""
-        await tracker.fail_run("run-001", error_message="Connection timeout")
+        mock_cur.fetchone.return_value = ("run-001",)
+        await tracker.fail_run(
+            "run-001",
+            source="pncp",
+            error_message="Connection timeout",
+        )
         call_sql = mock_cur.execute.call_args[0][0]
         assert "UPDATE pipeline_runs" in call_sql
         assert "failed" in call_sql

--- a/tests/test_provenance_crawler_contract.py
+++ b/tests/test_provenance_crawler_contract.py
@@ -1,0 +1,176 @@
+"""Crawler regressions for the keyword-only provenance terminal contract (#342)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from scripts.crawl import (
+    ciga_ckan_crawler as ciga,
+)
+from scripts.crawl import (
+    doe_sc_crawler as doe,
+)
+from scripts.crawl import (
+    dom_sc_crawler as dom,
+)
+from scripts.crawl import (
+    pcp_crawler as pcp,
+)
+from scripts.crawl import (
+    provenance_sync,
+)
+from scripts.crawl import (
+    tce_sc_crawler as tce,
+)
+
+
+class ProvenanceRecorder:
+    def __init__(self, *, complete_error: Exception | None = None) -> None:
+        self.complete_error = complete_error
+        self.started: list[dict[str, Any]] = []
+        self.completed: list[dict[str, Any]] = []
+        self.failed: list[dict[str, Any]] = []
+
+    def start(self, *, source: str, mode: str = "full", params=None) -> str:
+        call = {"source": source, "mode": mode, "params": params}
+        self.started.append(call)
+        return f"persisted-{source}-run"
+
+    def complete(self, *, run_id: str, source: str, **counts: Any) -> None:
+        self.completed.append({"run_id": run_id, "source": source, **counts})
+        if self.complete_error is not None:
+            raise self.complete_error
+
+    def fail(self, *, run_id: str, source: str, error_message: str, **counts: Any) -> None:
+        self.failed.append({"run_id": run_id, "source": source, "error_message": error_message, **counts})
+
+
+def _install_recorder(
+    monkeypatch: pytest.MonkeyPatch,
+    module: Any,
+    recorder: ProvenanceRecorder,
+) -> None:
+    targets = [module]
+    if module is ciga:
+        targets.append(provenance_sync)
+    for target in targets:
+        monkeypatch.setattr(target, "provenance_start", recorder.start, raising=False)
+        monkeypatch.setattr(target, "provenance_complete", recorder.complete, raising=False)
+        monkeypatch.setattr(target, "provenance_fail", recorder.fail, raising=False)
+
+
+def _configure_pcp(monkeypatch: pytest.MonkeyPatch) -> Callable[[], list[dict]]:
+    monkeypatch.setattr(pcp, "INGESTION_UFS", ["SC"])
+    monkeypatch.setattr(pcp, "_PCP_UF_CODE", {"SC": "42"})
+    monkeypatch.setattr(
+        pcp,
+        "_fetch_page",
+        lambda *_args: ([{"unidadeCompradora": {"uf": "SC"}}], False),
+    )
+    return lambda: pcp.crawl(mode="incremental")
+
+
+def _configure_doe(monkeypatch: pytest.MonkeyPatch) -> Callable[[], list[dict]]:
+    monkeypatch.setattr(doe, "DOE_SC_ENABLED", True)
+    monkeypatch.setattr(doe, "_load_categories", lambda: None)
+    monkeypatch.setattr(doe, "_fetch_materias", lambda *_args: [{"id": 1}, {"id": 2}])
+    return lambda: doe.crawl(mode="incremental")
+
+
+def _configure_dom(monkeypatch: pytest.MonkeyPatch) -> Callable[[], list[dict]]:
+    monkeypatch.setattr(dom, "DOM_SC_ENABLED", True)
+    monkeypatch.setattr(dom, "DOM_SC_CPF", "123")
+    monkeypatch.setattr(dom, "DOM_SC_CNPJ", "456")
+    monkeypatch.setattr(dom, "DOM_SC_API_KEY", "key")
+    monkeypatch.setattr(dom, "_fetch_publications", lambda *_args: [{"id": 1}])
+    return lambda: dom.crawl(mode="incremental")
+
+
+def _configure_tce(monkeypatch: pytest.MonkeyPatch) -> Callable[[], list[dict]]:
+    monkeypatch.setattr(tce, "TCE_SC_ENABLED", True)
+    monkeypatch.setattr(tce, "_fetch_licitacoes", lambda **_kwargs: [{"id": 1}])
+    monkeypatch.setattr(tce, "_fetch_contratos", lambda **_kwargs: [{"id": 2}])
+    monkeypatch.setattr(tce.time, "sleep", lambda _seconds: None)
+    return lambda: tce.crawl(mode="incremental")
+
+
+def _configure_ciga(monkeypatch: pytest.MonkeyPatch) -> Callable[[], list[dict]]:
+    monkeypatch.setattr(ciga, "list_domsc_months", lambda: ["domsc-janeiro-2026"])
+    monkeypatch.setattr(ciga, "download_month", lambda _month: [{"id": 1}, {"id": 2}, {"id": 3}])
+    return lambda: ciga.crawl(mode="incremental")
+
+
+CRAWLERS = [
+    ("pcp", pcp, _configure_pcp, 1),
+    ("doe_sc", doe, _configure_doe, 2),
+    ("dom_sc", dom, _configure_dom, 1),
+    ("tce_sc", tce, _configure_tce, 2),
+    ("ciga_ckan", ciga, _configure_ciga, 3),
+]
+
+
+@pytest.mark.parametrize(("source", "module", "configure", "expected_fetched"), CRAWLERS)
+def test_crawler_reuses_persisted_run_identity_and_named_counts(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    module: Any,
+    configure: Callable[[pytest.MonkeyPatch], Callable[[], list[dict]]],
+    expected_fetched: int,
+) -> None:
+    recorder = ProvenanceRecorder()
+    _install_recorder(monkeypatch, module, recorder)
+    crawl = configure(monkeypatch)
+
+    crawl()
+
+    assert recorder.started and recorder.started[0]["source"] == source
+    assert recorder.completed == [
+        {
+            "run_id": f"persisted-{source}-run",
+            "source": source,
+            "records_fetched": expected_fetched,
+            "duration_ms": recorder.completed[0]["duration_ms"],
+        }
+    ]
+    assert isinstance(recorder.completed[0]["duration_ms"], int)
+    assert recorder.failed == []
+
+
+@pytest.mark.parametrize(("source", "module", "configure", "_expected_fetched"), CRAWLERS)
+def test_crawler_does_not_convert_terminal_persistence_failure_to_success(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    module: Any,
+    configure: Callable[[pytest.MonkeyPatch], Callable[[], list[dict]]],
+    _expected_fetched: int,
+) -> None:
+    recorder = ProvenanceRecorder(complete_error=RuntimeError("terminal persistence unavailable"))
+    _install_recorder(monkeypatch, module, recorder)
+    crawl = configure(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="terminal persistence unavailable"):
+        crawl()
+
+    assert recorder.completed[0]["source"] == source
+
+
+def test_tce_failed_run_does_not_advance_watermark(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = ProvenanceRecorder()
+    _install_recorder(monkeypatch, tce, recorder)
+    monkeypatch.setattr(tce, "TCE_SC_ENABLED", True)
+    monkeypatch.setattr(tce, "_fetch_licitacoes", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("phase failed")))
+    monkeypatch.setattr(tce, "_fetch_contratos", lambda **_kwargs: [{"id": 2}])
+    monkeypatch.setattr(tce.time, "sleep", lambda _seconds: None)
+    committed: list[dict[str, Any]] = []
+    monkeypatch.setattr(tce, "watermark_commit", lambda **kwargs: committed.append(kwargs))
+
+    records = tce.crawl(mode="incremental", resume=True)
+
+    assert records == [{"id": 2, "_tipo": "contrato"}]
+    assert recorder.completed == []
+    assert recorder.failed[0]["source"] == "tce_sc"
+    assert recorder.failed[0]["records_failed"] == 1
+    assert committed == []

--- a/tests/test_provenance_sync.py
+++ b/tests/test_provenance_sync.py
@@ -1,23 +1,112 @@
-"""Tests for provenance_sync module."""
+"""Unit tests for the fail-closed synchronous provenance contract."""
+
 from __future__ import annotations
 
-from scripts.crawl.provenance_sync import provenance_complete, provenance_fail, provenance_start
+from typing import Any
+
+import pytest
+
+from scripts.crawl import provenance_sync
 
 
-class TestProvenanceSync:
-    """Unit tests for provenance_sync wrapper functions."""
+class RecordingTracker:
+    def __init__(self) -> None:
+        self.started: dict[str, Any] | None = None
+        self.completed: dict[str, Any] | None = None
+        self.failed: dict[str, Any] | None = None
 
-    def test_provenance_start_never_crashes(self):
-        """provenance_start returns a string or None — never crashes."""
-        run_id = provenance_start(source="test", mode="full")
-        assert run_id is None or isinstance(run_id, str)
+    async def start_run(self, run_id: str, source: str, **kwargs: Any) -> None:
+        self.started = {"run_id": run_id, "source": source, **kwargs}
 
-    def test_provenance_complete_never_crashes(self):
-        """provenance_complete returns True or False — never crashes."""
-        result = provenance_complete(run_id="test-run", source="test")
-        assert isinstance(result, bool)
+    async def complete_run(self, run_id: str, **kwargs: Any) -> None:
+        self.completed = {"run_id": run_id, **kwargs}
 
-    def test_provenance_fail_never_crashes(self):
-        """provenance_fail returns True or False — never crashes."""
-        result = provenance_fail(run_id="test-run", source="test", error_message="oops")
-        assert isinstance(result, bool)
+    async def fail_run(self, run_id: str, **kwargs: Any) -> None:
+        self.failed = {"run_id": run_id, **kwargs}
+
+
+@pytest.fixture
+def tracker(monkeypatch: pytest.MonkeyPatch) -> RecordingTracker:
+    recording = RecordingTracker()
+    monkeypatch.setattr(provenance_sync, "_tracker", recording)
+    return recording
+
+
+def test_start_returns_the_persisted_run_id(tracker: RecordingTracker) -> None:
+    run_id = provenance_sync.provenance_start(source="pcp", mode="incremental")
+
+    assert run_id.startswith("pcp-")
+    assert tracker.started == {
+        "run_id": run_id,
+        "source": "pcp",
+        "mode": "incremental",
+        "params": None,
+    }
+
+
+def test_complete_forwards_schema_counts_by_name(tracker: RecordingTracker) -> None:
+    provenance_sync.provenance_complete(
+        run_id="run-001",
+        source="pcp",
+        records_fetched=11,
+        records_deduplicated=2,
+        records_upserted=7,
+        records_dlq=1,
+        records_failed=1,
+        pages_planned=4,
+        pages_completed=3,
+        watermarks_committed=2,
+        duration_ms=987,
+    )
+
+    assert tracker.completed == {
+        "run_id": "run-001",
+        "source": "pcp",
+        "records_fetched": 11,
+        "records_deduplicated": 2,
+        "records_upserted": 7,
+        "records_dlq": 1,
+        "records_failed": 1,
+        "pages_planned": 4,
+        "pages_completed": 3,
+        "watermarks_committed": 2,
+        "duration_ms": 987,
+    }
+
+
+def test_fail_forwards_error_and_counts_by_name(tracker: RecordingTracker) -> None:
+    provenance_sync.provenance_fail(
+        run_id="run-002",
+        source="dom_sc",
+        error_message="upstream timeout",
+        records_fetched=5,
+        records_failed=1,
+        duration_ms=321,
+    )
+
+    assert tracker.failed is not None
+    assert tracker.failed["run_id"] == "run-002"
+    assert tracker.failed["source"] == "dom_sc"
+    assert tracker.failed["error_message"] == "upstream timeout"
+    assert tracker.failed["records_fetched"] == 5
+    assert tracker.failed["records_failed"] == 1
+    assert tracker.failed["duration_ms"] == 321
+
+
+def test_terminal_persistence_error_is_propagated(monkeypatch: pytest.MonkeyPatch) -> None:
+    class BrokenTracker(RecordingTracker):
+        async def complete_run(self, run_id: str, **kwargs: Any) -> None:
+            raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(provenance_sync, "_tracker", BrokenTracker())
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        provenance_sync.provenance_complete(run_id="run-003", source="pcp")
+
+
+def test_positional_terminal_arguments_are_rejected() -> None:
+    with pytest.raises(TypeError):
+        provenance_sync.provenance_complete("run-004", "pcp", 10)  # type: ignore[misc]
+
+    with pytest.raises(TypeError):
+        provenance_sync.provenance_fail("run-004", "pcp", "error")  # type: ignore[misc]


### PR DESCRIPTION
## Resultado

Corrige o deslocamento de assinatura que fazia source chegar a records_fetched e remove o soft-fail que deixava pipeline_runs em running após falha de persistência terminal.

- contrato sync keyword-only e contagens encaminhadas pelo nome canônico;
- identidade terminal validada por run_id + source + status running;
- run inexistente, source divergente e segunda transição terminal falham fechado;
- complete e fail persistem todas as contagens e duração do schema;
- PCP, DOM, DOE, TCE e CIGA reutilizam o run_id realmente persistido;
- TCE não avança watermark após execução failed;
- erro de persistência terminal permanece observável ao caller.

Closes #342

## Evidência no commit dcc04ba6

- PostgreSQL real: 4 passed em tests/integration/test_provenance_terminal_persistence.py, incluindo colunas complete/fail, identidade e transição única;
- regressões focadas: 154 passed para tracker, wrappers e crawlers;
- python3 -m ruff check .: PASS;
- generated-artifacts-policy: checked=13, violations=0;
- pr-reviewability ready: violations=0;
- CodeRabbit pós-correções: 0 findings.

## Suíte canônica local

A execução canônica com -x parou em test_write_concorrentes_report_domain_file por psycopg2.connect ter sido substituído pela fixture autouse MagicMock. O mesmo erro e as demais 14 falhas suplementares foram reproduzidos em worktree limpo de origin/main@1ffa079d, portanto não são regressões deste PR.

O problema conhecido de preflight está registrado em #341; o defeito distinto do fixture global foi aberto como #343. Nenhum deles foi misturado neste diff. A CI deste PR é a evidência autoritativa para o HEAD exato.

## Escopo

Sem mudança do feed CONFENGE, thresholds, coverage, mocks operacionais ou PR #231.