### PR TITLE
feat(quality): registry versionado de golden dataset factual

### DIFF
--- a/scripts/quality/golden_dataset.py
+++ b/scripts/quality/golden_dataset.py
@@ -1,0 +1,320 @@
+"""Versioned golden-dataset registry for coverage misses and factual corrections.
+
+Public truth-plane cases move candidate → adjudicated → golden. Replay never
+requires client, action, or outcome fields. Material regressions block promotion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, date, datetime
+from typing import Any, Literal
+
+SCHEMA_VERSION = 1
+Stage = Literal["candidate", "adjudicated", "golden"]
+STAGE_CANDIDATE: Stage = "candidate"
+STAGE_ADJUDICATED: Stage = "adjudicated"
+STAGE_GOLDEN: Stage = "golden"
+FORBIDDEN_AUTHORITY_FIELDS = frozenset({"client", "action", "outcome", "crm", "label_model"})
+CRITICAL_STAGES = (
+    "source_miss",
+    "pagination_miss",
+    "freshness_miss",
+    "document_ocr",
+    "dedup_conflict",
+    "identity_conflict",
+    "retificacao",
+    "factual_extraction",
+    "negative_zero",
+    "negative_revoked",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_payload(obj: Any) -> str:
+    return hashlib.sha256(_canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+def tokenize_pii(value: str) -> str:
+    """Deterministic tokenization — never store raw PII in the golden case."""
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+    return f"pii_{digest}"
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    case_id: str
+    stage: Stage
+    public_stage: str
+    origin: str
+    adjudicator: str | None
+    restriction: str
+    snapshot_at: str
+    published_at: str
+    split: Literal["train", "eval", "holdout"]
+    payload: dict[str, Any]
+    expected: dict[str, Any]
+    license: str
+    content_hash: str
+    version: str
+    pii_tokenized: bool = True
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class GoldenRegistry:
+    version: str
+    cases: dict[str, GoldenCase] = field(default_factory=dict)
+
+    def list_cases(self) -> list[dict[str, Any]]:
+        rows = []
+        for case in sorted(self.cases.values(), key=lambda c: c.case_id):
+            rows.append(
+                {
+                    "case_id": case.case_id,
+                    "version": case.version,
+                    "hash": case.content_hash,
+                    "origin": case.origin,
+                    "adjudicator": case.adjudicator,
+                    "restriction": case.restriction,
+                    "stage": case.stage,
+                    "public_stage": case.public_stage,
+                    "split": case.split,
+                }
+            )
+        return rows
+
+
+def _reject_authority_fields(payload: dict[str, Any]) -> None:
+    banned = FORBIDDEN_AUTHORITY_FIELDS.intersection(payload)
+    if banned:
+        raise ValueError(f"client/action/outcome fields are not authority: {sorted(banned)}")
+
+
+def assign_split(published_at: str, *, cutoff: str) -> Literal["train", "eval", "holdout"]:
+    """Temporal split. Items on/after cutoff never leak into train."""
+    pub = date.fromisoformat(published_at[:10])
+    cut = date.fromisoformat(cutoff[:10])
+    if pub < cut:
+        return "train"
+    if pub == cut:
+        return "eval"
+    return "holdout"
+
+
+def ingest_candidate(
+    *,
+    case_id: str,
+    public_stage: str,
+    origin: str,
+    snapshot_at: str,
+    published_at: str,
+    payload: dict[str, Any],
+    expected: dict[str, Any],
+    restriction: str = "public-authorized",
+    license_name: str = "public-domain-or-authorized",
+    split_cutoff: str,
+    version: str,
+) -> GoldenCase:
+    if public_stage not in CRITICAL_STAGES:
+        raise ValueError(f"unknown public stage: {public_stage}")
+    _reject_authority_fields(payload)
+    _reject_authority_fields(expected)
+    body = {
+        "case_id": case_id,
+        "public_stage": public_stage,
+        "origin": origin,
+        "payload": payload,
+        "expected": expected,
+        "published_at": published_at,
+    }
+    return GoldenCase(
+        case_id=case_id,
+        stage=STAGE_CANDIDATE,
+        public_stage=public_stage,
+        origin=origin,
+        adjudicator=None,
+        restriction=restriction,
+        snapshot_at=snapshot_at,
+        published_at=published_at,
+        split=assign_split(published_at, cutoff=split_cutoff),
+        payload=dict(payload),
+        expected=dict(expected),
+        license=license_name,
+        content_hash=sha256_payload(body),
+        version=version,
+        pii_tokenized=True,
+    )
+
+
+def adjudicate(case: GoldenCase, *, adjudicator: str, expected: dict[str, Any] | None = None) -> GoldenCase:
+    if not adjudicator.strip():
+        raise ValueError("adjudicator is required")
+    _reject_authority_fields(expected or {})
+    new_expected = dict(expected) if expected is not None else dict(case.expected)
+    body = {
+        "case_id": case.case_id,
+        "public_stage": case.public_stage,
+        "origin": case.origin,
+        "payload": case.payload,
+        "expected": new_expected,
+        "published_at": case.published_at,
+    }
+    return GoldenCase(
+        case_id=case.case_id,
+        stage=STAGE_ADJUDICATED,
+        public_stage=case.public_stage,
+        origin=case.origin,
+        adjudicator=adjudicator,
+        restriction=case.restriction,
+        snapshot_at=case.snapshot_at,
+        published_at=case.published_at,
+        split=case.split,
+        payload=dict(case.payload),
+        expected=new_expected,
+        license=case.license,
+        content_hash=sha256_payload(body),
+        version=case.version,
+        pii_tokenized=case.pii_tokenized,
+    )
+
+
+def promote_to_golden(case: GoldenCase) -> GoldenCase:
+    if case.stage != STAGE_ADJUDICATED:
+        raise ValueError("only adjudicated cases can become golden")
+    if not case.adjudicator:
+        raise ValueError("golden case requires an adjudicator")
+    return GoldenCase(
+        case_id=case.case_id,
+        stage=STAGE_GOLDEN,
+        public_stage=case.public_stage,
+        origin=case.origin,
+        adjudicator=case.adjudicator,
+        restriction=case.restriction,
+        snapshot_at=case.snapshot_at,
+        published_at=case.published_at,
+        split=case.split,
+        payload=dict(case.payload),
+        expected=dict(case.expected),
+        license=case.license,
+        content_hash=case.content_hash,
+        version=case.version,
+        pii_tokenized=case.pii_tokenized,
+    )
+
+
+def replay(case: GoldenCase, actual: dict[str, Any]) -> dict[str, Any]:
+    """Compare actual replay against adjudicated expected. No client fields needed."""
+    _reject_authority_fields(actual)
+    missing = [k for k in case.expected if actual.get(k) != case.expected[k]]
+    return {
+        "case_id": case.case_id,
+        "ok": not missing,
+        "mismatched": missing,
+        "stage": case.public_stage,
+        "split": case.split,
+    }
+
+
+def evaluate_benchmark(
+    cases: list[GoldenCase],
+    actual_by_id: dict[str, dict[str, Any]],
+    *,
+    baseline_rate: float | None = None,
+) -> dict[str, Any]:
+    """Emit baseline / delta / interval-ready rates per stage and split."""
+    by_stage: dict[str, dict[str, int]] = {}
+    by_split: dict[str, dict[str, int]] = {}
+    regressions: list[str] = []
+    for case in cases:
+        actual = actual_by_id.get(case.case_id)
+        if actual is None:
+            passed = False
+            mismatches = list(case.expected)
+        else:
+            result = replay(case, actual)
+            passed = bool(result["ok"])
+            mismatches = list(result["mismatched"])
+        bucket = by_stage.setdefault(case.public_stage, {"pass": 0, "total": 0})
+        bucket["total"] += 1
+        if passed:
+            bucket["pass"] += 1
+        else:
+            regressions.append(case.case_id)
+        split_b = by_split.setdefault(case.split, {"pass": 0, "total": 0})
+        split_b["total"] += 1
+        if passed:
+            split_b["pass"] += 1
+        if mismatches:
+            continue
+    rates = {stage: (vals["pass"] / vals["total"] if vals["total"] else None) for stage, vals in by_stage.items()}
+    overall_total = sum(v["total"] for v in by_stage.values())
+    overall_pass = sum(v["pass"] for v in by_stage.values())
+    overall = (overall_pass / overall_total) if overall_total else None
+    delta = None if baseline_rate is None or overall is None else overall - baseline_rate
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": _utc_now(),
+        "overall_rate": overall,
+        "baseline_rate": baseline_rate,
+        "delta": delta,
+        "by_stage": by_stage,
+        "by_split": by_split,
+        "rates": rates,
+        "regressions": regressions,
+        "n": overall_total,
+    }
+
+
+def promotion_blocked(benchmark: dict[str, Any], *, material_drop: float = 0.02) -> bool:
+    """Material regression blocks promotion. No silent exception path."""
+    if benchmark.get("overall_rate") is None:
+        return True
+    delta = benchmark.get("delta")
+    if delta is not None and delta < -abs(material_drop):
+        return True
+    if benchmark.get("regressions"):
+        return True
+    return False
+
+
+def register_miss(
+    registry: GoldenRegistry,
+    *,
+    case_id: str,
+    public_stage: str,
+    origin: str,
+    snapshot_at: str,
+    published_at: str,
+    payload: dict[str, Any],
+    expected: dict[str, Any],
+    split_cutoff: str,
+    adjudicator: str,
+) -> GoldenCase:
+    """Adjudicated miss/correction becomes a traceable golden candidate then case."""
+    candidate = ingest_candidate(
+        case_id=case_id,
+        public_stage=public_stage,
+        origin=origin,
+        snapshot_at=snapshot_at,
+        published_at=published_at,
+        payload=payload,
+        expected=expected,
+        split_cutoff=split_cutoff,
+        version=registry.version,
+    )
+    adjudicated = adjudicate(candidate, adjudicator=adjudicator)
+    golden = promote_to_golden(adjudicated)
+    registry.cases[golden.case_id] = golden
+    return golden

--- a/scripts/quality/golden_dataset.py
+++ b/scripts/quality/golden_dataset.py
@@ -18,6 +18,7 @@ STAGE_CANDIDATE: Stage = "candidate"
 STAGE_ADJUDICATED: Stage = "adjudicated"
 STAGE_GOLDEN: Stage = "golden"
 FORBIDDEN_AUTHORITY_FIELDS = frozenset({"client", "action", "outcome", "crm", "label_model"})
+PII_KEYS = frozenset({"cpf", "email", "telefone", "phone", "nome", "nome_pessoa", "rg", "endereco", "address"})
 CRITICAL_STAGES = (
     "source_miss",
     "pagination_miss",
@@ -48,6 +49,16 @@ def tokenize_pii(value: str) -> str:
     """Deterministic tokenization — never store raw PII in the golden case."""
     digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
     return f"pii_{digest}"
+
+
+def _tokenize_mapping(payload: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in payload.items():
+        if key.lower() in PII_KEYS and isinstance(value, str) and value:
+            out[key] = tokenize_pii(value)
+        else:
+            out[key] = value
+    return out
 
 
 @dataclass(frozen=True)
@@ -131,12 +142,14 @@ def ingest_candidate(
         raise ValueError(f"unknown public stage: {public_stage}")
     _reject_authority_fields(payload)
     _reject_authority_fields(expected)
+    safe_payload = _tokenize_mapping(payload)
+    safe_expected = _tokenize_mapping(expected)
     body = {
         "case_id": case_id,
         "public_stage": public_stage,
         "origin": origin,
-        "payload": payload,
-        "expected": expected,
+        "payload": safe_payload,
+        "expected": safe_expected,
         "published_at": published_at,
     }
     return GoldenCase(
@@ -149,8 +162,8 @@ def ingest_candidate(
         snapshot_at=snapshot_at,
         published_at=published_at,
         split=assign_split(published_at, cutoff=split_cutoff),
-        payload=dict(payload),
-        expected=dict(expected),
+        payload=safe_payload,
+        expected=safe_expected,
         license=license_name,
         content_hash=sha256_payload(body),
         version=version,
@@ -162,7 +175,7 @@ def adjudicate(case: GoldenCase, *, adjudicator: str, expected: dict[str, Any] |
     if not adjudicator.strip():
         raise ValueError("adjudicator is required")
     _reject_authority_fields(expected or {})
-    new_expected = dict(expected) if expected is not None else dict(case.expected)
+    new_expected = _tokenize_mapping(expected) if expected is not None else dict(case.expected)
     body = {
         "case_id": case.case_id,
         "public_stage": case.public_stage,

--- a/tests/test_golden_dataset.py
+++ b/tests/test_golden_dataset.py
@@ -99,6 +99,11 @@ def test_pii_is_tokenized() -> None:
     assert token.startswith("pii_")
     assert "123" not in token
     assert tokenize_pii("123.456.789-00") == token
+    case = _candidate(payload={"identity": "PNCP-1", "cpf": "123.456.789-00", "email": "a@b.com"})
+    assert case.payload["cpf"] == tokenize_pii("123.456.789-00")
+    assert case.payload["email"] == tokenize_pii("a@b.com")
+    assert "123.456.789-00" not in str(case.payload)
+    assert "a@b.com" not in str(case.payload)
 
 
 def test_replay_and_material_regression_blocks_promotion() -> None:

--- a/tests/test_golden_dataset.py
+++ b/tests/test_golden_dataset.py
@@ -1,0 +1,134 @@
+"""Tests for the golden-dataset registry (#138). Drives shipped functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.quality.golden_dataset import (
+    CRITICAL_STAGES,
+    STAGE_GOLDEN,
+    GoldenRegistry,
+    assign_split,
+    evaluate_benchmark,
+    ingest_candidate,
+    promotion_blocked,
+    register_miss,
+    replay,
+    tokenize_pii,
+)
+
+
+def _candidate(**overrides):
+    kwargs = {
+        "case_id": "gd-001",
+        "public_stage": "source_miss",
+        "origin": "alerta_only:#35",
+        "snapshot_at": "2026-07-15T00:00:00Z",
+        "published_at": "2026-07-01",
+        "payload": {"identity": "PNCP-1", "objeto": "obra"},
+        "expected": {"captured": False, "miss_reason": "source_gap"},
+        "split_cutoff": "2026-07-10",
+        "version": "2026.08.1",
+    }
+    kwargs.update(overrides)
+    return ingest_candidate(**kwargs)
+
+
+def test_registry_lists_version_hash_origin_adjudicator_restriction() -> None:
+    registry = GoldenRegistry(version="2026.08.1")
+    case = register_miss(
+        registry,
+        case_id="gd-001",
+        public_stage="source_miss",
+        origin="alerta_only:#35",
+        snapshot_at="2026-07-15T00:00:00Z",
+        published_at="2026-07-01",
+        payload={"identity": "PNCP-1"},
+        expected={"captured": True},
+        split_cutoff="2026-07-10",
+        adjudicator="qa-human",
+    )
+    assert case.stage == STAGE_GOLDEN
+    listed = registry.list_cases()
+    assert listed[0]["version"] == "2026.08.1"
+    assert listed[0]["hash"] == case.content_hash
+    assert listed[0]["origin"] == "alerta_only:#35"
+    assert listed[0]["adjudicator"] == "qa-human"
+    assert listed[0]["restriction"] == "public-authorized"
+
+
+def test_corpus_covers_critical_public_stages_including_negatives() -> None:
+    assert "negative_zero" in CRITICAL_STAGES
+    assert "negative_revoked" in CRITICAL_STAGES
+    assert "factual_extraction" in CRITICAL_STAGES
+    registry = GoldenRegistry(version="v1")
+    for idx, stage in enumerate(CRITICAL_STAGES):
+        register_miss(
+            registry,
+            case_id=f"st-{idx}",
+            public_stage=stage,
+            origin="audit",
+            snapshot_at="2026-07-15T00:00:00Z",
+            published_at="2026-06-01",
+            payload={"k": stage},
+            expected={"ok": True},
+            split_cutoff="2026-07-01",
+            adjudicator="qa",
+        )
+    stages = {c["public_stage"] for c in registry.list_cases()}
+    assert stages == set(CRITICAL_STAGES)
+
+
+def test_client_action_outcome_cannot_be_authority() -> None:
+    with pytest.raises(ValueError, match="not authority"):
+        _candidate(payload={"identity": "x", "client": "CONFENGE"})
+    with pytest.raises(ValueError, match="not authority"):
+        replay(_candidate(), {"captured": False, "outcome": "won"})
+
+
+def test_temporal_split_prevents_leakage() -> None:
+    assert assign_split("2026-06-30", cutoff="2026-07-10") == "train"
+    assert assign_split("2026-07-10", cutoff="2026-07-10") == "eval"
+    assert assign_split("2026-07-11", cutoff="2026-07-10") == "holdout"
+    case = _candidate(published_at="2026-07-20")
+    assert case.split == "holdout"
+
+
+def test_pii_is_tokenized() -> None:
+    token = tokenize_pii("123.456.789-00")
+    assert token.startswith("pii_")
+    assert "123" not in token
+    assert tokenize_pii("123.456.789-00") == token
+
+
+def test_replay_and_material_regression_blocks_promotion() -> None:
+    registry = GoldenRegistry(version="v1")
+    golden = register_miss(
+        registry,
+        case_id="gd-reg",
+        public_stage="pagination_miss",
+        origin="pncp",
+        snapshot_at="2026-07-15T00:00:00Z",
+        published_at="2026-06-01",
+        payload={"pages_expected": 3},
+        expected={"pages_fetched": 3, "captured": True},
+        split_cutoff="2026-07-01",
+        adjudicator="qa",
+    )
+    ok = replay(golden, {"pages_fetched": 3, "captured": True})
+    assert ok["ok"] is True
+    bench = evaluate_benchmark(
+        [golden],
+        {"gd-reg": {"pages_fetched": 2, "captured": False}},
+        baseline_rate=1.0,
+    )
+    assert bench["regressions"] == ["gd-reg"]
+    assert bench["delta"] == -1.0
+    assert promotion_blocked(bench) is True
+    good = evaluate_benchmark(
+        [golden],
+        {"gd-reg": {"pages_fetched": 3, "captured": True}},
+        baseline_rate=1.0,
+    )
+    assert promotion_blocked(good) is False
+    assert good["overall_rate"] == 1.0


### PR DESCRIPTION
## Summary
Registry de casos públicos autorizados com ciclo candidato→adjudicado→golden, hash, split temporal sem leakage, tokenização de PII e bloqueio de promoção em regressão material.

## Issues
Fixes #138

## Verification
- `pytest tests/test_golden_dataset.py` — 6 passed
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Replay não usa client/action/outcome como autoridade. Não promove corpus live nesta fatia.