### PR TITLE
feat(coverage): gate de recall extra-cli vs AlertaLicitação

### DIFF
--- a/scripts/coverage/alerta_recall_gate.py
+++ b/scripts/coverage/alerta_recall_gate.py
@@ -1,0 +1,372 @@
+"""Recall gate of extra-cli against an AlertaLicitação benchmark window.
+
+Measures Recall(extra-cli | AlertaLicitação) on equivalent windows. Extra-only
+items are audited as gain beyond the aggregator and are never added to the
+conditional-recall denominator. AlertaLicitação is not treated as absolute truth.
+
+This module is the fail-closed core of issue #35. It does not remove the XLS
+flow and does not use adapter counts or PNCP-only coverage as a recall proxy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+SCHEMA_VERSION = 1
+MatchBucket = Literal["both", "alerta_only", "extra_only"]
+RetirementDecision = Literal["continue", "reduce", "retire"]
+LAYER_BRUTO = "bruto"
+LAYER_ADERENTE = "aderente"
+LAYER_MATERIAL = "material"
+BUCKET_BOTH: MatchBucket = "both"
+BUCKET_ALERTA_ONLY: MatchBucket = "alerta_only"
+BUCKET_EXTRA_ONLY: MatchBucket = "extra_only"
+RETIRE_CONTINUE: RetirementDecision = "continue"
+RETIRE_REDUCE: RetirementDecision = "reduce"
+RETIRE_RETIRE: RetirementDecision = "retire"
+
+REQUIRED_STRATA = (
+    "ente",
+    "plataforma",
+    "tipo_fonte",
+    "modalidade",
+    "municipio",
+    "esfera",
+    "natureza_objeto",
+    "publicacao_original",
+)
+
+DEFAULT_SLO = {
+    "bruto_min": 0.80,
+    "aderente_min": 0.90,
+    "material_min": 0.95,
+    "retire_material_min": 0.97,
+    "retire_windows": 4,
+    "reduce_material_min": 0.93,
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_payload(obj: Any) -> str:
+    return hashlib.sha256(_canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+def wilson_interval(successes: int, trials: int, z: float = 1.96) -> tuple[float | None, float | None]:
+    """Wilson score interval. Returns (low, high) in [0, 1], or (None, None)."""
+    if trials <= 0:
+        return None, None
+    if successes < 0 or successes > trials:
+        raise ValueError("successes must be between 0 and trials")
+    phat = successes / trials
+    z2 = z * z
+    denom = 1.0 + z2 / trials
+    centre = (phat + z2 / (2.0 * trials)) / denom
+    margin = (z * math.sqrt((phat * (1.0 - phat) + z2 / (4.0 * trials)) / trials)) / denom
+    return max(0.0, centre - margin), min(1.0, centre + margin)
+
+
+@dataclass(frozen=True)
+class OpportunityRef:
+    identity: str
+    source_platform: str
+    ente_id: str | None = None
+    modalidade: str | None = None
+    municipio: str | None = None
+    esfera: str | None = None
+    natureza_objeto: str | None = None
+    publicacao_original: str | None = None
+    tipo_fonte: str | None = None
+    published_at: str | None = None
+    discovered_at: str | None = None
+    aderente: bool = True
+    material: bool = True
+    strata: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WindowManifest:
+    filters: dict[str, Any]
+    cutoff: str
+    universe_hash: str
+    strata: tuple[str, ...]
+    sample_size: int
+    slo: dict[str, float]
+    window_start: str
+    window_end: str
+    period_id: str
+    hashes: dict[str, str]
+
+
+@dataclass(frozen=True)
+class LayerMetric:
+    name: str
+    numerator: int
+    denominator: int
+    rate: float | None
+    misses: tuple[str, ...]
+    ci_low: float | None
+    ci_high: float | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MissAdjudication:
+    identity: str
+    cause: str
+    next_action: str
+    reconciles_with: str = "#346"
+
+
+@dataclass(frozen=True)
+class RecallReport:
+    manifest: WindowManifest
+    buckets: dict[str, tuple[str, ...]]
+    layers: dict[str, LayerMetric]
+    extra_only_audit: tuple[str, ...]
+    misses: tuple[MissAdjudication, ...]
+    retirement: RetirementDecision
+    retirement_reason: str
+    generated_at: str = field(default_factory=_utc_now)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": self.generated_at,
+            "manifest": asdict(self.manifest),
+            "buckets": {k: list(v) for k, v in self.buckets.items()},
+            "layers": {k: v.as_dict() for k, v in self.layers.items()},
+            "extra_only_audit": list(self.extra_only_audit),
+            "misses": [asdict(m) for m in self.misses],
+            "retirement": self.retirement,
+            "retirement_reason": self.retirement_reason,
+        }
+
+
+def match_key(item: OpportunityRef) -> str:
+    return item.identity.strip()
+
+
+def classify_match(
+    alerta: OpportunityRef,
+    extra: OpportunityRef | None,
+) -> MatchBucket:
+    if extra is None:
+        return BUCKET_ALERTA_ONLY
+    if match_key(alerta) != match_key(extra):
+        raise ValueError("classify_match requires the same identity")
+    return BUCKET_BOTH
+
+
+def build_window_manifest(
+    *,
+    alerta_items: list[OpportunityRef],
+    extra_items: list[OpportunityRef],
+    window_start: str,
+    window_end: str,
+    cutoff: str,
+    filters: dict[str, Any],
+    period_id: str,
+    slo: dict[str, float] | None = None,
+) -> WindowManifest:
+    if not window_start or not window_end:
+        raise ValueError("window_start and window_end are required")
+    if window_end < window_start:
+        raise ValueError("window_end precedes window_start")
+    resolved_slo = dict(DEFAULT_SLO)
+    if slo:
+        resolved_slo.update(slo)
+    universe = {
+        "alerta": sorted(match_key(i) for i in alerta_items),
+        "extra": sorted(match_key(i) for i in extra_items),
+    }
+    return WindowManifest(
+        filters=dict(filters),
+        cutoff=cutoff,
+        universe_hash=sha256_payload(universe),
+        strata=REQUIRED_STRATA,
+        sample_size=len(alerta_items),
+        slo=resolved_slo,
+        window_start=window_start,
+        window_end=window_end,
+        period_id=period_id,
+        hashes={
+            "alerta": sha256_payload([asdict(i) for i in alerta_items]),
+            "extra": sha256_payload([asdict(i) for i in extra_items]),
+            "filters": sha256_payload(filters),
+        },
+    )
+
+
+def _index(items: list[OpportunityRef]) -> dict[str, OpportunityRef]:
+    out: dict[str, OpportunityRef] = {}
+    for item in items:
+        key = match_key(item)
+        if not key:
+            raise ValueError("opportunity identity is required")
+        if key in out:
+            raise ValueError(f"duplicate identity in sample: {key}")
+        out[key] = item
+    return out
+
+
+def _layer_metric(name: str, captured: list[str], denom_ids: list[str]) -> LayerMetric:
+    denom = len(denom_ids)
+    num = len(captured)
+    rate = (num / denom) if denom else None
+    misses = tuple(sorted(set(denom_ids) - set(captured)))
+    low, high = wilson_interval(num, denom) if denom else (None, None)
+    return LayerMetric(
+        name=name,
+        numerator=num,
+        denominator=denom,
+        rate=rate,
+        misses=misses,
+        ci_low=low,
+        ci_high=high,
+    )
+
+
+def adjudicate_miss(item: OpportunityRef, *, latency_hours: float | None) -> MissAdjudication:
+    """Assign a cause and next action. Freshness miss is not a definitive miss."""
+    if latency_hours is not None and latency_hours > 24:
+        return MissAdjudication(
+            identity=item.identity,
+            cause="freshness_lag",
+            next_action="reconsultar a fonte na janela de freshness antes de contar miss definitivo",
+        )
+    if item.tipo_fonte in {"html", "pdf", "js"}:
+        return MissAdjudication(
+            identity=item.identity,
+            cause="source_surface_gap",
+            next_action="ativar ou corrigir o adapter da superfície que publicou o item",
+        )
+    return MissAdjudication(
+        identity=item.identity,
+        cause="match_or_coverage_gap",
+        next_action="reconciliar com #346 e atribuir o gap ao ente/fonte",
+    )
+
+
+def evaluate_retirement(
+    material: LayerMetric,
+    *,
+    consecutive_windows_meeting: int,
+    slo: dict[str, float],
+) -> tuple[RetirementDecision, str]:
+    """Formalize continue / reduce / retire. Never retires on a single window."""
+    rate = material.rate
+    if rate is None:
+        return RETIRE_CONTINUE, "denominador material vazio — sem evidência para retirar o XLS"
+    retire_min = float(slo.get("retire_material_min", DEFAULT_SLO["retire_material_min"]))
+    reduce_min = float(slo.get("reduce_material_min", DEFAULT_SLO["reduce_material_min"]))
+    windows_needed = int(slo.get("retire_windows", DEFAULT_SLO["retire_windows"]))
+    if rate >= retire_min and consecutive_windows_meeting >= windows_needed:
+        return (
+            RETIRE_RETIRE,
+            f"material {rate:.3f} >= {retire_min} em {consecutive_windows_meeting} janelas",
+        )
+    if rate >= reduce_min:
+        return RETIRE_REDUCE, f"material {rate:.3f} permite reduzir o XLS, não retirar"
+    return RETIRE_CONTINUE, f"material {rate:.3f} abaixo do limiar de redução {reduce_min}"
+
+
+def evaluate_recall(
+    *,
+    alerta_items: list[OpportunityRef],
+    extra_items: list[OpportunityRef],
+    window_start: str,
+    window_end: str,
+    cutoff: str,
+    filters: dict[str, Any],
+    period_id: str,
+    slo: dict[str, float] | None = None,
+    consecutive_windows_meeting: int = 0,
+    latency_hours_by_id: dict[str, float] | None = None,
+) -> RecallReport:
+    """Compute bruto / aderente / material recall and a retirement decision."""
+    if any(k in json.dumps(filters).lower() for k in ("count(*)", "db_row_count", "adapter_count")):
+        raise ValueError("filters must not use operational counts as a recall proxy")
+
+    alerta = _index(alerta_items)
+    extra = _index(extra_items)
+    both = sorted(set(alerta) & set(extra))
+    alerta_only = sorted(set(alerta) - set(extra))
+    extra_only = sorted(set(extra) - set(alerta))
+
+    def _ids(predicate: Callable[[OpportunityRef], bool]) -> list[str]:
+        return [k for k, item in alerta.items() if predicate(item)]
+
+    bruto_denom = list(alerta)
+    aderente_denom = _ids(lambda i: i.aderente)
+    material_denom = _ids(lambda i: i.aderente and i.material)
+
+    bruto_cap = [k for k in bruto_denom if k in extra]
+    aderente_cap = [k for k in aderente_denom if k in extra]
+    material_cap = [k for k in material_denom if k in extra]
+
+    layers = {
+        LAYER_BRUTO: _layer_metric(LAYER_BRUTO, bruto_cap, bruto_denom),
+        LAYER_ADERENTE: _layer_metric(LAYER_ADERENTE, aderente_cap, aderente_denom),
+        LAYER_MATERIAL: _layer_metric(LAYER_MATERIAL, material_cap, material_denom),
+    }
+
+    latency = latency_hours_by_id or {}
+    misses = tuple(adjudicate_miss(alerta[mid], latency_hours=latency.get(mid)) for mid in alerta_only)
+
+    manifest = build_window_manifest(
+        alerta_items=alerta_items,
+        extra_items=extra_items,
+        window_start=window_start,
+        window_end=window_end,
+        cutoff=cutoff,
+        filters=filters,
+        period_id=period_id,
+        slo=slo,
+    )
+    decision, reason = evaluate_retirement(
+        layers[LAYER_MATERIAL],
+        consecutive_windows_meeting=consecutive_windows_meeting,
+        slo=manifest.slo,
+    )
+    return RecallReport(
+        manifest=manifest,
+        buckets={
+            BUCKET_BOTH: tuple(both),
+            BUCKET_ALERTA_ONLY: tuple(alerta_only),
+            BUCKET_EXTRA_ONLY: tuple(extra_only),
+        },
+        layers=layers,
+        extra_only_audit=tuple(extra_only),
+        misses=misses,
+        retirement=decision,
+        retirement_reason=reason,
+    )
+
+
+def gate_exit(report: RecallReport) -> int:
+    """0 = SLO met; 2 = fail-closed. Extra-only never inflates the pass condition."""
+    slo = report.manifest.slo
+    for name, key in (
+        (LAYER_BRUTO, "bruto_min"),
+        (LAYER_ADERENTE, "aderente_min"),
+        (LAYER_MATERIAL, "material_min"),
+    ):
+        metric = report.layers[name]
+        if metric.rate is None or metric.rate < float(slo[key]):
+            return 2
+    return 0

--- a/tests/test_alerta_recall_gate.py
+++ b/tests/test_alerta_recall_gate.py
@@ -1,0 +1,211 @@
+"""Tests for the AlertaLicitação recall gate (#35). Drives shipped functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.coverage.alerta_recall_gate import (
+    BUCKET_ALERTA_ONLY,
+    BUCKET_EXTRA_ONLY,
+    LAYER_ADERENTE,
+    LAYER_BRUTO,
+    LAYER_MATERIAL,
+    RETIRE_CONTINUE,
+    RETIRE_REDUCE,
+    RETIRE_RETIRE,
+    OpportunityRef,
+    evaluate_recall,
+    evaluate_retirement,
+    gate_exit,
+    wilson_interval,
+)
+
+
+def _ref(
+    identity: str,
+    *,
+    aderente: bool = True,
+    material: bool = True,
+    tipo_fonte: str = "api",
+    platform: str = "alerta",
+) -> OpportunityRef:
+    return OpportunityRef(
+        identity=identity,
+        source_platform=platform,
+        ente_id="ente-1",
+        modalidade="pregao",
+        municipio="Florianopolis",
+        esfera="municipal",
+        natureza_objeto="engenharia",
+        publicacao_original="pncp",
+        tipo_fonte=tipo_fonte,
+        published_at="2026-07-01T10:00:00Z",
+        discovered_at="2026-07-01T12:00:00Z",
+        aderente=aderente,
+        material=material,
+        strata=("ente", "plataforma"),
+    )
+
+
+def test_wilson_interval_empty_and_full() -> None:
+    assert wilson_interval(0, 0) == (None, None)
+    low, high = wilson_interval(10, 10)
+    assert low is not None and high is not None
+    assert 0.0 <= low <= 1.0
+    assert high == 1.0 or high < 1.0
+    with pytest.raises(ValueError):
+        wilson_interval(2, 1)
+
+
+def test_recall_layers_exclude_extra_only_from_denominator() -> None:
+    alerta = [
+        _ref("A1"),
+        _ref("A2", aderente=True, material=False),
+        _ref("A3", aderente=False, material=False),
+        _ref("A4"),
+    ]
+    extra = [
+        _ref("A1", platform="extra"),
+        _ref("A2", platform="extra"),
+        _ref("X9", platform="extra"),  # extra_only gain
+    ]
+    report = evaluate_recall(
+        alerta_items=alerta,
+        extra_items=extra,
+        window_start="2026-07-01",
+        window_end="2026-07-31",
+        cutoff="2026-07-31T23:59:59Z",
+        filters={"uf": "SC", "profile": "confenge"},
+        period_id="2026-07",
+    )
+    assert "X9" in report.buckets[BUCKET_EXTRA_ONLY]
+    assert "X9" not in report.layers[LAYER_BRUTO].misses
+    assert report.layers[LAYER_BRUTO].denominator == 4
+    assert report.layers[LAYER_BRUTO].numerator == 2
+    assert report.layers[LAYER_ADERENTE].denominator == 3  # A1 A2 A4
+    assert report.layers[LAYER_ADERENTE].numerator == 2
+    assert report.layers[LAYER_MATERIAL].denominator == 2  # A1 A4
+    assert report.layers[LAYER_MATERIAL].numerator == 1
+    assert report.layers[LAYER_MATERIAL].misses == ("A4",)
+    assert "X9" in report.extra_only_audit
+    # extra_only must not appear in any layer denominator identity set
+    for layer in report.layers.values():
+        assert "X9" not in layer.misses
+        assert layer.denominator != 5
+
+
+def test_alerta_only_misses_are_adjudicated_with_346() -> None:
+    alerta = [_ref("M1", tipo_fonte="html"), _ref("M2")]
+    extra = [_ref("M2", platform="extra")]
+    report = evaluate_recall(
+        alerta_items=alerta,
+        extra_items=extra,
+        window_start="2026-01-01",
+        window_end="2026-01-31",
+        cutoff="2026-01-31T23:59:59Z",
+        filters={"setor": "engenharia"},
+        period_id="2026-01",
+        latency_hours_by_id={"M1": 40.0},
+    )
+    assert report.buckets[BUCKET_ALERTA_ONLY] == ("M1",)
+    assert len(report.misses) == 1
+    miss = report.misses[0]
+    assert miss.identity == "M1"
+    assert miss.reconciles_with == "#346"
+    assert miss.cause == "freshness_lag"
+    assert "freshness" in miss.next_action
+
+
+def test_window_manifest_records_filters_hashes_strata_and_slo() -> None:
+    alerta = [_ref("Z1")]
+    extra = [_ref("Z1", platform="extra")]
+    report = evaluate_recall(
+        alerta_items=alerta,
+        extra_items=extra,
+        window_start="2026-02-01",
+        window_end="2026-02-28",
+        cutoff="2026-02-28T23:59:59Z",
+        filters={"modalidade": "pregao", "esfera": "municipal"},
+        period_id="2026-02",
+    )
+    man = report.manifest
+    assert man.filters["modalidade"] == "pregao"
+    assert man.cutoff.endswith("Z")
+    assert man.universe_hash
+    assert man.sample_size == 1
+    assert "ente" in man.strata and "natureza_objeto" in man.strata
+    assert man.hashes["alerta"]
+    assert man.slo["material_min"] == 0.95
+    payload = report.as_dict()
+    assert payload["schema_version"] == 1
+    assert payload["layers"]["bruto"]["numerator"] == 1
+
+
+def test_operational_count_proxy_is_rejected() -> None:
+    with pytest.raises(ValueError, match="operational counts"):
+        evaluate_recall(
+            alerta_items=[_ref("A")],
+            extra_items=[],
+            window_start="2026-01-01",
+            window_end="2026-01-31",
+            cutoff="2026-01-31Z",
+            filters={"proxy": "db_row_count"},
+            period_id="x",
+        )
+
+
+def test_retirement_requires_repeated_windows() -> None:
+    from scripts.coverage.alerta_recall_gate import LayerMetric
+
+    perfect = LayerMetric(
+        name="material",
+        numerator=100,
+        denominator=100,
+        rate=1.0,
+        misses=(),
+        ci_low=0.96,
+        ci_high=1.0,
+    )
+    decision, _ = evaluate_retirement(
+        perfect,
+        consecutive_windows_meeting=1,
+        slo={"retire_material_min": 0.97, "retire_windows": 4, "reduce_material_min": 0.93},
+    )
+    assert decision == RETIRE_REDUCE
+    decision, _ = evaluate_retirement(
+        perfect,
+        consecutive_windows_meeting=4,
+        slo={"retire_material_min": 0.97, "retire_windows": 4, "reduce_material_min": 0.93},
+    )
+    assert decision == RETIRE_RETIRE
+    weak = LayerMetric(
+        name="material",
+        numerator=50,
+        denominator=100,
+        rate=0.5,
+        misses=("a",),
+        ci_low=0.4,
+        ci_high=0.6,
+    )
+    decision, _ = evaluate_retirement(
+        weak,
+        consecutive_windows_meeting=10,
+        slo={"retire_material_min": 0.97, "retire_windows": 4, "reduce_material_min": 0.93},
+    )
+    assert decision == RETIRE_CONTINUE
+
+
+def test_gate_exit_fail_closed_when_material_below_slo() -> None:
+    alerta = [_ref("A1"), _ref("A2"), _ref("A3"), _ref("A4"), _ref("A5")]
+    extra = [_ref("A1", platform="extra")]
+    report = evaluate_recall(
+        alerta_items=alerta,
+        extra_items=extra,
+        window_start="2026-03-01",
+        window_end="2026-03-31",
+        cutoff="2026-03-31T23:59:59Z",
+        filters={"uf": "SC"},
+        period_id="2026-03",
+    )
+    assert gate_exit(report) == 2
+    assert report.retirement == RETIRE_CONTINUE


### PR DESCRIPTION
## Summary
Estabelece o gate de recall `Recall(extra-cli | AlertaLicitação)` com três camadas (bruto, aderente, materialmente relevante), intervalo de Wilson, manifest de janela (filtros, cutoff, hashes, universo, strata, SLO) e critério formal continue/reduce/retire.

## Issues
Fixes #35

## Verification
- `pytest tests/test_alerta_recall_gate.py` — 7 passed
- `python3 -m scripts.ops.check_pr_reviewability --base origin/main` — PASS
- `python3 -m scripts.ops.check_generated_artifacts_policy --base origin/main` — PASS

## Truth ceiling
Não remove o fluxo XLS. Não declara paridade operacional nem `VPS_OPERATIONAL`. Extra-only não entra no denominador do recall condicional.