### PR TITLE
feat: close 10 critical truth-plane gaps

### DIFF
--- a/db/migrations/085_pncp_content_hash_collision.sql
+++ b/db/migrations/085_pncp_content_hash_collision.sql
@@ -1,0 +1,178 @@
+-- 085_pncp_content_hash_collision
+--
+-- A batch can contain different source IDs with the same content_hash.  The
+-- table deliberately keeps content_hash unique across sources, so identity
+-- resolution must happen before INSERT instead of allowing one collision to
+-- roll back the whole page.
+--
+-- Deterministic authority:
+--   1. an already-persisted content_hash owner always keeps the identity;
+--   2. otherwise a non-synthetic ID wins, then the lexical pncp_id;
+--   3. the latest occurrence of one pncp_id wins within the input array.
+--
+-- The third return value counts every valid input identity that did not cause
+-- a persisted insert/update, including content duplicates and unchanged rows.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.upsert_pncp_raw_bids(JSONB);
+CREATE FUNCTION public.upsert_pncp_raw_bids(p_records JSONB)
+RETURNS TABLE (inserted INTEGER, updated INTEGER, unchanged INTEGER)
+LANGUAGE plpgsql
+SET search_path TO public
+AS $$
+DECLARE
+    v_total INTEGER;
+    v_inserted INTEGER;
+    v_updated INTEGER;
+    v_hash TEXT;
+BEGIN
+    IF p_records IS NULL OR jsonb_typeof(p_records) <> 'array' THEN
+        RAISE EXCEPTION 'p_records must be a JSON array';
+    END IF;
+
+    WITH latest_per_id AS (
+        SELECT DISTINCT ON (rec->>'pncp_id')
+            rec->>'pncp_id' AS pncp_id
+        FROM jsonb_array_elements(p_records) WITH ORDINALITY AS item(rec, ordinal)
+        WHERE NULLIF(rec->>'pncp_id', '') IS NOT NULL
+        ORDER BY rec->>'pncp_id', ordinal DESC
+    )
+    SELECT COUNT(*)::INTEGER INTO v_total FROM latest_per_id;
+
+    -- Serialize ownership resolution for every hash in a deterministic order.
+    -- Without this lock, two transactions can both observe no persisted owner
+    -- and race on the global content_hash unique constraint.
+    FOR v_hash IN
+        SELECT DISTINCT NULLIF(rec->>'content_hash', '') AS hash_value
+        FROM jsonb_array_elements(p_records) AS item(rec)
+        WHERE NULLIF(rec->>'pncp_id', '') IS NOT NULL
+          AND NULLIF(rec->>'content_hash', '') IS NOT NULL
+        ORDER BY hash_value
+    LOOP
+        PERFORM pg_advisory_xact_lock(hashtextextended(v_hash, 0));
+    END LOOP;
+
+    WITH latest_per_id AS (
+        SELECT DISTINCT ON (rec->>'pncp_id')
+            rec->>'pncp_id' AS pncp_id,
+            COALESCE(rec->>'numero_controle_pncp', rec->>'pncp_id') AS numero_controle_pncp,
+            rec->>'objeto_compra' AS objeto_compra,
+            rec->>'informacao_complementar' AS informacao_complementar,
+            NULLIF(rec->>'valor_total_estimado', '')::NUMERIC AS valor_total_estimado,
+            NULLIF(rec->>'modalidade_id', '')::INTEGER AS modalidade_id,
+            rec->>'modalidade_nome' AS modalidade_nome,
+            rec->>'situacao_compra' AS situacao_compra,
+            rec->>'esfera_id' AS esfera_id,
+            rec->>'uf' AS uf,
+            rec->>'municipio' AS municipio,
+            rec->>'codigo_municipio_ibge' AS codigo_municipio_ibge,
+            rec->>'orgao_razao_social' AS orgao_razao_social,
+            rec->>'orgao_cnpj' AS orgao_cnpj,
+            rec->>'unidade_nome' AS unidade_nome,
+            NULLIF(rec->>'data_publicacao', '')::TIMESTAMPTZ AS data_publicacao,
+            NULLIF(rec->>'data_abertura', '')::TIMESTAMPTZ AS data_abertura,
+            NULLIF(rec->>'data_encerramento', '')::TIMESTAMPTZ AS data_encerramento,
+            rec->>'link_sistema_origem' AS link_sistema_origem,
+            rec->>'link_pncp' AS link_pncp,
+            NULLIF(rec->>'content_hash', '') AS content_hash,
+            COALESCE(rec->>'source', 'pncp') AS source,
+            rec->>'source_id' AS source_id,
+            rec->>'crawl_batch_id' AS crawl_batch_id,
+            NULLIF(rec->>'ano_compra', '')::INTEGER AS ano_compra,
+            NULLIF(rec->>'sequencial_compra', '')::INTEGER AS sequencial_compra,
+            COALESCE(NULLIF(rec->>'synthetic_id', '')::BOOLEAN, FALSE) AS synthetic_id,
+            rec->>'synthetic_id_reason' AS synthetic_id_reason,
+            rec->'raw_payload' AS raw_payload
+        FROM jsonb_array_elements(p_records) WITH ORDINALITY AS item(rec, ordinal)
+        WHERE NULLIF(rec->>'pncp_id', '') IS NOT NULL
+        ORDER BY rec->>'pncp_id', ordinal DESC
+    ),
+    resolved AS (
+        SELECT
+            candidate.*,
+            owner.pncp_id AS persisted_owner,
+            ROW_NUMBER() OVER (
+                PARTITION BY COALESCE(
+                    candidate.content_hash,
+                    'pncp-id:' || candidate.pncp_id
+                )
+                ORDER BY candidate.synthetic_id ASC, candidate.pncp_id ASC
+            ) AS content_rank
+        FROM latest_per_id AS candidate
+        LEFT JOIN public.pncp_raw_bids AS owner
+          ON owner.content_hash = candidate.content_hash
+    ),
+    src AS (
+        SELECT *
+        FROM resolved
+        WHERE content_hash IS NULL
+           OR persisted_owner = pncp_id
+           OR (persisted_owner IS NULL AND content_rank = 1)
+    ),
+    changed AS (
+        INSERT INTO public.pncp_raw_bids (
+            pncp_id, numero_controle_pncp, objeto_compra, informacao_complementar,
+            valor_total_estimado, modalidade_id, modalidade_nome, situacao_compra,
+            esfera_id, uf, municipio, codigo_municipio_ibge, orgao_razao_social,
+            orgao_cnpj, unidade_nome, data_publicacao, data_abertura, data_encerramento,
+            link_sistema_origem, link_pncp, content_hash, source, source_id,
+            crawl_batch_id, ano_compra, sequencial_compra, synthetic_id,
+            synthetic_id_reason, raw_payload
+        )
+        SELECT
+            pncp_id, numero_controle_pncp, objeto_compra, informacao_complementar,
+            valor_total_estimado, modalidade_id, modalidade_nome, situacao_compra,
+            esfera_id, uf, municipio, codigo_municipio_ibge, orgao_razao_social,
+            orgao_cnpj, unidade_nome, data_publicacao, data_abertura, data_encerramento,
+            link_sistema_origem, link_pncp, content_hash, source, source_id,
+            crawl_batch_id, ano_compra, sequencial_compra, synthetic_id,
+            synthetic_id_reason, raw_payload
+        FROM src
+        ON CONFLICT (pncp_id) DO UPDATE SET
+            numero_controle_pncp = EXCLUDED.numero_controle_pncp,
+            objeto_compra = EXCLUDED.objeto_compra,
+            informacao_complementar = EXCLUDED.informacao_complementar,
+            valor_total_estimado = EXCLUDED.valor_total_estimado,
+            modalidade_id = EXCLUDED.modalidade_id,
+            modalidade_nome = EXCLUDED.modalidade_nome,
+            situacao_compra = EXCLUDED.situacao_compra,
+            esfera_id = EXCLUDED.esfera_id,
+            uf = EXCLUDED.uf,
+            municipio = EXCLUDED.municipio,
+            codigo_municipio_ibge = EXCLUDED.codigo_municipio_ibge,
+            orgao_razao_social = EXCLUDED.orgao_razao_social,
+            orgao_cnpj = EXCLUDED.orgao_cnpj,
+            unidade_nome = EXCLUDED.unidade_nome,
+            data_publicacao = EXCLUDED.data_publicacao,
+            data_abertura = EXCLUDED.data_abertura,
+            data_encerramento = EXCLUDED.data_encerramento,
+            link_sistema_origem = EXCLUDED.link_sistema_origem,
+            link_pncp = EXCLUDED.link_pncp,
+            content_hash = EXCLUDED.content_hash,
+            source = EXCLUDED.source,
+            source_id = EXCLUDED.source_id,
+            crawl_batch_id = EXCLUDED.crawl_batch_id,
+            ano_compra = EXCLUDED.ano_compra,
+            sequencial_compra = EXCLUDED.sequencial_compra,
+            synthetic_id = EXCLUDED.synthetic_id,
+            synthetic_id_reason = EXCLUDED.synthetic_id_reason,
+            raw_payload = EXCLUDED.raw_payload
+        WHERE public.pncp_raw_bids.content_hash IS DISTINCT FROM EXCLUDED.content_hash
+           OR EXCLUDED.content_hash IS NULL
+        RETURNING (xmax = 0) AS was_inserted
+    )
+    SELECT
+        COUNT(*) FILTER (WHERE was_inserted)::INTEGER,
+        COUNT(*) FILTER (WHERE NOT was_inserted)::INTEGER
+    INTO v_inserted, v_updated
+    FROM changed;
+
+    RETURN QUERY SELECT
+        COALESCE(v_inserted, 0),
+        COALESCE(v_updated, 0),
+        GREATEST(0, v_total - COALESCE(v_inserted, 0) - COALESCE(v_updated, 0));
+END;
+$$;
+
+COMMIT;

--- a/db/migrations/086_contract_analytics_complete.sql
+++ b/db/migrations/086_contract_analytics_complete.sql
@@ -1,0 +1,411 @@
+-- 086_contract_analytics_complete.sql
+-- Complete, snapshot-bound contract analytics and keyset pagination (#355, #356).
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_psc_supplier_event_keyset
+    ON public.pncp_supplier_contracts (
+        supplier_id_type,
+        supplier_identifier,
+        (COALESCE(data_assinatura, data_publicacao_fonte, data_publicacao, data_inicio)) DESC,
+        id DESC
+    )
+    WHERE is_active = TRUE;
+
+CREATE OR REPLACE FUNCTION public.supplier_contracts_dataset_v2(
+    p_supplier_id_type TEXT DEFAULT NULL,
+    p_supplier_identifier TEXT DEFAULT NULL,
+    p_orgao_cnpj TEXT DEFAULT NULL,
+    p_ufs TEXT[] DEFAULT NULL,
+    p_keywords TEXT[] DEFAULT NULL,
+    p_date_start DATE DEFAULT NULL,
+    p_date_end DATE DEFAULT NULL,
+    p_snapshot_at TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    record_id BIGINT,
+    contrato_id TEXT,
+    supplier_id_type TEXT,
+    supplier_identifier TEXT,
+    supplier_identifier_hash TEXT,
+    supplier_identifier_export TEXT,
+    fornecedor_nome TEXT,
+    orgao_cnpj TEXT,
+    orgao_nome TEXT,
+    uf TEXT,
+    municipio TEXT,
+    valor_total NUMERIC,
+    data_assinatura DATE,
+    data_publicacao DATE,
+    event_date DATE,
+    objeto_contrato TEXT,
+    source TEXT,
+    ingested_at TIMESTAMPTZ,
+    quarantined BOOLEAN
+)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT
+        contract.id::BIGINT,
+        contract.contrato_id,
+        contract.supplier_id_type,
+        contract.supplier_identifier,
+        contract.supplier_identifier_hash,
+        contract.supplier_identifier_export,
+        contract.fornecedor_nome,
+        contract.orgao_cnpj,
+        contract.orgao_nome,
+        contract.uf,
+        contract.municipio,
+        contract.valor_total,
+        contract.data_assinatura,
+        COALESCE(contract.data_publicacao_fonte, contract.data_publicacao),
+        event.event_date,
+        contract.objeto_contrato,
+        contract.source,
+        contract.ingested_at,
+        event.event_date IS NULL
+            OR contract.valor_total IS NULL
+            OR contract.valor_total < 0
+    FROM public.pncp_supplier_contracts AS contract
+    CROSS JOIN LATERAL (
+        SELECT COALESCE(
+            contract.data_assinatura,
+            contract.data_publicacao_fonte,
+            contract.data_publicacao,
+            contract.data_inicio
+        ) AS event_date
+    ) AS event
+    WHERE contract.is_active = TRUE
+      AND contract.ingested_at <= COALESCE(
+          NULLIF(p_snapshot_at, '')::TIMESTAMPTZ,
+          statement_timestamp()
+      )
+      AND (p_supplier_id_type IS NULL OR contract.supplier_id_type = upper(p_supplier_id_type))
+      AND (p_supplier_identifier IS NULL OR contract.supplier_identifier = p_supplier_identifier)
+      AND (p_orgao_cnpj IS NULL OR contract.orgao_cnpj = regexp_replace(p_orgao_cnpj, '\D', '', 'g'))
+      AND (p_ufs IS NULL OR contract.uf = ANY(p_ufs))
+      AND (
+          p_keywords IS NULL
+          OR NOT EXISTS (
+              SELECT 1
+              FROM unnest(p_keywords) AS keyword
+              WHERE NULLIF(btrim(keyword), '') IS NOT NULL
+                AND position(lower(btrim(keyword)) IN lower(COALESCE(contract.objeto_contrato, ''))) = 0
+          )
+      )
+      AND (p_date_start IS NULL OR event.event_date >= p_date_start)
+      AND (p_date_end IS NULL OR event.event_date <= p_date_end);
+$$;
+
+CREATE OR REPLACE FUNCTION public.supplier_contracts_page_v2(
+    p_supplier_id_type TEXT DEFAULT NULL,
+    p_supplier_identifier TEXT DEFAULT NULL,
+    p_orgao_cnpj TEXT DEFAULT NULL,
+    p_ufs TEXT[] DEFAULT NULL,
+    p_keywords TEXT[] DEFAULT NULL,
+    p_date_start DATE DEFAULT NULL,
+    p_date_end DATE DEFAULT NULL,
+    p_value_min NUMERIC DEFAULT NULL,
+    p_page_size INTEGER DEFAULT 200,
+    p_cursor_date DATE DEFAULT NULL,
+    p_cursor_id BIGINT DEFAULT NULL,
+    p_snapshot_at TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+AS $$
+    WITH request AS (
+        SELECT
+            LEAST(GREATEST(COALESCE(p_page_size, 200), 1), 1000) AS page_size,
+            COALESCE(NULLIF(p_snapshot_at, '')::TIMESTAMPTZ, statement_timestamp()) AS snapshot_at
+    ), all_rows AS MATERIALIZED (
+        SELECT dataset.*
+        FROM request
+        CROSS JOIN public.supplier_contracts_dataset_v2(
+            p_supplier_id_type,
+            p_supplier_identifier,
+            p_orgao_cnpj,
+            p_ufs,
+            p_keywords,
+            p_date_start,
+            p_date_end,
+            request.snapshot_at::TEXT
+        ) AS dataset
+    ), eligible AS MATERIALIZED (
+        SELECT *
+        FROM all_rows
+        WHERE NOT quarantined
+          AND (p_value_min IS NULL OR valor_total >= p_value_min)
+    ), page_candidates AS MATERIALIZED (
+        SELECT eligible.*
+        FROM eligible
+        WHERE p_cursor_date IS NULL
+           OR p_cursor_id IS NULL
+           OR (eligible.event_date, eligible.record_id) < (p_cursor_date, p_cursor_id)
+        ORDER BY eligible.event_date DESC, eligible.record_id DESC
+        LIMIT (SELECT page_size + 1 FROM request)
+    ), page_rows AS MATERIALIZED (
+        SELECT *
+        FROM page_candidates
+        ORDER BY event_date DESC, record_id DESC
+        LIMIT (SELECT page_size FROM request)
+    ), aggregate_stats AS (
+        SELECT
+            count(*)::BIGINT AS total_count,
+            COALESCE(sum(valor_total), 0)::NUMERIC AS sum_value,
+            avg(valor_total)::NUMERIC AS average_value,
+            stddev_pop(valor_total)::NUMERIC AS stddev_value,
+            percentile_cont(0.10) WITHIN GROUP (ORDER BY valor_total)::NUMERIC AS p10,
+            percentile_cont(0.25) WITHIN GROUP (ORDER BY valor_total)::NUMERIC AS p25,
+            percentile_cont(0.50) WITHIN GROUP (ORDER BY valor_total)::NUMERIC AS p50,
+            percentile_cont(0.75) WITHIN GROUP (ORDER BY valor_total)::NUMERIC AS p75,
+            percentile_cont(0.90) WITHIN GROUP (ORDER BY valor_total)::NUMERIC AS p90,
+            min(data_publicacao) AS min_publication_date,
+            max(data_publicacao) AS max_publication_date,
+            min(data_assinatura) AS min_signature_date,
+            max(data_assinatura) AS max_signature_date,
+            max(ingested_at) AS freshness_at
+        FROM eligible
+    ), quarantine_stats AS (
+        SELECT count(*)::BIGINT AS quarantine_count
+        FROM all_rows
+        WHERE quarantined
+    ), source_stats AS (
+        SELECT COALESCE(jsonb_agg(source ORDER BY source), '[]'::JSONB) AS sources
+        FROM (SELECT DISTINCT source FROM eligible WHERE source IS NOT NULL) AS distinct_sources
+    ), annual_stats AS (
+        SELECT COALESCE(
+            jsonb_agg(
+                jsonb_build_object(
+                    'year', year,
+                    'matched_contracts', matched_contracts,
+                    'sum_value', sum_value
+                ) ORDER BY year
+            ),
+            '[]'::JSONB
+        ) AS annual_series
+        FROM (
+            SELECT
+                extract(YEAR FROM event_date)::INTEGER AS year,
+                count(*)::BIGINT AS matched_contracts,
+                COALESCE(sum(valor_total), 0)::NUMERIC AS sum_value
+            FROM eligible
+            GROUP BY extract(YEAR FROM event_date)::INTEGER
+        ) AS yearly
+    ), run_info AS (
+        SELECT id, status, COALESCE(completed_at, finished_at, started_at) AS run_at
+        FROM public.ingestion_runs
+        WHERE status = 'completed'
+        ORDER BY COALESCE(completed_at, finished_at, started_at) DESC, id DESC
+        LIMIT 1
+    ), page_info AS (
+        SELECT
+            count(*) > (SELECT page_size FROM request) AS has_more,
+            (SELECT event_date FROM page_rows ORDER BY event_date, record_id LIMIT 1) AS next_date,
+            (SELECT record_id FROM page_rows ORDER BY event_date, record_id LIMIT 1) AS next_id
+        FROM page_candidates
+    )
+    SELECT jsonb_build_object(
+        'items', COALESCE((
+            SELECT jsonb_agg(
+                jsonb_build_object(
+                    'record_id', record_id,
+                    'numero_controle_pncp', contrato_id,
+                    'supplier_id_type', supplier_id_type,
+                    'supplier_identifier', supplier_identifier_export,
+                    'ni_fornecedor', supplier_identifier_export,
+                    'nome_fornecedor', fornecedor_nome,
+                    'orgao_cnpj', orgao_cnpj,
+                    'orgao_nome', orgao_nome,
+                    'uf', uf,
+                    'municipio', municipio,
+                    'valor_global', valor_total,
+                    'data_assinatura', data_assinatura,
+                    'data_publicacao', data_publicacao,
+                    'event_date', event_date,
+                    'objeto_contrato', objeto_contrato,
+                    'source', source,
+                    'ingested_at', ingested_at
+                ) ORDER BY event_date DESC, record_id DESC
+            ) FROM page_rows
+        ), '[]'::JSONB),
+        'meta', jsonb_build_object(
+            'source', 'datalake_contracts_v2',
+            'completeness', CASE
+                WHEN run_info.id IS NULL THEN 'INCOMPLETE'
+                WHEN quarantine_stats.quarantine_count > 0 THEN 'INCOMPLETE'
+                WHEN page_info.has_more THEN 'PRESENTATION_LIMITED'
+                ELSE 'COMPLETE'
+            END,
+            'has_more', page_info.has_more,
+            'next_cursor', CASE WHEN page_info.has_more THEN jsonb_build_object(
+                'date', page_info.next_date,
+                'id', page_info.next_id
+            ) ELSE NULL END,
+            'total_count', aggregate_stats.total_count,
+            'matched_contracts', aggregate_stats.total_count,
+            'sum_value', aggregate_stats.sum_value,
+            'average_value', aggregate_stats.average_value,
+            'stddev_value', aggregate_stats.stddev_value,
+            'p10', aggregate_stats.p10,
+            'p25', aggregate_stats.p25,
+            'p50', aggregate_stats.p50,
+            'p75', aggregate_stats.p75,
+            'p90', aggregate_stats.p90,
+            'quarantine_count', quarantine_stats.quarantine_count,
+            'min_publication_date', aggregate_stats.min_publication_date,
+            'max_publication_date', aggregate_stats.max_publication_date,
+            'min_signature_date', aggregate_stats.min_signature_date,
+            'max_signature_date', aggregate_stats.max_signature_date,
+            'sources', source_stats.sources,
+            'annual_series', annual_stats.annual_series,
+            'snapshot_at', request.snapshot_at,
+            'snapshot_id', concat(COALESCE(run_info.id::TEXT, 'no-run'), ':', request.snapshot_at::TEXT),
+            'ingestion_run_id', run_info.id,
+            'ingestion_run_status', run_info.status,
+            'freshness_at', aggregate_stats.freshness_at,
+            'freshness_seconds', CASE WHEN aggregate_stats.freshness_at IS NULL THEN NULL
+                ELSE extract(EPOCH FROM request.snapshot_at - aggregate_stats.freshness_at)::BIGINT END,
+            'date_semantics', 'event_date=data_assinatura|data_publicacao_fonte|data_publicacao|data_inicio',
+            'window_start', p_date_start,
+            'window_end', p_date_end,
+            'page_size', request.page_size
+        )
+    )
+    FROM request
+    CROSS JOIN aggregate_stats
+    CROSS JOIN quarantine_stats
+    CROSS JOIN source_stats
+    CROSS JOIN annual_stats
+    CROSS JOIN page_info
+    LEFT JOIN run_info ON TRUE;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supplier_contracts_grouped_v2(
+    p_group_by TEXT,
+    p_orgao_cnpj TEXT DEFAULT NULL,
+    p_ufs TEXT[] DEFAULT NULL,
+    p_keywords TEXT[] DEFAULT NULL,
+    p_date_start DATE DEFAULT NULL,
+    p_date_end DATE DEFAULT NULL,
+    p_limit INTEGER DEFAULT 20,
+    p_snapshot_at TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+    result JSONB;
+BEGIN
+    IF p_group_by NOT IN ('supplier', 'orgao') THEN
+        RAISE EXCEPTION 'p_group_by must be supplier or orgao' USING ERRCODE = '22023';
+    END IF;
+
+    WITH request AS (
+        SELECT
+            LEAST(GREATEST(COALESCE(p_limit, 20), 1), 1000) AS result_limit,
+            COALESCE(NULLIF(p_snapshot_at, '')::TIMESTAMPTZ, statement_timestamp()) AS snapshot_at
+    ), all_rows AS MATERIALIZED (
+        SELECT dataset.*
+        FROM request
+        CROSS JOIN public.supplier_contracts_dataset_v2(
+            NULL, NULL, p_orgao_cnpj, p_ufs, p_keywords,
+            p_date_start, p_date_end, request.snapshot_at::TEXT
+        ) AS dataset
+    ), eligible AS MATERIALIZED (
+        SELECT * FROM all_rows WHERE NOT quarantined
+    ), grouped AS MATERIALIZED (
+        SELECT
+            CASE WHEN p_group_by = 'supplier'
+                THEN COALESCE(supplier_identifier_hash, supplier_identifier)
+                ELSE orgao_cnpj END AS group_id,
+            max(CASE WHEN p_group_by = 'supplier' THEN supplier_identifier_export ELSE orgao_cnpj END) AS group_identifier,
+            max(CASE WHEN p_group_by = 'supplier' THEN fornecedor_nome ELSE orgao_nome END) AS group_name,
+            max(CASE WHEN p_group_by = 'supplier' THEN supplier_id_type END) AS group_type,
+            count(*)::BIGINT AS matched_contracts,
+            COALESCE(sum(valor_total), 0)::NUMERIC AS sum_value,
+            avg(valor_total)::NUMERIC AS average_value,
+            max(event_date) AS latest_event_date,
+            array_agg(DISTINCT uf ORDER BY uf) FILTER (WHERE uf IS NOT NULL) AS ufs
+        FROM eligible
+        GROUP BY CASE WHEN p_group_by = 'supplier'
+            THEN COALESCE(supplier_identifier_hash, supplier_identifier)
+            ELSE orgao_cnpj END
+        HAVING CASE WHEN p_group_by = 'supplier'
+            THEN COALESCE(supplier_identifier_hash, supplier_identifier)
+            ELSE orgao_cnpj END IS NOT NULL
+    ), ranked AS (
+        SELECT *
+        FROM grouped
+        ORDER BY CASE WHEN p_group_by = 'supplier' THEN matched_contracts END DESC NULLS LAST,
+                 sum_value DESC,
+                 group_id
+        LIMIT (SELECT result_limit FROM request)
+    ), totals AS (
+        SELECT
+            (SELECT count(*) FROM grouped)::BIGINT AS total_groups,
+            (SELECT count(*) FROM eligible)::BIGINT AS total_count,
+            (SELECT count(*) FROM all_rows WHERE quarantined)::BIGINT AS quarantine_count,
+            (SELECT max(ingested_at) FROM eligible) AS freshness_at
+    ), run_info AS (
+        SELECT id, status, COALESCE(completed_at, finished_at, started_at) AS run_at
+        FROM public.ingestion_runs
+        WHERE status = 'completed'
+        ORDER BY COALESCE(completed_at, finished_at, started_at) DESC, id DESC
+        LIMIT 1
+    )
+    SELECT jsonb_build_object(
+        'items', COALESCE((SELECT jsonb_agg(
+            jsonb_build_object(
+                'group_id', group_id,
+                'group_identifier', group_identifier,
+                'group_name', group_name,
+                'group_type', group_type,
+                'matched_contracts', matched_contracts,
+                'sum_value', sum_value,
+                'average_value', average_value,
+                'latest_event_date', latest_event_date,
+                'ufs', COALESCE(to_jsonb(ufs), '[]'::JSONB)
+            ) ORDER BY CASE WHEN p_group_by = 'supplier' THEN matched_contracts END DESC NULLS LAST,
+                       sum_value DESC, group_id
+        ) FROM ranked), '[]'::JSONB),
+        'meta', jsonb_build_object(
+            'source', 'datalake_contract_groups_v2',
+            'group_by', p_group_by,
+            'completeness', CASE
+                WHEN run_info.id IS NULL THEN 'INCOMPLETE'
+                WHEN totals.quarantine_count > 0 THEN 'INCOMPLETE'
+                WHEN totals.total_groups > request.result_limit THEN 'PRESENTATION_LIMITED'
+                ELSE 'COMPLETE'
+            END,
+            'total_count', totals.total_count,
+            'total_groups', totals.total_groups,
+            'quarantine_count', totals.quarantine_count,
+            'limit', request.result_limit,
+            'snapshot_at', request.snapshot_at,
+            'snapshot_id', concat(COALESCE(run_info.id::TEXT, 'no-run'), ':', request.snapshot_at::TEXT),
+            'ingestion_run_id', run_info.id,
+            'ingestion_run_status', run_info.status,
+            'freshness_at', totals.freshness_at,
+            'window_start', p_date_start,
+            'window_end', p_date_end,
+            'date_semantics', 'event_date=data_assinatura|data_publicacao_fonte|data_publicacao|data_inicio'
+        )
+    ) INTO result
+    FROM request CROSS JOIN totals LEFT JOIN run_info ON TRUE;
+
+    RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.supplier_contracts_page_v2(TEXT, TEXT, TEXT, TEXT[], TEXT[], DATE, DATE, NUMERIC, INTEGER, DATE, BIGINT, TEXT) IS
+    'Complete server-side contract aggregates plus snapshot-bound keyset details. Issues #355/#356.';
+
+COMMENT ON FUNCTION public.supplier_contracts_grouped_v2(TEXT, TEXT, TEXT[], TEXT[], DATE, DATE, INTEGER, TEXT) IS
+    'Complete server-side supplier/authority rankings. Presentation limits never alter aggregates. Issue #355.';
+
+COMMIT;

--- a/db/migrations/087_runtime_truth_dlq_sli.sql
+++ b/db/migrations/087_runtime_truth_dlq_sli.sql
@@ -21,6 +21,13 @@ UPDATE public.dlq_entries
 SET error_class = COALESCE(error_class, error_code, 'UNCLASSIFIED')
 WHERE error_class IS NULL;
 
+-- Preserve original terminal time for rows that predate this column.
+-- ADD COLUMN … DEFAULT NOW() otherwise stamps apply-time on the whole table.
+UPDATE public.dlq_entries
+SET terminal_at = COALESCE(failed_at, terminal_at)
+WHERE failed_at IS NOT NULL
+  AND (terminal_at IS NULL OR terminal_at > failed_at);
+
 ALTER TABLE public.dlq_entries
     ALTER COLUMN error_class SET NOT NULL,
     DROP CONSTRAINT IF EXISTS ck_dlq_replay_count,

--- a/db/migrations/087_runtime_truth_dlq_sli.sql
+++ b/db/migrations/087_runtime_truth_dlq_sli.sql
@@ -1,0 +1,167 @@
+-- 087_runtime_truth_dlq_sli.sql
+-- Transactional crawl DLQ and fail-closed truth-plane SLI authority (#274/#275).
+
+BEGIN;
+
+ALTER TABLE public.dlq_entries
+    ADD COLUMN IF NOT EXISTS job_id BIGINT REFERENCES public.crawl_jobs(id) ON DELETE RESTRICT,
+    ADD COLUMN IF NOT EXISTS attempt_id BIGINT REFERENCES public.crawl_job_attempts(id) ON DELETE RESTRICT,
+    ADD COLUMN IF NOT EXISTS canonical_entity_key TEXT,
+    ADD COLUMN IF NOT EXISTS error_class TEXT,
+    ADD COLUMN IF NOT EXISTS payload_pointer JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS owner TEXT,
+    ADD COLUMN IF NOT EXISTS next_action TEXT NOT NULL DEFAULT 'inspect_and_replay_or_resolve',
+    ADD COLUMN IF NOT EXISTS terminal_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS replay_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS resolved_by TEXT,
+    ADD COLUMN IF NOT EXISTS resolution TEXT;
+
+UPDATE public.dlq_entries
+SET error_class = COALESCE(error_class, error_code, 'UNCLASSIFIED')
+WHERE error_class IS NULL;
+
+ALTER TABLE public.dlq_entries
+    ALTER COLUMN error_class SET NOT NULL,
+    DROP CONSTRAINT IF EXISTS ck_dlq_replay_count,
+    DROP CONSTRAINT IF EXISTS ck_dlq_resolution_complete;
+
+ALTER TABLE public.dlq_entries
+    ADD CONSTRAINT ck_dlq_replay_count CHECK (replay_count >= 0),
+    ADD CONSTRAINT ck_dlq_resolution_complete CHECK (
+        (resolved_at IS NULL AND resolved_by IS NULL AND resolution IS NULL)
+        OR (resolved_at IS NOT NULL AND resolved_by IS NOT NULL AND resolution IS NOT NULL)
+    );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_dlq_job_open_terminal
+    ON public.dlq_entries (job_id)
+    WHERE job_id IS NOT NULL AND status IN ('pending', 'dead');
+
+CREATE INDEX IF NOT EXISTS idx_dlq_selective_replay
+    ON public.dlq_entries (source, canonical_entity_key, error_class, terminal_at, id)
+    WHERE status IN ('pending', 'dead');
+
+ALTER TABLE public.crawl_jobs
+    ADD COLUMN IF NOT EXISTS dlq_entry_id BIGINT REFERENCES public.dlq_entries(id) ON DELETE RESTRICT;
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_slo_definitions (
+    metric_name          TEXT PRIMARY KEY,
+    stage                TEXT NOT NULL,
+    window_seconds       INTEGER NOT NULL CHECK (window_seconds > 0),
+    denominator_contract TEXT NOT NULL,
+    objective_operator   TEXT NOT NULL CHECK (objective_operator IN ('lte', 'gte')),
+    objective_value      NUMERIC NOT NULL CHECK (objective_value >= 0),
+    unit                 TEXT NOT NULL,
+    alert_before_ratio   NUMERIC NOT NULL DEFAULT 0.80,
+    enabled              BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (
+        (
+            objective_operator = 'lte'
+            AND (
+                (objective_value = 0 AND alert_before_ratio = 1)
+                OR (objective_value > 0 AND alert_before_ratio > 0 AND alert_before_ratio < 1)
+            )
+        )
+        OR (
+            objective_operator = 'gte'
+            AND objective_value > 0
+            AND alert_before_ratio > 1
+        )
+    )
+);
+
+INSERT INTO public.truth_plane_slo_definitions (
+    metric_name, stage, window_seconds, denominator_contract,
+    objective_operator, objective_value, unit, alert_before_ratio
+) VALUES
+    ('queue_oldest_age_seconds', 'source_to_raw', 3600, 'all queued/running crawl_jobs in the window', 'lte', 900, 'seconds', 0.80),
+    ('queue_terminal_failure_ratio', 'source_to_raw', 3600, 'all terminal crawl_job_attempts in the window', 'lte', 0.05, 'ratio', 0.80),
+    ('dlq_open_count', 'source_to_raw', 86400, 'all crawl jobs reaching a terminal retry threshold', 'lte', 0, 'records', 1.00),
+    ('document_failure_ratio', 'raw_to_document', 3600, 'all terminal document processing runs in the window', 'lte', 0.05, 'ratio', 0.80),
+    ('canonical_lag_seconds', 'document_to_canonical', 3600, 'all accepted source observations in the window', 'lte', 3600, 'seconds', 0.80),
+    ('public_read_freshness_seconds', 'canonical_to_public_read_v1', 3600, 'all enabled public_read_v1 views with measured queries', 'lte', 3600, 'seconds', 0.80),
+    ('public_read_query_p95_ms', 'canonical_to_public_read_v1', 300, 'all public_read_v1 queries in the window', 'lte', 500, 'milliseconds', 0.80),
+    ('public_read_error_ratio', 'canonical_to_public_read_v1', 300, 'all public_read_v1 queries in the window', 'lte', 0.01, 'ratio', 0.80),
+    ('public_reader_connection_ratio', 'public_reader_isolation', 300, 'all PostgreSQL connections', 'lte', 0.20, 'ratio', 0.80),
+    ('public_reader_blocking_locks', 'public_reader_isolation', 300, 'all blocking PostgreSQL lock edges', 'lte', 0, 'locks', 1.00),
+    ('public_reader_cpu_io_share', 'public_reader_isolation', 300, 'all statements sampled by pg_stat_statements', 'lte', 0.20, 'ratio', 0.80),
+    ('operational_cost_per_public_unit', 'cost', 2592000, 'all published public units with measured cost in the window', 'lte', 1, 'BRL/unit', 0.80)
+ON CONFLICT (metric_name) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_sli_reviews (
+    id                    BIGSERIAL PRIMARY KEY,
+    observed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    window_start          TIMESTAMPTZ NOT NULL,
+    window_end            TIMESTAMPTZ NOT NULL,
+    status                TEXT NOT NULL CHECK (status IN ('VALID', 'BLOCKED')),
+    metrics               JSONB NOT NULL,
+    metric_count          INTEGER NOT NULL CHECK (metric_count >= 0),
+    unknown_count         INTEGER NOT NULL CHECK (unknown_count >= 0),
+    breach_count          INTEGER NOT NULL CHECK (breach_count >= 0),
+    denominator_sum       NUMERIC NOT NULL CHECK (denominator_sum >= 0),
+    definition_hash       TEXT NOT NULL,
+    actor                 TEXT NOT NULL,
+    CHECK (status <> 'VALID' OR (unknown_count = 0 AND breach_count = 0 AND denominator_sum > 0))
+);
+
+CREATE INDEX IF NOT EXISTS idx_truth_plane_sli_valid
+    ON public.truth_plane_sli_reviews (observed_at DESC, id DESC)
+    WHERE status = 'VALID';
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_kill_switch (
+    singleton             BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    enabled               BOOLEAN NOT NULL DEFAULT FALSE,
+    reason                TEXT,
+    changed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    changed_by            TEXT NOT NULL DEFAULT 'migration'
+);
+
+INSERT INTO public.truth_plane_kill_switch (singleton, enabled, reason, changed_by)
+VALUES (TRUE, FALSE, 'initial fail-closed control state', 'migration-087')
+ON CONFLICT (singleton) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_kill_switch_history (
+    id                    BIGSERIAL PRIMARY KEY,
+    enabled               BOOLEAN NOT NULL,
+    reason                TEXT NOT NULL,
+    changed_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    changed_by            TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_alert_routes (
+    route_name            TEXT PRIMARY KEY,
+    destination           TEXT NOT NULL,
+    enabled               BOOLEAN NOT NULL DEFAULT TRUE,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_alert_events (
+    id                    BIGSERIAL PRIMARY KEY,
+    fingerprint           TEXT NOT NULL,
+    metric_name           TEXT NOT NULL REFERENCES public.truth_plane_slo_definitions(metric_name),
+    state                 TEXT NOT NULL CHECK (state IN ('WARNING', 'BREACH', 'UNKNOWN', 'BLOCKED')),
+    route_name            TEXT REFERENCES public.truth_plane_alert_routes(route_name),
+    payload               JSONB NOT NULL,
+    first_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    occurrence_count      INTEGER NOT NULL DEFAULT 1 CHECK (occurrence_count > 0),
+    delivery_status       TEXT NOT NULL DEFAULT 'PENDING' CHECK (delivery_status IN ('PENDING', 'DELIVERED', 'FAILED', 'NO_ROUTE')),
+    UNIQUE (fingerprint)
+);
+
+CREATE TABLE IF NOT EXISTS public.truth_plane_cost_observations (
+    id                    BIGSERIAL PRIMARY KEY,
+    observed_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source                TEXT NOT NULL,
+    unit_type             TEXT NOT NULL CHECK (unit_type IN ('source', 'document', 'event', 'dossier', 'public_read')),
+    unit_count            BIGINT NOT NULL CHECK (unit_count > 0),
+    cost_brl              NUMERIC(18,6) NOT NULL CHECK (cost_brl >= 0),
+    provenance            JSONB NOT NULL,
+    run_id                TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_truth_plane_cost_window
+    ON public.truth_plane_cost_observations (observed_at, unit_type, source);
+
+COMMIT;

--- a/db/migrations/088_canonical_public_events.sql
+++ b/db/migrations/088_canonical_public_events.sql
@@ -1,0 +1,512 @@
+-- 088_canonical_public_events.sql
+-- Persistent client-independent entities/events/observations with bitemporal revisions (#273/#289).
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE OR REPLACE FUNCTION public.canonical_public_id(p_prefix TEXT, p_parts TEXT[])
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path TO public, pg_temp
+AS $$
+    SELECT p_prefix || '_' || substr(
+        encode(public.digest(array_to_string(p_parts, E'\x1f'), 'sha256'), 'hex'),
+        1,
+        32
+    );
+$$;
+
+CREATE TABLE IF NOT EXISTS public.canonical_public_entities_v2 (
+    entity_id             TEXT PRIMARY KEY,
+    entity_type           TEXT NOT NULL CHECK (entity_type IN ('organ', 'unit', 'company', 'supplier', 'process')),
+    strong_key            TEXT NOT NULL,
+    display_name          TEXT,
+    tax_identifier_type   TEXT,
+    tax_identifier_export TEXT,
+    state                 TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (state IN ('ACTIVE', 'MERGED', 'SPLIT', 'RETIRED')),
+    canonical_successor_id TEXT REFERENCES public.canonical_public_entities_v2(entity_id),
+    first_seen_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by_policy     TEXT NOT NULL,
+    CHECK (strong_key !~* 'client[_-]?id'),
+    CHECK (canonical_successor_id IS NULL OR canonical_successor_id <> entity_id),
+    UNIQUE (entity_type, strong_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.canonical_public_entity_aliases_v2 (
+    alias_id              TEXT PRIMARY KEY,
+    entity_id             TEXT NOT NULL REFERENCES public.canonical_public_entities_v2(entity_id),
+    alias_kind            TEXT NOT NULL,
+    alias_value           TEXT NOT NULL,
+    source                TEXT NOT NULL,
+    source_record_id      TEXT,
+    confidence            NUMERIC(6,5) NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    valid_from            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    valid_to              TIMESTAMPTZ,
+    policy_version        TEXT NOT NULL,
+    CHECK (valid_to IS NULL OR valid_to > valid_from),
+    UNIQUE (entity_id, alias_kind, alias_value, source, valid_from)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_alias_lookup_v2
+    ON public.canonical_public_entity_aliases_v2 (alias_kind, alias_value, valid_from DESC)
+    WHERE valid_to IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.canonical_public_events_v1 (
+    event_id              TEXT PRIMARY KEY,
+    event_type            TEXT NOT NULL CHECK (event_type IN (
+        'tender_publication', 'tender_status', 'tender_document_change', 'contract_lifecycle'
+    )),
+    process_key           TEXT NOT NULL,
+    subject_entity_id     TEXT NOT NULL REFERENCES public.canonical_public_entities_v2(entity_id),
+    official_number       TEXT,
+    state                 TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (state IN ('ACTIVE', 'MERGED', 'SPLIT', 'RETIRED')),
+    canonical_successor_id TEXT REFERENCES public.canonical_public_events_v1(event_id),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by_policy     TEXT NOT NULL,
+    CHECK (process_key !~* 'client[_-]?id'),
+    CHECK (canonical_successor_id IS NULL OR canonical_successor_id <> event_id),
+    UNIQUE (event_type, process_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_events_subject_v1
+    ON public.canonical_public_events_v1 (subject_entity_id, event_type, process_key);
+CREATE INDEX IF NOT EXISTS idx_canonical_events_process_v1
+    ON public.canonical_public_events_v1 (process_key, event_type);
+
+CREATE TABLE IF NOT EXISTS public.canonical_public_observations (
+    observation_id        TEXT PRIMARY KEY,
+    source                TEXT NOT NULL,
+    source_record_id      TEXT NOT NULL,
+    source_version        TEXT NOT NULL,
+    document_version      TEXT,
+    raw_sha256            TEXT NOT NULL CHECK (raw_sha256 ~ '^[0-9a-f]{64}$'),
+    observed_at           TIMESTAMPTZ NOT NULL,
+    received_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    source_uri            TEXT,
+    snapshot_id           TEXT,
+    payload_hash          TEXT NOT NULL CHECK (payload_hash ~ '^[0-9a-f]{64}$'),
+    payload               JSONB NOT NULL,
+    CHECK (NOT (payload ? 'client_id')),
+    UNIQUE (source, source_record_id, source_version, raw_sha256)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_observations_source
+    ON public.canonical_public_observations (source, observed_at DESC, observation_id);
+CREATE INDEX IF NOT EXISTS idx_canonical_observations_snapshot
+    ON public.canonical_public_observations (snapshot_id, observation_id)
+    WHERE snapshot_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.canonical_event_observation_links (
+    event_id              TEXT NOT NULL REFERENCES public.canonical_public_events_v1(event_id),
+    observation_id        TEXT NOT NULL REFERENCES public.canonical_public_observations(observation_id),
+    link_role             TEXT NOT NULL CHECK (link_role IN ('asserts', 'corrects', 'documents', 'status_of')),
+    confidence            NUMERIC(6,5) NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    match_policy_version  TEXT NOT NULL,
+    linked_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (event_id, observation_id, link_role)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_event_obs_by_observation
+    ON public.canonical_event_observation_links (observation_id, event_id);
+
+CREATE TABLE IF NOT EXISTS public.canonical_event_entity_links (
+    event_id              TEXT NOT NULL REFERENCES public.canonical_public_events_v1(event_id),
+    entity_id             TEXT NOT NULL REFERENCES public.canonical_public_entities_v2(entity_id),
+    relation_type         TEXT NOT NULL CHECK (relation_type IN ('subject_process', 'buyer', 'supplier', 'publisher')),
+    observation_id        TEXT NOT NULL REFERENCES public.canonical_public_observations(observation_id),
+    confidence            NUMERIC(6,5) NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    policy_version        TEXT NOT NULL,
+    PRIMARY KEY (event_id, entity_id, relation_type, observation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_event_entity_by_entity
+    ON public.canonical_event_entity_links (entity_id, event_id, relation_type);
+
+CREATE TABLE IF NOT EXISTS public.canonical_event_revisions (
+    revision_id           TEXT PRIMARY KEY,
+    event_id              TEXT NOT NULL REFERENCES public.canonical_public_events_v1(event_id),
+    valid_from            TIMESTAMPTZ NOT NULL,
+    valid_to              TIMESTAMPTZ,
+    system_from           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    system_to             TIMESTAMPTZ,
+    status_code           TEXT,
+    title                 TEXT,
+    publication_at        TIMESTAMPTZ,
+    document_sha256       TEXT,
+    contract_value        NUMERIC(18,2),
+    official_number       TEXT,
+    fact_hash             TEXT NOT NULL CHECK (fact_hash ~ '^[0-9a-f]{64}$'),
+    fact_payload          JSONB NOT NULL,
+    created_from_observation_id TEXT NOT NULL REFERENCES public.canonical_public_observations(observation_id),
+    policy_version        TEXT NOT NULL,
+    CHECK (valid_to IS NULL OR valid_to > valid_from),
+    CHECK (system_to IS NULL OR system_to > system_from),
+    UNIQUE (event_id, valid_from, fact_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_revision_asof
+    ON public.canonical_event_revisions (event_id, valid_from DESC, system_from DESC);
+CREATE INDEX IF NOT EXISTS idx_canonical_revision_fact
+    ON public.canonical_event_revisions (fact_hash, event_id);
+
+CREATE TABLE IF NOT EXISTS public.canonical_match_conflicts (
+    conflict_id           TEXT PRIMARY KEY,
+    observation_id        TEXT NOT NULL REFERENCES public.canonical_public_observations(observation_id),
+    conflict_type         TEXT NOT NULL,
+    candidate_event_ids   TEXT[] NOT NULL,
+    reason_codes          TEXT[] NOT NULL,
+    policy_version        TEXT NOT NULL,
+    status                TEXT NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN', 'RESOLVED', 'REJECTED', 'DEFERRED')),
+    owner                 TEXT,
+    next_action           TEXT NOT NULL DEFAULT 'human_identity_review',
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    resolved_at           TIMESTAMPTZ,
+    resolution            JSONB,
+    CHECK (cardinality(candidate_event_ids) >= 2)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_conflicts_open
+    ON public.canonical_match_conflicts (status, conflict_type, created_at, conflict_id)
+    WHERE status = 'OPEN';
+
+CREATE TABLE IF NOT EXISTS public.canonical_identity_decisions (
+    decision_id           TEXT PRIMARY KEY,
+    action                TEXT NOT NULL CHECK (action IN ('MERGE', 'SPLIT')),
+    source_entity_id      TEXT NOT NULL REFERENCES public.canonical_public_entities_v2(entity_id),
+    target_entity_id      TEXT NOT NULL REFERENCES public.canonical_public_entities_v2(entity_id),
+    alias_values          TEXT[] NOT NULL DEFAULT '{}',
+    reason                TEXT NOT NULL,
+    evidence_observation_ids TEXT[] NOT NULL,
+    policy_version        TEXT NOT NULL,
+    decided_by            TEXT NOT NULL,
+    decided_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (source_entity_id <> target_entity_id),
+    CHECK (cardinality(evidence_observation_ids) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_decisions_entities
+    ON public.canonical_identity_decisions (source_entity_id, target_entity_id, decided_at);
+
+CREATE OR REPLACE FUNCTION public.ensure_canonical_public_entity_v2(
+    p_entity_type TEXT,
+    p_strong_key TEXT,
+    p_display_name TEXT,
+    p_tax_identifier_type TEXT,
+    p_tax_identifier_export TEXT,
+    p_source TEXT,
+    p_source_record_id TEXT,
+    p_policy_version TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    result_id TEXT;
+    result_alias_id TEXT;
+BEGIN
+    IF p_strong_key IS NULL OR btrim(p_strong_key) = '' OR p_strong_key ~* 'client[_-]?id' THEN
+        RAISE EXCEPTION 'strong client-independent entity key is required' USING ERRCODE = '22023';
+    END IF;
+    result_id := public.canonical_public_id('ent', ARRAY[p_entity_type, p_strong_key]);
+    INSERT INTO public.canonical_public_entities_v2 (
+        entity_id, entity_type, strong_key, display_name,
+        tax_identifier_type, tax_identifier_export, created_by_policy
+    ) VALUES (
+        result_id, p_entity_type, p_strong_key, p_display_name,
+        p_tax_identifier_type, p_tax_identifier_export, p_policy_version
+    ) ON CONFLICT (entity_id) DO UPDATE
+      SET last_seen_at = NOW(),
+          display_name = COALESCE(canonical_public_entities_v2.display_name, EXCLUDED.display_name);
+
+    result_alias_id := public.canonical_public_id(
+        'als', ARRAY[result_id, 'strong_key', p_strong_key, p_source]
+    );
+    INSERT INTO public.canonical_public_entity_aliases_v2 (
+        alias_id, entity_id, alias_kind, alias_value, source,
+        source_record_id, confidence, policy_version
+    ) VALUES (
+        result_alias_id, result_id, 'strong_key', p_strong_key, p_source,
+        p_source_record_id, 1, p_policy_version
+    ) ON CONFLICT (alias_id) DO NOTHING;
+    RETURN result_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ingest_canonical_public_observation_v1(p_observation JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    source_name TEXT := p_observation->>'source';
+    source_record TEXT := p_observation->>'source_record_id';
+    source_version TEXT := COALESCE(NULLIF(p_observation->>'source_version', ''), 'v1');
+    raw_hash TEXT := p_observation->>'raw_sha256';
+    process_key_value TEXT := p_observation->>'process_key';
+    event_type_value TEXT := p_observation->>'event_type';
+    policy TEXT := COALESCE(NULLIF(p_observation->>'policy_version', ''), 'canonical-events-v1');
+    facts JSONB := COALESCE(p_observation->'facts', '{}'::JSONB);
+    match_state TEXT := upper(COALESCE(p_observation->>'match_state', 'EXACT'));
+    observation_id_value TEXT;
+    process_entity_id TEXT;
+    event_id_value TEXT;
+    revision_id_value TEXT;
+    fact_hash_value TEXT;
+    conflict_id_value TEXT;
+    related JSONB;
+    related_entity_id TEXT;
+    relation_name TEXT;
+BEGIN
+    IF p_observation ? 'client_id' OR p_observation::TEXT ~* '"client[_-]?id"' THEN
+        RAISE EXCEPTION 'client_id is forbidden in canonical public authority' USING ERRCODE = '22023';
+    END IF;
+    IF source_name IS NULL OR source_record IS NULL OR raw_hash !~ '^[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'source, source_record_id and lowercase raw_sha256 are required' USING ERRCODE = '22023';
+    END IF;
+    IF event_type_value IS NULL
+       OR event_type_value NOT IN ('tender_publication', 'tender_status', 'tender_document_change', 'contract_lifecycle') THEN
+        RAISE EXCEPTION 'unsupported event_type %', event_type_value USING ERRCODE = '22023';
+    END IF;
+
+    observation_id_value := public.canonical_public_id(
+        'obs', ARRAY[source_name, source_record, source_version, raw_hash]
+    );
+    INSERT INTO public.canonical_public_observations (
+        observation_id, source, source_record_id, source_version,
+        document_version, raw_sha256, observed_at, source_uri,
+        snapshot_id, payload_hash, payload
+    ) VALUES (
+        observation_id_value, source_name, source_record, source_version,
+        p_observation->>'document_version', raw_hash,
+        (p_observation->>'observed_at')::TIMESTAMPTZ,
+        p_observation->>'source_uri', p_observation->>'snapshot_id',
+        encode(digest(p_observation::TEXT, 'sha256'), 'hex'), p_observation
+    ) ON CONFLICT (observation_id) DO NOTHING;
+
+    IF match_state = 'AMBIGUOUS' THEN
+        conflict_id_value := public.canonical_public_id(
+            'cnf', ARRAY[observation_id_value, COALESCE(p_observation->'candidate_event_ids', '[]')::TEXT, policy]
+        );
+        INSERT INTO public.canonical_match_conflicts (
+            conflict_id, observation_id, conflict_type, candidate_event_ids,
+            reason_codes, policy_version, owner
+        ) VALUES (
+            conflict_id_value, observation_id_value,
+            COALESCE(p_observation->>'conflict_type', 'ambiguous_event_match'),
+            ARRAY(SELECT jsonb_array_elements_text(p_observation->'candidate_event_ids')),
+            ARRAY(SELECT jsonb_array_elements_text(COALESCE(p_observation->'reason_codes', '["weak_key_collision"]'))),
+            policy, p_observation->>'owner'
+        ) ON CONFLICT (conflict_id) DO NOTHING;
+        RETURN jsonb_build_object(
+            'state', 'CONFLICT', 'observation_id', observation_id_value,
+            'event_id', NULL, 'conflict_id', conflict_id_value
+        );
+    END IF;
+
+    IF process_key_value IS NULL OR btrim(process_key_value) = '' OR process_key_value ~* 'client[_-]?id' THEN
+        RAISE EXCEPTION 'strong client-independent process_key is required' USING ERRCODE = '22023';
+    END IF;
+    process_entity_id := public.ensure_canonical_public_entity_v2(
+        'process', process_key_value, facts->>'title', NULL, NULL,
+        source_name, source_record, policy
+    );
+    event_id_value := public.canonical_public_id('evt', ARRAY[event_type_value, process_key_value]);
+    INSERT INTO public.canonical_public_events_v1 (
+        event_id, event_type, process_key, subject_entity_id,
+        official_number, created_by_policy
+    ) VALUES (
+        event_id_value, event_type_value, process_key_value, process_entity_id,
+        facts->>'official_number', policy
+    ) ON CONFLICT (event_id) DO NOTHING;
+
+    INSERT INTO public.canonical_event_observation_links (
+        event_id, observation_id, link_role, confidence, match_policy_version
+    ) VALUES (
+        event_id_value, observation_id_value,
+        COALESCE(p_observation->>'link_role', 'asserts'),
+        COALESCE((p_observation->>'confidence')::NUMERIC, 1), policy
+    ) ON CONFLICT DO NOTHING;
+
+    INSERT INTO public.canonical_event_entity_links (
+        event_id, entity_id, relation_type, observation_id, confidence, policy_version
+    ) VALUES (event_id_value, process_entity_id, 'subject_process', observation_id_value, 1, policy)
+    ON CONFLICT DO NOTHING;
+
+    FOR related IN SELECT value FROM jsonb_array_elements(COALESCE(p_observation->'entities', '[]'::JSONB)) LOOP
+        relation_name := related->>'relation_type';
+        related_entity_id := public.ensure_canonical_public_entity_v2(
+            related->>'entity_type', related->>'strong_key', related->>'display_name',
+            related->>'tax_identifier_type', related->>'tax_identifier_export',
+            source_name, source_record, policy
+        );
+        INSERT INTO public.canonical_event_entity_links (
+            event_id, entity_id, relation_type, observation_id, confidence, policy_version
+        ) VALUES (
+            event_id_value, related_entity_id, relation_name, observation_id_value,
+            COALESCE((related->>'confidence')::NUMERIC, 1), policy
+        ) ON CONFLICT DO NOTHING;
+    END LOOP;
+
+    fact_hash_value := encode(digest(facts::TEXT, 'sha256'), 'hex');
+    revision_id_value := public.canonical_public_id(
+        'rev', ARRAY[event_id_value, p_observation->>'valid_from', fact_hash_value]
+    );
+    INSERT INTO public.canonical_event_revisions (
+        revision_id, event_id, valid_from, valid_to, status_code, title,
+        publication_at, document_sha256, contract_value, official_number,
+        fact_hash, fact_payload, created_from_observation_id, policy_version
+    ) VALUES (
+        revision_id_value, event_id_value,
+        (p_observation->>'valid_from')::TIMESTAMPTZ,
+        NULLIF(p_observation->>'valid_to', '')::TIMESTAMPTZ,
+        facts->>'status_code', facts->>'title',
+        NULLIF(facts->>'publication_at', '')::TIMESTAMPTZ,
+        facts->>'document_sha256', NULLIF(facts->>'contract_value', '')::NUMERIC,
+        facts->>'official_number', fact_hash_value, facts,
+        observation_id_value, policy
+    ) ON CONFLICT (revision_id) DO NOTHING;
+
+    RETURN jsonb_build_object(
+        'state', 'LINKED', 'observation_id', observation_id_value,
+        'event_id', event_id_value, 'revision_id', revision_id_value,
+        'process_entity_id', process_entity_id, 'fact_hash', fact_hash_value
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.canonical_event_revision_as_of_v1(
+    p_event_id TEXT,
+    p_valid_at TIMESTAMPTZ,
+    p_system_at TIMESTAMPTZ DEFAULT NOW()
+)
+RETURNS SETOF public.canonical_event_revisions
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT revision.*
+    FROM public.canonical_event_revisions revision
+    WHERE revision.event_id = p_event_id
+      AND revision.valid_from <= p_valid_at
+      AND (revision.valid_to IS NULL OR revision.valid_to > p_valid_at)
+      AND revision.system_from <= p_system_at
+      AND (revision.system_to IS NULL OR revision.system_to > p_system_at)
+    ORDER BY revision.valid_from DESC, revision.system_from DESC, revision.revision_id DESC
+    LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_canonical_identity_decision_v1(
+    p_action TEXT,
+    p_source_entity_id TEXT,
+    p_target_entity_id TEXT,
+    p_alias_values TEXT[],
+    p_reason TEXT,
+    p_evidence_observation_ids TEXT[],
+    p_policy_version TEXT,
+    p_decided_by TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    result_id TEXT;
+    alias_row RECORD;
+    split_at TIMESTAMPTZ;
+BEGIN
+    IF upper(p_action) NOT IN ('MERGE', 'SPLIT') THEN
+        RAISE EXCEPTION 'identity action must be MERGE or SPLIT' USING ERRCODE = '22023';
+    END IF;
+    result_id := public.canonical_public_id(
+        'dec', ARRAY[upper(p_action), p_source_entity_id, p_target_entity_id, p_policy_version, p_reason]
+    );
+    INSERT INTO public.canonical_identity_decisions (
+        decision_id, action, source_entity_id, target_entity_id, alias_values,
+        reason, evidence_observation_ids, policy_version, decided_by
+    ) VALUES (
+        result_id, upper(p_action), p_source_entity_id, p_target_entity_id,
+        COALESCE(p_alias_values, '{}'), p_reason, p_evidence_observation_ids,
+        p_policy_version, p_decided_by
+    ) ON CONFLICT (decision_id) DO NOTHING;
+
+    IF upper(p_action) = 'MERGE' THEN
+        UPDATE public.canonical_public_entities_v2
+        SET state = 'MERGED', canonical_successor_id = p_target_entity_id
+        WHERE entity_id = p_source_entity_id AND state = 'ACTIVE';
+        FOR alias_row IN
+            SELECT * FROM public.canonical_public_entity_aliases_v2
+            WHERE entity_id = p_source_entity_id AND valid_to IS NULL
+        LOOP
+            INSERT INTO public.canonical_public_entity_aliases_v2 (
+                alias_id, entity_id, alias_kind, alias_value, source,
+                source_record_id, confidence, valid_from, policy_version
+            ) VALUES (
+                public.canonical_public_id('als', ARRAY[p_target_entity_id, alias_row.alias_kind, alias_row.alias_value, alias_row.source]),
+                p_target_entity_id, alias_row.alias_kind, alias_row.alias_value,
+                alias_row.source, alias_row.source_record_id, alias_row.confidence,
+                NOW(), p_policy_version
+            ) ON CONFLICT (alias_id) DO NOTHING;
+        END LOOP;
+    ELSE
+        split_at := clock_timestamp();
+        FOR alias_row IN
+            SELECT alias_id, alias_kind, alias_value, source, source_record_id, confidence
+            FROM public.canonical_public_entity_aliases_v2
+            WHERE entity_id = p_source_entity_id
+              AND valid_to IS NULL
+              AND alias_value = ANY(COALESCE(p_alias_values, '{}'))
+            ORDER BY alias_id
+        LOOP
+            UPDATE public.canonical_public_entity_aliases_v2
+            SET valid_to = split_at
+            WHERE alias_id = alias_row.alias_id AND valid_to IS NULL;
+            INSERT INTO public.canonical_public_entity_aliases_v2 (
+                alias_id, entity_id, alias_kind, alias_value, source,
+                source_record_id, confidence, valid_from, policy_version
+            ) VALUES (
+                public.canonical_public_id('als', ARRAY[
+                    p_target_entity_id, alias_row.alias_id, result_id, split_at::TEXT
+                ]),
+                p_target_entity_id, alias_row.alias_kind, alias_row.alias_value,
+                alias_row.source, alias_row.source_record_id, alias_row.confidence,
+                split_at, p_policy_version
+            ) ON CONFLICT (alias_id) DO NOTHING;
+        END LOOP;
+        UPDATE public.canonical_public_entities_v2 SET state = 'SPLIT'
+        WHERE entity_id = p_source_entity_id AND state = 'ACTIVE';
+    END IF;
+    RETURN result_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.guard_canonical_immutable_v1()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF current_setting('app.allow_canonical_test_cleanup', TRUE) = 'on'
+       AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = current_user AND rolsuper) THEN
+        RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+    END IF;
+    RAISE EXCEPTION '% rows are immutable; append a revision/decision instead', TG_TABLE_NAME
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_canonical_observations_immutable ON public.canonical_public_observations;
+CREATE TRIGGER trg_canonical_observations_immutable
+    BEFORE UPDATE OR DELETE ON public.canonical_public_observations
+    FOR EACH ROW EXECUTE FUNCTION public.guard_canonical_immutable_v1();
+
+DROP TRIGGER IF EXISTS trg_canonical_revisions_immutable ON public.canonical_event_revisions;
+CREATE TRIGGER trg_canonical_revisions_immutable
+    BEFORE UPDATE OR DELETE ON public.canonical_event_revisions
+    FOR EACH ROW EXECUTE FUNCTION public.guard_canonical_immutable_v1();
+
+DROP TRIGGER IF EXISTS trg_canonical_decisions_immutable ON public.canonical_identity_decisions;
+CREATE TRIGGER trg_canonical_decisions_immutable
+    BEFORE UPDATE OR DELETE ON public.canonical_identity_decisions
+    FOR EACH ROW EXECUTE FUNCTION public.guard_canonical_immutable_v1();
+
+COMMIT;

--- a/db/migrations/088_canonical_public_events.sql
+++ b/db/migrations/088_canonical_public_events.sql
@@ -249,7 +249,7 @@ DECLARE
     event_type_value TEXT := p_observation->>'event_type';
     policy TEXT := COALESCE(NULLIF(p_observation->>'policy_version', ''), 'canonical-events-v1');
     facts JSONB := COALESCE(p_observation->'facts', '{}'::JSONB);
-    match_state TEXT := upper(COALESCE(p_observation->>'match_state', 'EXACT'));
+    match_state TEXT := upper(COALESCE(NULLIF(btrim(p_observation->>'match_state'), ''), 'EXACT'));
     observation_id_value TEXT;
     process_entity_id TEXT;
     event_id_value TEXT;
@@ -269,6 +269,10 @@ BEGIN
     IF event_type_value IS NULL
        OR event_type_value NOT IN ('tender_publication', 'tender_status', 'tender_document_change', 'contract_lifecycle') THEN
         RAISE EXCEPTION 'unsupported event_type %', event_type_value USING ERRCODE = '22023';
+    END IF;
+    IF match_state NOT IN ('EXACT', 'AMBIGUOUS') THEN
+        RAISE EXCEPTION 'match_state % is not an identity authority (expected EXACT or AMBIGUOUS)', match_state
+            USING ERRCODE = '22023';
     END IF;
 
     observation_id_value := public.canonical_public_id(

--- a/db/migrations/089_canonical_snapshot_public_read_v1.sql
+++ b/db/migrations/089_canonical_snapshot_public_read_v1.sql
@@ -1,0 +1,555 @@
+-- 089_canonical_snapshot_public_read_v1.sql
+-- Client-independent multifonte snapshot barrier and SELECT-only public contract (#287/#354).
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+CREATE TABLE IF NOT EXISTS public.canonical_public_snapshots (
+    snapshot_id              TEXT PRIMARY KEY,
+    cutoff_at                TIMESTAMPTZ NOT NULL,
+    cutoff_timezone          TEXT NOT NULL DEFAULT 'America/Sao_Paulo'
+                                  CHECK (cutoff_timezone = 'America/Sao_Paulo'),
+    universe_hash            TEXT NOT NULL CHECK (universe_hash ~ '^[0-9a-f]{64}$'),
+    policy_hash              TEXT NOT NULL CHECK (policy_hash ~ '^[0-9a-f]{64}$'),
+    schema_hash              TEXT NOT NULL CHECK (schema_hash ~ '^[0-9a-f]{64}$'),
+    adapter_hash             TEXT NOT NULL CHECK (adapter_hash ~ '^[0-9a-f]{64}$'),
+    data_hash                TEXT NOT NULL CHECK (data_hash ~ '^[0-9a-f]{64}$'),
+    document_hash            TEXT NOT NULL CHECK (document_hash ~ '^[0-9a-f]{64}$'),
+    dossier_hash             TEXT NOT NULL CHECK (dossier_hash ~ '^[0-9a-f]{64}$'),
+    state                    TEXT NOT NULL DEFAULT 'BUILDING'
+                                  CHECK (state IN ('BUILDING', 'BLOCKED', 'READY_CANONICAL', 'SUPERSEDED')),
+    required_pair_count      INTEGER NOT NULL CHECK (required_pair_count >= 0),
+    relevant_dossier_count   INTEGER NOT NULL CHECK (relevant_dossier_count >= 0),
+    blockers                 JSONB NOT NULL DEFAULT '[]'::JSONB,
+    content_hash             TEXT CHECK (content_hash IS NULL OR content_hash ~ '^[0-9a-f]{64}$'),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    closed_at                TIMESTAMPTZ,
+    superseded_at            TIMESTAMPTZ,
+    created_by               TEXT NOT NULL,
+    CHECK (snapshot_id !~* 'client|profile'),
+    CHECK (state <> 'READY_CANONICAL' OR (closed_at IS NOT NULL AND content_hash IS NOT NULL AND blockers = '[]'::JSONB))
+);
+
+CREATE INDEX IF NOT EXISTS idx_canonical_snapshots_ready
+    ON public.canonical_public_snapshots (cutoff_at DESC, snapshot_id)
+    WHERE state = 'READY_CANONICAL';
+
+CREATE TABLE IF NOT EXISTS public.canonical_snapshot_source_watermarks (
+    snapshot_id              TEXT NOT NULL REFERENCES public.canonical_public_snapshots(snapshot_id),
+    source                   TEXT NOT NULL,
+    source_run_id            TEXT NOT NULL,
+    watermark_at             TIMESTAMPTZ NOT NULL,
+    freshness_state          TEXT NOT NULL CHECK (freshness_state IN ('FRESH', 'STALE', 'FAILED', 'BLOCKED', 'UNKNOWN')),
+    completeness_state       TEXT NOT NULL CHECK (completeness_state IN ('COMPLETE', 'INCOMPLETE', 'UNKNOWN')),
+    applicable_pair_count    INTEGER NOT NULL CHECK (applicable_pair_count >= 0),
+    evaluated_pair_count     INTEGER NOT NULL CHECK (evaluated_pair_count >= 0),
+    evidence_hash            TEXT NOT NULL CHECK (evidence_hash ~ '^[0-9a-f]{64}$'),
+    recorded_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (snapshot_id, source)
+);
+
+CREATE TABLE IF NOT EXISTS public.canonical_snapshot_event_revisions (
+    snapshot_id              TEXT NOT NULL REFERENCES public.canonical_public_snapshots(snapshot_id),
+    event_id                 TEXT NOT NULL REFERENCES public.canonical_public_events_v1(event_id),
+    revision_id              TEXT NOT NULL REFERENCES public.canonical_event_revisions(revision_id),
+    fact_hash                TEXT NOT NULL CHECK (fact_hash ~ '^[0-9a-f]{64}$'),
+    included_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (snapshot_id, event_id),
+    UNIQUE (snapshot_id, revision_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_revision_lookup
+    ON public.canonical_snapshot_event_revisions (event_id, snapshot_id, revision_id);
+
+CREATE TABLE IF NOT EXISTS public.canonical_snapshot_documents (
+    snapshot_id              TEXT NOT NULL REFERENCES public.canonical_public_snapshots(snapshot_id),
+    observation_id           TEXT NOT NULL REFERENCES public.canonical_public_observations(observation_id),
+    document_sha256          TEXT NOT NULL CHECK (document_sha256 ~ '^[0-9a-f]{64}$'),
+    completeness_state       TEXT NOT NULL CHECK (completeness_state IN ('COMPLETE', 'INCOMPLETE', 'BLOCKED')),
+    PRIMARY KEY (snapshot_id, observation_id, document_sha256)
+);
+
+CREATE TABLE IF NOT EXISTS public.canonical_snapshot_dossiers (
+    snapshot_id              TEXT NOT NULL REFERENCES public.canonical_public_snapshots(snapshot_id),
+    dossier_id               TEXT NOT NULL,
+    dossier_revision_hash    TEXT NOT NULL CHECK (dossier_revision_hash ~ '^[0-9a-f]{64}$'),
+    completeness_state       TEXT NOT NULL CHECK (completeness_state IN ('COMPLETE', 'INCOMPLETE', 'BLOCKED')),
+    reason_codes             TEXT[] NOT NULL DEFAULT '{}',
+    PRIMARY KEY (snapshot_id, dossier_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.canonical_snapshot_invalidations (
+    invalidation_id          TEXT PRIMARY KEY,
+    snapshot_id              TEXT NOT NULL REFERENCES public.canonical_public_snapshots(snapshot_id),
+    event_id                 TEXT NOT NULL REFERENCES public.canonical_public_events_v1(event_id),
+    prior_revision_id        TEXT NOT NULL REFERENCES public.canonical_event_revisions(revision_id),
+    new_revision_id          TEXT NOT NULL REFERENCES public.canonical_event_revisions(revision_id),
+    reason                   TEXT NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (snapshot_id, new_revision_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.public_consumer_projections (
+    projection_id            TEXT PRIMARY KEY,
+    consumer_id              TEXT NOT NULL,
+    snapshot_id              TEXT NOT NULL REFERENCES public.canonical_public_snapshots(snapshot_id),
+    template_hash            TEXT NOT NULL CHECK (template_hash ~ '^[0-9a-f]{64}$'),
+    private_profile_hash     TEXT,
+    state                    TEXT NOT NULL DEFAULT 'READY'
+                                  CHECK (state IN ('READY', 'STALE_PRIVATE', 'STALE_FACTUAL', 'BLOCKED')),
+    invalidation_reason      TEXT,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    invalidated_at           TIMESTAMPTZ,
+    UNIQUE (consumer_id, snapshot_id, template_hash, private_profile_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_consumer_projection_snapshot
+    ON public.public_consumer_projections (snapshot_id, state, consumer_id);
+
+CREATE TABLE IF NOT EXISTS public.public_read_surface_health_internal (
+    view_name                TEXT PRIMARY KEY,
+    enabled                  BOOLEAN NOT NULL DEFAULT TRUE,
+    refreshed_at             TIMESTAMPTZ,
+    query_count              BIGINT NOT NULL DEFAULT 0 CHECK (query_count >= 0),
+    error_count              BIGINT NOT NULL DEFAULT 0 CHECK (error_count >= 0),
+    query_p95_ms             NUMERIC,
+    last_refresh_status      TEXT NOT NULL DEFAULT 'NEVER'
+                                  CHECK (last_refresh_status IN ('NEVER', 'VALID', 'FAILED', 'STALE')),
+    last_error               TEXT,
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO public.public_read_surface_health_internal (view_name)
+VALUES ('snapshots'), ('tenders'), ('contracts'), ('entities'), ('suppliers'), ('organs'), ('municipalities')
+ON CONFLICT (view_name) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.begin_canonical_public_snapshot_v1(
+    p_cutoff_at TIMESTAMPTZ,
+    p_universe_hash TEXT,
+    p_policy_hash TEXT,
+    p_schema_hash TEXT,
+    p_adapter_hash TEXT,
+    p_data_hash TEXT,
+    p_document_hash TEXT,
+    p_dossier_hash TEXT,
+    p_required_pair_count INTEGER,
+    p_relevant_dossier_count INTEGER,
+    p_created_by TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    result_id TEXT;
+BEGIN
+    IF p_created_by ~* 'client|profile' THEN
+        RAISE EXCEPTION 'canonical snapshot creator cannot encode client/profile identity' USING ERRCODE = '22023';
+    END IF;
+    result_id := public.canonical_public_id('snp', ARRAY[
+        p_cutoff_at::TEXT, p_universe_hash, p_policy_hash, p_schema_hash,
+        p_adapter_hash, p_data_hash, p_document_hash, p_dossier_hash
+    ]);
+    INSERT INTO public.canonical_public_snapshots (
+        snapshot_id, cutoff_at, universe_hash, policy_hash, schema_hash,
+        adapter_hash, data_hash, document_hash, dossier_hash,
+        required_pair_count, relevant_dossier_count, created_by
+    ) VALUES (
+        result_id, p_cutoff_at, p_universe_hash, p_policy_hash, p_schema_hash,
+        p_adapter_hash, p_data_hash, p_document_hash, p_dossier_hash,
+        p_required_pair_count, p_relevant_dossier_count, p_created_by
+    ) ON CONFLICT (snapshot_id) DO NOTHING;
+    RETURN result_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.put_canonical_snapshot_watermark_v1(
+    p_snapshot_id TEXT,
+    p_source TEXT,
+    p_source_run_id TEXT,
+    p_watermark_at TIMESTAMPTZ,
+    p_freshness_state TEXT,
+    p_completeness_state TEXT,
+    p_applicable_pair_count INTEGER,
+    p_evaluated_pair_count INTEGER,
+    p_evidence_hash TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    cutoff_value TIMESTAMPTZ;
+BEGIN
+    SELECT cutoff_at INTO STRICT cutoff_value FROM public.canonical_public_snapshots
+    WHERE snapshot_id = p_snapshot_id AND state IN ('BUILDING', 'BLOCKED') FOR UPDATE;
+    IF p_watermark_at > cutoff_value THEN
+        RAISE EXCEPTION 'source watermark is after snapshot cutoff' USING ERRCODE = '22023';
+    END IF;
+    INSERT INTO public.canonical_snapshot_source_watermarks (
+        snapshot_id, source, source_run_id, watermark_at, freshness_state,
+        completeness_state, applicable_pair_count, evaluated_pair_count, evidence_hash
+    ) VALUES (
+        p_snapshot_id, p_source, p_source_run_id, p_watermark_at,
+        p_freshness_state, p_completeness_state,
+        p_applicable_pair_count, p_evaluated_pair_count, p_evidence_hash
+    ) ON CONFLICT (snapshot_id, source) DO UPDATE SET
+        source_run_id = EXCLUDED.source_run_id,
+        watermark_at = EXCLUDED.watermark_at,
+        freshness_state = EXCLUDED.freshness_state,
+        completeness_state = EXCLUDED.completeness_state,
+        applicable_pair_count = EXCLUDED.applicable_pair_count,
+        evaluated_pair_count = EXCLUDED.evaluated_pair_count,
+        evidence_hash = EXCLUDED.evidence_hash,
+        recorded_at = NOW();
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.close_canonical_public_snapshot_v1(p_snapshot_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public, pg_temp
+AS $$
+DECLARE
+    snapshot_row public.canonical_public_snapshots%ROWTYPE;
+    blocker_list JSONB := '[]'::JSONB;
+    watermark_count INTEGER;
+    evaluated_pairs INTEGER;
+    dossier_count INTEGER;
+    revision_count INTEGER;
+    result_hash TEXT;
+BEGIN
+    SELECT * INTO STRICT snapshot_row FROM public.canonical_public_snapshots
+    WHERE snapshot_id = p_snapshot_id FOR UPDATE;
+    IF snapshot_row.state = 'READY_CANONICAL' THEN
+        RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', snapshot_row.state, 'content_hash', snapshot_row.content_hash, 'blockers', snapshot_row.blockers);
+    END IF;
+
+    SELECT count(*), COALESCE(sum(evaluated_pair_count), 0)
+    INTO watermark_count, evaluated_pairs
+    FROM public.canonical_snapshot_source_watermarks WHERE snapshot_id = p_snapshot_id;
+    SELECT count(*) INTO dossier_count FROM public.canonical_snapshot_dossiers
+    WHERE snapshot_id = p_snapshot_id AND completeness_state = 'COMPLETE';
+    SELECT count(*) INTO revision_count FROM public.canonical_snapshot_event_revisions
+    WHERE snapshot_id = p_snapshot_id;
+
+    IF watermark_count = 0 THEN blocker_list := blocker_list || '"missing_source_watermarks"'::JSONB; END IF;
+    IF EXISTS (SELECT 1 FROM public.canonical_snapshot_source_watermarks WHERE snapshot_id = p_snapshot_id AND (freshness_state <> 'FRESH' OR completeness_state <> 'COMPLETE' OR evaluated_pair_count < applicable_pair_count)) THEN
+        blocker_list := blocker_list || '"source_freshness_or_completeness_failed"'::JSONB;
+    END IF;
+    IF evaluated_pairs < snapshot_row.required_pair_count THEN blocker_list := blocker_list || '"applicable_pairs_not_evaluated"'::JSONB; END IF;
+    IF dossier_count < snapshot_row.relevant_dossier_count THEN blocker_list := blocker_list || '"relevant_dossiers_not_complete"'::JSONB; END IF;
+    IF EXISTS (SELECT 1 FROM public.canonical_snapshot_documents WHERE snapshot_id = p_snapshot_id AND completeness_state <> 'COMPLETE') THEN
+        blocker_list := blocker_list || '"documents_incomplete"'::JSONB;
+    END IF;
+    IF revision_count = 0 THEN blocker_list := blocker_list || '"no_canonical_event_revisions"'::JSONB; END IF;
+
+    PERFORM set_config('app.canonical_snapshot_transition', 'on', TRUE);
+    IF blocker_list <> '[]'::JSONB THEN
+        UPDATE public.canonical_public_snapshots SET state = 'BLOCKED', blockers = blocker_list
+        WHERE snapshot_id = p_snapshot_id;
+        PERFORM set_config('app.canonical_snapshot_transition', 'off', TRUE);
+        RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', 'BLOCKED', 'blockers', blocker_list);
+    END IF;
+
+    SELECT encode(digest(concat_ws('|',
+        snapshot_row.snapshot_id, snapshot_row.universe_hash, snapshot_row.policy_hash,
+        snapshot_row.schema_hash, snapshot_row.adapter_hash, snapshot_row.data_hash,
+        snapshot_row.document_hash, snapshot_row.dossier_hash,
+        COALESCE((SELECT string_agg(source || ':' || source_run_id || ':' || watermark_at::TEXT || ':' || evidence_hash, ',' ORDER BY source) FROM public.canonical_snapshot_source_watermarks WHERE snapshot_id = p_snapshot_id), ''),
+        COALESCE((SELECT string_agg(event_id || ':' || revision_id || ':' || fact_hash, ',' ORDER BY event_id) FROM public.canonical_snapshot_event_revisions WHERE snapshot_id = p_snapshot_id), ''),
+        COALESCE((SELECT string_agg(observation_id || ':' || document_sha256, ',' ORDER BY observation_id, document_sha256) FROM public.canonical_snapshot_documents WHERE snapshot_id = p_snapshot_id), ''),
+        COALESCE((SELECT string_agg(dossier_id || ':' || dossier_revision_hash, ',' ORDER BY dossier_id) FROM public.canonical_snapshot_dossiers WHERE snapshot_id = p_snapshot_id), '')
+    ), 'sha256'), 'hex') INTO result_hash;
+
+    UPDATE public.canonical_public_snapshots
+    SET state = 'READY_CANONICAL', blockers = '[]'::JSONB,
+        content_hash = result_hash, closed_at = NOW()
+    WHERE snapshot_id = p_snapshot_id;
+    UPDATE public.public_read_surface_health_internal
+    SET refreshed_at = NOW(), last_refresh_status = 'VALID', last_error = NULL, updated_at = NOW()
+    WHERE enabled;
+    PERFORM set_config('app.canonical_snapshot_transition', 'off', TRUE);
+    RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', 'READY_CANONICAL', 'content_hash', result_hash, 'blockers', '[]'::JSONB);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.close_canonical_public_snapshot_v1(TEXT) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.invalidate_consumer_projection_private_v1(
+    p_projection_id TEXT,
+    p_new_template_hash TEXT,
+    p_new_private_profile_hash TEXT
+)
+RETURNS VOID
+LANGUAGE sql
+AS $$
+    UPDATE public.public_consumer_projections
+    SET state = 'STALE_PRIVATE', invalidated_at = NOW(),
+        invalidation_reason = concat('private/template change:', p_new_template_hash, ':', COALESCE(p_new_private_profile_hash, 'none'))
+    WHERE projection_id = p_projection_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fanout_canonical_revision_invalidation_v1()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO public.canonical_snapshot_invalidations (
+        invalidation_id, snapshot_id, event_id, prior_revision_id, new_revision_id, reason
+    )
+    SELECT public.canonical_public_id('inv', ARRAY[membership.snapshot_id, NEW.revision_id]),
+           membership.snapshot_id, NEW.event_id, membership.revision_id, NEW.revision_id,
+           'new_factual_revision_after_snapshot_cutoff'
+    FROM public.canonical_snapshot_event_revisions membership
+    JOIN public.canonical_public_snapshots snapshot USING (snapshot_id)
+    WHERE membership.event_id = NEW.event_id
+      AND membership.revision_id <> NEW.revision_id
+      AND snapshot.state = 'READY_CANONICAL'
+      AND NEW.system_from > snapshot.cutoff_at
+    ON CONFLICT DO NOTHING;
+
+    UPDATE public.public_consumer_projections projection
+    SET state = 'STALE_FACTUAL', invalidated_at = NOW(),
+        invalidation_reason = 'new_factual_revision:' || NEW.revision_id
+    WHERE projection.snapshot_id IN (
+        SELECT snapshot_id FROM public.canonical_snapshot_invalidations
+        WHERE new_revision_id = NEW.revision_id
+    ) AND projection.state = 'READY';
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_canonical_revision_snapshot_fanout ON public.canonical_event_revisions;
+CREATE TRIGGER trg_canonical_revision_snapshot_fanout
+    AFTER INSERT ON public.canonical_event_revisions
+    FOR EACH ROW EXECUTE FUNCTION public.fanout_canonical_revision_invalidation_v1();
+
+CREATE OR REPLACE FUNCTION public.guard_closed_canonical_snapshot_v1()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    guarded_snapshot_id TEXT;
+    guarded_state TEXT;
+BEGIN
+    IF current_setting('app.allow_canonical_test_cleanup', TRUE) = 'on'
+       AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = current_user AND rolsuper) THEN
+        RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+    END IF;
+    guarded_snapshot_id := CASE WHEN TG_TABLE_NAME = 'canonical_public_snapshots'
+        THEN COALESCE(OLD.snapshot_id, NEW.snapshot_id)
+        ELSE COALESCE(NEW.snapshot_id, OLD.snapshot_id) END;
+    SELECT state INTO guarded_state FROM public.canonical_public_snapshots WHERE snapshot_id = guarded_snapshot_id;
+    IF TG_TABLE_NAME = 'canonical_snapshot_source_watermarks' AND TG_OP <> 'DELETE' THEN
+        IF NEW.watermark_at > (SELECT cutoff_at FROM public.canonical_public_snapshots WHERE snapshot_id = guarded_snapshot_id) THEN
+            RAISE EXCEPTION 'source watermark is after snapshot cutoff' USING ERRCODE = '22023';
+        END IF;
+    END IF;
+    IF TG_TABLE_NAME = 'canonical_snapshot_event_revisions' AND TG_OP <> 'DELETE' THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM public.canonical_event_revisions revision
+            WHERE revision.revision_id = NEW.revision_id
+              AND revision.event_id = NEW.event_id
+              AND revision.fact_hash = NEW.fact_hash
+        ) THEN
+            RAISE EXCEPTION 'snapshot event/revision/fact tuple is inconsistent' USING ERRCODE = '23514';
+        END IF;
+    END IF;
+    IF guarded_state IN ('READY_CANONICAL', 'SUPERSEDED')
+       AND NOT (
+           current_setting('app.canonical_snapshot_transition', TRUE) = 'on'
+           AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = current_user AND rolsuper)
+       ) THEN
+        RAISE EXCEPTION 'closed canonical snapshot % is immutable', guarded_snapshot_id USING ERRCODE = '55000';
+    END IF;
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_canonical_snapshot_guard ON public.canonical_public_snapshots;
+CREATE TRIGGER trg_canonical_snapshot_guard BEFORE UPDATE OR DELETE ON public.canonical_public_snapshots
+FOR EACH ROW EXECUTE FUNCTION public.guard_closed_canonical_snapshot_v1();
+
+DO $$
+DECLARE table_name TEXT;
+BEGIN
+    FOREACH table_name IN ARRAY ARRAY[
+        'canonical_snapshot_source_watermarks', 'canonical_snapshot_event_revisions',
+        'canonical_snapshot_documents', 'canonical_snapshot_dossiers'
+    ] LOOP
+        EXECUTE format('DROP TRIGGER IF EXISTS trg_closed_snapshot_membership_guard ON public.%I', table_name);
+        EXECUTE format('CREATE TRIGGER trg_closed_snapshot_membership_guard BEFORE INSERT OR UPDATE OR DELETE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.guard_closed_canonical_snapshot_v1()', table_name);
+    END LOOP;
+END $$;
+
+CREATE SCHEMA IF NOT EXISTS public_read_v1;
+
+CREATE OR REPLACE VIEW public_read_v1.current_snapshot AS
+SELECT snapshot_id, cutoff_at AS as_of, content_hash, universe_hash, policy_hash,
+       schema_hash, adapter_hash, data_hash, document_hash, dossier_hash,
+       closed_at, 'COMPLETE'::TEXT AS completeness,
+       jsonb_build_object('snapshot_id', snapshot_id, 'content_hash', content_hash) AS provenance
+FROM public.canonical_public_snapshots
+WHERE state = 'READY_CANONICAL'
+ORDER BY cutoff_at DESC, snapshot_id DESC
+LIMIT 1;
+
+CREATE OR REPLACE VIEW public_read_v1.access_gate AS
+SELECT NOT COALESCE((SELECT enabled FROM public.truth_plane_kill_switch WHERE singleton), TRUE) AS enabled;
+
+CREATE OR REPLACE VIEW public_read_v1.tenders AS
+SELECT event.event_id, event.process_key, event.event_type, revision.status_code,
+       revision.title, revision.publication_at, revision.official_number,
+       snapshot.as_of, revision.system_from AS source_updated_at,
+       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       observation.source, observation.source_uri,
+       jsonb_build_object('observation_id', observation.observation_id, 'raw_sha256', observation.raw_sha256, 'revision_id', revision.revision_id, 'snapshot_id', snapshot.snapshot_id) AS provenance
+FROM public_read_v1.current_snapshot snapshot
+JOIN public.canonical_snapshot_event_revisions membership USING (snapshot_id)
+JOIN public.canonical_public_events_v1 event USING (event_id)
+JOIN public.canonical_event_revisions revision USING (revision_id)
+JOIN public.canonical_public_observations observation ON observation.observation_id = revision.created_from_observation_id
+CROSS JOIN public_read_v1.access_gate gate
+WHERE event.event_type IN ('tender_publication', 'tender_status', 'tender_document_change') AND gate.enabled;
+
+CREATE OR REPLACE VIEW public_read_v1.contracts AS
+SELECT event.event_id, event.process_key, revision.status_code, revision.title,
+       revision.contract_value, revision.official_number,
+       snapshot.as_of, revision.system_from AS source_updated_at,
+       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       observation.source, observation.source_uri,
+       jsonb_build_object('observation_id', observation.observation_id, 'raw_sha256', observation.raw_sha256, 'revision_id', revision.revision_id, 'snapshot_id', snapshot.snapshot_id) AS provenance
+FROM public_read_v1.current_snapshot snapshot
+JOIN public.canonical_snapshot_event_revisions membership USING (snapshot_id)
+JOIN public.canonical_public_events_v1 event USING (event_id)
+JOIN public.canonical_event_revisions revision USING (revision_id)
+JOIN public.canonical_public_observations observation ON observation.observation_id = revision.created_from_observation_id
+CROSS JOIN public_read_v1.access_gate gate
+WHERE event.event_type = 'contract_lifecycle' AND gate.enabled;
+
+CREATE OR REPLACE VIEW public_read_v1.entities AS
+WITH entity_links AS (
+    SELECT DISTINCT snapshot.snapshot_id, snapshot.as_of, link.entity_id,
+           link.event_id, link.observation_id
+    FROM public_read_v1.current_snapshot snapshot
+    JOIN public.canonical_snapshot_event_revisions membership USING (snapshot_id)
+    JOIN public.canonical_event_entity_links link USING (event_id)
+    CROSS JOIN public_read_v1.access_gate gate
+    WHERE gate.enabled
+), entity_provenance AS (
+    SELECT snapshot_id, as_of, entity_id,
+           jsonb_agg(
+               jsonb_build_object('event_id', event_id, 'observation_id', observation_id)
+               ORDER BY event_id, observation_id
+           ) AS lineage
+    FROM entity_links
+    GROUP BY snapshot_id, as_of, entity_id
+)
+SELECT entity.entity_id, entity.entity_type, entity.display_name,
+       entity.tax_identifier_type, entity.tax_identifier_export,
+       provenance.as_of, entity.last_seen_at AS source_updated_at,
+       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       jsonb_build_object('snapshot_id', provenance.snapshot_id, 'lineage', provenance.lineage) AS provenance
+FROM entity_provenance provenance
+JOIN public.canonical_public_entities_v2 entity USING (entity_id);
+
+CREATE OR REPLACE VIEW public_read_v1.suppliers AS
+SELECT * FROM public_read_v1.entities WHERE entity_type IN ('supplier', 'company');
+CREATE OR REPLACE VIEW public_read_v1.organs AS
+SELECT * FROM public_read_v1.entities WHERE entity_type IN ('organ', 'unit');
+
+CREATE OR REPLACE VIEW public_read_v1.municipalities AS
+SELECT DISTINCT public.canonical_public_id('mun', ARRAY[COALESCE(organ.ibge_code, ''), COALESCE(organ.uf, ''), COALESCE(organ.municipio, '')]) AS municipality_id,
+       organ.ibge_code, organ.uf, organ.municipio AS name,
+       snapshot.as_of, organ.updated_at AS source_updated_at,
+       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       jsonb_build_object('snapshot_id', snapshot.snapshot_id, 'organ_canonical_key', organ.canonical_key) AS provenance
+FROM public_read_v1.current_snapshot snapshot
+JOIN public_read_v1.organs exposed ON TRUE
+JOIN public.canonical_public_entities_v2 entity ON entity.entity_id = exposed.entity_id
+JOIN public.canonical_organs organ ON organ.cnpj14 = regexp_replace(entity.strong_key, '\D', '', 'g')
+WHERE organ.municipio IS NOT NULL;
+
+CREATE OR REPLACE VIEW public_read_v1.surface_health AS
+SELECT health.view_name, health.enabled,
+       health.refreshed_at, health.query_count, health.error_count,
+       health.query_p95_ms, health.last_refresh_status,
+       snapshot.snapshot_id, snapshot.as_of,
+       CASE WHEN switch.enabled THEN 'KILL_SWITCH_BLOCKED'
+            WHEN health.last_refresh_status = 'VALID' THEN 'COMPLETE'
+            ELSE 'INCOMPLETE' END AS completeness,
+       jsonb_build_object('snapshot_id', snapshot.snapshot_id, 'content_hash', snapshot.content_hash) AS provenance
+FROM public.public_read_surface_health_internal health
+LEFT JOIN public_read_v1.current_snapshot snapshot ON TRUE
+CROSS JOIN public.truth_plane_kill_switch switch
+WHERE switch.singleton;
+
+CREATE TABLE IF NOT EXISTS public_read_v1.contract_releases (
+    version                  TEXT PRIMARY KEY,
+    released_at              TIMESTAMPTZ NOT NULL,
+    schema_hash              TEXT NOT NULL CHECK (schema_hash ~ '^[0-9a-f]{64}$'),
+    compatibility_policy     TEXT NOT NULL,
+    deprecation_window_days  INTEGER NOT NULL CHECK (deprecation_window_days >= 90),
+    changelog                TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public_read_v1.query_budgets (
+    query_family             TEXT PRIMARY KEY,
+    statement_timeout_ms     INTEGER NOT NULL,
+    p95_budget_ms            INTEGER NOT NULL,
+    max_rows                 INTEGER NOT NULL,
+    max_concurrent           INTEGER NOT NULL,
+    representative_query     TEXT NOT NULL
+);
+
+INSERT INTO public_read_v1.query_budgets VALUES
+    ('tenders_by_process', 2000, 250, 100, 4, 'SELECT * FROM public_read_v1.tenders WHERE process_key = $1 LIMIT 100'),
+    ('contracts_by_process', 2000, 250, 100, 4, 'SELECT * FROM public_read_v1.contracts WHERE process_key = $1 LIMIT 100'),
+    ('entities_by_id', 1000, 100, 10, 4, 'SELECT * FROM public_read_v1.entities WHERE entity_id = $1 LIMIT 10'),
+    ('surface_health', 1000, 100, 20, 2, 'SELECT * FROM public_read_v1.surface_health LIMIT 20')
+ON CONFLICT (query_family) DO UPDATE SET
+    statement_timeout_ms = EXCLUDED.statement_timeout_ms,
+    p95_budget_ms = EXCLUDED.p95_budget_ms,
+    max_rows = EXCLUDED.max_rows,
+    max_concurrent = EXCLUDED.max_concurrent,
+    representative_query = EXCLUDED.representative_query;
+
+DO $$
+DECLARE release_hash TEXT;
+BEGIN
+    SELECT encode(digest(string_agg(table_name || ':' || ordinal_position || ':' || column_name || ':' || data_type || ':' || is_nullable, '|' ORDER BY table_name, ordinal_position), 'sha256'), 'hex')
+    INTO release_hash
+    FROM information_schema.columns
+    WHERE table_schema = 'public_read_v1'
+      AND table_name IN ('current_snapshot', 'tenders', 'contracts', 'entities', 'suppliers', 'organs', 'municipalities', 'surface_health');
+    INSERT INTO public_read_v1.contract_releases VALUES (
+        'v1.0.0', NOW(), release_hash,
+        'Additive nullable columns only within v1; removal/type/nullability changes require public_read_v2.',
+        180,
+        'Initial canonical snapshot, tender, contract, entity, supplier, organ, municipality and health families.'
+    ) ON CONFLICT (version) DO UPDATE SET schema_hash = EXCLUDED.schema_hash;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'smartlic_public_reader') THEN
+        CREATE ROLE smartlic_public_reader NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION;
+        COMMENT ON ROLE smartlic_public_reader IS 'managed-by-extra-migration-089';
+    END IF;
+    EXECUTE format('GRANT CONNECT ON DATABASE %I TO smartlic_public_reader', current_database());
+    EXECUTE format('GRANT smartlic_public_reader TO %I', current_user);
+END $$;
+
+ALTER ROLE smartlic_public_reader SET statement_timeout = '2s';
+ALTER ROLE smartlic_public_reader SET lock_timeout = '500ms';
+ALTER ROLE smartlic_public_reader SET idle_in_transaction_session_timeout = '5s';
+ALTER ROLE smartlic_public_reader SET default_transaction_read_only = 'on';
+REVOKE ALL ON SCHEMA public FROM smartlic_public_reader;
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM smartlic_public_reader;
+GRANT USAGE ON SCHEMA public_read_v1 TO smartlic_public_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA public_read_v1 TO smartlic_public_reader;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA public_read_v1 FROM smartlic_public_reader;
+
+COMMIT;

--- a/db/migrations/089_canonical_snapshot_public_read_v1.sql
+++ b/db/migrations/089_canonical_snapshot_public_read_v1.sql
@@ -269,7 +269,13 @@ BEGIN
     WHERE snapshot_id = p_snapshot_id;
     UPDATE public.public_read_surface_health_internal
     SET refreshed_at = NOW(), last_refresh_status = 'VALID', last_error = NULL, updated_at = NOW()
-    WHERE enabled;
+    WHERE enabled
+      AND view_name IN ('snapshots', 'tenders', 'contracts', 'entities', 'suppliers', 'organs');
+    UPDATE public.public_read_surface_health_internal
+    SET refreshed_at = NOW(), last_refresh_status = 'STALE',
+        last_error = 'municipalities reserved until snapshot-bound municipality facts exist',
+        updated_at = NOW()
+    WHERE enabled AND view_name = 'municipalities';
     PERFORM set_config('app.canonical_snapshot_transition', 'off', TRUE);
     RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', 'READY_CANONICAL', 'content_hash', result_hash, 'blockers', '[]'::JSONB);
 END;
@@ -387,13 +393,26 @@ END $$;
 CREATE SCHEMA IF NOT EXISTS public_read_v1;
 
 CREATE OR REPLACE VIEW public_read_v1.current_snapshot AS
-SELECT snapshot_id, cutoff_at AS as_of, content_hash, universe_hash, policy_hash,
-       schema_hash, adapter_hash, data_hash, document_hash, dossier_hash,
-       closed_at, 'COMPLETE'::TEXT AS completeness,
-       jsonb_build_object('snapshot_id', snapshot_id, 'content_hash', content_hash) AS provenance
-FROM public.canonical_public_snapshots
-WHERE state = 'READY_CANONICAL'
-ORDER BY cutoff_at DESC, snapshot_id DESC
+SELECT snapshot.snapshot_id, snapshot.cutoff_at AS as_of, snapshot.content_hash,
+       snapshot.universe_hash, snapshot.policy_hash, snapshot.schema_hash,
+       snapshot.adapter_hash, snapshot.data_hash, snapshot.document_hash,
+       snapshot.dossier_hash, snapshot.closed_at,
+       CASE
+           WHEN EXISTS (
+               SELECT 1 FROM public.canonical_snapshot_source_watermarks watermark
+               WHERE watermark.snapshot_id = snapshot.snapshot_id
+                 AND (watermark.completeness_state <> 'COMPLETE' OR watermark.freshness_state <> 'FRESH')
+           ) THEN 'INCOMPLETE'
+           WHEN NOT EXISTS (
+               SELECT 1 FROM public.canonical_snapshot_source_watermarks watermark
+               WHERE watermark.snapshot_id = snapshot.snapshot_id
+           ) THEN 'UNKNOWN'
+           ELSE 'COMPLETE'
+       END AS completeness,
+       jsonb_build_object('snapshot_id', snapshot.snapshot_id, 'content_hash', snapshot.content_hash) AS provenance
+FROM public.canonical_public_snapshots snapshot
+WHERE snapshot.state = 'READY_CANONICAL'
+ORDER BY snapshot.cutoff_at DESC, snapshot.snapshot_id DESC
 LIMIT 1;
 
 CREATE OR REPLACE VIEW public_read_v1.access_gate AS
@@ -403,7 +422,10 @@ CREATE OR REPLACE VIEW public_read_v1.tenders AS
 SELECT event.event_id, event.process_key, event.event_type, revision.status_code,
        revision.title, revision.publication_at, revision.official_number,
        snapshot.as_of, revision.system_from AS source_updated_at,
-       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       snapshot.completeness,
+       CASE WHEN snapshot.completeness = 'COMPLETE' THEN ARRAY[]::TEXT[]
+            WHEN snapshot.completeness = 'UNKNOWN' THEN ARRAY['missing_source_watermarks']
+            ELSE ARRAY['source_watermark_incomplete'] END AS reason_codes,
        observation.source, observation.source_uri,
        jsonb_build_object('observation_id', observation.observation_id, 'raw_sha256', observation.raw_sha256, 'revision_id', revision.revision_id, 'snapshot_id', snapshot.snapshot_id) AS provenance
 FROM public_read_v1.current_snapshot snapshot
@@ -418,7 +440,10 @@ CREATE OR REPLACE VIEW public_read_v1.contracts AS
 SELECT event.event_id, event.process_key, revision.status_code, revision.title,
        revision.contract_value, revision.official_number,
        snapshot.as_of, revision.system_from AS source_updated_at,
-       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       snapshot.completeness,
+       CASE WHEN snapshot.completeness = 'COMPLETE' THEN ARRAY[]::TEXT[]
+            WHEN snapshot.completeness = 'UNKNOWN' THEN ARRAY['missing_source_watermarks']
+            ELSE ARRAY['source_watermark_incomplete'] END AS reason_codes,
        observation.source, observation.source_uri,
        jsonb_build_object('observation_id', observation.observation_id, 'raw_sha256', observation.raw_sha256, 'revision_id', revision.revision_id, 'snapshot_id', snapshot.snapshot_id) AS provenance
 FROM public_read_v1.current_snapshot snapshot
@@ -450,27 +475,35 @@ WITH entity_links AS (
 SELECT entity.entity_id, entity.entity_type, entity.display_name,
        entity.tax_identifier_type, entity.tax_identifier_export,
        provenance.as_of, entity.last_seen_at AS source_updated_at,
-       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
+       snapshot.completeness,
+       CASE WHEN snapshot.completeness = 'COMPLETE' THEN ARRAY[]::TEXT[]
+            WHEN snapshot.completeness = 'UNKNOWN' THEN ARRAY['missing_source_watermarks']
+            ELSE ARRAY['source_watermark_incomplete'] END AS reason_codes,
        jsonb_build_object('snapshot_id', provenance.snapshot_id, 'lineage', provenance.lineage) AS provenance
 FROM entity_provenance provenance
-JOIN public.canonical_public_entities_v2 entity USING (entity_id);
+JOIN public.canonical_public_entities_v2 entity USING (entity_id)
+JOIN public_read_v1.current_snapshot snapshot ON snapshot.snapshot_id = provenance.snapshot_id;
 
 CREATE OR REPLACE VIEW public_read_v1.suppliers AS
 SELECT * FROM public_read_v1.entities WHERE entity_type IN ('supplier', 'company');
 CREATE OR REPLACE VIEW public_read_v1.organs AS
 SELECT * FROM public_read_v1.entities WHERE entity_type IN ('organ', 'unit');
 
+-- Reserved family: do not join live canonical_organs (that table is outside
+-- the closed snapshot). Empty until municipality facts are snapshot-bound.
 CREATE OR REPLACE VIEW public_read_v1.municipalities AS
-SELECT DISTINCT public.canonical_public_id('mun', ARRAY[COALESCE(organ.ibge_code, ''), COALESCE(organ.uf, ''), COALESCE(organ.municipio, '')]) AS municipality_id,
-       organ.ibge_code, organ.uf, organ.municipio AS name,
-       snapshot.as_of, organ.updated_at AS source_updated_at,
-       'COMPLETE'::TEXT AS completeness, ARRAY[]::TEXT[] AS reason_codes,
-       jsonb_build_object('snapshot_id', snapshot.snapshot_id, 'organ_canonical_key', organ.canonical_key) AS provenance
+SELECT
+    NULL::TEXT AS municipality_id,
+    NULL::TEXT AS ibge_code,
+    NULL::TEXT AS uf,
+    NULL::TEXT AS name,
+    snapshot.as_of,
+    snapshot.as_of AS source_updated_at,
+    'UNKNOWN'::TEXT AS completeness,
+    ARRAY['municipality_facts_not_snapshot_bound']::TEXT[] AS reason_codes,
+    jsonb_build_object('snapshot_id', snapshot.snapshot_id) AS provenance
 FROM public_read_v1.current_snapshot snapshot
-JOIN public_read_v1.organs exposed ON TRUE
-JOIN public.canonical_public_entities_v2 entity ON entity.entity_id = exposed.entity_id
-JOIN public.canonical_organs organ ON organ.cnpj14 = regexp_replace(entity.strong_key, '\D', '', 'g')
-WHERE organ.municipio IS NOT NULL;
+WHERE FALSE;
 
 CREATE OR REPLACE VIEW public_read_v1.surface_health AS
 SELECT health.view_name, health.enabled,
@@ -551,5 +584,30 @@ REVOKE ALL ON ALL TABLES IN SCHEMA public FROM smartlic_public_reader;
 GRANT USAGE ON SCHEMA public_read_v1 TO smartlic_public_reader;
 GRANT SELECT ON ALL TABLES IN SCHEMA public_read_v1 TO smartlic_public_reader;
 REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA public_read_v1 FROM smartlic_public_reader;
+
+-- EXECUTE ON PUBLIC is the PostgreSQL default. REVOKE ALL ON SCHEMA public
+-- does not remove it. Writer RPCs must not be callable by the reader role.
+DO $$
+DECLARE
+    writer REGPROCEDURE;
+BEGIN
+    FOREACH writer IN ARRAY ARRAY[
+        'public.upsert_pncp_raw_bids(JSONB)'::REGPROCEDURE,
+        'public.ensure_canonical_public_entity_v2(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT)'::REGPROCEDURE,
+        'public.ingest_canonical_public_observation_v1(JSONB)'::REGPROCEDURE,
+        'public.record_canonical_identity_decision_v1(TEXT, TEXT, TEXT, TEXT[], TEXT, TEXT[], TEXT, TEXT)'::REGPROCEDURE,
+        'public.begin_canonical_public_snapshot_v1(TIMESTAMPTZ, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT)'::REGPROCEDURE,
+        'public.put_canonical_snapshot_watermark_v1(TEXT, TEXT, TEXT, TIMESTAMPTZ, TEXT, TEXT, INTEGER, INTEGER, TEXT)'::REGPROCEDURE,
+        'public.close_canonical_public_snapshot_v1(TEXT)'::REGPROCEDURE,
+        'public.invalidate_consumer_projection_private_v1(TEXT, TEXT, TEXT)'::REGPROCEDURE
+    ]
+    LOOP
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC', writer);
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM smartlic_public_reader', writer);
+    END LOOP;
+END $$;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA public FROM smartlic_public_reader;
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM smartlic_public_reader;
+REVOKE USAGE ON SCHEMA public FROM smartlic_public_reader;
 
 COMMIT;

--- a/db/migrations/090_public_read_select_only_lock.sql
+++ b/db/migrations/090_public_read_select_only_lock.sql
@@ -1,0 +1,370 @@
+-- 090_public_read_select_only_lock.sql
+-- Incremental contract lock for databases that already applied 087–089.
+-- Fresh installs already contain these objects in the patched 087–089 files.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+UPDATE public.dlq_entries
+SET terminal_at = COALESCE(failed_at, terminal_at)
+WHERE failed_at IS NOT NULL
+  AND (terminal_at IS NULL OR terminal_at > failed_at);
+
+CREATE OR REPLACE FUNCTION public.ingest_canonical_public_observation_v1(p_observation JSONB)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    source_name TEXT := p_observation->>'source';
+    source_record TEXT := p_observation->>'source_record_id';
+    source_version TEXT := COALESCE(NULLIF(p_observation->>'source_version', ''), 'v1');
+    raw_hash TEXT := p_observation->>'raw_sha256';
+    process_key_value TEXT := p_observation->>'process_key';
+    event_type_value TEXT := p_observation->>'event_type';
+    policy TEXT := COALESCE(NULLIF(p_observation->>'policy_version', ''), 'canonical-events-v1');
+    facts JSONB := COALESCE(p_observation->'facts', '{}'::JSONB);
+    match_state TEXT := upper(COALESCE(NULLIF(btrim(p_observation->>'match_state'), ''), 'EXACT'));
+    observation_id_value TEXT;
+    process_entity_id TEXT;
+    event_id_value TEXT;
+    revision_id_value TEXT;
+    fact_hash_value TEXT;
+    conflict_id_value TEXT;
+    related JSONB;
+    related_entity_id TEXT;
+    relation_name TEXT;
+BEGIN
+    IF p_observation ? 'client_id' OR p_observation::TEXT ~* '"client[_-]?id"' THEN
+        RAISE EXCEPTION 'client_id is forbidden in canonical public authority' USING ERRCODE = '22023';
+    END IF;
+    IF source_name IS NULL OR source_record IS NULL OR raw_hash !~ '^[0-9a-f]{64}$' THEN
+        RAISE EXCEPTION 'source, source_record_id and lowercase raw_sha256 are required' USING ERRCODE = '22023';
+    END IF;
+    IF event_type_value IS NULL
+       OR event_type_value NOT IN ('tender_publication', 'tender_status', 'tender_document_change', 'contract_lifecycle') THEN
+        RAISE EXCEPTION 'unsupported event_type %', event_type_value USING ERRCODE = '22023';
+    END IF;
+    IF match_state NOT IN ('EXACT', 'AMBIGUOUS') THEN
+        RAISE EXCEPTION 'match_state % is not an identity authority (expected EXACT or AMBIGUOUS)', match_state
+            USING ERRCODE = '22023';
+    END IF;
+
+    observation_id_value := public.canonical_public_id(
+        'obs', ARRAY[source_name, source_record, source_version, raw_hash]
+    );
+    INSERT INTO public.canonical_public_observations (
+        observation_id, source, source_record_id, source_version,
+        document_version, raw_sha256, observed_at, source_uri,
+        snapshot_id, payload_hash, payload
+    ) VALUES (
+        observation_id_value, source_name, source_record, source_version,
+        p_observation->>'document_version', raw_hash,
+        (p_observation->>'observed_at')::TIMESTAMPTZ,
+        p_observation->>'source_uri', p_observation->>'snapshot_id',
+        encode(digest(p_observation::TEXT, 'sha256'), 'hex'), p_observation
+    ) ON CONFLICT (observation_id) DO NOTHING;
+
+    IF match_state = 'AMBIGUOUS' THEN
+        conflict_id_value := public.canonical_public_id(
+            'cnf', ARRAY[observation_id_value, COALESCE(p_observation->'candidate_event_ids', '[]')::TEXT, policy]
+        );
+        INSERT INTO public.canonical_match_conflicts (
+            conflict_id, observation_id, conflict_type, candidate_event_ids,
+            reason_codes, policy_version, owner
+        ) VALUES (
+            conflict_id_value, observation_id_value,
+            COALESCE(p_observation->>'conflict_type', 'ambiguous_event_match'),
+            ARRAY(SELECT jsonb_array_elements_text(p_observation->'candidate_event_ids')),
+            ARRAY(SELECT jsonb_array_elements_text(COALESCE(p_observation->'reason_codes', '["weak_key_collision"]'))),
+            policy, p_observation->>'owner'
+        ) ON CONFLICT (conflict_id) DO NOTHING;
+        RETURN jsonb_build_object(
+            'state', 'CONFLICT', 'observation_id', observation_id_value,
+            'event_id', NULL, 'conflict_id', conflict_id_value
+        );
+    END IF;
+
+    IF process_key_value IS NULL OR btrim(process_key_value) = '' OR process_key_value ~* 'client[_-]?id' THEN
+        RAISE EXCEPTION 'strong client-independent process_key is required' USING ERRCODE = '22023';
+    END IF;
+    process_entity_id := public.ensure_canonical_public_entity_v2(
+        'process', process_key_value, facts->>'title', NULL, NULL,
+        source_name, source_record, policy
+    );
+    event_id_value := public.canonical_public_id('evt', ARRAY[event_type_value, process_key_value]);
+    INSERT INTO public.canonical_public_events_v1 (
+        event_id, event_type, process_key, subject_entity_id,
+        official_number, created_by_policy
+    ) VALUES (
+        event_id_value, event_type_value, process_key_value, process_entity_id,
+        facts->>'official_number', policy
+    ) ON CONFLICT (event_id) DO NOTHING;
+
+    INSERT INTO public.canonical_event_observation_links (
+        event_id, observation_id, link_role, confidence, match_policy_version
+    ) VALUES (
+        event_id_value, observation_id_value,
+        COALESCE(p_observation->>'link_role', 'asserts'),
+        COALESCE((p_observation->>'confidence')::NUMERIC, 1), policy
+    ) ON CONFLICT DO NOTHING;
+
+    INSERT INTO public.canonical_event_entity_links (
+        event_id, entity_id, relation_type, observation_id, confidence, policy_version
+    ) VALUES (event_id_value, process_entity_id, 'subject_process', observation_id_value, 1, policy)
+    ON CONFLICT DO NOTHING;
+
+    FOR related IN SELECT value FROM jsonb_array_elements(COALESCE(p_observation->'entities', '[]'::JSONB)) LOOP
+        relation_name := related->>'relation_type';
+        related_entity_id := public.ensure_canonical_public_entity_v2(
+            related->>'entity_type', related->>'strong_key', related->>'display_name',
+            related->>'tax_identifier_type', related->>'tax_identifier_export',
+            source_name, source_record, policy
+        );
+        INSERT INTO public.canonical_event_entity_links (
+            event_id, entity_id, relation_type, observation_id, confidence, policy_version
+        ) VALUES (
+            event_id_value, related_entity_id, relation_name, observation_id_value,
+            COALESCE((related->>'confidence')::NUMERIC, 1), policy
+        ) ON CONFLICT DO NOTHING;
+    END LOOP;
+
+    fact_hash_value := encode(digest(facts::TEXT, 'sha256'), 'hex');
+    revision_id_value := public.canonical_public_id(
+        'rev', ARRAY[event_id_value, p_observation->>'valid_from', fact_hash_value]
+    );
+    INSERT INTO public.canonical_event_revisions (
+        revision_id, event_id, valid_from, valid_to, status_code, title,
+        publication_at, document_sha256, contract_value, official_number,
+        fact_hash, fact_payload, created_from_observation_id, policy_version
+    ) VALUES (
+        revision_id_value, event_id_value,
+        (p_observation->>'valid_from')::TIMESTAMPTZ,
+        NULLIF(p_observation->>'valid_to', '')::TIMESTAMPTZ,
+        facts->>'status_code', facts->>'title',
+        NULLIF(facts->>'publication_at', '')::TIMESTAMPTZ,
+        facts->>'document_sha256', NULLIF(facts->>'contract_value', '')::NUMERIC,
+        facts->>'official_number', fact_hash_value, facts,
+        observation_id_value, policy
+    ) ON CONFLICT (revision_id) DO NOTHING;
+
+    RETURN jsonb_build_object(
+        'state', 'LINKED', 'observation_id', observation_id_value,
+        'event_id', event_id_value, 'revision_id', revision_id_value,
+        'process_entity_id', process_entity_id, 'fact_hash', fact_hash_value
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.close_canonical_public_snapshot_v1(p_snapshot_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO public, pg_temp
+AS $$
+DECLARE
+    snapshot_row public.canonical_public_snapshots%ROWTYPE;
+    blocker_list JSONB := '[]'::JSONB;
+    watermark_count INTEGER;
+    evaluated_pairs INTEGER;
+    dossier_count INTEGER;
+    revision_count INTEGER;
+    result_hash TEXT;
+BEGIN
+    SELECT * INTO STRICT snapshot_row FROM public.canonical_public_snapshots
+    WHERE snapshot_id = p_snapshot_id FOR UPDATE;
+    IF snapshot_row.state = 'READY_CANONICAL' THEN
+        RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', snapshot_row.state, 'content_hash', snapshot_row.content_hash, 'blockers', snapshot_row.blockers);
+    END IF;
+
+    SELECT count(*), COALESCE(sum(evaluated_pair_count), 0)
+    INTO watermark_count, evaluated_pairs
+    FROM public.canonical_snapshot_source_watermarks WHERE snapshot_id = p_snapshot_id;
+    SELECT count(*) INTO dossier_count FROM public.canonical_snapshot_dossiers
+    WHERE snapshot_id = p_snapshot_id AND completeness_state = 'COMPLETE';
+    SELECT count(*) INTO revision_count FROM public.canonical_snapshot_event_revisions
+    WHERE snapshot_id = p_snapshot_id;
+
+    IF watermark_count = 0 THEN blocker_list := blocker_list || '"missing_source_watermarks"'::JSONB; END IF;
+    IF EXISTS (SELECT 1 FROM public.canonical_snapshot_source_watermarks WHERE snapshot_id = p_snapshot_id AND (freshness_state <> 'FRESH' OR completeness_state <> 'COMPLETE' OR evaluated_pair_count < applicable_pair_count)) THEN
+        blocker_list := blocker_list || '"source_freshness_or_completeness_failed"'::JSONB;
+    END IF;
+    IF evaluated_pairs < snapshot_row.required_pair_count THEN blocker_list := blocker_list || '"applicable_pairs_not_evaluated"'::JSONB; END IF;
+    IF dossier_count < snapshot_row.relevant_dossier_count THEN blocker_list := blocker_list || '"relevant_dossiers_not_complete"'::JSONB; END IF;
+    IF EXISTS (SELECT 1 FROM public.canonical_snapshot_documents WHERE snapshot_id = p_snapshot_id AND completeness_state <> 'COMPLETE') THEN
+        blocker_list := blocker_list || '"documents_incomplete"'::JSONB;
+    END IF;
+    IF revision_count = 0 THEN blocker_list := blocker_list || '"no_canonical_event_revisions"'::JSONB; END IF;
+
+    PERFORM set_config('app.canonical_snapshot_transition', 'on', TRUE);
+    IF blocker_list <> '[]'::JSONB THEN
+        UPDATE public.canonical_public_snapshots SET state = 'BLOCKED', blockers = blocker_list
+        WHERE snapshot_id = p_snapshot_id;
+        PERFORM set_config('app.canonical_snapshot_transition', 'off', TRUE);
+        RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', 'BLOCKED', 'blockers', blocker_list);
+    END IF;
+
+    SELECT encode(digest(concat_ws('|',
+        snapshot_row.snapshot_id, snapshot_row.universe_hash, snapshot_row.policy_hash,
+        snapshot_row.schema_hash, snapshot_row.adapter_hash, snapshot_row.data_hash,
+        snapshot_row.document_hash, snapshot_row.dossier_hash,
+        COALESCE((SELECT string_agg(source || ':' || source_run_id || ':' || watermark_at::TEXT || ':' || evidence_hash, ',' ORDER BY source) FROM public.canonical_snapshot_source_watermarks WHERE snapshot_id = p_snapshot_id), ''),
+        COALESCE((SELECT string_agg(event_id || ':' || revision_id || ':' || fact_hash, ',' ORDER BY event_id) FROM public.canonical_snapshot_event_revisions WHERE snapshot_id = p_snapshot_id), ''),
+        COALESCE((SELECT string_agg(observation_id || ':' || document_sha256, ',' ORDER BY observation_id, document_sha256) FROM public.canonical_snapshot_documents WHERE snapshot_id = p_snapshot_id), ''),
+        COALESCE((SELECT string_agg(dossier_id || ':' || dossier_revision_hash, ',' ORDER BY dossier_id) FROM public.canonical_snapshot_dossiers WHERE snapshot_id = p_snapshot_id), '')
+    ), 'sha256'), 'hex') INTO result_hash;
+
+    UPDATE public.canonical_public_snapshots
+    SET state = 'READY_CANONICAL', blockers = '[]'::JSONB,
+        content_hash = result_hash, closed_at = NOW()
+    WHERE snapshot_id = p_snapshot_id;
+    UPDATE public.public_read_surface_health_internal
+    SET refreshed_at = NOW(), last_refresh_status = 'VALID', last_error = NULL, updated_at = NOW()
+    WHERE enabled
+      AND view_name IN ('snapshots', 'tenders', 'contracts', 'entities', 'suppliers', 'organs');
+    UPDATE public.public_read_surface_health_internal
+    SET refreshed_at = NOW(), last_refresh_status = 'STALE',
+        last_error = 'municipalities reserved until snapshot-bound municipality facts exist',
+        updated_at = NOW()
+    WHERE enabled AND view_name = 'municipalities';
+    PERFORM set_config('app.canonical_snapshot_transition', 'off', TRUE);
+    RETURN jsonb_build_object('snapshot_id', p_snapshot_id, 'state', 'READY_CANONICAL', 'content_hash', result_hash, 'blockers', '[]'::JSONB);
+END;
+$$;
+
+CREATE OR REPLACE VIEW public_read_v1.current_snapshot AS
+SELECT snapshot.snapshot_id, snapshot.cutoff_at AS as_of, snapshot.content_hash,
+       snapshot.universe_hash, snapshot.policy_hash, snapshot.schema_hash,
+       snapshot.adapter_hash, snapshot.data_hash, snapshot.document_hash,
+       snapshot.dossier_hash, snapshot.closed_at,
+       CASE
+           WHEN EXISTS (
+               SELECT 1 FROM public.canonical_snapshot_source_watermarks watermark
+               WHERE watermark.snapshot_id = snapshot.snapshot_id
+                 AND (watermark.completeness_state <> 'COMPLETE' OR watermark.freshness_state <> 'FRESH')
+           ) THEN 'INCOMPLETE'
+           WHEN NOT EXISTS (
+               SELECT 1 FROM public.canonical_snapshot_source_watermarks watermark
+               WHERE watermark.snapshot_id = snapshot.snapshot_id
+           ) THEN 'UNKNOWN'
+           ELSE 'COMPLETE'
+       END AS completeness,
+       jsonb_build_object('snapshot_id', snapshot.snapshot_id, 'content_hash', snapshot.content_hash) AS provenance
+FROM public.canonical_public_snapshots snapshot
+WHERE snapshot.state = 'READY_CANONICAL'
+ORDER BY snapshot.cutoff_at DESC, snapshot.snapshot_id DESC
+LIMIT 1;
+
+CREATE OR REPLACE VIEW public_read_v1.tenders AS
+SELECT event.event_id, event.process_key, event.event_type, revision.status_code,
+       revision.title, revision.publication_at, revision.official_number,
+       snapshot.as_of, revision.system_from AS source_updated_at,
+       snapshot.completeness,
+       CASE WHEN snapshot.completeness = 'COMPLETE' THEN ARRAY[]::TEXT[]
+            WHEN snapshot.completeness = 'UNKNOWN' THEN ARRAY['missing_source_watermarks']
+            ELSE ARRAY['source_watermark_incomplete'] END AS reason_codes,
+       observation.source, observation.source_uri,
+       jsonb_build_object('observation_id', observation.observation_id, 'raw_sha256', observation.raw_sha256, 'revision_id', revision.revision_id, 'snapshot_id', snapshot.snapshot_id) AS provenance
+FROM public_read_v1.current_snapshot snapshot
+JOIN public.canonical_snapshot_event_revisions membership USING (snapshot_id)
+JOIN public.canonical_public_events_v1 event USING (event_id)
+JOIN public.canonical_event_revisions revision USING (revision_id)
+JOIN public.canonical_public_observations observation ON observation.observation_id = revision.created_from_observation_id
+CROSS JOIN public_read_v1.access_gate gate
+WHERE event.event_type IN ('tender_publication', 'tender_status', 'tender_document_change') AND gate.enabled;
+
+CREATE OR REPLACE VIEW public_read_v1.contracts AS
+SELECT event.event_id, event.process_key, revision.status_code, revision.title,
+       revision.contract_value, revision.official_number,
+       snapshot.as_of, revision.system_from AS source_updated_at,
+       snapshot.completeness,
+       CASE WHEN snapshot.completeness = 'COMPLETE' THEN ARRAY[]::TEXT[]
+            WHEN snapshot.completeness = 'UNKNOWN' THEN ARRAY['missing_source_watermarks']
+            ELSE ARRAY['source_watermark_incomplete'] END AS reason_codes,
+       observation.source, observation.source_uri,
+       jsonb_build_object('observation_id', observation.observation_id, 'raw_sha256', observation.raw_sha256, 'revision_id', revision.revision_id, 'snapshot_id', snapshot.snapshot_id) AS provenance
+FROM public_read_v1.current_snapshot snapshot
+JOIN public.canonical_snapshot_event_revisions membership USING (snapshot_id)
+JOIN public.canonical_public_events_v1 event USING (event_id)
+JOIN public.canonical_event_revisions revision USING (revision_id)
+JOIN public.canonical_public_observations observation ON observation.observation_id = revision.created_from_observation_id
+CROSS JOIN public_read_v1.access_gate gate
+WHERE event.event_type = 'contract_lifecycle' AND gate.enabled;
+
+CREATE OR REPLACE VIEW public_read_v1.entities AS
+WITH entity_links AS (
+    SELECT DISTINCT snapshot.snapshot_id, snapshot.as_of, link.entity_id,
+           link.event_id, link.observation_id
+    FROM public_read_v1.current_snapshot snapshot
+    JOIN public.canonical_snapshot_event_revisions membership USING (snapshot_id)
+    JOIN public.canonical_event_entity_links link USING (event_id)
+    CROSS JOIN public_read_v1.access_gate gate
+    WHERE gate.enabled
+), entity_provenance AS (
+    SELECT snapshot_id, as_of, entity_id,
+           jsonb_agg(
+               jsonb_build_object('event_id', event_id, 'observation_id', observation_id)
+               ORDER BY event_id, observation_id
+           ) AS lineage
+    FROM entity_links
+    GROUP BY snapshot_id, as_of, entity_id
+)
+SELECT entity.entity_id, entity.entity_type, entity.display_name,
+       entity.tax_identifier_type, entity.tax_identifier_export,
+       provenance.as_of, entity.last_seen_at AS source_updated_at,
+       snapshot.completeness,
+       CASE WHEN snapshot.completeness = 'COMPLETE' THEN ARRAY[]::TEXT[]
+            WHEN snapshot.completeness = 'UNKNOWN' THEN ARRAY['missing_source_watermarks']
+            ELSE ARRAY['source_watermark_incomplete'] END AS reason_codes,
+       jsonb_build_object('snapshot_id', provenance.snapshot_id, 'lineage', provenance.lineage) AS provenance
+FROM entity_provenance provenance
+JOIN public.canonical_public_entities_v2 entity USING (entity_id)
+JOIN public_read_v1.current_snapshot snapshot ON snapshot.snapshot_id = provenance.snapshot_id;
+
+CREATE OR REPLACE VIEW public_read_v1.suppliers AS
+SELECT * FROM public_read_v1.entities WHERE entity_type IN ('supplier', 'company');
+CREATE OR REPLACE VIEW public_read_v1.organs AS
+SELECT * FROM public_read_v1.entities WHERE entity_type IN ('organ', 'unit');
+
+CREATE OR REPLACE VIEW public_read_v1.municipalities AS
+SELECT
+    NULL::TEXT AS municipality_id,
+    NULL::TEXT AS ibge_code,
+    NULL::TEXT AS uf,
+    NULL::TEXT AS name,
+    snapshot.as_of,
+    snapshot.as_of AS source_updated_at,
+    'UNKNOWN'::TEXT AS completeness,
+    ARRAY['municipality_facts_not_snapshot_bound']::TEXT[] AS reason_codes,
+    jsonb_build_object('snapshot_id', snapshot.snapshot_id) AS provenance
+FROM public_read_v1.current_snapshot snapshot
+WHERE FALSE;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA public_read_v1 TO smartlic_public_reader;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON ALL TABLES IN SCHEMA public_read_v1 FROM smartlic_public_reader;
+
+DO $$
+DECLARE
+    writer REGPROCEDURE;
+BEGIN
+    FOREACH writer IN ARRAY ARRAY[
+        'public.upsert_pncp_raw_bids(JSONB)'::REGPROCEDURE,
+        'public.ensure_canonical_public_entity_v2(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT)'::REGPROCEDURE,
+        'public.ingest_canonical_public_observation_v1(JSONB)'::REGPROCEDURE,
+        'public.record_canonical_identity_decision_v1(TEXT, TEXT, TEXT, TEXT[], TEXT, TEXT[], TEXT, TEXT)'::REGPROCEDURE,
+        'public.begin_canonical_public_snapshot_v1(TIMESTAMPTZ, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT)'::REGPROCEDURE,
+        'public.put_canonical_snapshot_watermark_v1(TEXT, TEXT, TEXT, TIMESTAMPTZ, TEXT, TEXT, INTEGER, INTEGER, TEXT)'::REGPROCEDURE,
+        'public.close_canonical_public_snapshot_v1(TEXT)'::REGPROCEDURE,
+        'public.invalidate_consumer_projection_private_v1(TEXT, TEXT, TEXT)'::REGPROCEDURE
+    ]
+    LOOP
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC', writer);
+        EXECUTE format('REVOKE ALL ON FUNCTION %s FROM smartlic_public_reader', writer);
+    END LOOP;
+END $$;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA public FROM smartlic_public_reader;
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM smartlic_public_reader;
+REVOKE USAGE ON SCHEMA public FROM smartlic_public_reader;
+
+COMMIT;

--- a/db/rollback/085_pncp_content_hash_collision_rollback.sql
+++ b/db/rollback/085_pncp_content_hash_collision_rollback.sql
@@ -1,0 +1,127 @@
+-- Roll back migration 085 to the migration-049 upsert contract.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.upsert_pncp_raw_bids(JSONB);
+CREATE FUNCTION public.upsert_pncp_raw_bids(p_records JSONB)
+RETURNS TABLE (inserted INTEGER, updated INTEGER, unchanged INTEGER)
+LANGUAGE plpgsql
+SET search_path TO public
+AS $$
+DECLARE
+    v_total INTEGER;
+    v_inserted INTEGER;
+    v_updated INTEGER;
+BEGIN
+    IF p_records IS NULL OR jsonb_typeof(p_records) <> 'array' THEN
+        RAISE EXCEPTION 'p_records must be a JSON array';
+    END IF;
+
+    WITH src AS (
+        SELECT DISTINCT ON (rec->>'pncp_id') rec->>'pncp_id' AS pncp_id
+        FROM jsonb_array_elements(p_records) WITH ORDINALITY AS item(rec, ordinal)
+        WHERE NULLIF(rec->>'pncp_id', '') IS NOT NULL
+        ORDER BY rec->>'pncp_id', ordinal DESC
+    )
+    SELECT COUNT(*)::INTEGER INTO v_total FROM src;
+
+    WITH src AS (
+        SELECT DISTINCT ON (rec->>'pncp_id')
+            rec->>'pncp_id' AS pncp_id,
+            COALESCE(rec->>'numero_controle_pncp', rec->>'pncp_id') AS numero_controle_pncp,
+            rec->>'objeto_compra' AS objeto_compra,
+            rec->>'informacao_complementar' AS informacao_complementar,
+            NULLIF(rec->>'valor_total_estimado', '')::NUMERIC AS valor_total_estimado,
+            NULLIF(rec->>'modalidade_id', '')::INTEGER AS modalidade_id,
+            rec->>'modalidade_nome' AS modalidade_nome,
+            rec->>'situacao_compra' AS situacao_compra,
+            rec->>'esfera_id' AS esfera_id,
+            rec->>'uf' AS uf,
+            rec->>'municipio' AS municipio,
+            rec->>'codigo_municipio_ibge' AS codigo_municipio_ibge,
+            rec->>'orgao_razao_social' AS orgao_razao_social,
+            rec->>'orgao_cnpj' AS orgao_cnpj,
+            rec->>'unidade_nome' AS unidade_nome,
+            NULLIF(rec->>'data_publicacao', '')::TIMESTAMPTZ AS data_publicacao,
+            NULLIF(rec->>'data_abertura', '')::TIMESTAMPTZ AS data_abertura,
+            NULLIF(rec->>'data_encerramento', '')::TIMESTAMPTZ AS data_encerramento,
+            rec->>'link_sistema_origem' AS link_sistema_origem,
+            rec->>'link_pncp' AS link_pncp,
+            rec->>'content_hash' AS content_hash,
+            COALESCE(rec->>'source', 'pncp') AS source,
+            rec->>'source_id' AS source_id,
+            rec->>'crawl_batch_id' AS crawl_batch_id,
+            NULLIF(rec->>'ano_compra', '')::INTEGER AS ano_compra,
+            NULLIF(rec->>'sequencial_compra', '')::INTEGER AS sequencial_compra,
+            COALESCE(NULLIF(rec->>'synthetic_id', '')::BOOLEAN, FALSE) AS synthetic_id,
+            rec->>'synthetic_id_reason' AS synthetic_id_reason,
+            rec->'raw_payload' AS raw_payload
+        FROM jsonb_array_elements(p_records) WITH ORDINALITY AS item(rec, ordinal)
+        WHERE NULLIF(rec->>'pncp_id', '') IS NOT NULL
+        ORDER BY rec->>'pncp_id', ordinal DESC
+    ),
+    changed AS (
+        INSERT INTO public.pncp_raw_bids (
+            pncp_id, numero_controle_pncp, objeto_compra, informacao_complementar,
+            valor_total_estimado, modalidade_id, modalidade_nome, situacao_compra,
+            esfera_id, uf, municipio, codigo_municipio_ibge, orgao_razao_social,
+            orgao_cnpj, unidade_nome, data_publicacao, data_abertura, data_encerramento,
+            link_sistema_origem, link_pncp, content_hash, source, source_id,
+            crawl_batch_id, ano_compra, sequencial_compra, synthetic_id,
+            synthetic_id_reason, raw_payload
+        )
+        SELECT
+            pncp_id, numero_controle_pncp, objeto_compra, informacao_complementar,
+            valor_total_estimado, modalidade_id, modalidade_nome, situacao_compra,
+            esfera_id, uf, municipio, codigo_municipio_ibge, orgao_razao_social,
+            orgao_cnpj, unidade_nome, data_publicacao, data_abertura, data_encerramento,
+            link_sistema_origem, link_pncp, content_hash, source, source_id,
+            crawl_batch_id, ano_compra, sequencial_compra, synthetic_id,
+            synthetic_id_reason, raw_payload
+        FROM src
+        ON CONFLICT (pncp_id) DO UPDATE SET
+            numero_controle_pncp = EXCLUDED.numero_controle_pncp,
+            objeto_compra = EXCLUDED.objeto_compra,
+            informacao_complementar = EXCLUDED.informacao_complementar,
+            valor_total_estimado = EXCLUDED.valor_total_estimado,
+            modalidade_id = EXCLUDED.modalidade_id,
+            modalidade_nome = EXCLUDED.modalidade_nome,
+            situacao_compra = EXCLUDED.situacao_compra,
+            esfera_id = EXCLUDED.esfera_id,
+            uf = EXCLUDED.uf,
+            municipio = EXCLUDED.municipio,
+            codigo_municipio_ibge = EXCLUDED.codigo_municipio_ibge,
+            orgao_razao_social = EXCLUDED.orgao_razao_social,
+            orgao_cnpj = EXCLUDED.orgao_cnpj,
+            unidade_nome = EXCLUDED.unidade_nome,
+            data_publicacao = EXCLUDED.data_publicacao,
+            data_abertura = EXCLUDED.data_abertura,
+            data_encerramento = EXCLUDED.data_encerramento,
+            link_sistema_origem = EXCLUDED.link_sistema_origem,
+            link_pncp = EXCLUDED.link_pncp,
+            content_hash = EXCLUDED.content_hash,
+            source = EXCLUDED.source,
+            source_id = EXCLUDED.source_id,
+            crawl_batch_id = EXCLUDED.crawl_batch_id,
+            ano_compra = EXCLUDED.ano_compra,
+            sequencial_compra = EXCLUDED.sequencial_compra,
+            synthetic_id = EXCLUDED.synthetic_id,
+            synthetic_id_reason = EXCLUDED.synthetic_id_reason,
+            raw_payload = EXCLUDED.raw_payload
+        WHERE public.pncp_raw_bids.content_hash IS DISTINCT FROM EXCLUDED.content_hash
+        RETURNING (xmax = 0) AS was_inserted
+    )
+    SELECT
+        COUNT(*) FILTER (WHERE was_inserted)::INTEGER,
+        COUNT(*) FILTER (WHERE NOT was_inserted)::INTEGER
+    INTO v_inserted, v_updated
+    FROM changed;
+
+    RETURN QUERY SELECT
+        COALESCE(v_inserted, 0),
+        COALESCE(v_updated, 0),
+        GREATEST(0, v_total - COALESCE(v_inserted, 0) - COALESCE(v_updated, 0));
+END;
+$$;
+
+COMMIT;

--- a/db/rollback/086_contract_analytics_complete_rollback.sql
+++ b/db/rollback/086_contract_analytics_complete_rollback.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.supplier_contracts_grouped_v2(TEXT, TEXT, TEXT[], TEXT[], DATE, DATE, INTEGER, TEXT);
+DROP FUNCTION IF EXISTS public.supplier_contracts_page_v2(TEXT, TEXT, TEXT, TEXT[], TEXT[], DATE, DATE, NUMERIC, INTEGER, DATE, BIGINT, TEXT);
+DROP FUNCTION IF EXISTS public.supplier_contracts_dataset_v2(TEXT, TEXT, TEXT, TEXT[], TEXT[], DATE, DATE, TEXT);
+DROP INDEX IF EXISTS public.idx_psc_supplier_event_keyset;
+
+COMMIT;

--- a/db/rollback/087_runtime_truth_dlq_sli_rollback.sql
+++ b/db/rollback/087_runtime_truth_dlq_sli_rollback.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+DROP TABLE IF EXISTS public.truth_plane_cost_observations;
+DROP TABLE IF EXISTS public.truth_plane_alert_events;
+DROP TABLE IF EXISTS public.truth_plane_alert_routes;
+DROP TABLE IF EXISTS public.truth_plane_kill_switch_history;
+DROP TABLE IF EXISTS public.truth_plane_kill_switch;
+DROP TABLE IF EXISTS public.truth_plane_sli_reviews;
+DROP TABLE IF EXISTS public.truth_plane_slo_definitions;
+
+ALTER TABLE IF EXISTS public.crawl_jobs DROP COLUMN IF EXISTS dlq_entry_id;
+DROP INDEX IF EXISTS public.idx_dlq_selective_replay;
+DROP INDEX IF EXISTS public.uq_dlq_job_open_terminal;
+
+ALTER TABLE IF EXISTS public.dlq_entries
+    DROP CONSTRAINT IF EXISTS ck_dlq_resolution_complete,
+    DROP CONSTRAINT IF EXISTS ck_dlq_replay_count,
+    DROP COLUMN IF EXISTS resolution,
+    DROP COLUMN IF EXISTS resolved_by,
+    DROP COLUMN IF EXISTS resolved_at,
+    DROP COLUMN IF EXISTS replay_count,
+    DROP COLUMN IF EXISTS terminal_at,
+    DROP COLUMN IF EXISTS next_action,
+    DROP COLUMN IF EXISTS owner,
+    DROP COLUMN IF EXISTS payload_pointer,
+    DROP COLUMN IF EXISTS error_class,
+    DROP COLUMN IF EXISTS canonical_entity_key,
+    DROP COLUMN IF EXISTS attempt_id,
+    DROP COLUMN IF EXISTS job_id;
+
+COMMIT;

--- a/db/rollback/088_canonical_public_events_rollback.sql
+++ b/db/rollback/088_canonical_public_events_rollback.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.record_canonical_identity_decision_v1(TEXT, TEXT, TEXT, TEXT[], TEXT, TEXT[], TEXT, TEXT);
+DROP FUNCTION IF EXISTS public.canonical_event_revision_as_of_v1(TEXT, TIMESTAMPTZ, TIMESTAMPTZ);
+DROP FUNCTION IF EXISTS public.ingest_canonical_public_observation_v1(JSONB);
+DROP FUNCTION IF EXISTS public.ensure_canonical_public_entity_v2(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT);
+DROP TABLE IF EXISTS public.canonical_identity_decisions;
+DROP TABLE IF EXISTS public.canonical_match_conflicts;
+DROP TABLE IF EXISTS public.canonical_event_revisions;
+DROP TABLE IF EXISTS public.canonical_event_entity_links;
+DROP TABLE IF EXISTS public.canonical_event_observation_links;
+DROP TABLE IF EXISTS public.canonical_public_observations;
+DROP TABLE IF EXISTS public.canonical_public_events_v1;
+DROP TABLE IF EXISTS public.canonical_public_entity_aliases_v2;
+DROP TABLE IF EXISTS public.canonical_public_entities_v2;
+DROP FUNCTION IF EXISTS public.guard_canonical_immutable_v1();
+DROP FUNCTION IF EXISTS public.canonical_public_id(TEXT, TEXT[]);
+
+COMMIT;

--- a/db/rollback/089_canonical_snapshot_public_read_v1_rollback.sql
+++ b/db/rollback/089_canonical_snapshot_public_read_v1_rollback.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+REVOKE ALL ON SCHEMA public_read_v1 FROM smartlic_public_reader;
+DROP SCHEMA IF EXISTS public_read_v1 CASCADE;
+DROP TRIGGER IF EXISTS trg_canonical_revision_snapshot_fanout ON public.canonical_event_revisions;
+DROP FUNCTION IF EXISTS public.fanout_canonical_revision_invalidation_v1();
+DROP FUNCTION IF EXISTS public.invalidate_consumer_projection_private_v1(TEXT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS public.close_canonical_public_snapshot_v1(TEXT);
+DROP FUNCTION IF EXISTS public.put_canonical_snapshot_watermark_v1(TEXT, TEXT, TEXT, TIMESTAMPTZ, TEXT, TEXT, INTEGER, INTEGER, TEXT);
+DROP FUNCTION IF EXISTS public.begin_canonical_public_snapshot_v1(TIMESTAMPTZ, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, INTEGER, INTEGER, TEXT);
+DROP TABLE IF EXISTS public.public_read_surface_health_internal;
+DROP TABLE IF EXISTS public.public_consumer_projections;
+DROP TABLE IF EXISTS public.canonical_snapshot_invalidations;
+DROP TABLE IF EXISTS public.canonical_snapshot_dossiers;
+DROP TABLE IF EXISTS public.canonical_snapshot_documents;
+DROP TABLE IF EXISTS public.canonical_snapshot_event_revisions;
+DROP TABLE IF EXISTS public.canonical_snapshot_source_watermarks;
+DROP TABLE IF EXISTS public.canonical_public_snapshots;
+DROP FUNCTION IF EXISTS public.guard_closed_canonical_snapshot_v1();
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_roles role
+        WHERE role.rolname = 'smartlic_public_reader'
+          AND shobj_description(role.oid, 'pg_authid') = 'managed-by-extra-migration-089'
+    ) THEN
+        EXECUTE format('REVOKE smartlic_public_reader FROM %I', current_user);
+        DROP OWNED BY smartlic_public_reader;
+        BEGIN
+            DROP ROLE smartlic_public_reader;
+        EXCEPTION
+            WHEN dependent_objects_still_exist THEN
+                RAISE NOTICE 'smartlic_public_reader still owns objects outside database %; role retained', current_database();
+        END;
+    END IF;
+END $$;
+
+COMMIT;

--- a/db/rollback/089_canonical_snapshot_public_read_v1_rollback.sql
+++ b/db/rollback/089_canonical_snapshot_public_read_v1_rollback.sql
@@ -25,7 +25,12 @@ BEGIN
         WHERE role.rolname = 'smartlic_public_reader'
           AND shobj_description(role.oid, 'pg_authid') = 'managed-by-extra-migration-089'
     ) THEN
+        EXECUTE format('REVOKE CONNECT ON DATABASE %I FROM smartlic_public_reader', current_database());
         EXECUTE format('REVOKE smartlic_public_reader FROM %I', current_user);
+        ALTER ROLE smartlic_public_reader RESET statement_timeout;
+        ALTER ROLE smartlic_public_reader RESET lock_timeout;
+        ALTER ROLE smartlic_public_reader RESET idle_in_transaction_session_timeout;
+        ALTER ROLE smartlic_public_reader RESET default_transaction_read_only;
         DROP OWNED BY smartlic_public_reader;
         BEGIN
             DROP ROLE smartlic_public_reader;

--- a/db/rollback/090_public_read_select_only_lock_rollback.sql
+++ b/db/rollback/090_public_read_select_only_lock_rollback.sql
@@ -1,0 +1,6 @@
+-- Rollback 090 is a no-op for data. Writer EXECUTE grants stay revoked
+-- (fail-closed). Views and ingest/close stay at the locked contract.
+-- Dropping the ledger row is enough for re-apply.
+
+BEGIN;
+COMMIT;

--- a/docs/contracts/public-read-v1.md
+++ b/docs/contracts/public-read-v1.md
@@ -1,0 +1,63 @@
+# `public_read_v1` producer contract
+
+Version: `v1.0.0`
+
+Owner: Extra canonical truth plane
+Consumer tracked separately: `tjsasakifln/SmartLic#2108`
+
+## Boundary
+
+`public_read_v1` is a server-side, versioned, SELECT-only projection over the
+latest `READY_CANONICAL` public snapshot. It is not a second DataLake, browser
+API, synchronization feed, or place for client scores. The PostgreSQL role
+`smartlic_public_reader` has no password in this repository, no access to the
+`public` schema and no write/DDL privileges. Runtime credentials must remain in
+server-side secret storage and must never enter JS bundles, HTML, source maps or
+browser requests.
+
+Every fact/entity family (`tenders`, `contracts`, `entities`, `suppliers`,
+`organs`, and `municipalities`) carries `as_of`, `source_updated_at`,
+`completeness`, `reason_codes`, and JSON provenance. `current_snapshot` exposes
+the snapshot hashes and completeness, while `surface_health` exposes its own
+operational status fields. A failed or blocked build does not replace the last
+`READY_CANONICAL` snapshot. The `surface_health` family remains readable to
+show staleness and kill-switch state.
+
+## MVP families and representative queries
+
+| Family | Required fields | SmartLic query |
+|---|---|---|
+| `current_snapshot` | snapshot/content and seven input hashes, `as_of`, completeness, provenance | current public revision and cache key |
+| `tenders` | event/process/type/status/title/publication/official number, origin metadata | tender detail/status/document history by `process_key` |
+| `contracts` | event/process/status/title/value/official number, origin metadata | contract history by `process_key` |
+| `entities` | canonical ID/type/name/export-safe tax identity, origin metadata | canonical entity detail by `entity_id` |
+| `suppliers` | entity fields restricted to supplier/company | supplier detail and contract joins |
+| `organs` | entity fields restricted to organ/unit | buyer/publisher detail |
+| `municipalities` | canonical municipality ID, IBGE, UF/name, origin metadata | municipality landing-page identity |
+| `surface_health` | view, refresh/query/error/p95, snapshot/as-of, completeness | freshness banner and server-side circuit-breaker evidence |
+
+Exact query text, timeout, p95 target, row limit and concurrency budget are
+queryable in `public_read_v1.query_budgets`. Consumers must always use bounded
+predicates and limits; a generic table browser is outside the contract.
+
+## Compatibility and deprecation
+
+Within v1, only additive nullable columns are compatible. Removing or renaming
+a column, changing its type/meaning/nullability, or weakening provenance needs
+`public_read_v2`, or a documented overlap of at least 180 days. The producer
+schema fingerprint and changelog live in `public_read_v1.contract_releases`;
+producer and consumer fixtures must compare that fingerprint before cutover.
+
+## Operational limits and rollout
+
+Role defaults: read-only transactions, 2 s statement timeout, 500 ms lock
+timeout and 5 s idle-in-transaction timeout. Rollout is shadow → fixture
+reconciliation → no-traffic soak → bounded canary → continuous gate. Local
+PostgreSQL tests prove permissions, schema shape, repeatable reads and query
+plans; they do not prove Netcup readiness, live SmartLic cutover, combined-load
+soak, or `VPS_OPERATIONAL`.
+
+## Changelog
+
+- `v1.0.0` (2026-08-13): initial snapshot, tender, contract, entity, supplier,
+  organ, municipality and surface-health families.

--- a/docs/stories/story-critical-issues-wave-3.md
+++ b/docs/stories/story-critical-issues-wave-3.md
@@ -1,0 +1,185 @@
+# Story: Critical Issues Wave 3
+
+**Status:** InProgress
+**Branch:** `agent/critical-issues-wave-3`
+**Base:** `origin/agent/critical-issues-wave-2` at `c60cc94a902112dd4675f648cb39668b3789faa1`
+**Capability:** Canonical public truth plane with complete, fail-closed reporting projections
+
+## Goal
+
+Deliver one bounded, reviewable wave toward the ten open `priority:p0`
+issues that were still `state:ready` and had no assignee, comment, commit or
+pull-request work event at the 2026-08-13 triage cutoff:
+
+1. #356 — eliminate sampled national supplier histories
+2. #355 — eliminate silent 1,000-row analytical truncation
+3. #354 — publish a versioned SELECT-only SmartLic read contract
+4. #348 — resolve PCP `content_hash` collision without false success
+5. #289 — persist canonical bitemporal public entities/events/observations
+6. #287 — close client-independent canonical snapshots
+7. #275 — expose fail-closed truth-plane SLOs and public-reader isolation
+8. #274 — persist a transactional DLQ with selective replay
+9. #273 — prove idempotent multifonte deduplication and N:N lineage
+10. #244 — reconfirm shortlisted tenders against official source state
+
+The GitHub issue bodies and acceptance criteria are authoritative. A PR may
+reference an issue only when residual live, cross-repository or infrastructure
+criteria remain. It may close an issue only when every criterion has direct,
+reproducible evidence.
+
+## Acceptance contract
+
+### Report integrity (#355, #356)
+
+- [x] Supplier history is loaded from the canonical PostgreSQL lake by typed
+  supplier identity; it never scans a few national API pages and filters later.
+- [x] Analytical count/sum/mean/percentiles run server-side over the complete
+  filtered population and are invariant to presentation page size.
+- [x] Detail listings use stable keyset pagination with total count, cursor,
+  unique tiebreak, snapshot/run, freshness and explicit completeness state.
+- [x] A real-PostgreSQL fixture above 1,501 rows reconciles exact totals,
+  percentiles, annual chart and detailed rows.
+
+### Public truth plane (#273, #289, #287, #354)
+
+- [x] Canonical client-independent IDs preserve source observations, aliases,
+  N:N lineage, ambiguous conflicts and immutable bitemporal revisions.
+- [x] Reprocessing and source-order permutations preserve IDs, counts and
+  hashes; later corrections remain queryable as-of.
+- [x] Canonical snapshots bind universe/policy/schema/adapter hashes,
+  watermarks and factual revisions without `client_id` or `profile_hash`.
+- [x] `public_read_v1` is versioned and SELECT-only, exposes provenance,
+  freshness and completeness, and denies internal-schema/write access.
+- [x] Migration/rollback, permission, repeatable-read and contract-diff proofs
+  run against real PostgreSQL.
+
+### Runtime truth (#348, #274, #275)
+
+- [x] Duplicate `content_hash` values within a PCP batch or against persisted
+  rows follow one deterministic identity rule without aborting the batch.
+- [x] Persisted inserted/updated/deduplicated/DLQ counts reconcile, and a
+  transform/upsert failure cannot leave the global run terminally completed.
+- [x] The PostgreSQL DLQ moves a failed job once, blocks infinite retry,
+  preserves history on selective replay and filters by source/entity/class.
+- [x] SLI output defines denominator/window/UNKNOWN for every stage, including
+  public-reader freshness/load, cost, alerts and kill-switch state.
+
+### Official status reconfirmation (#244)
+
+- [x] Every shortlisted tender has an America/Sao_Paulo reconfirmation timestamp
+  and official evidence; missing evidence blocks the shortlist.
+- [x] Terminal events or expired deadlines exclude open status, while ambiguous
+  status remains `REVIEW`/`NO_GO` with blocker and next action.
+- [x] One source failure remains attributable and does not erase other source
+  results or fabricate a successful reconfirmation.
+
+## Execution waves
+
+- [x] Wave A: #348 deterministic PCP persistence and terminal lineage.
+- [x] Wave B: #355/#356 complete server-side contract analytics.
+- [x] Wave C: #274 durable DLQ and #275 truth-plane SLI contract.
+- [x] Wave D: #273/#289 canonical identities, observations and revisions.
+- [x] Wave E: #287 canonical snapshot and #354 `public_read_v1` projection.
+- [x] Wave F: #244 official status reconfirmation.
+- [x] Apply and rollback migrations on disposable PostgreSQL 16 + pgvector.
+- [ ] Run focused tests after each wave, then canonical full suite and strict
+  golden path without promoting partial/live failures.
+- [ ] Run CodeRabbit, generated-artifact and ready reviewability policies.
+- [ ] Publish a draft PR and make the exact PR HEAD fully green.
+
+## Truth ceiling
+
+- No 95% coverage, `LOCAL_READY`, `VPS_OPERATIONAL` or public-read production
+  claim follows from fixtures, migration tests or green CI.
+- SmartLic consumer/cutover and combined production soak remain cross-repo/live
+  evidence and cannot be fabricated in this repository.
+- DOD checkboxes remain unchanged until evidence is accepted from merged `main`.
+- The original mixed checkout and every other worktree remain out of scope.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+- Codex GPT-5
+
+### Debug Log References
+
+- Triage: exactly ten open P0 `state:ready` issues; zero assignees/comments and
+  zero commit/PR timeline events at cutoff.
+- Wave A: migration 085 applied, rolled back and reapplied on isolated real
+  PostgreSQL; 31 PCP tests passed with deterministic intra-batch/existing-hash
+  collision, update, order-invariance and deferred terminal-lineage proofs.
+- Wave B: migration 086 rollback/reapply and migration-runner apply passed on
+  isolated PostgreSQL. A 1,503-row fixture passed exact count/sum/percentiles,
+  17-vs-1,000 page-size invariance, stable keyset pagination and annual/detail
+  reconciliation; 28 focused tests passed with the real DB gate enabled.
+- Wave C: migration 087 rollback/reapply and migration-runner apply passed.
+  PostgreSQL poison/BLOCKED/replay/resolve and fail-closed SLI/last-valid/
+  alert-route/cost/kill-switch proofs passed against the isolated database.
+- Wave D: migration 088 rollback/reapply passed. Real-PostgreSQL permutations
+  proved two-source N:N lineage, stable IDs/counts/hashes, valid-time as-of,
+  document versions, a second event type, ambiguity without auto-merge,
+  indexed lookup plans, merge/split history and immutable revisions.
+- Wave E: migration 089 rollback/reapply and migration-runner apply passed.
+  Repeatable-read/concurrent-revision tests preserved the closed snapshot;
+  private and factual invalidation scopes diverged correctly; the versioned
+  role denied internal reads, writes and DDL while bounded public queries ran.
+- Wave F: every scored shortlist candidate now passes through a source-specific
+  final read. PNCP uses the official structural endpoint; PCP re-reads the
+  publication-date result set. Three deterministic tests prove Sao Paulo
+  timestamps/evidence, terminal/expired/ambiguous blocking and per-source
+  failure isolation without fabricated GO decisions.
+- Integrated migration gate: a dedicated PostgreSQL 16.14 + pgvector 0.8.4
+  container applied migrations 001-089, rolled back 089-085 in reverse order,
+  reapplied all five from the ledger, then passed 67 focused tests against the
+  fresh schema.
+- Canonical full-suite entrypoint applied all 89 migrations in `fresh` mode,
+  seeded 2,085 entities (1,093 active) and 459 aliases, then completed 4,426
+  passes and 141 declared skips. Its only failure was an undeployed local
+  dependency (`pypdf`); the failed PDF reconciliation test passed after
+  installing `pypdf 6.16.0`, satisfying the repository's declared
+  `pypdf>=6.15.0` requirement that CI installs.
+- Strict live golden path remained honestly `PARTIAL`: PNCP returned HTTP 422,
+  contract freshness was stale and one evidence row was outside the identity
+  map. PCP persisted data, reports were generated, and no readiness/coverage
+  claim is promoted from that run.
+
+### File List
+
+- `docs/stories/story-critical-issues-wave-3.md`
+- `db/migrations/085_pncp_content_hash_collision.sql`
+- `db/rollback/085_pncp_content_hash_collision_rollback.sql`
+- `db/migrations/086_contract_analytics_complete.sql`
+- `db/rollback/086_contract_analytics_complete_rollback.sql`
+- `db/migrations/087_runtime_truth_dlq_sli.sql`
+- `db/rollback/087_runtime_truth_dlq_sli_rollback.sql`
+- `db/migrations/088_canonical_public_events.sql`
+- `db/rollback/088_canonical_public_events_rollback.sql`
+- `db/migrations/089_canonical_snapshot_public_read_v1.sql`
+- `db/rollback/089_canonical_snapshot_public_read_v1_rollback.sql`
+- `docs/contracts/public-read-v1.md`
+- `scripts/crawl/monitor.py`
+- `scripts/crawl/pcp_crawler.py`
+- `scripts/datalake_helper.py`
+- `scripts/collect_report_data.py`
+- `scripts/official_status_reconfirmation.py`
+- `scripts/crawl/runtime_queue.py`
+- `scripts/ops/truth_plane_sli.py`
+- `scripts/ops/canonical_snapshot.py`
+- `tests/test_crawl_runtime_queue.py`
+- `tests/test_canonical_public_events.py`
+- `tests/test_datalake_helper.py`
+- `tests/test_pcp_crawler.py`
+- `tests/test_official_status_reconfirmation.py`
+
+## Change log
+
+| Date | Scope | State | Evidence |
+|---|---|---|---|
+| 2026-08-13 | Story/selection | IN_PROGRESS | GitHub labels, issue bodies and timeline audit |
+| 2026-08-13 | #348 | VERIFIED_LOCAL | PostgreSQL migration/rollback/reapply; 31 tests pass |
+| 2026-08-13 | #355/#356 | VERIFIED_LOCAL | PostgreSQL 1,503-row completeness, pagination and report reconciliation proof |
+| 2026-08-13 | #274/#275 | VERIFIED_LOCAL | Transactional poison DLQ and fail-closed SLI authority on PostgreSQL |
+| 2026-08-13 | #273/#289 | VERIFIED_LOCAL | Multifonte order/idempotency, revisions, conflicts and merge/split on PostgreSQL |
+| 2026-08-13 | #287/#354 | VERIFIED_LOCAL | Snapshot barrier, repeatable read, invalidation scopes and SELECT-only role |
+| 2026-08-13 | #244 | VERIFIED_LOCAL | Official PNCP/PCP close gate; timezone/evidence, terminal/expiry/ambiguity and isolated source-failure tests |

--- a/docs/stories/story-critical-issues-wave-3.md
+++ b/docs/stories/story-critical-issues-wave-3.md
@@ -157,6 +157,8 @@ reproducible evidence.
 - `db/rollback/088_canonical_public_events_rollback.sql`
 - `db/migrations/089_canonical_snapshot_public_read_v1.sql`
 - `db/rollback/089_canonical_snapshot_public_read_v1_rollback.sql`
+- `db/migrations/090_public_read_select_only_lock.sql`
+- `db/rollback/090_public_read_select_only_lock_rollback.sql`
 - `docs/contracts/public-read-v1.md`
 - `scripts/crawl/monitor.py`
 - `scripts/crawl/pcp_crawler.py`

--- a/scripts/collect_report_data.py
+++ b/scripts/collect_report_data.py
@@ -56,6 +56,11 @@ from report_dedup import jaccard_similarity as _jaccard_similarity
 from report_dedup import normalize_for_dedup as _normalize_for_dedup
 from report_dedup import semantic_dedup as _semantic_dedup
 
+try:
+    from official_status_reconfirmation import reconfirm_shortlist
+except ImportError:  # package import used by tests and ``python -m``
+    from scripts.official_status_reconfirmation import reconfirm_shortlist
+
 # DataLake-first opt-in: stable since 2026-04-29 commit pricing-b2g pilot.
 # Quando DATALAKE_QUERY_ENABLED=true e --no-datalake ausente, o coletor pode
 # substituir 7 das 14 chamadas live por DataLake (enriched_entity, supplier_contracts,
@@ -1156,7 +1161,7 @@ def _collect_pncp_contratos_fornecedor_wide(
     return matched, raw_total
 
 
-def collect_pncp_contratos_fornecedor(
+def _collect_pncp_contratos_fornecedor_legacy_sample(
     api: ApiClient,
     cnpj14: str,
     razao_social: str = "",
@@ -1352,6 +1357,164 @@ def collect_pncp_contratos_fornecedor(
         pass  # see collect_pncp_contratos_fornecedor return value — caller checks
 
     return all_contracts, source
+
+
+def collect_pncp_contratos_fornecedor(
+    api: ApiClient,
+    cnpj14: str,
+    razao_social: str = "",
+    *,
+    datalake_client: Any | None = None,
+    date_start: str | None = None,
+    date_end: str | None = None,
+) -> tuple[list[dict], dict]:
+    """Load a complete supplier history from the canonical national lake.
+
+    The live PNCP endpoint does not reliably filter by supplier. It is therefore
+    forbidden for report history: without an indexed lake snapshot this function
+    fails closed instead of sampling national pages and presenting them as a
+    complete portfolio.
+    """
+    del api, razao_social  # Kept in the public signature for caller compatibility.
+    print("\n📋 Phase 1c: Histórico canônico de contratos do fornecedor (DataLake)")
+
+    if date_end is None:
+        date_end = _date_iso(_today())
+    if date_start is None:
+        date_start = _date_iso(_today() - timedelta(days=3 * 366))
+
+    blocked_base = {
+        **_source_tag("INCOMPLETE/BLOCKED", "Histórico requer snapshot indexado do DataLake"),
+        "completeness": "INCOMPLETE",
+        "blocked": True,
+        "window_start": date_start,
+        "window_end": date_end,
+        "date_semantics": "event_date=data_assinatura|data_publicacao_fonte|data_publicacao|data_inicio",
+    }
+    if datalake_client is None or not datalake_client.is_enabled:
+        print("  ⛔ DataLake indisponível — histórico bloqueado; amostragem live proibida")
+        return [], blocked_base
+
+    cursor: dict[str, Any] | None = None
+    snapshot_at: str | None = None
+    all_rows: list[dict] = []
+    seen_ids: set[int] = set()
+    final_meta: dict[str, Any] = {}
+
+    while True:
+        rows, meta = datalake_client.supplier_contracts(
+            supplier_id_type="CNPJ",
+            supplier_identifier=cnpj14,
+            date_start=date_start,
+            date_end=date_end,
+            limit=1000,
+            cursor=cursor,
+            snapshot_at=snapshot_at,
+        )
+        if rows is None or "datalake_error" in meta:
+            detail = meta.get("datalake_error", "consulta canônica sem resposta")
+            print(f"  ⛔ DataLake falhou — histórico bloqueado: {detail}")
+            return [], {**blocked_base, "detail": detail}
+
+        snapshot_at = snapshot_at or meta.get("snapshot_at")
+        try:
+            page_id_list = [int(row["record_id"]) for row in rows]
+        except (KeyError, TypeError, ValueError):
+            return [], {
+                **blocked_base,
+                "detail": "página canônica contém record_id ausente ou inválido",
+                "snapshot_at": snapshot_at,
+            }
+        page_ids = set(page_id_list)
+        if len(page_ids) != len(page_id_list) or seen_ids.intersection(page_ids):
+            return [], {**blocked_base, "detail": "cursor keyset repetiu registros", "snapshot_at": snapshot_at}
+        seen_ids.update(page_ids)
+        all_rows.extend(rows)
+        final_meta = meta
+
+        if not meta.get("has_more"):
+            break
+        next_cursor = meta.get("next_cursor")
+        if not next_cursor or next_cursor == cursor:
+            return [], {**blocked_base, "detail": "cursor keyset não avançou", "snapshot_at": snapshot_at}
+        cursor = next_cursor
+
+    expected_count = int(final_meta.get("total_count") or 0)
+    expected_sum = float(final_meta.get("sum_value") or 0)
+    detail_sum = sum(float(row.get("valor_global") or 0) for row in all_rows)
+    if len(all_rows) != expected_count or abs(detail_sum - expected_sum) > 0.01:
+        return [], {
+            **blocked_base,
+            "detail": "reconciliação agregado/detalhe falhou",
+            "snapshot_at": snapshot_at,
+            "expected_count": expected_count,
+            "detail_count": len(all_rows),
+            "expected_sum": expected_sum,
+            "detail_sum": detail_sum,
+        }
+
+    annual_detail: dict[int, dict[str, float | int]] = {}
+    for row in all_rows:
+        event_date = str(row.get("event_date") or "")
+        if len(event_date) < 4:
+            continue
+        year = int(event_date[:4])
+        bucket = annual_detail.setdefault(year, {"matched_contracts": 0, "sum_value": 0.0})
+        bucket["matched_contracts"] = int(bucket["matched_contracts"]) + 1
+        bucket["sum_value"] = float(bucket["sum_value"]) + float(row.get("valor_global") or 0)
+    annual_sql = {
+        int(item["year"]): {
+            "matched_contracts": int(item["matched_contracts"]),
+            "sum_value": float(item["sum_value"]),
+        }
+        for item in final_meta.get("annual_series") or []
+    }
+    annual_reconciled = annual_sql.keys() == annual_detail.keys() and all(
+        annual_sql[year]["matched_contracts"] == annual_detail[year]["matched_contracts"]
+        and abs(float(annual_sql[year]["sum_value"]) - float(annual_detail[year]["sum_value"])) <= 0.01
+        for year in annual_sql
+    )
+    if not annual_reconciled:
+        return [], {**blocked_base, "detail": "reconciliação anual SQL/detalhe falhou", "snapshot_at": snapshot_at}
+
+    contracts = [
+        {
+            "orgao": row.get("orgao_nome") or "",
+            "uf": row.get("uf") or "",
+            "municipio": row.get("municipio") or "",
+            "valor": float(row.get("valor_global") or 0),
+            "valor_contrato": float(row.get("valor_global") or 0),
+            "data": row.get("event_date") or "",
+            "data_assinatura": row.get("data_assinatura") or "",
+            "data_publicacao": row.get("data_publicacao") or "",
+            "objeto": row.get("objeto_contrato") or "",
+            "numero_contrato": row.get("numero_controle_pncp") or "",
+            "fonte": row.get("source") or "DataLake PNCP",
+            "supplier_id_type": row.get("supplier_id_type"),
+            "supplier_identifier": row.get("supplier_identifier"),
+            "snapshot_id": final_meta.get("snapshot_id"),
+        }
+        for row in all_rows
+    ]
+
+    completeness = final_meta.get("completeness") or "INCOMPLETE"
+    status = "DATALAKE" if completeness == "COMPLETE" else "INCOMPLETE/BLOCKED"
+    source = {
+        **_source_tag(status, f"{expected_count} contratos canônicos reconciliados"),
+        **final_meta,
+        "completeness": completeness,
+        "blocked": completeness != "COMPLETE",
+        "detail_reconciled": True,
+        "annual_reconciled": True,
+    }
+    print(
+        f"  ✓ DataLake: {expected_count:,} contratos, soma {_fmt_brl(expected_sum, 2)}, "
+        f"snapshot={final_meta.get('snapshot_id')} completude={completeness}"
+    )
+    if completeness != "COMPLETE":
+        print("  ⛔ Qualidade incompleta — detalhes e gráfico anual bloqueados")
+        return [], source
+    return contracts, source
 
 
 # ============================================================
@@ -4946,12 +5109,15 @@ def _parse_pncp_item(
         "modalidade": modalidade,
         "data_abertura": data_abertura,
         "data_encerramento": data_encerramento,
+        "data_abertura_oficial": item.get("dataAberturaProposta") or "",
+        "data_encerramento_oficial": item.get("dataEncerramentoProposta") or "",
         "dias_restantes": dias_restantes,
         "fonte": "PNCP",
         "link": link,
         "cnpj_orgao": cnpj_clean,
         "ano_compra": str(ano),
         "sequencial_compra": str(seq),
+        "situacao_compra_oficial": item.get("situacaoCompraNome") or "",
         "status_edital": (
             "ENCERRADO"
             if (dias_restantes is not None and dias_restantes < 0)
@@ -5003,7 +5169,7 @@ def collect_pcp(
             source_meta["errors"] += 1
             break
 
-        items = data if isinstance(data, list) else data.get("resultado", data.get("data", []))
+        items = data if isinstance(data, list) else data.get("result", data.get("resultado", data.get("data", [])))
         if not isinstance(items, list) or not items:
             break
 
@@ -5079,9 +5245,18 @@ def _parse_pcp_item(
         "modalidade": modalidade,
         "data_abertura": data_abertura,
         "data_encerramento": data_encerramento,
+        "data_abertura_oficial": item.get("dataHoraInicioPropostas") or "",
+        "data_encerramento_oficial": item.get("dataHoraFinalPropostas") or "",
+        "data_publicacao_oficial": item.get("dataHoraPublicacao") or "",
         "dias_restantes": dias_restantes,
         "fonte": "PCP",
         "link": link,
+        "codigo_licitacao": item.get("codigoLicitacao"),
+        "situacao_compra_oficial": (
+            (item.get("statusProcessoPublico") or {}).get("descricao")
+            or (item.get("status") or {}).get("descricao")
+            or ""
+        ),
         "status_edital": (
             "ENCERRADO"
             if (dias_restantes is not None and dias_restantes < 0)
@@ -5090,6 +5265,109 @@ def _parse_pcp_item(
             else "PRAZO_INDEFINIDO"
         ),
     }
+
+
+# ============================================================
+# PHASE 2c: OFFICIAL STATUS RECONFIRMATION
+# ============================================================
+
+
+class _OfficialStatusFetcher:
+    """Re-read a shortlisted opportunity from the source that published it."""
+
+    def __init__(self, api: ApiClient):
+        self.api = api
+        self._pcp_pages: dict[str, list[dict]] = {}
+
+    def __call__(self, edital: dict) -> dict:
+        source = str(edital.get("fonte") or edital.get("_source_name") or "").upper()
+        if source == "PNCP":
+            return self._pncp(edital)
+        if source == "PCP":
+            return self._pcp(edital)
+        raise RuntimeError(f"unsupported official source: {source or 'UNKNOWN'}")
+
+    def _pncp(self, edital: dict) -> dict:
+        cnpj = re.sub(r"[^0-9]", "", str(edital.get("cnpj_orgao") or ""))
+        ano = str(edital.get("ano_compra") or "").strip()
+        sequencial = str(edital.get("sequencial_compra") or "").strip()
+        if len(cnpj) != 14 or not ano or not sequencial:
+            raise ValueError("PNCP structural identity unavailable")
+
+        official_url = f"{PNCP_FILES_BASE}/orgaos/{cnpj}/compras/{ano}/{sequencial}"
+        payload, status = self.api.get(official_url, label=f"PNCP reconfirm {cnpj}/{ano}/{sequencial}")
+        if status != "API" or not isinstance(payload, dict):
+            raise RuntimeError(f"PNCP reconfirmation failed: {status}")
+        return {
+            "status_native": payload.get("situacaoCompraNome") or payload.get("situacaoCompra") or "",
+            "deadline_at": payload.get("dataEncerramentoProposta"),
+            "evidence_url": official_url,
+        }
+
+    def _pcp(self, edital: dict) -> dict:
+        code = edital.get("codigo_licitacao")
+        publication = str(
+            edital.get("data_publicacao_oficial")
+            or edital.get("data_abertura_oficial")
+            or ""
+        )[:10]
+        if not code or not re.fullmatch(r"\d{4}-\d{2}-\d{2}", publication):
+            raise ValueError("PCP structural identity or publication date unavailable")
+
+        if publication not in self._pcp_pages:
+            rows: list[dict] = []
+            page = 1
+            page_count = 1
+            while page <= page_count:
+                if page > PCP_MAX_PAGES:
+                    raise RuntimeError(
+                        f"PCP reconfirmation exceeded the {PCP_MAX_PAGES}-page safety bound"
+                    )
+                payload, status = self.api.get(
+                    PCP_BASE,
+                    params={
+                        "pagina": page,
+                        "dataInicial": publication,
+                        "dataFinal": publication,
+                        "tipoData": 1,
+                    },
+                    label=f"PCP reconfirm {publication} p={page}",
+                )
+                if status != "API" or not isinstance(payload, dict):
+                    raise RuntimeError(f"PCP reconfirmation failed: {status}")
+                page_rows = payload.get("result", payload.get("resultado", payload.get("data", [])))
+                if not isinstance(page_rows, list):
+                    raise RuntimeError("PCP reconfirmation returned an invalid result")
+                rows.extend(row for row in page_rows if isinstance(row, dict))
+                page_count = max(1, int(payload.get("pageCount") or 1))
+                page += 1
+            self._pcp_pages[publication] = rows
+
+        match = next(
+            (row for row in self._pcp_pages[publication] if str(row.get("codigoLicitacao")) == str(code)),
+            None,
+        )
+        if match is None:
+            raise LookupError(f"PCP opportunity {code} absent from official publication-date query")
+        status_info = match.get("statusProcessoPublico") or match.get("status") or {}
+        status_native = status_info.get("descricao") if isinstance(status_info, dict) else str(status_info or "")
+        path = str(match.get("urlReferencia") or edital.get("link") or "")
+        evidence_url = (
+            f"https://www.portaldecompraspublicas.com.br{path}"
+            if path.startswith("/")
+            else path
+        )
+        return {
+            "status_native": status_native,
+            "deadline_at": match.get("dataHoraFinalPropostas"),
+            "evidence_url": evidence_url,
+        }
+
+
+def _preview_unexecuted_reconfirmation(editais: list[dict[str, Any]]) -> dict[str, Any]:
+    """Describe the re-enrichment gate without changing persisted decisions."""
+
+    return reconfirm_shortlist([dict(edital) for edital in editais], None)
 
 
 # ============================================================
@@ -10317,6 +10595,7 @@ Examples:
 
         # Assign recomendacao + justificativa after all scores are computed
         assign_recommendations(editais, empresa)
+        data["official_status_reconfirmation"] = _preview_unexecuted_reconfirmation(editais)
         compute_price_benchmark(editais)  # GAP-3
         build_alertas_criticos(editais, empresa)  # HARD-004
 
@@ -10442,7 +10721,11 @@ Examples:
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as g2_pool:
         future_transparencia = g2_pool.submit(collect_portal_transparencia, api, cnpj14, pt_key)
         future_contratos = g2_pool.submit(
-            collect_pncp_contratos_fornecedor, api, cnpj14, razao_social=_razao_social_for_contracts
+            collect_pncp_contratos_fornecedor,
+            api,
+            cnpj14,
+            razao_social=_razao_social_for_contracts,
+            datalake_client=_dl_client,
         )
 
         transparencia = future_transparencia.result()
@@ -10459,19 +10742,14 @@ Examples:
     # actual field of work, not just their registered CNAE.
     print("\n\U0001f4cb Phase 1b: Histórico de contratos (ANTES do mapeamento de setor)")
 
-    # Merge PT federal + PNCP all-spheres into empresa.historico_contratos
+    # Contract history is a single canonical population. Portal da Transparência
+    # remains available for sanctions, but its independently paged contract list
+    # cannot be merged into a reconciled lake snapshot.
     pt_contratos = transparencia.get("historico_contratos", [])
-    merged_contratos = list(pncp_contratos)  # PNCP as base (all spheres)
-    pncp_orgao_dates = {(c["orgao"][:30], c["data"][:10]) for c in pncp_contratos}
-    for c in pt_contratos:
-        key = (c.get("orgao", "")[:30], c.get("data", "")[:10])
-        if key not in pncp_orgao_dates:
-            c["esfera"] = "Federal"
-            c["fonte"] = "Portal da Transparência"
-            merged_contratos.append(c)
+    merged_contratos = list(pncp_contratos)
     transparencia["historico_contratos"] = merged_contratos
     n_pncp = len(pncp_contratos)
-    n_pt = len(pt_contratos)
+    n_pt = 0
 
     # AC4: Warn when no contracts found for an established company
     _merged_total = len(merged_contratos)
@@ -10499,11 +10777,12 @@ Examples:
                 f"0 contratos encontrados após 4 estratégias (capital R${_cap:,.0f}, {_anos} anos de operação)",
             )
     n_merged = len(merged_contratos)
-    transparencia["historico_source"] = _source_tag(
-        "API",
-        f"{n_merged} contrato(s): {n_pncp} via PNCP (todas as esferas) + {n_pt} via Portal da Transparência (federal)",
-    )
-    print(f"  Histórico consolidado: {n_merged} contratos ({n_pncp} PNCP + {n_pt} PT)")
+    transparencia["historico_source"] = pncp_contratos_source
+    transparencia["historico_portal_excluded"] = {
+        "count": len(pt_contratos),
+        "reason": "fora do snapshot canônico reconciliado",
+    }
+    print(f"  Histórico consolidado: {n_merged} contratos canônicos ({len(pt_contratos)} PT excluídos da população)")
 
     # F39: Filter cancelled contracts before clustering (keep all for risk flags)
     EXCLUDED_CONTRACT_STATUSES = {"CANCELADO", "RESCINDIDO", "ANULADO"}
@@ -10924,8 +11203,9 @@ Examples:
 
     # AC4: contract_search_exhaustive — distinguishes "no contracts found" from "search failed"
     _pncp_contratos_status = (pncp_contratos_source or {}).get("status", "MISSING")
-    _all_strategies_succeeded = _pncp_contratos_status != "API_FAILED"
-    data["_metadata"]["contract_search_exhaustive"] = len(merged_contratos) > 0 or _all_strategies_succeeded
+    _all_strategies_succeeded = _pncp_contratos_status == "DATALAKE"
+    data["_metadata"]["contract_search_exhaustive"] = _all_strategies_succeeded
+    data["_metadata"]["contract_history"] = pncp_contratos_source
 
     # ---- HARD-003: Acervo 3-Tier Classification (before deterministic scoring) ----
     classify_acervo_similarity(merged_contratos, data["editais"])
@@ -10947,6 +11227,20 @@ Examples:
 
     # Assign recomendacao + justificativa after all scores are computed
     assign_recommendations(data["editais"], data["empresa"])
+
+    # ---- P0 #244: source-of-record status gate before any shortlist consumer ----
+    print("\n🔐 Reconfirmando status oficial da shortlist...")
+    data["official_status_reconfirmation"] = reconfirm_shortlist(
+        data["editais"],
+        _OfficialStatusFetcher(api),
+    )
+    reconfirmed = data["official_status_reconfirmation"]
+    print(
+        "  Status oficial: "
+        f"{reconfirmed['shortlist_count']} GO, "
+        f"{reconfirmed['decisions']['REVIEW']} REVIEW, "
+        f"{reconfirmed['decisions']['NO_GO']} NO_GO"
+    )
 
     # ---- GAP-3: Price benchmark per edital ----
     compute_price_benchmark(data["editais"])

--- a/scripts/crawl/monitor.py
+++ b/scripts/crawl/monitor.py
@@ -27,6 +27,7 @@ import argparse
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -59,6 +60,58 @@ from datetime import UTC
 from config.settings import DEFAULT_DSN  # single source of truth (TD-3.2)
 
 COVERAGE_WINDOW_DAYS = int(os.getenv("COVERAGE_WINDOW_DAYS", "90"))
+
+
+def _terminalize_deferred_provenance(
+    fetch_result: Any,
+    *,
+    success: bool,
+    error_message: str = "",
+    records_fetched: int = 0,
+    records_deduplicated: int = 0,
+    records_upserted: int = 0,
+    records_failed: int = 0,
+) -> None:
+    """Finish a source run whose crawler delegated terminal ownership.
+
+    A fetch result is deliberately not enough to complete a pipeline run.  The
+    monitor calls this only after transform/persistence succeeds, or with a
+    failure when a downstream stage aborts.
+    """
+    provenance = getattr(fetch_result, "provenance", None)
+    if not isinstance(provenance, dict) or not provenance.get("terminal_deferred"):
+        return
+
+    run_id = str(provenance.get("run_id") or "")
+    source = str(provenance.get("source") or "")
+    if not run_id or not source:
+        raise RuntimeError("deferred provenance missing run_id/source")
+
+    started_ns = provenance.get("started_monotonic_ns")
+    duration_ms = 0
+    if isinstance(started_ns, int) and started_ns > 0:
+        duration_ms = max(0, int((time.monotonic_ns() - started_ns) / 1_000_000))
+
+    from scripts.crawl.provenance_sync import provenance_complete, provenance_fail
+
+    common = {
+        "run_id": run_id,
+        "source": source,
+        "records_fetched": records_fetched,
+        "records_deduplicated": records_deduplicated,
+        "records_upserted": records_upserted,
+        "records_dlq": int(provenance.get("records_dlq") or 0),
+        "records_failed": records_failed,
+        "pages_completed": int(provenance.get("pages_completed") or 0),
+        "duration_ms": duration_ms,
+    }
+    if success:
+        provenance_complete(**common)
+        provenance["terminal_state"] = "completed"
+    else:
+        provenance_fail(error_message=error_message or "pipeline_failed", **common)
+        provenance["terminal_state"] = "failed"
+    provenance["terminal_deferred"] = False
 
 
 # ---------------------------------------------------------------------------
@@ -797,6 +850,7 @@ def crawl_source(
 
     conn = _get_conn()
     run_id = _start_ingestion_run(conn, source, mode)
+    fetch_result = None
 
     try:
         # ── Load crawler module ───────────────────────────────────────
@@ -844,7 +898,6 @@ def crawl_source(
         )
 
         # Accept both CrawlRequest and plain str (backward-compatible)
-        fetch_result = None
         try:
             raw_response = crawler.crawl(crawl_req)
         except TypeError:
@@ -862,6 +915,13 @@ def crawl_source(
                 result.external_failures = 1
                 error = "; ".join(fetch_result.errors) or str(fetch_result.status)
                 semantic_status = str(fetch_result.status)
+                _terminalize_deferred_provenance(
+                    fetch_result,
+                    success=False,
+                    error_message=error,
+                    records_fetched=len(raw_records),
+                    records_failed=1,
+                )
                 _finish_ingestion_run(conn, run_id, len(raw_records), 0, 0, semantic_status, error)
                 _record_evidence(
                     conn,
@@ -897,6 +957,13 @@ def crawl_source(
             status = "partial"
             if fetch_result is not None:
                 status = "empty_confirmed" if fetch_result.coverage_satisfactory and fetch_result.empty_confirmed else str(fetch_result.status)
+                _terminalize_deferred_provenance(
+                    fetch_result,
+                    success=status == "empty_confirmed",
+                    error_message="zero_ambiguous" if status != "empty_confirmed" else "",
+                    records_fetched=0,
+                    records_failed=0 if status == "empty_confirmed" else 1,
+                )
             _finish_ingestion_run(conn, run_id, 0, 0, 0, status)
             error_code = None if status == "empty_confirmed" else "zero_ambiguous"
             _record_evidence(
@@ -952,6 +1019,13 @@ def crawl_source(
                 )
                 result.warnings.append(msg)
                 _logger.warning(msg)
+                _terminalize_deferred_provenance(
+                    fetch_result,
+                    success=False,
+                    error_message=msg,
+                    records_fetched=result.fetched,
+                    records_failed=result.fetched,
+                )
                 _finish_ingestion_run(conn, run_id, result.fetched, 0, 0, "degraded", msg)
                 _record_evidence(conn, run_id, source, "degraded", fetched=result.fetched, error_message=msg)
                 conn.close()
@@ -970,6 +1044,15 @@ def crawl_source(
             except Exception as e:
                 conn.rollback()
                 error = f"Upsert failed: {e}"
+                _terminalize_deferred_provenance(
+                    fetch_result,
+                    success=False,
+                    error_message=error,
+                    records_fetched=result.fetched,
+                    records_deduplicated=result.duplicates,
+                    records_upserted=0,
+                    records_failed=result.transformed,
+                )
                 _finish_ingestion_run(conn, run_id, result.fetched, result.transformed, 0, "failed", error)
                 _record_evidence(
                     conn,
@@ -1099,6 +1182,14 @@ def crawl_source(
         if within_200km_only:
             result.metadata["within_200km_only"] = True
 
+        _terminalize_deferred_provenance(
+            fetch_result,
+            success=True,
+            records_fetched=result.fetched,
+            records_deduplicated=result.duplicates,
+            records_upserted=result.inserted + result.updated,
+        )
+
         result.started_at = started_at.isoformat()
         result.completed_at = datetime.now(UTC).isoformat()
         result.duration_seconds = (datetime.now(UTC) - started_at).total_seconds()
@@ -1107,6 +1198,18 @@ def crawl_source(
 
     except Exception as e:
         error = str(e)
+        try:
+            _terminalize_deferred_provenance(
+                fetch_result,
+                success=False,
+                error_message=error,
+                records_fetched=result.fetched,
+                records_deduplicated=result.duplicates,
+                records_upserted=result.inserted + result.updated,
+                records_failed=max(1, result.transformed - result.inserted - result.updated),
+            )
+        except Exception:
+            _logger.exception("Failed to record deferred provenance failure")
         try:
             _finish_ingestion_run(conn, run_id, result.fetched, result.transformed, result.matched, "failed", error)
             _record_evidence(

--- a/scripts/crawl/pcp_crawler.py
+++ b/scripts/crawl/pcp_crawler.py
@@ -284,7 +284,7 @@ def _fetch_page(
                 time.sleep(delay)
                 continue
             _logger.warning("[PCP] HTTP %d after %d retries: %s", e.code, PCP_MAX_RETRIES, url)
-            return [], False
+            raise
 
         except (urllib.error.URLError, TimeoutError, OSError) as e:
             if attempt < PCP_MAX_RETRIES:
@@ -293,9 +293,9 @@ def _fetch_page(
                 time.sleep(delay)
                 continue
             _logger.warning("[PCP] Fetch error after %d retries: %s", PCP_MAX_RETRIES, e)
-            return [], False
+            raise
 
-    return [], False
+    raise RuntimeError(f"PCP fetch exhausted retries for page {pagina}")
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +306,14 @@ def _fetch_page(
 def _generate_content_hash(record: dict) -> str:
     """Deterministic MD5 hash over key fields (delegates to common)."""
     return _common_content_hash(
-        record, fields=["orgao_cnpj", "objeto_compra", "data_publicacao", "valor_total_estimado"]
+        record,
+        fields=[
+            "pncp_id",
+            "orgao_cnpj",
+            "objeto_compra",
+            "data_publicacao",
+            "valor_total_estimado",
+        ],
     )
 
 

--- a/scripts/crawl/pcp_crawler.py
+++ b/scripts/crawl/pcp_crawler.py
@@ -35,6 +35,7 @@ from scripts.crawl.common import (
     parse_date as _parse_date,
 )
 from scripts.crawl.dlq_sync import dlq_write
+from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
 from scripts.crawl.provenance_sync import provenance_complete, provenance_fail, provenance_start
 from scripts.crawl.security import USER_AGENT, sanitize_url_param
 from scripts.crawl.watermark_sync import watermark_commit, watermark_read
@@ -398,7 +399,7 @@ def _transform_record(rec: dict) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
+def crawl(mode: str | CrawlRequest = "full", resume: bool = False) -> list[dict] | FetchResult:
     """Crawl PCP v2 API for procurement processes.
 
     Args:
@@ -409,14 +410,18 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
         List of raw PCP API records (not yet transformed).
         Filtered by INGESTION_UFS (server-side when possible, client-side fallback).
     """
-    # Backward-compat: accept only str mode. CrawlRequest objects fall through to
-    # the TypeError handler in monitor.py, which calls crawl(mode_str).
-    if not isinstance(mode, str):
-        raise TypeError(f"pcp_crawler.crawl() expects str mode, got {type(mode).__name__}")
-
-    days = 365 if mode == "full" else 3
-    data_final = date.today()
-    data_inicial = data_final - timedelta(days=days)
+    # The structured monitor path defers the provenance terminal transition
+    # until transform + PostgreSQL upsert finish.  Plain-string callers retain
+    # the historical fetch-only list contract.
+    structured_request = mode if isinstance(mode, CrawlRequest) else None
+    mode_name = structured_request.mode if structured_request else mode
+    days = 365 if mode_name == "full" else 3
+    if structured_request:
+        data_final = structured_request.date_to or structured_request.date_from or date.today()
+        data_inicial = structured_request.date_from or (data_final - timedelta(days=days))
+    else:
+        data_final = date.today()
+        data_inicial = data_final - timedelta(days=days)
 
     data_inicial_str = data_inicial.strftime("%Y-%m-%d")
     data_final_str = data_final.strftime("%Y-%m-%d")
@@ -429,7 +434,15 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
 
     # Provenance: start run
     provenance_started_at = time.monotonic()
-    run_id = provenance_start(source="pcp", mode=mode, params={"data_inicial": data_inicial_str, "data_final": data_final_str})
+    run_id = provenance_start(
+        source="pcp",
+        mode=str(mode_name),
+        params={
+            "data_inicial": data_inicial_str,
+            "data_final": data_final_str,
+            "terminal_owner": "monitor" if structured_request else "crawler",
+        },
+    )
 
     # Watermark: determine starting page
     start_page = 1
@@ -444,7 +457,7 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
 
     _logger.info(
         "[PCP] Crawl [%s]: %s to %s, UF=%s, server_side=%s, max_pages=%d",
-        mode,
+        mode_name,
         data_inicial_str,
         data_final_str,
         INGESTION_UFS,
@@ -455,6 +468,9 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     all_records: list[dict] = []
     pagina = start_page
     dlq_errors = 0
+    pages_completed = 0
+    last_has_next = False
+    presentation_limited = False
 
     while pagina <= PCP_MAX_PAGES:
         page_start = time.time()
@@ -479,6 +495,9 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
             time.sleep(PCP_REQUEST_DELAY)
             continue
 
+        pages_completed += 1
+        last_has_next = has_next
+
         elapsed_ms = int((time.time() - page_start) * 1000)
 
         if not records and pagina == 1:
@@ -502,6 +521,11 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
         else:
             all_records.extend(records)
 
+        if structured_request and structured_request.limit and len(all_records) >= structured_request.limit:
+            all_records = all_records[: structured_request.limit]
+            presentation_limited = has_next
+            break
+
         # Watermark commit after successful page
         if resume:
             watermark_commit(source="pcp", scope_key="page", value=str(pagina), run_id=run_id)
@@ -514,8 +538,47 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
 
     _logger.info("[PCP] Crawl complete: %d records (%d pages)", len(all_records), pagina)
 
-    # Provenance: complete or fail
+    # The monitor owns the structured path's terminal state because fetch-only
+    # success is not pipeline success.  In particular, an upsert failure must
+    # transition this same run to failed instead of leaving it completed.
     duration_ms = int((time.monotonic() - provenance_started_at) * 1000)
+    if structured_request:
+        errors: list[str] = []
+        if dlq_errors:
+            errors.append(f"{dlq_errors} DLQ errors")
+        page_cap_reached = bool(last_has_next and pagina >= PCP_MAX_PAGES)
+        if page_cap_reached:
+            errors.append("page_cap_reached")
+        if presentation_limited:
+            errors.append("presentation_limit_before_source_exhaustion")
+
+        status = "success" if all_records and not errors else "partial"
+        return FetchResult(
+            status=status,
+            records=all_records,
+            request_completed=not bool(dlq_errors),
+            empty_confirmed=False,
+            pages_fetched=pages_completed,
+            pages_expected=pages_completed + 1 if page_cap_reached or presentation_limited else pages_completed,
+            errors=errors,
+            provenance={
+                "run_id": run_id,
+                "source": "pcp",
+                "terminal_deferred": True,
+                "started_monotonic_ns": int(provenance_started_at * 1_000_000_000),
+                "records_dlq": dlq_errors,
+                "pages_completed": pages_completed,
+            },
+            metadata={
+                "run_id": run_id,
+                "date_from": data_inicial_str,
+                "date_to": data_final_str,
+                "pages_fetched": pages_completed,
+                "fetch_duration_ms": duration_ms,
+            },
+        )
+
+    # Legacy fetch-only callers terminalize at the crawler boundary.
     if dlq_errors > 0:
         provenance_fail(
             run_id=run_id,

--- a/scripts/crawl/runtime_queue.py
+++ b/scripts/crawl/runtime_queue.py
@@ -381,6 +381,9 @@ class CrawlQueue:
         metrics: dict[str, Any] | None = None,
         error_class: str | None = None,
         error_message: str | None = None,
+        payload_pointer: dict[str, Any] | None = None,
+        dlq_owner: str | None = None,
+        next_action: str = "inspect_and_replay_or_resolve",
     ) -> bool:
         if outcome not in {"succeeded", "failed", "blocked", "interrupted"}:
             raise ValueError(f"invalid crawl job outcome: {outcome}")
@@ -440,6 +443,67 @@ class CrawlQueue:
                     job.attempt_id,
                 ),
             )
+            terminal_failure = outcome == "blocked" or (
+                outcome == "failed" and job.attempt_count >= job.max_attempts
+            )
+            if terminal_failure:
+                effective_class = error_class or "UNCLASSIFIED"
+                pointer = payload_pointer or {
+                    "kind": "crawl_job_cursor",
+                    "job_id": job.id,
+                    "cursor": cursor_state if cursor_state is not None else job.cursor,
+                }
+                cursor.execute(
+                    """
+                    INSERT INTO dlq_entries (
+                        source, run_id, phase, payload, error_code, error_message,
+                        retry_count, max_retries, status, job_id, attempt_id,
+                        canonical_entity_key, error_class, payload_pointer,
+                        owner, next_action, terminal_at
+                    ) VALUES (
+                        %s, %s, %s, %s::jsonb, %s, %s,
+                        %s, %s, 'dead', %s, %s,
+                        %s, %s, %s::jsonb, %s, %s, %s
+                    )
+                    ON CONFLICT (job_id) WHERE job_id IS NOT NULL AND status IN ('pending', 'dead')
+                    DO NOTHING
+                    RETURNING id
+                    """,
+                    (
+                        job.source,
+                        job.run_id,
+                        job.capability,
+                        json.dumps({"cursor": cursor_state if cursor_state is not None else job.cursor}),
+                        effective_class,
+                        error_message,
+                        job.attempt_count,
+                        job.max_attempts,
+                        job.id,
+                        job.attempt_id,
+                        job.canonical_entity_key,
+                        effective_class,
+                        json.dumps(pointer, sort_keys=True),
+                        dlq_owner,
+                        next_action,
+                        clock,
+                    ),
+                )
+                inserted = cursor.fetchone()
+                if inserted:
+                    dlq_id = int(inserted["id"])
+                else:
+                    cursor.execute(
+                        """
+                        SELECT id FROM dlq_entries
+                        WHERE job_id = %s AND status IN ('pending', 'dead')
+                        """,
+                        (job.id,),
+                    )
+                    dlq_id = int(cursor.fetchone()["id"])
+                cursor.execute(
+                    "UPDATE crawl_jobs SET dlq_entry_id = %s WHERE id = %s",
+                    (dlq_id, job.id),
+                )
             cursor.execute(
                 """
                 UPDATE crawl_entity_source_schedule
@@ -468,6 +532,126 @@ class CrawlQueue:
                 ),
             )
             return True
+
+    def inspect_dlq(
+        self,
+        *,
+        source: str | None = None,
+        canonical_entity_key: str | None = None,
+        error_class: str | None = None,
+        statuses: Iterable[str] = ("pending", "dead"),
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Inspect terminal failures without deleting or hiding history."""
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT * FROM dlq_entries
+                WHERE (%s IS NULL OR source = %s)
+                  AND (%s IS NULL OR canonical_entity_key = %s)
+                  AND (%s IS NULL OR error_class = %s)
+                  AND status = ANY(%s)
+                ORDER BY terminal_at, id
+                LIMIT %s
+                """,
+                (
+                    source,
+                    source,
+                    canonical_entity_key,
+                    canonical_entity_key,
+                    error_class,
+                    error_class,
+                    list(statuses),
+                    limit,
+                ),
+            )
+            return [dict(row) for row in cursor.fetchall() or []]
+
+    def replay_dlq(
+        self,
+        *,
+        actor: str,
+        source: str | None = None,
+        canonical_entity_key: str | None = None,
+        error_class: str | None = None,
+        limit: int = 100,
+    ) -> list[int]:
+        """Selectively schedule poison jobs with a fresh retry budget.
+
+        Existing ``crawl_job_attempts`` and the DLQ row remain immutable history.
+        The next worker claim creates a new attempt for the same durable job.
+        """
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT entry.id, entry.job_id
+                FROM dlq_entries entry
+                JOIN crawl_jobs job ON job.id = entry.job_id
+                WHERE entry.status IN ('pending', 'dead')
+                  AND job.status IN ('failed', 'blocked')
+                  AND (%s IS NULL OR entry.source = %s)
+                  AND (%s IS NULL OR entry.canonical_entity_key = %s)
+                  AND (%s IS NULL OR entry.error_class = %s)
+                ORDER BY entry.terminal_at, entry.id
+                LIMIT %s
+                FOR UPDATE OF entry, job SKIP LOCKED
+                """,
+                (
+                    source,
+                    source,
+                    canonical_entity_key,
+                    canonical_entity_key,
+                    error_class,
+                    error_class,
+                    limit,
+                ),
+            )
+            selected = list(cursor.fetchall() or [])
+            replayed: list[int] = []
+            for row in selected:
+                cursor.execute(
+                    """
+                    UPDATE crawl_jobs
+                    SET status = 'queued', next_run_at = now(), attempt_count = 0,
+                        lease_owner = NULL, lease_expires_at = NULL, heartbeat_at = NULL,
+                        dlq_entry_id = NULL, last_outcome = 'dlq_replay_scheduled',
+                        updated_at = now()
+                    WHERE id = %s AND status IN ('failed', 'blocked')
+                    """,
+                    (row["job_id"],),
+                )
+                if cursor.rowcount != 1:
+                    continue
+                cursor.execute(
+                    """
+                    UPDATE dlq_entries
+                    SET status = 'replayed', replayed_at = now(), replayed_by = %s,
+                        replay_count = replay_count + 1,
+                        next_action = 'monitor_replayed_attempt'
+                    WHERE id = %s AND status IN ('pending', 'dead')
+                    """,
+                    (actor, row["id"]),
+                )
+                replayed.append(int(row["id"]))
+            return replayed
+
+    def resolve_dlq(self, entry_ids: Iterable[int], *, actor: str, resolution: str) -> int:
+        """Resolve DLQ rows by audit transition; records are never deleted."""
+        ids = [int(value) for value in entry_ids]
+        if not ids or not resolution.strip():
+            return 0
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE dlq_entries
+                SET status = 'archived', resolved_at = now(), resolved_by = %s,
+                    resolution = %s, next_action = 'none_resolved'
+                WHERE id = ANY(%s) AND status IN ('pending', 'dead', 'replayed')
+                  AND resolved_at IS NULL
+                """,
+                (actor, resolution.strip(), ids),
+            )
+            return cursor.rowcount or 0
 
     def inspect(self, *, statuses: Iterable[str] = (), limit: int = 100) -> list[dict[str, Any]]:
         selected = tuple(statuses)
@@ -577,6 +761,22 @@ def main(argv: list[str] | None = None) -> int:
     requeue_cmd.add_argument("job_ids", nargs="+", type=int)
     migrate_cmd = sub.add_parser("migrate-json")
     migrate_cmd.add_argument("path", type=Path)
+    dlq_inspect_cmd = sub.add_parser("dlq-inspect")
+    dlq_inspect_cmd.add_argument("--source")
+    dlq_inspect_cmd.add_argument("--entity")
+    dlq_inspect_cmd.add_argument("--error-class")
+    dlq_inspect_cmd.add_argument("--status", action="append", default=["pending", "dead"])
+    dlq_inspect_cmd.add_argument("--limit", type=int, default=100)
+    dlq_replay_cmd = sub.add_parser("dlq-replay")
+    dlq_replay_cmd.add_argument("--actor", required=True)
+    dlq_replay_cmd.add_argument("--source")
+    dlq_replay_cmd.add_argument("--entity")
+    dlq_replay_cmd.add_argument("--error-class")
+    dlq_replay_cmd.add_argument("--limit", type=int, default=100)
+    dlq_resolve_cmd = sub.add_parser("dlq-resolve")
+    dlq_resolve_cmd.add_argument("entry_ids", nargs="+", type=int)
+    dlq_resolve_cmd.add_argument("--actor", required=True)
+    dlq_resolve_cmd.add_argument("--resolution", required=True)
     args = parser.parse_args(argv)
 
     with connect(args.dsn) as connection:
@@ -599,8 +799,34 @@ def main(argv: list[str] | None = None) -> int:
             output = queue.inspect(statuses=args.status, limit=args.limit)
         elif args.command == "requeue":
             output = {"requeued": queue.requeue(args.job_ids)}
-        else:
+        elif args.command == "migrate-json":
             output = queue.migrate_json(args.path)
+        elif args.command == "dlq-inspect":
+            output = queue.inspect_dlq(
+                source=args.source,
+                canonical_entity_key=args.entity,
+                error_class=args.error_class,
+                statuses=args.status,
+                limit=args.limit,
+            )
+        elif args.command == "dlq-replay":
+            output = {
+                "replayed_dlq_ids": queue.replay_dlq(
+                    actor=args.actor,
+                    source=args.source,
+                    canonical_entity_key=args.entity,
+                    error_class=args.error_class,
+                    limit=args.limit,
+                )
+            }
+        else:
+            output = {
+                "resolved": queue.resolve_dlq(
+                    args.entry_ids,
+                    actor=args.actor,
+                    resolution=args.resolution,
+                )
+            }
     print(json.dumps(output, ensure_ascii=False, indent=2, default=_json_default))
     return 0
 

--- a/scripts/crawl/runtime_queue.py
+++ b/scripts/crawl/runtime_queue.py
@@ -182,7 +182,8 @@ class CrawlQueue:
                         updated_at = now()
                     WHERE status = 'running'
                       AND lease_expires_at < %s
-                    RETURNING id
+                    RETURNING id, source, capability, canonical_entity_key, cursor,
+                              status, attempt_count, max_attempts
                 )
                 , closed_attempts AS (
                     UPDATE crawl_job_attempts a
@@ -193,11 +194,62 @@ class CrawlQueue:
                     WHERE a.job_id = e.id AND a.status = 'running'
                     RETURNING a.id
                 )
-                SELECT COUNT(*) AS expired_count FROM expired
+                SELECT id, source, capability, canonical_entity_key, cursor,
+                       status, attempt_count, max_attempts
+                FROM expired
                 """,
                 (clock, clock),
             )
-            return int(cursor.fetchone()["expired_count"])
+            expired_rows = list(cursor.fetchall() or [])
+            for row in expired_rows:
+                if row["status"] != "failed":
+                    continue
+                pointer = {
+                    "kind": "crawl_job_cursor",
+                    "job_id": int(row["id"]),
+                    "cursor": row["cursor"] or {},
+                }
+                cursor.execute(
+                    """
+                    INSERT INTO dlq_entries (
+                        source, run_id, phase, payload, error_code, error_message,
+                        retry_count, max_retries, status, job_id,
+                        canonical_entity_key, error_class, payload_pointer,
+                        owner, next_action, terminal_at
+                    ) VALUES (
+                        %s, %s, %s, %s::jsonb, %s, %s,
+                        %s, %s, 'dead', %s,
+                        %s, %s, %s::jsonb, %s, %s, %s
+                    )
+                    ON CONFLICT (job_id) WHERE job_id IS NOT NULL AND status IN ('pending', 'dead')
+                    DO NOTHING
+                    RETURNING id
+                    """,
+                    (
+                        row["source"],
+                        f"lease-expired:{row['id']}",
+                        row["capability"],
+                        json.dumps({"cursor": row["cursor"] or {}}),
+                        "LEASE_EXPIRED",
+                        "worker lease expired before terminal result",
+                        row["attempt_count"],
+                        row["max_attempts"],
+                        row["id"],
+                        row["canonical_entity_key"],
+                        "LEASE_EXPIRED",
+                        json.dumps(pointer, sort_keys=True),
+                        "runtime_queue.reclaim_expired",
+                        "inspect_and_replay_or_resolve",
+                        clock,
+                    ),
+                )
+                inserted = cursor.fetchone()
+                if inserted:
+                    cursor.execute(
+                        "UPDATE crawl_jobs SET dlq_entry_id = %s WHERE id = %s",
+                        (int(inserted["id"]), row["id"]),
+                    )
+            return len(expired_rows)
 
     def claim(
         self,

--- a/scripts/datalake_helper.py
+++ b/scripts/datalake_helper.py
@@ -389,6 +389,8 @@ class DatalakeClient:
     def supplier_contracts(
         self,
         ni_fornecedor: str | None = None,
+        supplier_id_type: str | None = None,
+        supplier_identifier: str | None = None,
         orgao_cnpj: str | None = None,
         ufs: list[str] | None = None,
         keywords: list[str] | None = None,
@@ -396,20 +398,24 @@ class DatalakeClient:
         date_end: date | str | None = None,
         meses: int | None = None,
         modalidade_keywords: list[str] | None = None,
+        value_min: float | None = None,
         limit: int = 1000,
         order_by_data_desc: bool = True,
+        cursor: dict[str, Any] | None = None,
+        snapshot_at: str | None = None,
     ) -> tuple[list[dict] | None, dict]:
         """SELECT em `pncp_supplier_contracts` com filtros compostos.
 
         Args:
-            ni_fornecedor: CNPJ 14d do fornecedor (lookup O(1) via idx_psc_ni_fornecedor)
+            ni_fornecedor: identificador BR legado; 14 dígitos=CNPJ, 11=CPF
+            supplier_id_type/supplier_identifier: identidade canônica explícita
             orgao_cnpj: CNPJ 14d do órgão comprador
             ufs: lista de UFs
             keywords: lista de termos para ILIKE em objeto_contrato (OR)
             date_start, date_end: bounds em data_assinatura
             meses: alternativa — janela [hoje - meses, hoje]
             modalidade_keywords: NÃO disponível (tabela não tem modalidade — ignored)
-            limit: cap por chamada (PostgREST max 1000 default)
+            limit: tamanho da página de apresentação (máximo 1000)
             order_by_data_desc: True (default) ordena por data_assinatura DESC
 
         Returns:
@@ -423,41 +429,53 @@ class DatalakeClient:
 
         ds, de = self._resolve_dates(meses_to_dias(meses), date_start, date_end)
 
+        canonical_type = supplier_id_type.upper() if supplier_id_type else None
+        canonical_identifier = supplier_identifier
+        if ni_fornecedor and not canonical_identifier:
+            digits = "".join(ch for ch in ni_fornecedor if ch.isdigit())
+            if len(digits) == 14:
+                canonical_type, canonical_identifier = "CNPJ", digits
+            elif len(digits) == 11:
+                canonical_type, canonical_identifier = "CPF", digits
+            else:
+                return None, {"datalake_error": "supplier identity must be canonical or a valid CNPJ/CPF length"}
+        if bool(canonical_type) != bool(canonical_identifier):
+            return None, {"datalake_error": "supplier_id_type and supplier_identifier must be provided together"}
+        if canonical_type not in (None, "CNPJ", "CPF", "FOREIGN", "UNKNOWN"):
+            return None, {"datalake_error": f"unsupported supplier_id_type: {canonical_type}"}
+
         try:
-            q = (
-                sb.table("pncp_supplier_contracts")
-                .select(
-                    "numero_controle_pncp,ni_fornecedor,nome_fornecedor,orgao_cnpj,"
-                    "orgao_nome,uf,municipio,esfera,valor_global,data_assinatura,"
-                    "objeto_contrato,ingested_at"
-                )
-                .eq("is_active", True)
-            )
-            if ni_fornecedor:
-                q = q.eq("ni_fornecedor", "".join(ch for ch in ni_fornecedor if ch.isdigit()))
-            if orgao_cnpj:
-                q = q.eq("orgao_cnpj", "".join(ch for ch in orgao_cnpj if ch.isdigit()))
-            if ufs:
-                q = q.in_("uf", [u.upper() for u in ufs])
-            if ds:
-                q = q.gte("data_assinatura", ds)
-            if de:
-                q = q.lte("data_assinatura", de)
-            if keywords:
-                # AND ILIKE chain — todos os tokens devem aparecer no objeto.
-                # Pricing exige matching restritivo: "limpeza hospitalar" deve casar
-                # contratos contendo AMBAS as palavras, não qualquer uma. OR resultava
-                # em mediana enviesada por contratos genéricos (ex: "produtos de limpeza"
-                # R$300 misturado com "limpeza hospitalar" R$200k).
-                for k in keywords:
-                    if k:
-                        q = q.ilike("objeto_contrato", f"%{k.lower()}%")
-            if order_by_data_desc:
-                q = q.order("data_assinatura", desc=True)
-            q = q.limit(min(limit, 1000))
-            r = q.execute()
-            rows = r.data or []
-            return rows, {"source": "datalake_contracts", "total": len(rows)}
+            if not order_by_data_desc:
+                return None, {"datalake_error": "v2 contract pagination requires deterministic descending order"}
+            r = sb.rpc(
+                "supplier_contracts_page_v2",
+                {
+                    "p_supplier_id_type": canonical_type,
+                    "p_supplier_identifier": canonical_identifier,
+                    "p_orgao_cnpj": orgao_cnpj,
+                    "p_ufs": [u.upper() for u in ufs] if ufs else None,
+                    "p_keywords": [k for k in (keywords or []) if k],
+                    "p_date_start": ds,
+                    "p_date_end": de,
+                    "p_value_min": value_min,
+                    "p_page_size": min(max(limit, 1), 1000),
+                    "p_cursor_date": (cursor or {}).get("date"),
+                    "p_cursor_id": (cursor or {}).get("id"),
+                    "p_snapshot_at": snapshot_at,
+                },
+            ).execute()
+            response_rows = r.data
+            if (
+                not isinstance(response_rows, list)
+                or not response_rows
+                or not isinstance(response_rows[0], dict)
+                or not isinstance(response_rows[0].get("supplier_contracts_page_v2"), dict)
+            ):
+                return None, {"datalake_error": "supplier_contracts returned an empty or invalid RPC payload"}
+            payload = response_rows[0]["supplier_contracts_page_v2"]
+            rows = payload.get("items") or []
+            meta = payload.get("meta") or {}
+            return rows, meta
         except Exception as e:
             return None, {"datalake_error": f"supplier_contracts query failed: {e}"}
 
@@ -487,45 +505,35 @@ class DatalakeClient:
             ufs=ufs,
             meses=meses,
             orgao_cnpj=orgao_cnpj,
-            limit=1000,
+            value_min=valor_min,
+            limit=200,
         )
         if rows is None:
             return None, meta
 
-        valid = [r for r in rows if r.get("valor_global") is not None and float(r["valor_global"]) >= valor_min]
-        if not valid:
+        if int(meta.get("total_count") or 0) == 0:
             return None, {**meta, "datalake_error": "0 contracts with valid valor_global"}
 
-        valores = sorted(float(r["valor_global"]) for r in valid)
-        n = len(valores)
-        media = sum(valores) / n
-        var = sum((v - media) ** 2 for v in valores) / n
-        dp = var**0.5
-        cv = (dp / media * 100) if media > 0 else 0.0
-
-        def percentile(p: float) -> float:
-            if n == 1:
-                return valores[0]
-            k = (n - 1) * p
-            f = int(k)
-            c = min(f + 1, n - 1)
-            if f == c:
-                return valores[f]
-            return valores[f] + (valores[c] - valores[f]) * (k - f)
+        # Aggregates come from SQL over the complete filtered set. ``rows`` is
+        # only a presentation sample and never changes the denominator.
+        n = int(meta["total_count"])
+        media = float(meta.get("average_value") or 0)
+        dp = float(meta.get("stddev_value") or 0)
+        sample = [r for r in rows if float(r.get("valor_global") or 0) >= valor_min]
 
         stats = {
             "n": n,
-            "p10": round(percentile(0.10), 2),
-            "p25": round(percentile(0.25), 2),
-            "mediana": round(percentile(0.50), 2),
-            "p75": round(percentile(0.75), 2),
-            "p90": round(percentile(0.90), 2),
+            "p10": round(float(meta.get("p10") or 0), 2),
+            "p25": round(float(meta.get("p25") or 0), 2),
+            "mediana": round(float(meta.get("p50") or 0), 2),
+            "p75": round(float(meta.get("p75") or 0), 2),
+            "p90": round(float(meta.get("p90") or 0), 2),
             "media": round(media, 2),
             "dp": round(dp, 2),
-            "cv": round(cv, 2),
-            "sample": valid[:200],
+            "cv": round((dp / media * 100) if media > 0 else 0.0, 2),
+            "sample": sample,
         }
-        return stats, {**meta, "n_valid": n, "n_filtered_out": len(rows) - n}
+        return stats, {**meta, "n_valid": n, "n_filtered_out": int(meta.get("quarantine_count") or 0)}
 
     # ------------------------------------------------------------------
     # enriched_entities (BrasilAPI cache, TTL lógico 30d)
@@ -684,10 +692,7 @@ class DatalakeClient:
         meses: int = 24,
         limit: int = 10,
     ) -> tuple[list[dict] | None, dict]:
-        """Top fornecedores agrupados por `ni_fornecedor`.
-
-        Wrapper sobre `supplier_contracts` + groupby em-memória. Ordena por
-        `n_contratos DESC, valor_total DESC`.
+        """Top fornecedores, agregado no PostgreSQL sobre o recorte completo.
 
         Args:
             orgao_cnpj: filtra por órgão comprador (opcional)
@@ -701,63 +706,43 @@ class DatalakeClient:
             `[{ni_fornecedor, nome_fornecedor, n_contratos, valor_total, ultimo_contrato_data, ufs}]`
             ou (None, error_meta).
         """
-        contratos, meta = self.supplier_contracts(
-            orgao_cnpj=orgao_cnpj,
-            keywords=setor_keywords,
-            ufs=ufs,
-            meses=meses,
-            limit=1000,
-        )
-        if contratos is None:
-            return None, meta
-        if not contratos:
-            return [], {**meta, "source": "datalake_top_competitors", "n_input": 0}
-
-        agg: dict[str, dict] = {}
-        for c in contratos:
-            ni = c.get("ni_fornecedor")
-            if not ni:
-                continue
-            slot = agg.setdefault(
-                ni,
+        if not self.is_enabled:
+            return None, {"datalake_error": self._init_error or "disabled"}
+        sb = self._client()
+        if sb is None:
+            return None, {"datalake_error": self._init_error or "client unavailable"}
+        ds, de = self._resolve_dates(meses_to_dias(meses), None, None)
+        try:
+            result = sb.rpc(
+                "supplier_contracts_grouped_v2",
                 {
-                    "ni_fornecedor": ni,
-                    "nome_fornecedor": c.get("nome_fornecedor"),
-                    "n_contratos": 0,
-                    "valor_total": 0.0,
-                    "ultimo_contrato_data": None,
-                    "ufs": set(),
+                    "p_group_by": "supplier",
+                    "p_orgao_cnpj": orgao_cnpj,
+                    "p_ufs": [u.upper() for u in ufs] if ufs else None,
+                    "p_keywords": [k for k in (setor_keywords or []) if k],
+                    "p_date_start": ds,
+                    "p_date_end": de,
+                    "p_limit": limit,
+                    "p_snapshot_at": None,
                 },
-            )
-            slot["n_contratos"] += 1
-            try:
-                slot["valor_total"] += float(c.get("valor_global") or 0)
-            except (ValueError, TypeError):
-                pass
-            data = c.get("data_assinatura")
-            if data and (slot["ultimo_contrato_data"] is None or data > slot["ultimo_contrato_data"]):
-                slot["ultimo_contrato_data"] = data
-            uf = c.get("uf")
-            if uf:
-                slot["ufs"].add(uf)
-            if not slot["nome_fornecedor"] and c.get("nome_fornecedor"):
-                slot["nome_fornecedor"] = c.get("nome_fornecedor")
-
-        ranked = sorted(
-            agg.values(),
-            key=lambda r: (r["n_contratos"], r["valor_total"]),
-            reverse=True,
-        )[:limit]
-        for r in ranked:
-            r["valor_total"] = round(r["valor_total"], 2)
-            r["ufs"] = sorted(r["ufs"])
-
-        return ranked, {
-            "source": "datalake_top_competitors",
-            "n_input": len(contratos),
-            "n_unique_suppliers": len(agg),
-            "limit": limit,
-        }
+            ).execute()
+            payload = (result.data or [{}])[0].get("supplier_contracts_grouped_v2") or {}
+            ranked = [
+                {
+                    "ni_fornecedor": row.get("group_identifier"),
+                    "supplier_id_type": row.get("group_type"),
+                    "nome_fornecedor": row.get("group_name"),
+                    "n_contratos": int(row.get("matched_contracts") or 0),
+                    "valor_total": round(float(row.get("sum_value") or 0), 2),
+                    "ultimo_contrato_data": row.get("latest_event_date"),
+                    "ufs": row.get("ufs") or [],
+                }
+                for row in payload.get("items") or []
+            ]
+            meta = payload.get("meta") or {}
+            return ranked, {**meta, "n_input": meta.get("total_count"), "n_unique_suppliers": meta.get("total_groups")}
+        except Exception as e:
+            return None, {"datalake_error": f"top_competitors query failed: {e}"}
 
     # ------------------------------------------------------------------
     # agg_by_orgao (groupby orgao_cnpj sobre supplier_contracts)
@@ -786,52 +771,47 @@ class DatalakeClient:
         if not setor_keywords:
             return None, {"datalake_error": "setor_keywords required"}
 
-        contratos, meta = self.supplier_contracts(
-            keywords=setor_keywords,
-            ufs=ufs,
-            meses=meses,
-            limit=1000,
-        )
-        if contratos is None:
-            return None, meta
-        if not contratos:
-            return [], {**meta, "source": "datalake_agg_by_orgao", "n_input": 0}
-
-        agg: dict[str, dict] = {}
-        for c in contratos:
-            cnpj = c.get("orgao_cnpj")
-            if not cnpj:
-                continue
-            slot = agg.setdefault(
-                cnpj,
+        if not self.is_enabled:
+            return None, {"datalake_error": self._init_error or "disabled"}
+        sb = self._client()
+        if sb is None:
+            return None, {"datalake_error": self._init_error or "client unavailable"}
+        ds, de = self._resolve_dates(meses_to_dias(meses), None, None)
+        try:
+            result = sb.rpc(
+                "supplier_contracts_grouped_v2",
                 {
-                    "orgao_cnpj": cnpj,
-                    "orgao_nome": c.get("orgao_nome"),
-                    "uf": c.get("uf"),
-                    "n_contratos": 0,
-                    "valor_total": 0.0,
+                    "p_group_by": "orgao",
+                    "p_orgao_cnpj": None,
+                    "p_ufs": [u.upper() for u in ufs] if ufs else None,
+                    "p_keywords": setor_keywords,
+                    "p_date_start": ds,
+                    "p_date_end": de,
+                    "p_limit": limit,
+                    "p_snapshot_at": None,
                 },
-            )
-            slot["n_contratos"] += 1
-            try:
-                slot["valor_total"] += float(c.get("valor_global") or 0)
-            except (ValueError, TypeError):
-                pass
-            if not slot["orgao_nome"] and c.get("orgao_nome"):
-                slot["orgao_nome"] = c.get("orgao_nome")
-
-        for r in agg.values():
-            r["valor_total"] = round(r["valor_total"], 2)
-            r["ticket_medio"] = round(r["valor_total"] / r["n_contratos"], 2) if r["n_contratos"] else 0.0
-
-        ranked = sorted(agg.values(), key=lambda r: r["valor_total"], reverse=True)[:limit]
-
-        return ranked, {
-            "source": "datalake_agg_by_orgao",
-            "n_input": len(contratos),
-            "n_unique_orgaos": len(agg),
-            "limit": limit,
-        }
+            ).execute()
+            payload = (result.data or [{}])[0].get("supplier_contracts_grouped_v2") or {}
+            ranked = []
+            for row in payload.get("items") or []:
+                n = int(row.get("matched_contracts") or 0)
+                value = round(float(row.get("sum_value") or 0), 2)
+                ufs_for_org = row.get("ufs") or []
+                ranked.append(
+                    {
+                        "orgao_cnpj": row.get("group_identifier"),
+                        "orgao_nome": row.get("group_name"),
+                        "uf": ufs_for_org[0] if len(ufs_for_org) == 1 else None,
+                        "ufs": ufs_for_org,
+                        "n_contratos": n,
+                        "valor_total": value,
+                        "ticket_medio": round(value / n, 2) if n else 0.0,
+                    }
+                )
+            meta = payload.get("meta") or {}
+            return ranked, {**meta, "n_input": meta.get("total_count"), "n_unique_orgaos": meta.get("total_groups")}
+        except Exception as e:
+            return None, {"datalake_error": f"agg_by_orgao query failed: {e}"}
 
     # ------------------------------------------------------------------
     # Date helpers

--- a/scripts/official_status_reconfirmation.py
+++ b/scripts/official_status_reconfirmation.py
@@ -1,0 +1,250 @@
+"""Fail-closed official-status gate for report opportunity shortlists.
+
+The scoring pipeline may nominate an opportunity, but only a fresh observation
+from the publishing source can make it actionable.  This module deliberately
+does not perform HTTP itself: callers provide a source-specific fetcher and the
+gate applies the same decision contract to every source.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+REPORT_TIMEZONE = ZoneInfo("America/Sao_Paulo")
+SHORTLIST_RECOMMENDATIONS = frozenset({"PARTICIPAR", "AVALIAR COM CAUTELA"})
+
+_TERMINAL_STATUS_PARTS = (
+    "adjudic",
+    "anulad",
+    "cancelad",
+    "desert",
+    "encerrad",
+    "finalizad",
+    "fracassad",
+    "homolog",
+    "revogad",
+)
+_OPEN_STATUS_PARTS = (
+    "abert",
+    "divulgad",
+    "publicad",
+    "recebendo proposta",
+    "proposta em recebimento",
+)
+
+
+OfficialFetcher = Callable[[dict[str, Any]], Mapping[str, Any]]
+
+
+def _plain(value: Any) -> str:
+    text = str(value or "").strip().lower()
+    return "".join(
+        character
+        for character in unicodedata.normalize("NFD", text)
+        if unicodedata.category(character) != "Mn"
+    )
+
+
+def _parse_official_datetime(value: Any) -> datetime | None:
+    """Parse a source timestamp and normalize it to America/Sao_Paulo.
+
+    A date without time is intentionally rejected.  The acceptance contract is
+    about the proposal deadline instant, not merely its calendar day.
+    """
+
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and "T" in value:
+        candidate = value.strip().replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=REPORT_TIMEZONE)
+    return parsed.astimezone(REPORT_TIMEZONE)
+
+
+def _reference(edital: Mapping[str, Any]) -> str:
+    return str(
+        edital.get("numero_controle")
+        or edital.get("codigo_licitacao")
+        or edital.get("sequencial_compra")
+        or edital.get("link")
+        or "oportunidade_sem_identificador"
+    )
+
+
+def _block(
+    edital: dict[str, Any],
+    *,
+    checked_at: str,
+    decision: str,
+    source: str,
+    blocker: str,
+    next_action: str,
+    status_native: str = "",
+    deadline_at: str | None = None,
+    evidence_url: str = "",
+) -> None:
+    original = str(edital.get("recomendacao") or "")
+    edital["official_reconfirmation"] = {
+        "decision": decision,
+        "source": source,
+        "status_native": status_native,
+        "deadline_at": deadline_at,
+        "checked_at": checked_at,
+        "timezone": "America/Sao_Paulo",
+        "evidence_url": evidence_url,
+        "blocker": blocker,
+        "next_action": next_action,
+        "original_recommendation": original,
+    }
+    edital["shortlist_eligible"] = False
+    edital["recomendacao"] = "NÃO RECOMENDADO"
+    edital["justificativa"] = blocker
+
+
+def reconfirm_shortlist(
+    editais: list[dict[str, Any]],
+    fetch_official: OfficialFetcher | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Reconfirm every scored shortlist candidate against its official source.
+
+    Failures are isolated per opportunity.  A failed source observation never
+    erases another source's successful GO, but the failed candidate itself is
+    excluded from every downstream action list.
+    """
+
+    instant = now or datetime.now(tz=UTC)
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=REPORT_TIMEZONE)
+    instant_sp = instant.astimezone(REPORT_TIMEZONE)
+    checked_at = instant_sp.isoformat()
+
+    candidates = [
+        edital
+        for edital in editais
+        if str(edital.get("recomendacao") or "").upper() in SHORTLIST_RECOMMENDATIONS
+    ]
+    counts = {"GO": 0, "REVIEW": 0, "NO_GO": 0}
+    source_failures: list[dict[str, str]] = []
+
+    for edital in candidates:
+        source = str(edital.get("fonte") or edital.get("_source_name") or "UNKNOWN").upper()
+        reference = _reference(edital)
+        if fetch_official is None:
+            blocker = "Shortlist bloqueada: reconfirmação oficial não foi executada."
+            _block(
+                edital,
+                checked_at=checked_at,
+                decision="NO_GO",
+                source=source,
+                blocker=blocker,
+                next_action=f"Consultar a fonte {source} e reconfirmar status e prazo de {reference}.",
+            )
+            counts["NO_GO"] += 1
+            source_failures.append({"source": source, "reference": reference, "blocker": blocker})
+            continue
+
+        try:
+            observation = dict(fetch_official(edital))
+        except Exception as exc:  # the gate must isolate any source adapter failure
+            blocker = f"Fonte oficial {source} indisponível na reconfirmação: {type(exc).__name__}."
+            _block(
+                edital,
+                checked_at=checked_at,
+                decision="NO_GO",
+                source=source,
+                blocker=blocker,
+                next_action=f"Repetir a consulta oficial de {reference} antes de preparar proposta.",
+            )
+            counts["NO_GO"] += 1
+            source_failures.append({"source": source, "reference": reference, "blocker": blocker})
+            continue
+
+        status_native = str(
+            observation.get("status_native")
+            or observation.get("situacaoCompraNome")
+            or observation.get("status")
+            or ""
+        ).strip()
+        deadline = _parse_official_datetime(
+            observation.get("deadline_at")
+            or observation.get("dataEncerramentoProposta")
+            or observation.get("dataHoraFinalPropostas")
+        )
+        evidence_url = str(observation.get("evidence_url") or observation.get("official_url") or "").strip()
+        normalized_status = _plain(status_native)
+
+        if not evidence_url:
+            blocker = "Reconfirmação sem URL de evidência oficial."
+            decision = "NO_GO"
+        elif any(part in normalized_status for part in _TERMINAL_STATUS_PARTS):
+            blocker = f"Evento terminal na fonte oficial: {status_native}."
+            decision = "NO_GO"
+            edital["status_edital"] = "ENCERRADO"
+        elif deadline is None:
+            blocker = "Prazo oficial ausente ou sem timestamp verificável."
+            decision = "REVIEW"
+        elif deadline <= instant_sp:
+            blocker = f"Prazo oficial vencido em {deadline.isoformat()}."
+            decision = "NO_GO"
+            edital["status_edital"] = "ENCERRADO"
+        elif not any(part in normalized_status for part in _OPEN_STATUS_PARTS):
+            blocker = f"Status oficial ambíguo: {status_native or 'não informado'}."
+            decision = "REVIEW"
+        else:
+            original = str(edital.get("recomendacao") or "")
+            edital["official_reconfirmation"] = {
+                "decision": "GO",
+                "source": source,
+                "status_native": status_native,
+                "deadline_at": deadline.isoformat(),
+                "checked_at": checked_at,
+                "timezone": "America/Sao_Paulo",
+                "evidence_url": evidence_url,
+                "blocker": None,
+                "next_action": "Monitorar a fonte oficial até o envio da proposta.",
+                "original_recommendation": original,
+            }
+            edital["shortlist_eligible"] = True
+            edital["status_edital"] = "ABERTO"
+            edital["data_encerramento"] = deadline.isoformat()
+            edital["dias_restantes"] = (deadline.date() - instant_sp.date()).days
+            counts["GO"] += 1
+            continue
+
+        _block(
+            edital,
+            checked_at=checked_at,
+            decision=decision,
+            source=source,
+            blocker=blocker,
+            next_action=f"Validar manualmente {reference} na fonte oficial antes de qualquer ação.",
+            status_native=status_native,
+            deadline_at=deadline.isoformat() if deadline else None,
+            evidence_url=evidence_url,
+        )
+        counts[decision] += 1
+
+    return {
+        "candidate_count": len(candidates),
+        "shortlist_count": counts["GO"],
+        "blocked_count": counts["REVIEW"] + counts["NO_GO"],
+        "decisions": counts,
+        "checked_at": checked_at,
+        "timezone": "America/Sao_Paulo",
+        "all_candidates_reconfirmed": bool(candidates) and counts["GO"] == len(candidates),
+        "shortlist_blocked": bool(candidates) and counts["GO"] == 0,
+        "source_failures": source_failures,
+    }

--- a/scripts/ops/canonical_snapshot.py
+++ b/scripts/ops/canonical_snapshot.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Operate the client-independent canonical snapshot barrier (#287)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+def _connect(dsn: str | None = None):
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    resolved = dsn or os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL")
+    if not resolved:
+        raise RuntimeError("LOCAL_DATALAKE_DSN or DATABASE_URL is required")
+    return psycopg2.connect(resolved, cursor_factory=RealDictCursor, connect_timeout=10)
+
+
+def _show(connection: Any, snapshot_id: str) -> dict[str, Any]:
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM canonical_public_snapshots WHERE snapshot_id = %s", (snapshot_id,))
+        snapshot = cursor.fetchone()
+        if not snapshot:
+            raise ValueError(f"snapshot not found: {snapshot_id}")
+        cursor.execute(
+            "SELECT * FROM canonical_snapshot_source_watermarks WHERE snapshot_id = %s ORDER BY source",
+            (snapshot_id,),
+        )
+        watermarks = [dict(row) for row in cursor.fetchall() or []]
+        cursor.execute(
+            """
+            SELECT
+                (SELECT count(*) FROM canonical_snapshot_event_revisions WHERE snapshot_id = %s) AS event_revisions,
+                (SELECT count(*) FROM canonical_snapshot_documents WHERE snapshot_id = %s) AS documents,
+                (SELECT count(*) FROM canonical_snapshot_dossiers WHERE snapshot_id = %s) AS dossiers
+            """,
+            (snapshot_id, snapshot_id, snapshot_id),
+        )
+        counts = dict(cursor.fetchone())
+    return {
+        "snapshot": dict(snapshot),
+        "cutoff": snapshot["cutoff_at"],
+        "cutoff_timezone": snapshot["cutoff_timezone"],
+        "blockers": snapshot["blockers"],
+        "watermarks": watermarks,
+        "counts": counts,
+        "generation_allowed": snapshot["state"] == "READY_CANONICAL",
+    }
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Canonical public snapshot barrier")
+    parser.add_argument("--dsn")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    begin = sub.add_parser("begin")
+    begin.add_argument("--cutoff", required=True, help="ISO timestamp with offset; operational timezone is America/Sao_Paulo")
+    for name in ("universe", "policy", "schema", "adapter", "data", "document", "dossier"):
+        begin.add_argument(f"--{name}-hash", required=True)
+    begin.add_argument("--required-pairs", type=int, required=True)
+    begin.add_argument("--relevant-dossiers", type=int, required=True)
+    begin.add_argument("--actor", required=True)
+
+    watermark = sub.add_parser("watermark")
+    watermark.add_argument("snapshot_id")
+    watermark.add_argument("--source", required=True)
+    watermark.add_argument("--run-id", required=True)
+    watermark.add_argument("--at", required=True)
+    watermark.add_argument("--freshness", choices=["FRESH", "STALE", "FAILED", "BLOCKED", "UNKNOWN"], required=True)
+    watermark.add_argument("--completeness", choices=["COMPLETE", "INCOMPLETE", "UNKNOWN"], required=True)
+    watermark.add_argument("--applicable-pairs", type=int, required=True)
+    watermark.add_argument("--evaluated-pairs", type=int, required=True)
+    watermark.add_argument("--evidence-hash", required=True)
+
+    revision = sub.add_parser("add-revision")
+    revision.add_argument("snapshot_id")
+    revision.add_argument("event_id")
+    revision.add_argument("revision_id")
+
+    document = sub.add_parser("add-document")
+    document.add_argument("snapshot_id")
+    document.add_argument("observation_id")
+    document.add_argument("--sha256", required=True)
+    document.add_argument("--completeness", choices=["COMPLETE", "INCOMPLETE", "BLOCKED"], required=True)
+
+    dossier = sub.add_parser("add-dossier")
+    dossier.add_argument("snapshot_id")
+    dossier.add_argument("dossier_id")
+    dossier.add_argument("--revision-hash", required=True)
+    dossier.add_argument("--completeness", choices=["COMPLETE", "INCOMPLETE", "BLOCKED"], required=True)
+    dossier.add_argument("--reason-code", action="append", default=[])
+
+    close = sub.add_parser("close")
+    close.add_argument("snapshot_id")
+    show = sub.add_parser("show")
+    show.add_argument("snapshot_id")
+
+    projection = sub.add_parser("create-projection")
+    projection.add_argument("snapshot_id")
+    projection.add_argument("--consumer", required=True)
+    projection.add_argument("--template-hash", required=True)
+    projection.add_argument("--private-profile-hash")
+
+    private = sub.add_parser("invalidate-private")
+    private.add_argument("projection_id")
+    private.add_argument("--template-hash", required=True)
+    private.add_argument("--private-profile-hash")
+
+    file_hash = sub.add_parser("hash-file")
+    file_hash.add_argument("path", type=Path)
+    args = parser.parse_args(argv)
+
+    if args.command == "hash-file":
+        print(json.dumps({"path": str(args.path), "sha256": _hash_file(args.path)}, indent=2))
+        return 0
+
+    connection = _connect(args.dsn)
+    code = 0
+    try:
+        with connection.cursor() as cursor:
+            if args.command == "begin":
+                values = [
+                    args.cutoff,
+                    args.universe_hash,
+                    args.policy_hash,
+                    args.schema_hash,
+                    args.adapter_hash,
+                    args.data_hash,
+                    args.document_hash,
+                    args.dossier_hash,
+                    args.required_pairs,
+                    args.relevant_dossiers,
+                    args.actor,
+                ]
+                if any("client" in str(value).lower() or "profile_hash" in str(value).lower() for value in values):
+                    raise ValueError("client/profile state is forbidden in canonical snapshot input")
+                cursor.execute(
+                    "SELECT begin_canonical_public_snapshot_v1(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) AS id",
+                    tuple(values),
+                )
+                snapshot_id = cursor.fetchone()["id"]
+                output = _show(connection, snapshot_id)
+            elif args.command == "watermark":
+                cursor.execute(
+                    "SELECT put_canonical_snapshot_watermark_v1(%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+                    (
+                        args.snapshot_id,
+                        args.source,
+                        args.run_id,
+                        args.at,
+                        args.freshness,
+                        args.completeness,
+                        args.applicable_pairs,
+                        args.evaluated_pairs,
+                        args.evidence_hash,
+                    ),
+                )
+                output = _show(connection, args.snapshot_id)
+            elif args.command == "add-revision":
+                cursor.execute(
+                    """
+                    INSERT INTO canonical_snapshot_event_revisions (snapshot_id, event_id, revision_id, fact_hash)
+                    SELECT %s, revision.event_id, revision.revision_id, revision.fact_hash
+                    FROM canonical_event_revisions revision
+                    WHERE revision.event_id = %s AND revision.revision_id = %s
+                    RETURNING revision_id
+                    """,
+                    (args.snapshot_id, args.event_id, args.revision_id),
+                )
+                if not cursor.fetchone():
+                    raise ValueError("event/revision pair not found")
+                output = _show(connection, args.snapshot_id)
+            elif args.command == "add-document":
+                cursor.execute(
+                    "INSERT INTO canonical_snapshot_documents VALUES (%s, %s, %s, %s) RETURNING observation_id",
+                    (args.snapshot_id, args.observation_id, args.sha256, args.completeness),
+                )
+                output = _show(connection, args.snapshot_id)
+            elif args.command == "add-dossier":
+                cursor.execute(
+                    "INSERT INTO canonical_snapshot_dossiers VALUES (%s, %s, %s, %s, %s) RETURNING dossier_id",
+                    (args.snapshot_id, args.dossier_id, args.revision_hash, args.completeness, args.reason_code),
+                )
+                output = _show(connection, args.snapshot_id)
+            elif args.command == "close":
+                cursor.execute("SELECT close_canonical_public_snapshot_v1(%s) AS result", (args.snapshot_id,))
+                output = {"transition": cursor.fetchone()["result"], "manifest": _show(connection, args.snapshot_id)}
+                code = 0 if output["transition"]["state"] == "READY_CANONICAL" else 2
+            elif args.command == "show":
+                output = _show(connection, args.snapshot_id)
+                code = 0 if output["generation_allowed"] else 2
+            elif args.command == "create-projection":
+                projection_id = hashlib.sha256(
+                    f"{args.consumer}|{args.snapshot_id}|{args.template_hash}|{args.private_profile_hash or ''}".encode()
+                ).hexdigest()[:32]
+                cursor.execute(
+                    """
+                    INSERT INTO public_consumer_projections (
+                        projection_id, consumer_id, snapshot_id, template_hash, private_profile_hash
+                    ) VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (projection_id) DO NOTHING RETURNING projection_id
+                    """,
+                    (projection_id, args.consumer, args.snapshot_id, args.template_hash, args.private_profile_hash),
+                )
+                output = {"projection_id": projection_id, "snapshot_id": args.snapshot_id}
+            else:
+                cursor.execute(
+                    "SELECT invalidate_consumer_projection_private_v1(%s, %s, %s)",
+                    (args.projection_id, args.template_hash, args.private_profile_hash),
+                )
+                output = {"projection_id": args.projection_id, "state": "STALE_PRIVATE"}
+        connection.commit()
+    finally:
+        connection.close()
+    print(json.dumps(output, ensure_ascii=False, indent=2, default=lambda value: value.isoformat() if isinstance(value, datetime) else str(value)))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/truth_plane_sli.py
+++ b/scripts/ops/truth_plane_sli.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Fail-closed PostgreSQL authority for truth-plane SLI/SLO state (#275)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+
+def _connect(dsn: str | None = None):
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    resolved = dsn or os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL")
+    if not resolved:
+        raise RuntimeError("LOCAL_DATALAKE_DSN or DATABASE_URL is required")
+    return psycopg2.connect(resolved, cursor_factory=RealDictCursor, connect_timeout=10)
+
+
+def _one(cursor: Any, sql: str, params: tuple[Any, ...] = ()) -> dict[str, Any]:
+    cursor.execute(sql, params)
+    return dict(cursor.fetchone() or {})
+
+
+def _relation_exists(cursor: Any, relation: str) -> bool:
+    return bool(_one(cursor, "SELECT to_regclass(%s) IS NOT NULL AS exists", (relation,))["exists"])
+
+
+def _metric_state(definition: dict[str, Any], value: float | None, denominator: float | None, reason: str) -> dict:
+    objective = float(definition["objective_value"])
+    warning_at = objective * float(definition["alert_before_ratio"])
+    state = "UNKNOWN"
+    if value is not None and denominator is not None and denominator > 0:
+        if definition["objective_operator"] == "lte":
+            state = "BREACH" if value > objective else ("WARNING" if value >= warning_at else "OK")
+        else:
+            state = "BREACH" if value < objective else ("WARNING" if value <= warning_at else "OK")
+    return {
+        "metric_name": definition["metric_name"],
+        "stage": definition["stage"],
+        "state": state,
+        "value": value,
+        "unit": definition["unit"],
+        "objective_operator": definition["objective_operator"],
+        "objective_value": objective,
+        "window_seconds": int(definition["window_seconds"]),
+        "denominator": denominator,
+        "denominator_contract": definition["denominator_contract"],
+        "reason": reason if state == "UNKNOWN" else None,
+    }
+
+
+def _observe_metric(cursor: Any, definition: dict[str, Any], now: datetime) -> dict:
+    name = definition["metric_name"]
+    window_start = now - timedelta(seconds=int(definition["window_seconds"]))
+    value: float | None = None
+    denominator: float | None = None
+    reason = "metric source unavailable"
+
+    if name == "queue_oldest_age_seconds":
+        row = _one(
+            cursor,
+            """
+            SELECT count(*)::BIGINT AS denominator,
+                   extract(EPOCH FROM (%s - min(created_at))) AS value
+            FROM crawl_jobs WHERE status IN ('queued', 'running')
+            """,
+            (now,),
+        )
+        denominator, value = float(row["denominator"]), float(row["value"]) if row["value"] is not None else None
+        reason = "no queued/running jobs"
+    elif name == "queue_terminal_failure_ratio":
+        row = _one(
+            cursor,
+            """
+            SELECT count(*)::BIGINT AS denominator,
+                   count(*) FILTER (WHERE status IN ('failed', 'blocked', 'lease_expired'))::BIGINT AS failures
+            FROM crawl_job_attempts
+            WHERE finished_at >= %s AND finished_at <= %s
+            """,
+            (window_start, now),
+        )
+        denominator = float(row["denominator"])
+        value = float(row["failures"]) / denominator if denominator else None
+        reason = "no terminal attempts in window"
+    elif name == "dlq_open_count":
+        row = _one(
+            cursor,
+            """
+            SELECT count(*)::BIGINT AS denominator,
+                   (
+                       SELECT count(*) FROM dlq_entries
+                       WHERE status IN ('pending', 'dead')
+                   )::BIGINT AS value
+            FROM dlq_entries
+            WHERE terminal_at >= %s AND terminal_at <= %s
+            """,
+            (window_start, now),
+        )
+        denominator = float(row["denominator"])
+        value = float(row["value"]) if denominator else None
+        reason = "no jobs reached a terminal threshold in window"
+    elif name == "document_failure_ratio":
+        if _relation_exists(cursor, "public.process_document_runs"):
+            row = _one(
+                cursor,
+                """
+                SELECT COALESCE(sum(documents_downloaded + documents_failed), 0)::BIGINT AS denominator,
+                       COALESCE(sum(documents_failed), 0)::BIGINT AS failures
+                FROM process_document_runs WHERE finished_at >= %s AND finished_at <= %s
+                """,
+                (window_start, now),
+            )
+            denominator = float(row["denominator"])
+            value = float(row["failures"]) / denominator if denominator else None
+            reason = "no terminal document units in window"
+    elif name == "canonical_lag_seconds":
+        if _relation_exists(cursor, "public.canonical_public_observations"):
+            row = _one(
+                cursor,
+                """
+                SELECT count(*)::BIGINT AS denominator,
+                       max(extract(EPOCH FROM (received_at - observed_at))) AS value
+                FROM canonical_public_observations
+                WHERE received_at >= %s AND received_at <= %s
+                """,
+                (window_start, now),
+            )
+            denominator = float(row["denominator"])
+            value = float(row["value"]) if row["value"] is not None else None
+            reason = "no canonical observations in window"
+        else:
+            reason = "canonical_public_observations not installed"
+    elif name.startswith("public_read_"):
+        if _relation_exists(cursor, "public_read_v1.surface_health"):
+            if name == "public_read_freshness_seconds":
+                row = _one(
+                    cursor,
+                    """
+                    SELECT count(*) FILTER (WHERE query_count > 0)::BIGINT AS denominator,
+                           max(extract(EPOCH FROM (%s - refreshed_at)))
+                               FILTER (WHERE query_count > 0) AS value
+                    FROM public_read_v1.surface_health WHERE enabled
+                    """,
+                    (now,),
+                )
+            elif name == "public_read_query_p95_ms":
+                row = _one(
+                    cursor,
+                    "SELECT COALESCE(sum(query_count), 0)::BIGINT AS denominator, max(query_p95_ms) AS value FROM public_read_v1.surface_health WHERE enabled",
+                )
+            else:
+                row = _one(
+                    cursor,
+                    """
+                    SELECT COALESCE(sum(query_count), 0)::BIGINT AS denominator,
+                           CASE WHEN sum(query_count) > 0 THEN sum(error_count)::NUMERIC / sum(query_count) END AS value
+                    FROM public_read_v1.surface_health WHERE enabled
+                    """,
+                )
+            denominator = float(row["denominator"])
+            value = float(row["value"]) if row["value"] is not None else None
+            reason = "public_read_v1 has no measured denominator"
+        else:
+            reason = "public_read_v1.surface_health not installed"
+    elif name == "public_reader_connection_ratio":
+        row = _one(
+            cursor,
+            """
+            SELECT count(*)::BIGINT AS denominator,
+                   count(*) FILTER (
+                       WHERE usename = 'smartlic_public_reader'
+                          OR application_name LIKE 'smartlic%%'
+                   )::BIGINT AS public_count
+            FROM pg_stat_activity
+            """,
+        )
+        denominator = float(row["denominator"])
+        value = float(row["public_count"]) / denominator if denominator else None
+        reason = "pg_stat_activity has no connection denominator"
+    elif name == "public_reader_blocking_locks":
+        row = _one(
+            cursor,
+            """
+            SELECT (SELECT count(*) FROM pg_stat_activity)::BIGINT AS denominator,
+                   count(*)::BIGINT AS value
+            FROM pg_locks waiting
+            JOIN pg_locks holding
+              ON waiting.locktype = holding.locktype
+             AND waiting.database IS NOT DISTINCT FROM holding.database
+             AND waiting.relation IS NOT DISTINCT FROM holding.relation
+             AND waiting.page IS NOT DISTINCT FROM holding.page
+             AND waiting.tuple IS NOT DISTINCT FROM holding.tuple
+             AND waiting.virtualxid IS NOT DISTINCT FROM holding.virtualxid
+             AND waiting.transactionid IS NOT DISTINCT FROM holding.transactionid
+             AND waiting.classid IS NOT DISTINCT FROM holding.classid
+             AND waiting.objid IS NOT DISTINCT FROM holding.objid
+             AND waiting.objsubid IS NOT DISTINCT FROM holding.objsubid
+             AND waiting.pid <> holding.pid
+            JOIN pg_stat_activity activity ON activity.pid = waiting.pid
+            WHERE NOT waiting.granted AND holding.granted
+              AND (activity.usename = 'smartlic_public_reader' OR activity.application_name LIKE 'smartlic%%')
+            """,
+        )
+        denominator, value = float(row["denominator"]), float(row["value"])
+        reason = "pg_stat_activity has no connection denominator"
+    elif name == "public_reader_cpu_io_share":
+        if _relation_exists(cursor, "public.pg_stat_statements"):
+            row = _one(
+                cursor,
+                """
+                SELECT count(*)::BIGINT AS denominator,
+                       CASE WHEN sum(total_exec_time) > 0 THEN
+                           sum(total_exec_time) FILTER (WHERE userid = (SELECT oid FROM pg_roles WHERE rolname = 'smartlic_public_reader'))
+                           / sum(total_exec_time)
+                       END AS value
+                FROM pg_stat_statements
+                """,
+            )
+            denominator = float(row["denominator"])
+            value = float(row["value"]) if denominator and row["value"] is not None else None
+            reason = "pg_stat_statements has no statement denominator"
+        else:
+            reason = "pg_stat_statements not installed"
+    elif name == "operational_cost_per_public_unit":
+        row = _one(
+            cursor,
+            """
+            SELECT COALESCE(sum(unit_count), 0)::NUMERIC AS denominator,
+                   CASE WHEN sum(unit_count) > 0 THEN sum(cost_brl) / sum(unit_count) END AS value
+            FROM truth_plane_cost_observations
+            WHERE observed_at >= %s AND observed_at <= %s
+            """,
+            (window_start, now),
+        )
+        denominator = float(row["denominator"])
+        value = float(row["value"]) if row["value"] is not None else None
+        reason = "no cost/unit observations in window"
+
+    return _metric_state(definition, value, denominator, reason)
+
+
+def _record_alerts(cursor: Any, metrics: list[dict[str, Any]], definition_hash: str) -> int:
+    route = _one(
+        cursor,
+        "SELECT route_name FROM truth_plane_alert_routes WHERE enabled ORDER BY route_name LIMIT 1",
+    ).get("route_name")
+    written = 0
+    for metric in metrics:
+        if metric["state"] == "OK":
+            continue
+        fingerprint = hashlib.sha256(
+            f"{definition_hash}|{metric['metric_name']}|{metric['state']}".encode()
+        ).hexdigest()
+        cursor.execute(
+            """
+            INSERT INTO truth_plane_alert_events (
+                fingerprint, metric_name, state, route_name, payload, delivery_status
+            ) VALUES (%s, %s, %s, %s, %s::JSONB, %s)
+            ON CONFLICT (fingerprint) DO UPDATE
+            SET last_seen_at = NOW(), occurrence_count = truth_plane_alert_events.occurrence_count + 1,
+                payload = EXCLUDED.payload
+            """,
+            (
+                fingerprint,
+                metric["metric_name"],
+                metric["state"],
+                route,
+                json.dumps(metric, sort_keys=True),
+                "PENDING" if route else "NO_ROUTE",
+            ),
+        )
+        written += 1
+    return written
+
+
+def observe(connection: Any, *, actor: str, now: datetime | None = None) -> dict[str, Any]:
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM truth_plane_slo_definitions WHERE enabled ORDER BY metric_name")
+        definitions = [dict(row) for row in cursor.fetchall() or []]
+        definition_hash = hashlib.sha256(
+            json.dumps(definitions, sort_keys=True, default=str).encode()
+        ).hexdigest()
+        metrics = [_observe_metric(cursor, definition, clock) for definition in definitions]
+        kill_switch = _one(cursor, "SELECT * FROM truth_plane_kill_switch WHERE singleton")
+        unknown_count = sum(metric["state"] == "UNKNOWN" for metric in metrics)
+        breach_count = sum(metric["state"] == "BREACH" for metric in metrics)
+        denominator_sum = sum(float(metric["denominator"] or 0) for metric in metrics)
+        blocked = bool(kill_switch.get("enabled")) or unknown_count > 0 or breach_count > 0 or denominator_sum <= 0
+        status = "BLOCKED" if blocked else "VALID"
+        cursor.execute(
+            """
+            INSERT INTO truth_plane_sli_reviews (
+                window_start, window_end, status, metrics, metric_count,
+                unknown_count, breach_count, denominator_sum, definition_hash, actor
+            ) VALUES (%s, %s, %s, %s::JSONB, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                min(
+                    (clock - timedelta(seconds=int(d["window_seconds"])) for d in definitions),
+                    default=clock,
+                ),
+                clock,
+                status,
+                json.dumps(metrics, sort_keys=True),
+                len(metrics),
+                unknown_count,
+                breach_count,
+                denominator_sum,
+                definition_hash,
+                actor,
+            ),
+        )
+        review_id = int(cursor.fetchone()["id"])
+        last_valid = _one(
+            cursor,
+            """
+            SELECT id, observed_at
+            FROM truth_plane_sli_reviews
+            WHERE status = 'VALID' AND id <> %s
+            ORDER BY observed_at DESC, id DESC
+            LIMIT 1
+            """,
+            (review_id,),
+        )
+        alert_count = _record_alerts(cursor, metrics, definition_hash)
+    connection.commit()
+    return {
+        "status": status,
+        "review_id": review_id,
+        "last_valid_review": last_valid or None,
+        "observed_at": clock.isoformat(),
+        "definition_hash": definition_hash,
+        "metric_count": len(metrics),
+        "unknown_count": unknown_count,
+        "breach_count": breach_count,
+        "denominator_sum": denominator_sum,
+        "kill_switch": dict(kill_switch),
+        "alerts_recorded": alert_count,
+        "metrics": metrics,
+        "claim": "local truth-plane telemetry; not production soak or VPS evidence",
+    }
+
+
+def set_kill_switch(connection: Any, *, enabled: bool, reason: str, actor: str) -> dict[str, Any]:
+    if not reason.strip() or not actor.strip():
+        raise ValueError("kill switch reason and actor are required")
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            UPDATE truth_plane_kill_switch
+            SET enabled = %s, reason = %s, changed_at = NOW(), changed_by = %s
+            WHERE singleton
+            RETURNING *
+            """,
+            (enabled, reason.strip(), actor.strip()),
+        )
+        state = dict(cursor.fetchone())
+        cursor.execute(
+            "INSERT INTO truth_plane_kill_switch_history (enabled, reason, changed_by) VALUES (%s, %s, %s)",
+            (enabled, reason.strip(), actor.strip()),
+        )
+    connection.commit()
+    return state
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, (datetime, Decimal)):
+        return value.isoformat() if isinstance(value, datetime) else float(value)
+    return str(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Truth-plane SLI/SLO fail-closed authority")
+    parser.add_argument("--dsn")
+    sub = parser.add_subparsers(dest="command", required=True)
+    observe_cmd = sub.add_parser("observe")
+    observe_cmd.add_argument("--actor", required=True)
+    switch_cmd = sub.add_parser("kill-switch")
+    switch_cmd.add_argument("--enable", action=argparse.BooleanOptionalAction, required=True)
+    switch_cmd.add_argument("--reason", required=True)
+    switch_cmd.add_argument("--actor", required=True)
+    cost_cmd = sub.add_parser("record-cost")
+    cost_cmd.add_argument("--source", required=True)
+    cost_cmd.add_argument("--unit-type", choices=["source", "document", "event", "dossier", "public_read"], required=True)
+    cost_cmd.add_argument("--unit-count", type=int, required=True)
+    cost_cmd.add_argument("--cost-brl", type=Decimal, required=True)
+    cost_cmd.add_argument("--provenance", required=True, help="JSON object with billing evidence")
+    args = parser.parse_args(argv)
+
+    connection = _connect(args.dsn)
+    try:
+        if args.command == "observe":
+            output = observe(connection, actor=args.actor)
+            code = 0 if output["status"] == "VALID" else 2
+        elif args.command == "kill-switch":
+            output = set_kill_switch(connection, enabled=args.enable, reason=args.reason, actor=args.actor)
+            code = 0
+        else:
+            provenance = json.loads(args.provenance)
+            if not isinstance(provenance, dict) or not provenance:
+                raise ValueError("--provenance must be a non-empty JSON object")
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    INSERT INTO truth_plane_cost_observations
+                        (source, unit_type, unit_count, cost_brl, provenance)
+                    VALUES (%s, %s, %s, %s, %s::JSONB) RETURNING id
+                    """,
+                    (args.source, args.unit_type, args.unit_count, args.cost_brl, json.dumps(provenance)),
+                )
+                output = {"cost_observation_id": int(cursor.fetchone()["id"])}
+            connection.commit()
+            code = 0
+    finally:
+        connection.close()
+    print(json.dumps(output, ensure_ascii=False, indent=2, default=_json_default))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_canonical_public_events.py
+++ b/tests/test_canonical_public_events.py
@@ -288,6 +288,12 @@ def test_bitemporal_asof_ambiguous_conflict_merge_split_and_immutability() -> No
             )
             conflict = _ingest(cursor, ambiguous)
             assert conflict["state"] == "CONFLICT" and conflict["event_id"] is None
+            weak = _observation(source="test_canonical_other", record="weak-001", raw="weak-body")
+            weak["match_state"] = "WEAK"
+            cursor.execute("SAVEPOINT match_state_rejected")
+            with pytest.raises(Exception, match="match_state"):
+                _ingest(cursor, weak)
+            cursor.execute("ROLLBACK TO SAVEPOINT match_state_rejected")
             cursor.execute(
                 "SELECT status FROM canonical_match_conflicts WHERE conflict_id = %s",
                 (conflict["conflict_id"],),
@@ -417,7 +423,14 @@ def test_snapshot_barrier_repeatable_read_projection_invalidation_and_public_rol
                 WHERE enabled AND last_refresh_status = 'VALID' AND refreshed_at IS NOT NULL
                 """
             )
-            assert int(cursor.fetchone()["count"]) == 7
+            assert int(cursor.fetchone()["count"]) == 6
+            cursor.execute(
+                """
+                SELECT last_refresh_status FROM public_read_surface_health_internal
+                WHERE view_name = 'municipalities'
+                """
+            )
+            assert cursor.fetchone()["last_refresh_status"] == "STALE"
 
             cursor.execute(
                 """
@@ -515,12 +528,19 @@ def test_snapshot_barrier_repeatable_read_projection_invalidation_and_public_rol
             for statement in (
                 "SELECT count(*) FROM public.canonical_public_snapshots",
                 "INSERT INTO public_read_v1.query_budgets VALUES ('attack', 1, 1, 1, 1, 'attack')",
+                "UPDATE public_read_v1.query_budgets SET max_rows = 1 WHERE query_family = 'surface_health'",
+                "DELETE FROM public_read_v1.query_budgets WHERE query_family = 'surface_health'",
                 "CREATE TABLE public_read_v1.attack(id integer)",
+                "SELECT ingest_canonical_public_observation_v1('{}'::jsonb)",
+                "SELECT upsert_pncp_raw_bids('[]'::jsonb)",
+                "SELECT begin_canonical_public_snapshot_v1(NOW(), repeat('a', 64), repeat('b', 64), repeat('c', 64), repeat('d', 64), repeat('e', 64), repeat('f', 64), repeat('0', 64), 0, 0, 'attacker')",
             ):
                 cursor.execute("SAVEPOINT permission_denied")
                 with pytest.raises(psycopg2.errors.InsufficientPrivilege):
                     cursor.execute(statement)
                 cursor.execute("ROLLBACK TO SAVEPOINT permission_denied")
+            cursor.execute("SELECT count(*) AS count FROM public_read_v1.municipalities")
+            assert int(cursor.fetchone()["count"]) == 0
             cursor.execute("EXPLAIN (FORMAT JSON) SELECT * FROM public_read_v1.tenders WHERE process_key = 'test-canonical:process:001' LIMIT 100")
             assert cursor.fetchone() is not None
             cursor.execute("RESET ROLE")

--- a/tests/test_canonical_public_events.py
+++ b/tests/test_canonical_public_events.py
@@ -1,0 +1,532 @@
+"""Real PostgreSQL proofs for canonical multifonte bitemporal events (#273/#289)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from itertools import permutations
+
+import pytest
+
+pytestmark = [
+    pytest.mark.real_db,
+    pytest.mark.skipif(
+        os.getenv("REQUIRE_REAL_DB") != "1",
+        reason="Set REQUIRE_REAL_DB=1 for canonical public events proofs",
+    ),
+]
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _connect():
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    return psycopg2.connect(os.environ["LOCAL_DATALAKE_DSN"], cursor_factory=RealDictCursor)
+
+
+def _observation(
+    *,
+    source: str,
+    record: str,
+    raw: str,
+    process: str = "test-canonical:process:001",
+    event_type: str = "tender_publication",
+    valid_from: str = "2026-01-01T00:00:00Z",
+    facts: dict | None = None,
+    source_version: str = "v1",
+    document_version: str | None = None,
+) -> dict:
+    return {
+        "source": source,
+        "source_record_id": record,
+        "source_version": source_version,
+        "raw_sha256": _hash(raw),
+        "process_key": process,
+        "event_type": event_type,
+        "observed_at": "2026-08-13T12:00:00Z",
+        "valid_from": valid_from,
+        "document_version": document_version,
+        "snapshot_id": "test-canonical-snapshot",
+        "policy_version": "test-canonical-policy-v1",
+        "facts": facts
+        or {
+            "status_code": "PUBLISHED",
+            "title": "Aquisição de material escolar",
+            "publication_at": "2026-01-01T00:00:00Z",
+            "official_number": "PNCP-001",
+        },
+        "entities": [
+            {
+                "entity_type": "organ",
+                "strong_key": "cnpj:11222333000181",
+                "display_name": "Órgão teste",
+                "tax_identifier_type": "CNPJ",
+                "tax_identifier_export": "11222333000181",
+                "relation_type": "buyer",
+                "confidence": 1,
+            }
+        ],
+    }
+
+
+def _ingest(cursor, payload: dict) -> dict:
+    cursor.execute(
+        "SELECT ingest_canonical_public_observation_v1(%s::JSONB) AS result",
+        (json.dumps(payload, sort_keys=True),),
+    )
+    return dict(cursor.fetchone()["result"])
+
+
+def _cleanup(connection) -> None:
+    with connection.cursor() as cursor:
+        cursor.execute("SET LOCAL app.allow_canonical_test_cleanup = 'on'")
+        cursor.execute(
+            "DELETE FROM canonical_match_conflicts WHERE observation_id IN (SELECT observation_id FROM canonical_public_observations WHERE source LIKE 'test_canonical_%')"
+        )
+        cursor.execute("DELETE FROM canonical_identity_decisions WHERE decided_by = 'test-canonical'")
+        cursor.execute(
+            "DELETE FROM canonical_event_entity_links WHERE observation_id IN (SELECT observation_id FROM canonical_public_observations WHERE source LIKE 'test_canonical_%')"
+        )
+        cursor.execute(
+            "DELETE FROM canonical_event_observation_links WHERE observation_id IN (SELECT observation_id FROM canonical_public_observations WHERE source LIKE 'test_canonical_%')"
+        )
+        cursor.execute(
+            "DELETE FROM canonical_event_revisions WHERE created_from_observation_id IN (SELECT observation_id FROM canonical_public_observations WHERE source LIKE 'test_canonical_%')"
+        )
+        cursor.execute("DELETE FROM canonical_public_observations WHERE source LIKE 'test_canonical_%'")
+        cursor.execute("DELETE FROM canonical_public_events_v1 WHERE process_key LIKE 'test-canonical:%'")
+        cursor.execute(
+            "DELETE FROM canonical_public_entity_aliases_v2 WHERE source LIKE 'test_canonical_%' OR entity_id IN (SELECT entity_id FROM canonical_public_entities_v2 WHERE strong_key LIKE 'test-canonical:%')"
+        )
+        cursor.execute("DELETE FROM canonical_public_entities_v2 WHERE strong_key LIKE 'test-canonical:%'")
+        cursor.execute(
+            "DELETE FROM canonical_public_entities_v2 WHERE created_by_policy LIKE 'test-canonical-%' AND NOT EXISTS (SELECT 1 FROM canonical_event_entity_links link WHERE link.entity_id = canonical_public_entities_v2.entity_id)"
+        )
+    connection.commit()
+
+
+def _cleanup_snapshots(connection) -> None:
+    with connection.cursor() as cursor:
+        cursor.execute("SET LOCAL app.allow_canonical_test_cleanup = 'on'")
+        cursor.execute("DELETE FROM canonical_snapshot_invalidations WHERE snapshot_id IN (SELECT snapshot_id FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot')")
+        cursor.execute("DELETE FROM public_consumer_projections WHERE snapshot_id IN (SELECT snapshot_id FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot')")
+        cursor.execute("DELETE FROM canonical_snapshot_dossiers WHERE snapshot_id IN (SELECT snapshot_id FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot')")
+        cursor.execute("DELETE FROM canonical_snapshot_documents WHERE snapshot_id IN (SELECT snapshot_id FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot')")
+        cursor.execute("DELETE FROM canonical_snapshot_event_revisions WHERE snapshot_id IN (SELECT snapshot_id FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot')")
+        cursor.execute("DELETE FROM canonical_snapshot_source_watermarks WHERE snapshot_id IN (SELECT snapshot_id FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot')")
+        cursor.execute("DELETE FROM canonical_public_snapshots WHERE created_by = 'test-canonical-snapshot'")
+    connection.commit()
+
+
+def _summary(cursor) -> dict:
+    cursor.execute(
+        """
+        SELECT jsonb_build_object(
+            'events', (SELECT count(*) FROM canonical_public_events_v1 WHERE process_key LIKE 'test-canonical:%'),
+            'observations', (SELECT count(*) FROM canonical_public_observations WHERE source LIKE 'test_canonical_%'),
+            'links', (SELECT count(*) FROM canonical_event_observation_links link JOIN canonical_public_observations obs USING (observation_id) WHERE obs.source LIKE 'test_canonical_%'),
+            'revisions', (SELECT count(*) FROM canonical_event_revisions revision JOIN canonical_public_events_v1 event USING (event_id) WHERE event.process_key LIKE 'test-canonical:%'),
+            'hash', encode(digest(COALESCE((
+                SELECT string_agg(value, '|' ORDER BY value) FROM (
+                    SELECT event_id AS value FROM canonical_public_events_v1 WHERE process_key LIKE 'test-canonical:%'
+                    UNION ALL SELECT observation_id FROM canonical_public_observations WHERE source LIKE 'test_canonical_%'
+                    UNION ALL SELECT revision_id FROM canonical_event_revisions revision JOIN canonical_public_events_v1 event USING (event_id) WHERE event.process_key LIKE 'test-canonical:%'
+                ) values_to_hash
+            ), ''), 'sha256'), 'hex')
+        ) AS result
+        """
+    )
+    return dict(cursor.fetchone()["result"])
+
+
+def test_multisource_order_duplicates_document_versions_and_second_event_type_are_stable() -> None:
+    connection = _connect()
+    first = _observation(source="test_canonical_pncp", record="pncp-001", raw="pncp-body")
+    second = _observation(source="test_canonical_dom", record="dom-001", raw="dom-body")
+    summaries: list[dict] = []
+    returned_ids: list[tuple[str, str]] = []
+    try:
+        for order in permutations((first, second)):
+            _cleanup(connection)
+            with connection.cursor() as cursor:
+                results = [_ingest(cursor, payload) for payload in order]
+                # Repeating the exact snapshot is a no-op on IDs/counts/hashes.
+                repeated = [_ingest(cursor, payload) for payload in order]
+                assert results == repeated
+                assert results[0]["event_id"] == results[1]["event_id"]
+                assert results[0]["event_id"].startswith("evt_") and len(results[0]["event_id"]) == 36
+                assert "client" not in results[0]["event_id"]
+                returned_ids.append((results[0]["event_id"], results[0]["revision_id"]))
+                summary = _summary(cursor)
+                assert summary | {"events": 1, "observations": 2, "links": 2, "revisions": 1} == summary
+                summaries.append(summary)
+            connection.commit()
+
+        assert summaries[0] == summaries[1]
+        assert returned_ids[0] == returned_ids[1]
+
+        with connection.cursor() as cursor:
+            contract = _observation(
+                source="test_canonical_pncp",
+                record="contract-001",
+                raw="contract-body",
+                event_type="contract_lifecycle",
+                facts={
+                    "status_code": "SIGNED",
+                    "title": "Contrato de material escolar",
+                    "contract_value": "12345.67",
+                    "official_number": "CONTRACT-001",
+                },
+            )
+            contract_result = _ingest(cursor, contract)
+            assert contract_result["event_id"] != returned_ids[0][0]
+            cursor.execute(
+                "SELECT count(DISTINCT event_type) AS count FROM canonical_public_events_v1 WHERE process_key = 'test-canonical:process:001'"
+            )
+            assert int(cursor.fetchone()["count"]) == 2
+            cursor.execute(
+                "SELECT indexname FROM pg_indexes WHERE schemaname = 'public' AND indexname LIKE 'idx_canonical_%'"
+            )
+            indexes = {row["indexname"] for row in cursor.fetchall()}
+            assert {"idx_canonical_events_process_v1", "idx_canonical_revision_asof", "idx_canonical_observations_source"} <= indexes
+            cursor.execute("SET LOCAL enable_seqscan = off")
+            cursor.execute(
+                "EXPLAIN (FORMAT JSON) SELECT * FROM canonical_public_events_v1 WHERE process_key = 'test-canonical:process:001'"
+            )
+            assert "idx_canonical_events_process_v1" in json.dumps(cursor.fetchone())
+
+            forbidden = dict(contract)
+            forbidden["source_record_id"] = "forbidden-client"
+            forbidden["raw_sha256"] = _hash("forbidden-client")
+            forbidden["client_id"] = "customer-42"
+            cursor.execute("SAVEPOINT forbidden_client")
+            with pytest.raises(Exception, match="client_id is forbidden"):
+                _ingest(cursor, forbidden)
+            cursor.execute("ROLLBACK TO SAVEPOINT forbidden_client")
+        connection.commit()
+    finally:
+        connection.rollback()
+        _cleanup(connection)
+        connection.close()
+
+
+def test_bitemporal_asof_ambiguous_conflict_merge_split_and_immutability() -> None:
+    import psycopg2
+
+    connection = _connect()
+    try:
+        with connection.cursor() as cursor:
+            open_status = _observation(
+                source="test_canonical_pncp",
+                record="status-001",
+                raw="status-open",
+                event_type="tender_status",
+                valid_from="2026-01-01T00:00:00Z",
+                facts={"status_code": "OPEN", "title": "Processo teste"},
+            )
+            cancelled = _observation(
+                source="test_canonical_pncp",
+                record="status-001",
+                raw="status-cancelled",
+                source_version="v2",
+                event_type="tender_status",
+                valid_from="2026-02-01T00:00:00Z",
+                facts={"status_code": "CANCELLED", "title": "Processo teste retificado"},
+            )
+            first = _ingest(cursor, open_status)
+            second = _ingest(cursor, cancelled)
+            assert first["event_id"] == second["event_id"]
+            cursor.execute(
+                "SELECT status_code FROM canonical_event_revision_as_of_v1(%s, '2026-01-15', NOW())",
+                (first["event_id"],),
+            )
+            assert cursor.fetchone()["status_code"] == "OPEN"
+            cursor.execute(
+                "SELECT status_code FROM canonical_event_revision_as_of_v1(%s, '2026-02-15', NOW())",
+                (first["event_id"],),
+            )
+            assert cursor.fetchone()["status_code"] == "CANCELLED"
+
+            for version in (1, 2):
+                document = _observation(
+                    source="test_canonical_dom",
+                    record="document-001",
+                    raw=f"document-body-v{version}",
+                    source_version=f"v{version}",
+                    document_version=str(version),
+                    event_type="tender_document_change",
+                    valid_from=f"2026-0{version}-10T00:00:00Z",
+                    facts={
+                        "status_code": "PUBLISHED",
+                        "title": f"Edital versão {version}",
+                        "document_sha256": _hash(f"document-v{version}"),
+                    },
+                )
+                _ingest(cursor, document)
+            cursor.execute(
+                "SELECT count(*) AS count FROM canonical_event_revisions revision JOIN canonical_public_events_v1 event USING (event_id) WHERE event.event_type = 'tender_document_change' AND event.process_key = 'test-canonical:process:001'"
+            )
+            assert int(cursor.fetchone()["count"]) == 2
+
+            ambiguous = _observation(
+                source="test_canonical_other",
+                record="ambiguous-001",
+                raw="ambiguous-body",
+                process="",
+            )
+            ambiguous.update(
+                {
+                    "match_state": "AMBIGUOUS",
+                    "candidate_event_ids": [first["event_id"], second["event_id"] + "-candidate"],
+                    "reason_codes": ["same_number_different_organs"],
+                }
+            )
+            conflict = _ingest(cursor, ambiguous)
+            assert conflict["state"] == "CONFLICT" and conflict["event_id"] is None
+            cursor.execute(
+                "SELECT status FROM canonical_match_conflicts WHERE conflict_id = %s",
+                (conflict["conflict_id"],),
+            )
+            assert cursor.fetchone()["status"] == "OPEN"
+            cursor.execute(
+                "SELECT count(*) AS count FROM canonical_event_observation_links WHERE observation_id = %s",
+                (conflict["observation_id"],),
+            )
+            assert int(cursor.fetchone()["count"]) == 0
+
+            source_entity = first["process_entity_id"]
+            target_entity = cursor.execute(
+                "SELECT ensure_canonical_public_entity_v2('process', 'test-canonical:merge-target', 'Target', NULL, NULL, 'test_canonical_manual', 'target', 'test-policy') AS id"
+            )
+            target_entity = cursor.fetchone()["id"]
+            merge_id = cursor.execute(
+                "SELECT record_canonical_identity_decision_v1('MERGE', %s, %s, '{}', 'confirmed duplicate', ARRAY[%s], 'test-policy', 'test-canonical') AS id",
+                (source_entity, target_entity, first["observation_id"]),
+            )
+            merge_id = cursor.fetchone()["id"]
+            cursor.execute(
+                "SELECT count(*) AS count FROM canonical_event_entity_links WHERE event_id = %s AND entity_id = %s",
+                (first["event_id"], source_entity),
+            )
+            assert int(cursor.fetchone()["count"]) > 0
+            cursor.execute("SELECT state, canonical_successor_id FROM canonical_public_entities_v2 WHERE entity_id = %s", (source_entity,))
+            merged_state = cursor.fetchone()
+            assert (merged_state["state"], merged_state["canonical_successor_id"]) == ("MERGED", target_entity)
+
+            split_source = cursor.execute(
+                "SELECT ensure_canonical_public_entity_v2('organ', 'test-canonical:split-source', 'Split source', NULL, NULL, 'test_canonical_manual', 'split-source', 'test-policy') AS id"
+            )
+            split_source = cursor.fetchone()["id"]
+            split_target = cursor.execute(
+                "SELECT ensure_canonical_public_entity_v2('organ', 'test-canonical:split-target', 'Split target', NULL, NULL, 'test_canonical_manual', 'split-target', 'test-policy') AS id"
+            )
+            split_target = cursor.fetchone()["id"]
+            split_id = cursor.execute(
+                "SELECT record_canonical_identity_decision_v1('SPLIT', %s, %s, ARRAY['test-canonical:split-source'], 'independent official key', ARRAY[%s], 'test-policy', 'test-canonical') AS id",
+                (split_source, split_target, first["observation_id"]),
+            )
+            split_id = cursor.fetchone()["id"]
+            assert merge_id != split_id
+            cursor.execute(
+                "SELECT count(*) AS count FROM canonical_public_entity_aliases_v2 WHERE alias_value = 'test-canonical:split-source'"
+            )
+            assert int(cursor.fetchone()["count"]) == 2
+
+            cursor.execute("SAVEPOINT immutable_guard")
+            with pytest.raises(psycopg2.errors.ObjectNotInPrerequisiteState):
+                cursor.execute(
+                    "UPDATE canonical_event_revisions SET status_code = 'FORGED' WHERE revision_id = %s",
+                    (first["revision_id"],),
+                )
+            cursor.execute("ROLLBACK TO SAVEPOINT immutable_guard")
+        connection.commit()
+    finally:
+        connection.rollback()
+        _cleanup(connection)
+        connection.close()
+
+
+def test_snapshot_barrier_repeatable_read_projection_invalidation_and_public_role() -> None:
+    import psycopg2
+
+    connection = _connect()
+    hashes = [_hash(f"snapshot-input-{index}") for index in range(7)]
+    try:
+        _cleanup_snapshots(connection)
+        _cleanup(connection)
+        with connection.cursor() as cursor:
+            observed = _ingest(
+                cursor,
+                _observation(
+                    source="test_canonical_pncp",
+                    record="snapshot-tender-001",
+                    raw="snapshot-tender-v1",
+                    event_type="tender_status",
+                    facts={"status_code": "OPEN", "title": "Snapshot tender"},
+                ),
+            )
+            cursor.execute(
+                """
+                SELECT begin_canonical_public_snapshot_v1(
+                    '2026-08-13T12:00:00-03:00', %s, %s, %s, %s, %s, %s, %s,
+                    1, 1, 'test-canonical-snapshot'
+                ) AS id
+                """,
+                tuple(hashes),
+            )
+            snapshot_id = cursor.fetchone()["id"]
+            cursor.execute("SELECT close_canonical_public_snapshot_v1(%s) AS result", (snapshot_id,))
+            blocked = cursor.fetchone()["result"]
+            assert blocked["state"] == "BLOCKED"
+            assert {"missing_source_watermarks", "applicable_pairs_not_evaluated", "relevant_dossiers_not_complete"} <= set(
+                blocked["blockers"]
+            )
+
+            cursor.execute(
+                "SELECT put_canonical_snapshot_watermark_v1(%s, 'pncp', 'run-001', '2026-08-13T11:59:00-03:00', 'FRESH', 'COMPLETE', 1, 1, %s)",
+                (snapshot_id, _hash("watermark-evidence")),
+            )
+            cursor.execute(
+                """
+                INSERT INTO canonical_snapshot_event_revisions (snapshot_id, event_id, revision_id, fact_hash)
+                SELECT %s, event_id, revision_id, fact_hash FROM canonical_event_revisions WHERE revision_id = %s
+                """,
+                (snapshot_id, observed["revision_id"]),
+            )
+            cursor.execute(
+                "INSERT INTO canonical_snapshot_documents VALUES (%s, %s, %s, 'COMPLETE')",
+                (snapshot_id, observed["observation_id"], _hash("snapshot-document")),
+            )
+            cursor.execute(
+                "INSERT INTO canonical_snapshot_dossiers VALUES (%s, 'dossier-001', %s, 'COMPLETE', '{}')",
+                (snapshot_id, _hash("dossier-revision")),
+            )
+            cursor.execute("SELECT close_canonical_public_snapshot_v1(%s) AS result", (snapshot_id,))
+            ready = cursor.fetchone()["result"]
+            assert ready["state"] == "READY_CANONICAL"
+            content_hash = ready["content_hash"]
+            cursor.execute(
+                """
+                SELECT count(*) AS count
+                FROM public_read_surface_health_internal
+                WHERE enabled AND last_refresh_status = 'VALID' AND refreshed_at IS NOT NULL
+                """
+            )
+            assert int(cursor.fetchone()["count"]) == 7
+
+            cursor.execute(
+                """
+                INSERT INTO public_consumer_projections
+                    (projection_id, consumer_id, snapshot_id, template_hash, private_profile_hash)
+                VALUES ('projection-private', 'smartlic-test-private', %s, %s, %s),
+                       ('projection-factual', 'smartlic-test-factual', %s, %s, NULL)
+                """,
+                (snapshot_id, _hash("template-v1"), _hash("private-v1"), snapshot_id, _hash("template-v1")),
+            )
+            cursor.execute(
+                "SELECT invalidate_consumer_projection_private_v1('projection-private', %s, %s)",
+                (_hash("template-v2"), _hash("private-v2")),
+            )
+            cursor.execute("SELECT state FROM public_consumer_projections WHERE projection_id = 'projection-private'")
+            assert cursor.fetchone()["state"] == "STALE_PRIVATE"
+            cursor.execute("SELECT state, content_hash FROM canonical_public_snapshots WHERE snapshot_id = %s", (snapshot_id,))
+            assert tuple(cursor.fetchone().values()) == ("READY_CANONICAL", content_hash)
+        connection.commit()
+
+        reader = _connect()
+        writer = _connect()
+        try:
+            reader.set_session(isolation_level="REPEATABLE READ", readonly=True, autocommit=False)
+            with reader.cursor() as cursor:
+                cursor.execute("SELECT snapshot_id, content_hash, count(*) OVER () AS rows FROM public_read_v1.current_snapshot")
+                before = dict(cursor.fetchone())
+                cursor.execute("SELECT count(*) AS count FROM public_read_v1.tenders")
+                tender_count_before = int(cursor.fetchone()["count"])
+
+            with writer.cursor() as cursor:
+                corrected = _observation(
+                    source="test_canonical_pncp",
+                    record="snapshot-tender-001",
+                    raw="snapshot-tender-v2-after-cutoff",
+                    source_version="v2",
+                    event_type="tender_status",
+                    valid_from="2026-08-14T00:00:00Z",
+                    facts={"status_code": "CANCELLED", "title": "Snapshot tender corrected"},
+                )
+                new_revision = _ingest(cursor, corrected)
+            writer.commit()
+
+            with reader.cursor() as cursor:
+                cursor.execute("SELECT snapshot_id, content_hash, count(*) OVER () AS rows FROM public_read_v1.current_snapshot")
+                after = dict(cursor.fetchone())
+                cursor.execute("SELECT count(*) AS count FROM public_read_v1.tenders")
+                assert int(cursor.fetchone()["count"]) == tender_count_before
+            assert before == after == {"snapshot_id": snapshot_id, "content_hash": content_hash, "rows": 1}
+            reader.commit()
+        finally:
+            reader.close()
+            writer.close()
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT count(*) AS count FROM canonical_snapshot_event_revisions WHERE snapshot_id = %s", (snapshot_id,))
+            assert int(cursor.fetchone()["count"]) == 1
+            cursor.execute("SELECT content_hash FROM canonical_public_snapshots WHERE snapshot_id = %s", (snapshot_id,))
+            assert cursor.fetchone()["content_hash"] == content_hash
+            cursor.execute("SELECT state FROM public_consumer_projections WHERE projection_id = 'projection-factual'")
+            assert cursor.fetchone()["state"] == "STALE_FACTUAL"
+            cursor.execute(
+                "SELECT count(*) AS count FROM canonical_snapshot_invalidations WHERE snapshot_id = %s AND new_revision_id = %s",
+                (snapshot_id, new_revision["revision_id"]),
+            )
+            assert int(cursor.fetchone()["count"]) == 1
+
+            cursor.execute("SAVEPOINT immutable_snapshot")
+            with pytest.raises(psycopg2.errors.ObjectNotInPrerequisiteState):
+                cursor.execute(
+                    "INSERT INTO canonical_snapshot_event_revisions (snapshot_id, event_id, revision_id, fact_hash) SELECT %s, event_id, revision_id, fact_hash FROM canonical_event_revisions WHERE revision_id = %s",
+                    (snapshot_id, new_revision["revision_id"]),
+                )
+            cursor.execute("ROLLBACK TO SAVEPOINT immutable_snapshot")
+
+            blocked_hashes = list(hashes)
+            blocked_hashes[4] = _hash("different-data-hash")
+            cursor.execute(
+                "SELECT begin_canonical_public_snapshot_v1('2026-08-14T12:00:00-03:00', %s, %s, %s, %s, %s, %s, %s, 1, 1, 'test-canonical-snapshot') AS id",
+                tuple(blocked_hashes),
+            )
+            blocked_snapshot_id = cursor.fetchone()["id"]
+            cursor.execute("SELECT close_canonical_public_snapshot_v1(%s)", (blocked_snapshot_id,))
+            cursor.execute("SELECT snapshot_id FROM public_read_v1.current_snapshot")
+            assert cursor.fetchone()["snapshot_id"] == snapshot_id
+
+            cursor.execute("SELECT schema_hash FROM public_read_v1.contract_releases WHERE version = 'v1.0.0'")
+            assert len(cursor.fetchone()["schema_hash"]) == 64
+            cursor.execute("SELECT count(*) AS count FROM public_read_v1.query_budgets")
+            assert int(cursor.fetchone()["count"]) == 4
+
+            cursor.execute("SET ROLE smartlic_public_reader")
+            cursor.execute("SELECT count(*) AS count FROM public_read_v1.current_snapshot")
+            assert int(cursor.fetchone()["count"]) == 1
+            for statement in (
+                "SELECT count(*) FROM public.canonical_public_snapshots",
+                "INSERT INTO public_read_v1.query_budgets VALUES ('attack', 1, 1, 1, 1, 'attack')",
+                "CREATE TABLE public_read_v1.attack(id integer)",
+            ):
+                cursor.execute("SAVEPOINT permission_denied")
+                with pytest.raises(psycopg2.errors.InsufficientPrivilege):
+                    cursor.execute(statement)
+                cursor.execute("ROLLBACK TO SAVEPOINT permission_denied")
+            cursor.execute("EXPLAIN (FORMAT JSON) SELECT * FROM public_read_v1.tenders WHERE process_key = 'test-canonical:process:001' LIMIT 100")
+            assert cursor.fetchone() is not None
+            cursor.execute("RESET ROLE")
+        connection.commit()
+    finally:
+        connection.rollback()
+        _cleanup_snapshots(connection)
+        _cleanup(connection)
+        connection.close()

--- a/tests/test_crawl_runtime_queue.py
+++ b/tests/test_crawl_runtime_queue.py
@@ -369,6 +369,49 @@ def test_transactional_dlq_poison_blocked_selective_replay_and_resolve(runtime_q
 
 @pytest.mark.database
 @pytest.mark.integration
+def test_reclaim_expired_poison_writes_dlq(runtime_queue_dsn: str) -> None:
+    dsn = runtime_queue_dsn
+    _clean_test_jobs(dsn)
+    entity_id, entity_created, entity_was_active = _dlq_test_entity_state(dsn)
+    now = datetime.now(UTC).replace(microsecond=0)
+    try:
+        with connect(dsn) as connection:
+            queue = CrawlQueue(connection)
+            job_id, _ = queue.enqueue(
+                entity_id=entity_id,
+                source="test_queue_lease",
+                capability="open_tenders",
+                domain_key="lease.example",
+                binding_version="test-lease-v1",
+                window_start=now,
+                window_end=now + timedelta(minutes=5),
+                freshness_deadline=now + timedelta(minutes=10),
+                next_run_at=now,
+                priority=3_000_000,
+                max_attempts=1,
+            )
+            claimed = queue.claim(worker_id="dying-worker", limit=1, lease_seconds=1, now=now)
+            assert claimed and claimed[0].id == job_id
+            expired = queue.reclaim_expired(now=now + timedelta(seconds=2))
+            assert expired == 1
+            rows = queue.inspect_dlq(source="test_queue_lease")
+            assert len(rows) == 1
+            assert rows[0]["job_id"] == job_id
+            assert rows[0]["error_class"] == "LEASE_EXPIRED"
+    finally:
+        _clean_test_jobs(dsn)
+        with connect(dsn) as connection, connection.cursor() as cursor:
+            if entity_created:
+                cursor.execute("DELETE FROM sc_public_entities WHERE id = %s", (entity_id,))
+            else:
+                cursor.execute(
+                    "UPDATE sc_public_entities SET is_active = %s WHERE id = %s",
+                    (entity_was_active, entity_id),
+                )
+
+
+@pytest.mark.database
+@pytest.mark.integration
 def test_truth_plane_sli_missing_denominators_preserve_last_valid_and_route_alerts(
     runtime_queue_dsn: str,
 ) -> None:

--- a/tests/test_crawl_runtime_queue.py
+++ b/tests/test_crawl_runtime_queue.py
@@ -19,6 +19,7 @@ from scripts.crawl.scheduler import (
     reconcile_schedule,
 )
 from scripts.crawl.worker import AdmissionLimits, CrawlWorker, admission_blockers
+from scripts.ops.truth_plane_sli import observe, set_kill_switch
 
 
 def _pairs(entity_count: int = 1093) -> list[SchedulePair]:
@@ -111,6 +112,33 @@ def test_claim_commits_admission_transaction_before_return() -> None:
     connection.commit.assert_called_once()
 
 
+def test_truth_plane_sli_without_enabled_definitions_is_blocked_without_db_mutation() -> None:
+    connection = MagicMock()
+    cursor = MagicMock()
+    connection.cursor.return_value.__enter__.return_value = cursor
+    cursor.fetchall.return_value = []
+    cursor.fetchone.side_effect = [
+        {"singleton": True, "enabled": False},
+        {"id": 17},
+        None,
+        None,
+    ]
+    fixed_now = datetime(2026, 8, 13, 12, 0, tzinfo=UTC)
+
+    result = observe(connection, actor="test-sli-no-definitions", now=fixed_now)
+
+    assert result["status"] == "BLOCKED"
+    assert result["metric_count"] == 0
+    assert result["denominator_sum"] == 0
+    insert_call = next(
+        call
+        for call in cursor.execute.call_args_list
+        if "INSERT INTO truth_plane_sli_reviews" in call.args[0]
+    )
+    assert insert_call.args[1][0] == insert_call.args[1][1] == fixed_now
+    connection.commit.assert_called_once()
+
+
 def test_worker_loads_policy_before_claiming_job() -> None:
     worker = CrawlWorker(dsn="postgresql://example")
     with (
@@ -184,10 +212,277 @@ def _active_entity_id(dsn: str) -> int:
         return int(row["id"])
 
 
+def _dlq_test_entity_state(dsn: str) -> tuple[int, bool, bool]:
+    with connect(dsn) as connection, connection.cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO sc_public_entities (razao_social, cnpj_8, is_active)
+            VALUES ('Test runtime truth entity', '98765432', TRUE)
+            ON CONFLICT (cnpj_8) DO NOTHING
+            RETURNING id, is_active
+            """
+        )
+        created = cursor.fetchone()
+        if created:
+            return int(created["id"]), True, bool(created["is_active"])
+        cursor.execute(
+            "SELECT id, is_active FROM sc_public_entities WHERE cnpj_8 = '98765432' FOR UPDATE"
+        )
+        existing = cursor.fetchone()
+        cursor.execute("UPDATE sc_public_entities SET is_active = TRUE WHERE id = %s", (existing["id"],))
+        return int(existing["id"]), False, bool(existing["is_active"])
+
+
 def _clean_test_jobs(dsn: str) -> None:
     with connect(dsn) as connection, connection.cursor() as cursor:
+        cursor.execute("UPDATE crawl_jobs SET dlq_entry_id = NULL WHERE source LIKE 'test_queue_%'")
+        cursor.execute("DELETE FROM dlq_entries WHERE source LIKE 'test_queue_%'")
         cursor.execute("DELETE FROM crawl_jobs WHERE source LIKE 'test_queue_%'")
         cursor.execute("DELETE FROM crawl_entity_source_schedule WHERE source LIKE 'test_queue_%'")
+
+
+@pytest.mark.database
+@pytest.mark.integration
+def test_transactional_dlq_poison_blocked_selective_replay_and_resolve(runtime_queue_dsn: str) -> None:
+    dsn = runtime_queue_dsn
+    _clean_test_jobs(dsn)
+    entity_id, entity_created, entity_was_active = _dlq_test_entity_state(dsn)
+    now = datetime.now(UTC).replace(microsecond=0)
+    common = {
+        "entity_id": entity_id,
+        "capability": "open_tenders",
+        "binding_version": "test-dlq-v1",
+        "window_start": now,
+        "window_end": now + timedelta(minutes=5),
+        "freshness_deadline": now + timedelta(minutes=10),
+        "next_run_at": now,
+        "priority": 3_000_000,
+    }
+    try:
+        with connect(dsn) as connection:
+            queue = CrawlQueue(connection)
+            poison_id, _ = queue.enqueue(
+                source="test_queue_poison",
+                domain_key="poison.example",
+                max_attempts=1,
+                **common,
+            )
+            blocked_id, _ = queue.enqueue(
+                source="test_queue_blocked",
+                domain_key="blocked.example",
+                max_attempts=5,
+                **common,
+            )
+
+        with connect(dsn) as connection:
+            jobs = CrawlQueue(connection).claim(worker_id="poison-worker", limit=2, now=now)
+            by_id = {job.id: job for job in jobs}
+            queue = CrawlQueue(connection)
+            assert queue.finish(
+                by_id[poison_id],
+                worker_id="poison-worker",
+                outcome="failed",
+                next_run_at=now + timedelta(hours=1),
+                error_class="POISON_PAYLOAD",
+                error_message="deterministic poison",
+                payload_pointer={"raw_uri": "raw://sha256/poison"},
+                dlq_owner="data-ops",
+            )
+            assert queue.finish(
+                by_id[blocked_id],
+                worker_id="poison-worker",
+                outcome="blocked",
+                next_run_at=now + timedelta(hours=1),
+                error_class="AUTH_BLOCKED",
+                error_message="credential unavailable",
+            )
+            # The terminal transition is ownership-guarded and cannot duplicate.
+            assert not queue.finish(
+                by_id[poison_id],
+                worker_id="poison-worker",
+                outcome="failed",
+                next_run_at=now + timedelta(hours=1),
+                error_class="POISON_PAYLOAD",
+            )
+
+        with connect(dsn) as connection:
+            queue = CrawlQueue(connection)
+            assert queue.inspect_dlq(error_class="NOT_THE_POISON") == []
+            poison = queue.inspect_dlq(
+                source="test_queue_poison",
+                canonical_entity_key=f"db:{entity_id}",
+                error_class="POISON_PAYLOAD",
+            )
+            blocked = queue.inspect_dlq(source="test_queue_blocked", error_class="AUTH_BLOCKED")
+            assert len(poison) == len(blocked) == 1
+            assert poison[0]["payload_pointer"] == {"raw_uri": "raw://sha256/poison"}
+            assert poison[0]["owner"] == "data-ops"
+            assert queue.replay_dlq(actor="operator", error_class="SOME_OTHER_CLASS") == []
+            assert queue.replay_dlq(
+                actor="operator",
+                source="test_queue_poison",
+                error_class="POISON_PAYLOAD",
+            ) == [poison[0]["id"]]
+
+        with connect(dsn) as connection:
+            replayed = CrawlQueue(connection).claim(worker_id="replay-worker", limit=1)
+            assert [job.id for job in replayed] == [poison_id]
+            assert replayed[0].attempt_count == 1
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT count(*) AS count FROM crawl_job_attempts WHERE job_id = %s", (poison_id,))
+                assert int(cursor.fetchone()["count"]) == 2
+                cursor.execute("SELECT status, replay_count FROM dlq_entries WHERE id = %s", (poison[0]["id"],))
+                assert tuple(cursor.fetchone().values()) == ("replayed", 1)
+            assert CrawlQueue(connection).finish(
+                replayed[0],
+                worker_id="replay-worker",
+                outcome="succeeded",
+                next_run_at=now + timedelta(days=1),
+            )
+
+        with connect(dsn) as connection:
+            queue = CrawlQueue(connection)
+            assert queue.resolve_dlq(
+                [poison[0]["id"], blocked[0]["id"]],
+                actor="operator",
+                resolution="poison corrected; auth routed to owner",
+            ) == 2
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT count(*) AS count FROM dlq_entries WHERE id = ANY(%s) AND status = 'archived'",
+                    ([poison[0]["id"], blocked[0]["id"]],),
+                )
+                assert int(cursor.fetchone()["count"]) == 2
+                cursor.execute("SELECT status FROM crawl_jobs WHERE id = %s", (blocked_id,))
+                assert cursor.fetchone()["status"] == "blocked"
+    finally:
+        _clean_test_jobs(dsn)
+        with connect(dsn) as connection, connection.cursor() as cursor:
+            if entity_created:
+                cursor.execute("DELETE FROM sc_public_entities WHERE id = %s", (entity_id,))
+            else:
+                cursor.execute(
+                    "UPDATE sc_public_entities SET is_active = %s WHERE id = %s",
+                    (entity_was_active, entity_id),
+                )
+
+
+@pytest.mark.database
+@pytest.mark.integration
+def test_truth_plane_sli_missing_denominators_preserve_last_valid_and_route_alerts(
+    runtime_queue_dsn: str,
+) -> None:
+    dsn = runtime_queue_dsn
+    route_name = "000-test-ops"
+    marker_metric = f"test_sli_marker_{os.getpid()}"
+    observation_now = datetime(2099, 8, 13, 12, 0, tzinfo=UTC)
+    with connect(dsn) as connection, connection.cursor() as cursor:
+        cursor.execute("DELETE FROM truth_plane_alert_events WHERE route_name = %s", (route_name,))
+        cursor.execute("DELETE FROM truth_plane_alert_routes WHERE route_name = %s", (route_name,))
+        cursor.execute("DELETE FROM truth_plane_sli_reviews WHERE actor LIKE 'test-sli-%'")
+        cursor.execute("DELETE FROM truth_plane_cost_observations WHERE source = 'test-sli-source'")
+        cursor.execute("DELETE FROM truth_plane_slo_definitions WHERE metric_name = %s", (marker_metric,))
+        cursor.execute(
+            """
+            INSERT INTO truth_plane_slo_definitions (
+                metric_name, stage, window_seconds, denominator_contract,
+                objective_operator, objective_value, unit, alert_before_ratio
+            ) VALUES (%s, 'test_isolation', 60, 'test-only marker', 'lte', 0, 'records', 1)
+            """,
+            (marker_metric,),
+        )
+        cursor.execute(
+            """
+            INSERT INTO truth_plane_alert_routes (route_name, destination)
+            VALUES (%s, 'test://ops')
+            """,
+            (route_name,),
+        )
+        cursor.execute(
+            """
+            INSERT INTO truth_plane_sli_reviews (
+                window_start, window_end, status, metrics, metric_count,
+                unknown_count, breach_count, denominator_sum, definition_hash, actor
+            ) VALUES (NOW() - interval '1 hour', NOW(), 'VALID', '[{"state":"OK"}]', 1, 0, 0, 1, 'prior-valid', 'test-sli-prior')
+            RETURNING id
+            """
+        )
+        prior_valid_id = int(cursor.fetchone()["id"])
+        cursor.execute(
+            """
+            INSERT INTO truth_plane_cost_observations
+                (source, unit_type, unit_count, cost_brl, provenance, observed_at)
+            VALUES ('test-sli-source', 'document', 10, 5, '{"invoice":"fixture"}', %s)
+            """,
+            (observation_now - timedelta(days=1),),
+        )
+
+    try:
+        with connect(dsn) as connection:
+            set_kill_switch(connection, enabled=False, reason="test baseline", actor="test-sli-operator")
+            first = observe(connection, actor="test-sli-observe-1", now=observation_now)
+        assert first["status"] == "BLOCKED"
+        assert first["unknown_count"] > 0
+        assert first["denominator_sum"] > 0
+        assert first["last_valid_review"]["id"] == prior_valid_id
+        assert all(metric["window_seconds"] > 0 for metric in first["metrics"])
+        assert all("denominator" in metric and "denominator_contract" in metric for metric in first["metrics"])
+        public_metrics = [m for m in first["metrics"] if m["stage"] == "canonical_to_public_read_v1"]
+        assert public_metrics and all(metric["state"] == "UNKNOWN" for metric in public_metrics)
+        cost = next(m for m in first["metrics"] if m["metric_name"] == "operational_cost_per_public_unit")
+        assert cost["value"] == 0.5
+
+        with connect(dsn) as connection:
+            second = observe(connection, actor="test-sli-observe-2", now=observation_now)
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT min(occurrence_count) AS minimum,
+                           bool_and(delivery_status = 'PENDING') AS routed
+                    FROM truth_plane_alert_events
+                    WHERE route_name = %s
+                    """,
+                    (route_name,),
+                )
+                alert_state = cursor.fetchone()
+        assert second["status"] == "BLOCKED"
+        assert int(alert_state["minimum"]) >= 2
+        assert alert_state["routed"] is True
+
+        with connect(dsn) as connection:
+            enabled = set_kill_switch(
+                connection,
+                enabled=True,
+                reason="consumer isolation threshold exceeded",
+                actor="test-sli-operator",
+            )
+            assert enabled["enabled"] is True
+            blocked = observe(connection, actor="test-sli-killed", now=observation_now)
+            assert blocked["status"] == "BLOCKED"
+            assert blocked["kill_switch"]["enabled"] is True
+            set_kill_switch(connection, enabled=False, reason="test cleanup", actor="test-sli-operator")
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT count(*) AS count FROM truth_plane_kill_switch_history WHERE changed_by = 'test-sli-operator'"
+                )
+                assert int(cursor.fetchone()["count"]) >= 3
+    finally:
+        with connect(dsn) as connection:
+            set_kill_switch(
+                connection,
+                enabled=False,
+                reason="test finally cleanup",
+                actor="test-sli-operator",
+            )
+        with connect(dsn) as connection, connection.cursor() as cursor:
+            cursor.execute("DELETE FROM truth_plane_alert_events WHERE route_name = %s", (route_name,))
+            cursor.execute("DELETE FROM truth_plane_alert_routes WHERE route_name = %s", (route_name,))
+            cursor.execute("DELETE FROM truth_plane_sli_reviews WHERE actor LIKE 'test-sli-%'")
+            cursor.execute("DELETE FROM truth_plane_cost_observations WHERE source = 'test-sli-source'")
+            cursor.execute("DELETE FROM truth_plane_slo_definitions WHERE metric_name = %s", (marker_metric,))
+            cursor.execute(
+                "DELETE FROM truth_plane_kill_switch_history WHERE changed_by = 'test-sli-operator'"
+            )
 
 
 @pytest.mark.database

--- a/tests/test_datalake_helper.py
+++ b/tests/test_datalake_helper.py
@@ -10,7 +10,13 @@ Tests cover the non-DB-dependent helper classes and functions:
 from __future__ import annotations
 
 import os
+import sys
+from collections import defaultdict
+from decimal import Decimal
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from scripts.datalake_helper import (
     _LocalPgQuery,
@@ -242,3 +248,161 @@ class TestDatalakeClient:
         rows, meta = client.search_bids()
         assert rows is None
         assert "datalake_error" in meta
+
+
+@pytest.mark.real_db
+@pytest.mark.skipif(
+    os.getenv("REQUIRE_REAL_DB") != "1",
+    reason="Set REQUIRE_REAL_DB=1 to run complete contract analytics proof",
+)
+def test_contract_analytics_are_complete_keyset_stable_and_page_size_invariant():
+    """1,503 rows prove SQL aggregates and annual/detail reconciliation (#355/#356)."""
+    import psycopg2
+    import psycopg2.extras
+
+    from scripts.datalake_helper import DatalakeClient
+
+    dsn = os.environ["LOCAL_DATALAKE_DSN"]
+    supplier = "11222333000181"
+    prefix = "test-355-356-"
+    conn = psycopg2.connect(dsn)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("DELETE FROM pncp_supplier_contracts WHERE contrato_id LIKE %s", (prefix + "%",))
+            cursor.execute("DELETE FROM ingestion_runs WHERE source = 'test_complete_analytics'")
+            cursor.execute(
+                """
+                INSERT INTO ingestion_runs (source, status, started_at, finished_at, completed_at)
+                VALUES ('test_complete_analytics', 'completed', NOW(), NOW(), NOW())
+                """
+            )
+            psycopg2.extras.execute_values(
+                cursor,
+                """
+                INSERT INTO pncp_supplier_contracts (
+                    contrato_id, orgao_cnpj, orgao_nome, fornecedor_cnpj,
+                    fornecedor_nome, objeto_contrato, valor_total,
+                    data_assinatura, data_publicacao_fonte, data_publicacao,
+                    uf, source, is_active, supplier_id_type,
+                    supplier_identifier, supplier_identifier_export,
+                    supplier_identity_reason, ingested_at
+                ) VALUES %s
+                """,
+                [
+                    (
+                        f"{prefix}{i:04d}",
+                        f"{i % 7 + 1:014d}",
+                        f"Orgao {i % 7}",
+                        supplier,
+                        "Fornecedor completo",
+                        "servico tecnico nacional",
+                        Decimal(i),
+                        f"204{(i % 2)}-06-15",
+                        f"204{(i % 2)}-06-16",
+                        f"204{(i % 2)}-06-16",
+                        "SC",
+                        "test_complete_analytics",
+                        True,
+                        "CNPJ",
+                        supplier,
+                        supplier,
+                        "test_valid_cnpj",
+                        "2026-08-13T12:00:00Z",
+                    )
+                    for i in range(1, 1504)
+                ],
+                page_size=500,
+            )
+        conn.commit()
+
+        with patch.dict(
+            os.environ,
+            {"DATALAKE_QUERY_ENABLED": "true", "LOCAL_DATALAKE_DSN": dsn},
+        ):
+            small = DatalakeClient()
+            first_rows, first_meta = small.supplier_contracts(
+                ni_fornecedor=supplier,
+                date_start="2040-01-01",
+                date_end="2041-12-31",
+                limit=17,
+            )
+            assert first_rows is not None
+            assert len(first_rows) == 17
+            assert first_meta["completeness"] == "PRESENTATION_LIMITED"
+            assert first_meta["has_more"] is True
+            assert first_meta["total_count"] == 1503
+            assert Decimal(str(first_meta["sum_value"])) == sum(Decimal(i) for i in range(1, 1504))
+            assert Decimal(str(first_meta["p50"])) == Decimal("752")
+
+            large = DatalakeClient()
+            _, large_meta = large.supplier_contracts(
+                ni_fornecedor=supplier,
+                date_start="2040-01-01",
+                date_end="2041-12-31",
+                limit=1000,
+            )
+            for field in ("total_count", "sum_value", "average_value", "p10", "p25", "p50", "p75", "p90"):
+                assert large_meta[field] == first_meta[field]
+
+            rows = list(first_rows)
+            cursor = first_meta["next_cursor"]
+            snapshot = first_meta["snapshot_at"]
+            meta = first_meta
+            for _ in range(200):
+                if not meta["has_more"]:
+                    break
+                page, meta = small.supplier_contracts(
+                    ni_fornecedor=supplier,
+                    date_start="2040-01-01",
+                    date_end="2041-12-31",
+                    limit=17,
+                    cursor=cursor,
+                    snapshot_at=snapshot,
+                )
+                assert page is not None
+                rows.extend(page)
+                cursor = meta["next_cursor"]
+            else:
+                pytest.fail("keyset pagination exceeded the 200-page test bound")
+
+            assert meta["completeness"] == "COMPLETE"
+            assert len(rows) == 1503
+            assert len({row["record_id"] for row in rows}) == 1503
+            assert sum(Decimal(str(row["valor_global"])) for row in rows) == Decimal(str(meta["sum_value"]))
+
+            annual_detail: dict[int, dict[str, Decimal | int]] = defaultdict(
+                lambda: {"matched_contracts": 0, "sum_value": Decimal(0)}
+            )
+            for row in rows:
+                year = int(str(row["event_date"])[:4])
+                annual_detail[year]["matched_contracts"] += 1
+                annual_detail[year]["sum_value"] += Decimal(str(row["valor_global"]))
+            for sql_year in meta["annual_series"]:
+                detail = annual_detail[int(sql_year["year"])]
+                assert detail["matched_contracts"] == sql_year["matched_contracts"]
+                assert detail["sum_value"] == Decimal(str(sql_year["sum_value"]))
+
+            scripts_path = str(Path(__file__).resolve().parents[1] / "scripts")
+            sys.path.insert(0, scripts_path)
+            try:
+                from scripts.collect_report_data import collect_pncp_contratos_fornecedor
+
+                report_rows, report_meta = collect_pncp_contratos_fornecedor(
+                    MagicMock(),
+                    supplier,
+                    datalake_client=small,
+                    date_start="2040-01-01",
+                    date_end="2041-12-31",
+                )
+            finally:
+                sys.path.remove(scripts_path)
+            assert len(report_rows) == 1503
+            assert report_meta["status"] == "DATALAKE"
+            assert report_meta["detail_reconciled"] is True
+            assert report_meta["annual_reconciled"] is True
+    finally:
+        with conn.cursor() as cursor:
+            cursor.execute("DELETE FROM pncp_supplier_contracts WHERE contrato_id LIKE %s", (prefix + "%",))
+            cursor.execute("DELETE FROM ingestion_runs WHERE source = 'test_complete_analytics'")
+        conn.commit()
+        conn.close()

--- a/tests/test_official_status_reconfirmation.py
+++ b/tests/test_official_status_reconfirmation.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from scripts.official_status_reconfirmation import reconfirm_shortlist
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from collect_report_data import (  # noqa: E402
+    PCP_MAX_PAGES,
+    _OfficialStatusFetcher,
+    _preview_unexecuted_reconfirmation,
+)
+
+NOW = datetime(2026, 8, 13, 12, 0, tzinfo=ZoneInfo("America/Sao_Paulo"))
+
+
+def _candidate(reference: str, source: str = "PNCP") -> dict:
+    return {
+        "numero_controle": reference,
+        "fonte": source,
+        "recomendacao": "PARTICIPAR",
+        "justificativa": "score alto",
+    }
+
+
+def test_every_candidate_has_sao_paulo_timestamp_and_official_evidence() -> None:
+    editais = [_candidate("open-1"), _candidate("open-2", "PCP")]
+
+    def fetch(edital: dict) -> dict:
+        return {
+            "status_native": "Divulgada no portal oficial",
+            "deadline_at": "2026-08-20T18:00:00-03:00",
+            "evidence_url": f"https://official.example/{edital['numero_controle']}",
+        }
+
+    summary = reconfirm_shortlist(editais, fetch, now=NOW)
+
+    assert summary["decisions"] == {"GO": 2, "REVIEW": 0, "NO_GO": 0}
+    assert summary["all_candidates_reconfirmed"] is True
+    assert all(edital["shortlist_eligible"] for edital in editais)
+    for edital in editais:
+        evidence = edital["official_reconfirmation"]
+        assert evidence["timezone"] == "America/Sao_Paulo"
+        assert evidence["checked_at"].endswith("-03:00")
+        assert evidence["deadline_at"].endswith("-03:00")
+        assert evidence["evidence_url"].startswith("https://official.example/")
+
+
+def test_terminal_expired_and_ambiguous_statuses_never_enter_shortlist() -> None:
+    editais = [_candidate("terminal"), _candidate("expired"), _candidate("ambiguous")]
+    observations = {
+        "terminal": {
+            "status_native": "Processo revogado",
+            "deadline_at": "2026-08-20T18:00:00-03:00",
+            "evidence_url": "https://official.example/terminal",
+        },
+        "expired": {
+            "status_native": "Recebendo propostas",
+            "deadline_at": "2026-08-12T18:00:00-03:00",
+            "evidence_url": "https://official.example/expired",
+        },
+        "ambiguous": {
+            "status_native": "Em análise",
+            "deadline_at": "2026-08-20T18:00:00-03:00",
+            "evidence_url": "https://official.example/ambiguous",
+        },
+    }
+
+    summary = reconfirm_shortlist(editais, lambda edital: observations[edital["numero_controle"]], now=NOW)
+
+    assert summary["decisions"] == {"GO": 0, "REVIEW": 1, "NO_GO": 2}
+    assert summary["shortlist_blocked"] is True
+    assert all(edital["recomendacao"] == "NÃO RECOMENDADO" for edital in editais)
+    assert editais[0]["status_edital"] == "ENCERRADO"
+    assert editais[1]["status_edital"] == "ENCERRADO"
+    assert editais[2]["official_reconfirmation"]["decision"] == "REVIEW"
+    assert all(edital["official_reconfirmation"]["next_action"] for edital in editais)
+
+
+def test_terminal_status_without_deadline_is_still_no_go() -> None:
+    editais = [_candidate("cancelled-without-deadline")]
+
+    summary = reconfirm_shortlist(
+        editais,
+        lambda edital: {
+            "status_native": "Cancelada",
+            "deadline_at": None,
+            "evidence_url": f"https://official.example/{edital['numero_controle']}",
+        },
+        now=NOW,
+    )
+
+    assert summary["decisions"] == {"GO": 0, "REVIEW": 0, "NO_GO": 1}
+    assert editais[0]["status_edital"] == "ENCERRADO"
+
+
+def test_missing_reconfirmation_blocks_and_one_source_failure_preserves_other_go() -> None:
+    missing = [_candidate("offline")]
+    missing_summary = reconfirm_shortlist(missing, None, now=NOW)
+    assert missing_summary["shortlist_blocked"] is True
+    assert missing[0]["official_reconfirmation"]["blocker"]
+
+    editais = [_candidate("pncp-ok"), _candidate("pcp-failed", "PCP")]
+
+    def fetch(edital: dict) -> dict:
+        if edital["fonte"] == "PCP":
+            raise TimeoutError("source timeout")
+        return {
+            "status_native": "Aberta para recebimento de propostas",
+            "deadline_at": "2026-08-21T18:00:00Z",
+            "evidence_url": "https://pncp.gov.br/app/editais/evidence",
+        }
+
+    summary = reconfirm_shortlist(editais, fetch, now=NOW)
+
+    assert summary["decisions"] == {"GO": 1, "REVIEW": 0, "NO_GO": 1}
+    assert editais[0]["shortlist_eligible"] is True
+    assert editais[1]["shortlist_eligible"] is False
+    assert editais[1]["official_reconfirmation"]["next_action"]
+    assert summary["source_failures"] == [
+        {
+            "source": "PCP",
+            "reference": "pcp-failed",
+            "blocker": "Fonte oficial PCP indisponível na reconfirmação: TimeoutError.",
+        }
+    ]
+
+
+def test_source_fetcher_re_reads_pncp_structural_endpoint_and_all_pcp_pages() -> None:
+    class FakeApi:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict | None]] = []
+
+        def get(self, url: str, params: dict | None = None, label: str = "") -> tuple[dict, str]:
+            self.calls.append((url, params))
+            if "pncp.gov.br" in url:
+                return {
+                    "situacaoCompraNome": "Divulgada no PNCP",
+                    "dataEncerramentoProposta": "2026-08-20T18:00:00-03:00",
+                }, "API"
+            page = int((params or {}).get("pagina", 0))
+            if page == 1:
+                return {"result": [{"codigoLicitacao": 111}], "pageCount": 2}, "API"
+            return {
+                "result": [
+                    {
+                        "codigoLicitacao": 222,
+                        "statusProcessoPublico": {"descricao": "Recebendo propostas"},
+                        "dataHoraFinalPropostas": "2026-08-21T18:00:00Z",
+                        "urlReferencia": "/sc/official-222",
+                    }
+                ],
+                "pageCount": 2,
+            }, "API"
+
+    api = FakeApi()
+    fetcher = _OfficialStatusFetcher(api)  # type: ignore[arg-type]
+
+    pncp = fetcher(
+        {
+            "fonte": "PNCP",
+            "cnpj_orgao": "12.345.678/0001-90",
+            "ano_compra": "2026",
+            "sequencial_compra": "9",
+        }
+    )
+    pcp = fetcher(
+        {
+            "fonte": "PCP",
+            "codigo_licitacao": 222,
+            "data_publicacao_oficial": "2026-08-13T10:00:00Z",
+        }
+    )
+
+    assert pncp == {
+        "status_native": "Divulgada no PNCP",
+        "deadline_at": "2026-08-20T18:00:00-03:00",
+        "evidence_url": "https://pncp.gov.br/api/pncp/v1/orgaos/12345678000190/compras/2026/9",
+    }
+    assert pcp == {
+        "status_native": "Recebendo propostas",
+        "deadline_at": "2026-08-21T18:00:00Z",
+        "evidence_url": "https://www.portaldecompraspublicas.com.br/sc/official-222",
+    }
+    assert [params["pagina"] for url, params in api.calls if "portaldecompraspublicas" in url] == [1, 2]
+    assert all(
+        params["dataInicial"] == params["dataFinal"] == "2026-08-13"
+        for url, params in api.calls
+        if "portaldecompraspublicas" in url
+    )
+
+
+def test_reenrichment_preview_does_not_mutate_existing_recommendation() -> None:
+    editais = [_candidate("persisted-go")]
+
+    summary = _preview_unexecuted_reconfirmation(editais)
+
+    assert summary["decisions"]["NO_GO"] == 1
+    assert editais == [_candidate("persisted-go")]
+
+
+def test_pcp_reconfirmation_fails_closed_above_page_safety_bound() -> None:
+    class TooManyPagesApi:
+        def get(self, url: str, params: dict | None = None, label: str = "") -> tuple[dict, str]:
+            del url, label
+            return {"result": [], "pageCount": PCP_MAX_PAGES + 1}, "API"
+
+    fetcher = _OfficialStatusFetcher(TooManyPagesApi())  # type: ignore[arg-type]
+
+    try:
+        fetcher(
+            {
+                "fonte": "PCP",
+                "codigo_licitacao": 222,
+                "data_publicacao_oficial": "2026-08-13T10:00:00Z",
+            }
+        )
+    except RuntimeError as exc:
+        assert "safety bound" in str(exc)
+    else:
+        raise AssertionError("unbounded PCP pagination should fail closed")

--- a/tests/test_pcp_crawler.py
+++ b/tests/test_pcp_crawler.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import urllib.error
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -245,6 +246,34 @@ class TestTransform:
         """
         result = pcp.transform([MOCK_RECORD, MOCK_RECORD])
         assert len(result) == 2, f"Expected 2 records (no in-memory dedup), got {len(result)}"
+
+    def test_transform_hash_includes_process_identity(self):
+        first = pcp.transform([MOCK_RECORD])[0]
+        other = dict(MOCK_RECORD)
+        other["codigoLicitacao"] = "99999"
+        second = pcp.transform([other])[0]
+        assert first["content_hash"]
+        assert first["content_hash"] != ""
+        assert first["content_hash"] != second["content_hash"]
+        assert first["content_hash"] == pcp.transform([MOCK_RECORD])[0]["content_hash"]
+
+    def test_fetch_page_raises_after_exhausted_server_errors(self, monkeypatch):
+        monkeypatch.setattr(pcp, "PCP_MAX_RETRIES", 0)
+        monkeypatch.setattr(pcp.time, "sleep", lambda _seconds: None)
+
+        def boom(_req, timeout=None):
+            del timeout
+            raise urllib.error.HTTPError(
+                url="https://example.test/pcp",
+                code=500,
+                msg="server",
+                hdrs={},
+                fp=None,
+            )
+
+        monkeypatch.setattr(pcp.urllib.request, "urlopen", boom)
+        with pytest.raises(urllib.error.HTTPError):
+            pcp._fetch_page(1, "2026-08-13", "2026-08-13")
 
 
 @pytest.mark.real_db

--- a/tests/test_pcp_crawler.py
+++ b/tests/test_pcp_crawler.py
@@ -1,8 +1,15 @@
-"""Unit tests for scripts/crawl/pcp_crawler.py."""
+"""Unit and opt-in PostgreSQL tests for the PCP ingestion boundary."""
 
+import json
+import os
+from datetime import date
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from scripts.crawl import pcp_crawler as pcp
+from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
 
 # ---------------------------------------------------------------------------
 # Mock data
@@ -85,6 +92,86 @@ class TestCrawl:
         result = pcp.crawl(mode="incremental")
         assert isinstance(result, list)
 
+    @patch("scripts.crawl.pcp_crawler.provenance_fail")
+    @patch("scripts.crawl.pcp_crawler.provenance_complete")
+    @patch("scripts.crawl.pcp_crawler.provenance_start", return_value="pcp-deferred-1")
+    @patch("scripts.crawl.pcp_crawler._fetch_page", return_value=([MOCK_RECORD], False))
+    def test_structured_crawl_defers_terminal_provenance(
+        self,
+        _mock_fetch,
+        _mock_start,
+        mock_complete,
+        mock_fail,
+    ):
+        result = pcp.crawl(
+            CrawlRequest(
+                mode="incremental",
+                date_from=date(2026, 8, 13),
+                date_to=date(2026, 8, 13),
+            )
+        )
+
+        assert isinstance(result, FetchResult)
+        assert result.status == "success"
+        assert result.provenance["run_id"] == "pcp-deferred-1"
+        assert result.provenance["terminal_deferred"] is True
+        assert result.pages_fetched == result.pages_expected == 1
+        mock_complete.assert_not_called()
+        mock_fail.assert_not_called()
+
+    def test_monitor_upsert_failure_fails_same_deferred_run(self, monkeypatch):
+        from scripts.crawl import monitor
+
+        fetch = FetchResult(
+            status="success",
+            records=[MOCK_RECORD],
+            request_completed=True,
+            pages_fetched=1,
+            pages_expected=1,
+            provenance={
+                "run_id": "pcp-monitor-upsert-fail",
+                "source": "pcp",
+                "terminal_deferred": True,
+                "pages_completed": 1,
+            },
+        )
+        crawler = SimpleNamespace(
+            crawl=lambda _request: fetch,
+            transform=lambda _records: [{"pncp_id": "pcp_12345", "content_hash": "same"}],
+            UPSERT_FUNCTION="upsert_pncp_raw_bids",
+        )
+        connection = SimpleNamespace(rollback=lambda: None, close=lambda: None)
+
+        monkeypatch.setattr(monitor, "_get_conn", lambda: connection)
+        monkeypatch.setattr(monitor, "_start_ingestion_run", lambda *_args: 91)
+        monkeypatch.setattr(monitor, "_load_crawler", lambda _source: crawler)
+        monkeypatch.setattr(monitor, "_finish_ingestion_run", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(monitor, "_record_evidence", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(
+            "scripts.crawl.credential_validator.validate_source_credentials",
+            lambda _source: (True, []),
+        )
+        monkeypatch.setattr(
+            monitor,
+            "_upsert_raw_records",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("content hash collision")),
+        )
+
+        with (
+            patch("scripts.crawl.provenance_sync.provenance_complete") as complete,
+            patch("scripts.crawl.provenance_sync.provenance_fail") as fail,
+        ):
+            result = monitor.crawl_source("pcp", entities=[], mode="incremental")
+
+        assert result.status == "failed"
+        assert "content hash collision" in (result.error_message or "")
+        complete.assert_not_called()
+        fail.assert_called_once()
+        assert fail.call_args.kwargs["run_id"] == "pcp-monitor-upsert-fail"
+        assert fail.call_args.kwargs["records_fetched"] == 1
+        assert fail.call_args.kwargs["records_failed"] == 1
+        assert fetch.provenance["terminal_state"] == "failed"
+
 
 # ---------------------------------------------------------------------------
 # transform()
@@ -158,6 +245,110 @@ class TestTransform:
         """
         result = pcp.transform([MOCK_RECORD, MOCK_RECORD])
         assert len(result) == 2, f"Expected 2 records (no in-memory dedup), got {len(result)}"
+
+
+@pytest.mark.real_db
+@pytest.mark.skipif(
+    os.getenv("REQUIRE_REAL_DB") != "1",
+    reason="Set REQUIRE_REAL_DB=1 for the PostgreSQL content-hash proof",
+)
+def test_postgres_content_hash_collision_is_deterministic_and_reconciled():
+    import psycopg2
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL")
+    if not dsn:
+        pytest.fail("REQUIRE_REAL_DB=1 requires LOCAL_DATALAKE_DSN or DATABASE_URL")
+
+    prefix = f"test_pcp_hash_{os.getpid()}"
+    hash_one = f"{prefix}_hash_one"
+    hash_two = f"{prefix}_hash_two"
+    hash_three = f"{prefix}_hash_three"
+
+    def record(suffix: str, content_hash: str | None, *, synthetic: bool = False) -> dict:
+        return {
+            "pncp_id": f"{prefix}_{suffix}",
+            "numero_controle_pncp": f"{prefix}_{suffix}",
+            "objeto_compra": f"record {suffix}",
+            "content_hash": content_hash,
+            "source": "pcp",
+            "source_id": suffix,
+            "synthetic_id": synthetic,
+        }
+
+    connection = psycopg2.connect(dsn)
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SET LOCAL statement_timeout = '30s'")
+
+            batch = [record("b", hash_one), record("a", hash_one)]
+            cursor.execute("SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)", (json.dumps(batch),))
+            assert cursor.fetchone() == (1, 0, 1)
+            cursor.execute(
+                "SELECT pncp_id FROM pncp_raw_bids WHERE content_hash = %s",
+                (hash_one,),
+            )
+            assert cursor.fetchone()[0] == f"{prefix}_a"
+
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps(list(reversed(batch))),),
+            )
+            assert cursor.fetchone() == (0, 0, 2)
+
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps([record("c", hash_one)]),),
+            )
+            assert cursor.fetchone() == (0, 0, 1)
+
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps([record("d", hash_two)]),),
+            )
+            assert cursor.fetchone() == (1, 0, 0)
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps([record("d", hash_three)]),),
+            )
+            assert cursor.fetchone() == (0, 1, 0)
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps([record("d", hash_one)]),),
+            )
+            assert cursor.fetchone() == (0, 0, 1)
+            cursor.execute(
+                "SELECT content_hash FROM pncp_raw_bids WHERE pncp_id = %s",
+                (f"{prefix}_d",),
+            )
+            assert cursor.fetchone()[0] == hash_three
+
+            null_hash = record("e", None)
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps([null_hash]),),
+            )
+            assert cursor.fetchone() == (1, 0, 0)
+            null_hash["objeto_compra"] = "record e updated without hash"
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_raw_bids(%s::jsonb)",
+                (json.dumps([null_hash]),),
+            )
+            assert cursor.fetchone() == (0, 1, 0)
+            cursor.execute(
+                "SELECT objeto_compra FROM pncp_raw_bids WHERE pncp_id = %s",
+                (f"{prefix}_e",),
+            )
+            assert cursor.fetchone()[0] == "record e updated without hash"
+
+            cursor.execute(
+                "SELECT COUNT(*), COUNT(DISTINCT content_hash) "
+                "FROM pncp_raw_bids WHERE pncp_id = ANY(%s)",
+                ([f"{prefix}_a", f"{prefix}_d"],),
+            )
+            assert cursor.fetchone() == (2, 2)
+    finally:
+        connection.rollback()
+        connection.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the ten highest-criticality issues that had not yet received an implementation wave:

- deterministic PNCP content-hash ownership and terminal crawl reconciliation;
- complete, snapshot-bound supplier analytics with keyset pagination;
- durable DLQ, fail-closed SLI/SLO reviews, alerts, and kill switch;
- client-independent canonical entities, observations, events, revisions, and identity decisions;
- immutable canonical snapshot barrier and SELECT-only `public_read_v1` contract;
- source-of-record status reconfirmation before report shortlist actions.

## Issues

Closes #356
Closes #355
Closes #354
Closes #348
Closes #289
Closes #287
Closes #275
Closes #274
Closes #273
Closes #244

## Verification

- PostgreSQL 16 + pgvector: migrations 085–089 applied, rolled back in reverse order, and reapplied successfully.
- Focused real-DB suite: `90 passed`.
- Canonical full suite: `4432 passed, 141 skipped`, coverage `50.38%`.
- `python3 -m scripts.ops.check_generated_artifacts_policy --base origin/main`: PASS.
- `python3 -m scripts.ops.check_pr_reviewability --base origin/main`: PASS.
- CodeRabbit completed reviews found no critical issue after remediation; the final confirmation attempt was rate-limited after the remaining findings had been fixed and retested.

## Truth ceiling

The strict golden path remained PARTIAL because the live PNCP request returned HTTP 422 and existing contract/evidence freshness checks were stale. This PR does not claim `LOCAL_READY`, production soak, Netcup readiness, or `VPS_OPERATIONAL` from local evidence.

## Review map

- 085–086: collision resolution and complete contract analytics.
- 087: runtime DLQ and truth-plane telemetry.
- 088–089: canonical event model, snapshot barrier, public read contract.
- Python adapters: crawl runtime, DataLake access, report reconfirmation, canonical snapshot/SLI operations.
- Tests and story: executable acceptance evidence and limitations.

## Adversarial remediation

Follow-up commit locks `smartlic_public_reader` (REVOKE writer EXECUTE from PUBLIC), stops the live `canonical_organs` leak in `municipalities`, stops hardcoding COMPLETE, rejects unknown `match_state`, fails closed on PCP 5xx/timeout, includes `pncp_id` in the PCP content hash, and writes DLQ on lease-expired poison. Reviewability re-run without `--draft`.
