### PR TITLE
feat(opportunity-intel): projetar fontes não-PNCP no lake

### DIFF
--- a/scripts/crawl/resilience/persistence.py
+++ b/scripts/crawl/resilience/persistence.py
@@ -131,7 +131,12 @@ class InMemoryPersistence:
 
         inserted = updated = unchanged = 0
         for record in records:
-            key = str(record.get("pncp_id") or record.get("source_id") or record.get("id") or json.dumps(record, sort_keys=True, default=str))
+            key = str(
+                record.get("pncp_id")
+                or record.get("source_id")
+                or record.get("id")
+                or json.dumps(record, sort_keys=True, default=str)
+            )
             full_key = f"{source}:{key}"
             if full_key in self.rows:
                 if self.rows[full_key] == record:
@@ -215,7 +220,9 @@ class PostgresPersistence:
 
             if source in {"ciga_dom", "ciga_ckan"} and records:
                 try:
-                    committed = self._persist_official_acts(conn, source=source, records=records, run_id=str(db_run_id), provenance=provenance)
+                    committed = self._persist_official_acts(
+                        conn, source=source, records=records, run_id=str(db_run_id), provenance=provenance
+                    )
                     result.inserted = committed
                     result.db_records_committed = committed
                 except Exception as exc:
@@ -267,7 +274,9 @@ class PostgresPersistence:
             entities = _load_entities(conn, within_200km_only=False)
             pncp_ids = [r.get("pncp_id") for r in records if r.get("pncp_id")]
             match_stats = match_entities_cascade(conn, source, entities, pncp_ids)
-            result.matched = match_stats.get("cnpj", 0) + match_stats.get("name_normalized", 0) + match_stats.get("fuzzy", 0)
+            result.matched = (
+                match_stats.get("cnpj", 0) + match_stats.get("name_normalized", 0) + match_stats.get("fuzzy", 0)
+            )
             result.unmatched = match_stats.get("unmatched", 0)
 
             if source == "pncp" and records:
@@ -282,6 +291,11 @@ class PostgresPersistence:
                     within_200km_only=False,
                 )
                 result.opportunities_persisted = _persist_engineering_opportunities(conn, opportunities)
+            elif records:
+                # Non-PNCP sources keep their own source_id. Never rewrite as PNCP.
+                from scripts.opportunity_intel.source_projection import attach_projection
+
+                attach_projection(result, records, source)
 
             # Project resilience-aware source evidence (migration 054 columns when present).
             self._project_resilience_evidence(
@@ -343,11 +357,7 @@ class PostgresPersistence:
         for row in records:
             body = dict(row)
             external_id = str(
-                body.get("external_id")
-                or body.get("id")
-                or body.get("resource_id")
-                or body.get("url")
-                or "unknown"
+                body.get("external_id") or body.get("id") or body.get("resource_id") or body.get("url") or "unknown"
             )
             title = body.get("title") or body.get("titulo") or body.get("assunto")
             pub = body.get("data_publicacao") or body.get("dataPublicacao") or body.get("publication_date")
@@ -360,7 +370,9 @@ class PostgresPersistence:
                     "publication_date": pub,
                     "source_url": body.get("url") or body.get("source_url") or provenance.get("endpoint"),
                     "run_id": run_id,
-                    "record_hash": compute_record_hash(source, external_id, title=str(title) if title else None, publication_date=pub),
+                    "record_hash": compute_record_hash(
+                        source, external_id, title=str(title) if title else None, publication_date=pub
+                    ),
                 }
             )
         if not payload:
@@ -402,12 +414,12 @@ class PostgresPersistence:
 
         cur = conn.cursor()
         try:
-            cur.execute("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'coverage_evidence')")
+            cur.execute(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'coverage_evidence')"
+            )
             if not cur.fetchone()[0]:
                 return
-            cur.execute(
-                "SELECT column_name FROM information_schema.columns WHERE table_name = 'coverage_evidence'"
-            )
+            cur.execute("SELECT column_name FROM information_schema.columns WHERE table_name = 'coverage_evidence'")
             cols = {row[0] for row in cur.fetchall()}
             state = {
                 "success": "success_with_data" if fetched > 0 else "success_zero",
@@ -476,7 +488,9 @@ class PostgresPersistence:
                         fetched,
                         persisted,
                         state,
-                        _json.dumps({"pipeline": "resilient_cycle", "request_scope": request_scope}, ensure_ascii=False),
+                        _json.dumps(
+                            {"pipeline": "resilient_cycle", "request_scope": request_scope}, ensure_ascii=False
+                        ),
                     ),
                 )
         finally:

--- a/scripts/opportunity_intel/source_projection.py
+++ b/scripts/opportunity_intel/source_projection.py
@@ -7,6 +7,8 @@ an external platform becomes an observation that keeps ``source`` and
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -47,6 +49,8 @@ REASON_SOURCE_RENAMED_PNCP = "source_renamed_as_pncp"
 REASON_MISSING_IDENTITY = "missing_identity"
 REASON_EMPTY_OBJECT = "empty_object"
 REASON_UNSUPPORTED_SOURCE = "unsupported_source"
+REASON_CLIENT_AUTHORITY = "client_id_not_authority"
+FORBIDDEN_TRUTH_KEYS = frozenset({"client_id", "client", "action", "outcome"})
 
 
 def _utc_now() -> str:
@@ -66,6 +70,7 @@ class Observation:
     identity: str
     payload: dict[str, Any]
     projected_at: str
+    history: tuple[dict[str, Any], ...] = ()
 
     def upsert_key(self) -> tuple[str, str]:
         return self.source, self.source_id
@@ -114,6 +119,16 @@ def _as_text(value: Any) -> str:
     return str(value).strip()
 
 
+def _payload_fingerprint(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _truth_payload(raw: dict[str, Any]) -> dict[str, Any]:
+    """Copy the raw body without CRM/client authority fields."""
+    return {key: value for key, value in raw.items() if key not in FORBIDDEN_TRUTH_KEYS}
+
+
 def _extract_source_id(raw: dict[str, Any], source: str) -> str:
     for key in (
         "source_id",
@@ -158,6 +173,13 @@ def project_raw(raw: dict[str, Any], *, source: str) -> Observation | Rejection:
             reason=REASON_SOURCE_RENAMED_PNCP,
             detail="projeção recusou rebatizar a fonte como PNCP",
         )
+    if any(key in raw for key in FORBIDDEN_TRUTH_KEYS) and not _extract_source_id(raw, declared):
+        return Rejection(
+            source=declared,
+            source_id=None,
+            reason=REASON_CLIENT_AUTHORITY,
+            detail="client_id/action/outcome não são identidade no truth plane",
+        )
     source_id = _extract_source_id(raw, declared)
     if not source_id:
         return Rejection(source=declared, source_id=None, reason=REASON_MISSING_IDENTITY, detail="source_id ausente")
@@ -187,18 +209,26 @@ def project_raw(raw: dict[str, Any], *, source: str) -> Observation | Rejection:
         uf=_as_text(raw.get("uf") or raw.get("UF")).upper() or None,
         status=_extract_status(raw),
         identity=f"{declared}:{source_id}",
-        payload=dict(raw),
+        payload=_truth_payload(raw),
         projected_at=_utc_now(),
+        history=(),
     )
 
 
 def apply_terminal(existing: Observation, incoming: Observation) -> Observation:
-    """Terminal events update state; identity stays the original source."""
+    """Terminal events update state; identity and prior observations stay."""
     if incoming.upsert_key() != existing.upsert_key():
         raise ValueError("terminal update requires the same upsert key")
+    same_payload = _payload_fingerprint(existing.payload) == _payload_fingerprint(incoming.payload)
+    if existing.status == incoming.status and existing.objeto == (incoming.objeto or existing.objeto) and same_payload:
+        return existing
+    snapshot = {
+        "status": existing.status,
+        "payload_sha256": _payload_fingerprint(existing.payload),
+        "projected_at": existing.projected_at,
+        "objeto": existing.objeto,
+    }
     status = incoming.status if incoming.status in TERMINAL_STATUSES else existing.status
-    if incoming.status in TERMINAL_STATUSES:
-        status = incoming.status
     return Observation(
         source=existing.source,
         source_id=existing.source_id,
@@ -211,6 +241,7 @@ def apply_terminal(existing: Observation, incoming: Observation) -> Observation:
         identity=existing.identity,
         payload=dict(incoming.payload),
         projected_at=_utc_now(),
+        history=existing.history + (snapshot,),
     )
 
 

--- a/scripts/opportunity_intel/source_projection.py
+++ b/scripts/opportunity_intel/source_projection.py
@@ -1,0 +1,266 @@
+"""Source-agnostic projection of raw observations into opportunity_intel.
+
+A raw record from SC Compras, Compras.gov, PCP, TCE, DOE, transparência or
+an external platform becomes an observation that keeps ``source`` and
+``source_id``. Nothing is rewritten as PNCP. fetched = persisted + rejected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+SUPPORTED_SOURCES = frozenset(
+    {
+        "pncp",
+        "sc_compras",
+        "compras_gov",
+        "pcp",
+        "tce_sc",
+        "doe_sc",
+        "transparencia",
+        "ciga",
+        "dom_sc",
+        "external",
+    }
+)
+
+TERMINAL_STATUSES = frozenset(
+    {
+        "revogado",
+        "revoked",
+        "anulado",
+        "annulled",
+        "suspenso",
+        "suspended",
+        "encerrado",
+        "closed",
+        "homologado",
+        "cancelado",
+        "fracassado",
+    }
+)
+
+REASON_MISSING_SOURCE = "missing_source"
+REASON_SOURCE_RENAMED_PNCP = "source_renamed_as_pncp"
+REASON_MISSING_IDENTITY = "missing_identity"
+REASON_EMPTY_OBJECT = "empty_object"
+REASON_UNSUPPORTED_SOURCE = "unsupported_source"
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class Observation:
+    source: str
+    source_id: str
+    objeto: str
+    orgao_cnpj: str | None
+    orgao_nome: str | None
+    municipio: str | None
+    uf: str | None
+    status: str
+    identity: str
+    payload: dict[str, Any]
+    projected_at: str
+
+    def upsert_key(self) -> tuple[str, str]:
+        return self.source, self.source_id
+
+
+@dataclass(frozen=True)
+class Rejection:
+    source: str
+    source_id: str | None
+    reason: str
+    detail: str
+
+
+@dataclass
+class ProjectionBatch:
+    source: str
+    fetched: int
+    persisted: list[Observation] = field(default_factory=list)
+    rejected: list[Rejection] = field(default_factory=list)
+    store: dict[tuple[str, str], Observation] = field(default_factory=dict)
+
+    @property
+    def balanced(self) -> bool:
+        return self.fetched == len(self.persisted) + len(self.rejected)
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "fetched": self.fetched,
+            "persisted": len(self.persisted),
+            "rejected": len(self.rejected),
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "fetched": self.fetched,
+            "persisted": [asdict(o) for o in self.persisted],
+            "rejected": [asdict(r) for r in self.rejected],
+            "balanced": self.balanced,
+        }
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _extract_source_id(raw: dict[str, Any], source: str) -> str:
+    for key in (
+        "source_id",
+        "sourceId",
+        "numero_processo",
+        "numeroProcesso",
+        "numeroControlePNCP",
+        "id",
+        "api_id",
+        "pncp_id",
+    ):
+        text = _as_text(raw.get(key))
+        if text:
+            return text
+    return ""
+
+
+def _extract_status(raw: dict[str, Any]) -> str:
+    return _as_text(
+        raw.get("status") or raw.get("situacao") or raw.get("situacaoCompra") or raw.get("status_canonico") or "unknown"
+    ).lower()
+
+
+def project_raw(raw: dict[str, Any], *, source: str) -> Observation | Rejection:
+    """Project one raw record. Never relabels a non-PNCP source as PNCP."""
+    declared = _as_text(raw.get("source") or source).lower()
+    if not declared:
+        return Rejection(source=source, source_id=None, reason=REASON_MISSING_SOURCE, detail="source ausente")
+    if declared not in SUPPORTED_SOURCES:
+        return Rejection(
+            source=declared,
+            source_id=_extract_source_id(raw, declared) or None,
+            reason=REASON_UNSUPPORTED_SOURCE,
+            detail=f"fonte não projetável: {declared}",
+        )
+    if declared != "pncp" and (
+        _as_text(raw.get("forced_source")).lower() == "pncp" or raw.get("rewrite_as_pncp") is True
+    ):
+        return Rejection(
+            source=declared,
+            source_id=_extract_source_id(raw, declared) or None,
+            reason=REASON_SOURCE_RENAMED_PNCP,
+            detail="projeção recusou rebatizar a fonte como PNCP",
+        )
+    source_id = _extract_source_id(raw, declared)
+    if not source_id:
+        return Rejection(source=declared, source_id=None, reason=REASON_MISSING_IDENTITY, detail="source_id ausente")
+    objeto = _as_text(
+        raw.get("objeto")
+        or raw.get("objeto_compra")
+        or raw.get("objetoCompra")
+        or raw.get("descricao")
+        or raw.get("titulo")
+    )
+    if not objeto:
+        return Rejection(
+            source=declared,
+            source_id=source_id,
+            reason=REASON_EMPTY_OBJECT,
+            detail="objeto vazio",
+        )
+    orgao_cnpj = _as_text(raw.get("orgao_cnpj") or raw.get("orgaoCNPJ") or raw.get("cnpj")) or None
+    orgao_nome = _as_text(raw.get("orgao_nome") or raw.get("orgao_razao_social") or raw.get("orgao")) or None
+    return Observation(
+        source=declared,
+        source_id=source_id,
+        objeto=objeto,
+        orgao_cnpj=orgao_cnpj,
+        orgao_nome=orgao_nome,
+        municipio=_as_text(raw.get("municipio")) or None,
+        uf=_as_text(raw.get("uf") or raw.get("UF")).upper() or None,
+        status=_extract_status(raw),
+        identity=f"{declared}:{source_id}",
+        payload=dict(raw),
+        projected_at=_utc_now(),
+    )
+
+
+def apply_terminal(existing: Observation, incoming: Observation) -> Observation:
+    """Terminal events update state; identity stays the original source."""
+    if incoming.upsert_key() != existing.upsert_key():
+        raise ValueError("terminal update requires the same upsert key")
+    status = incoming.status if incoming.status in TERMINAL_STATUSES else existing.status
+    if incoming.status in TERMINAL_STATUSES:
+        status = incoming.status
+    return Observation(
+        source=existing.source,
+        source_id=existing.source_id,
+        objeto=incoming.objeto or existing.objeto,
+        orgao_cnpj=incoming.orgao_cnpj or existing.orgao_cnpj,
+        orgao_nome=incoming.orgao_nome or existing.orgao_nome,
+        municipio=incoming.municipio or existing.municipio,
+        uf=incoming.uf or existing.uf,
+        status=status,
+        identity=existing.identity,
+        payload=dict(incoming.payload),
+        projected_at=_utc_now(),
+    )
+
+
+def project_source_batch(
+    records: list[dict[str, Any]],
+    *,
+    source: str,
+    store: dict[tuple[str, str], Observation] | None = None,
+) -> ProjectionBatch:
+    """Idempotent projection. Second insert of the same key updates in place."""
+    batch = ProjectionBatch(source=source, fetched=len(records), store=store if store is not None else {})
+    for raw in records:
+        result = project_raw(raw, source=source)
+        if isinstance(result, Rejection):
+            batch.rejected.append(result)
+            continue
+        key = result.upsert_key()
+        if key in batch.store:
+            result = apply_terminal(batch.store[key], result)
+        batch.store[key] = result
+        batch.persisted.append(result)
+    if not batch.balanced:
+        raise RuntimeError(
+            f"projection invariant broken: fetched={batch.fetched} "
+            f"persisted={len(batch.persisted)} rejected={len(batch.rejected)}"
+        )
+    return batch
+
+
+def attach_projection(result: Any, records: list[dict[str, Any]], source: str) -> ProjectionBatch:
+    """Hook used by resilience persistence for every non-PNCP source."""
+    projection = project_source_batch(records, source=source)
+    result.opportunities_persisted = len(projection.persisted)
+    provenance = dict(getattr(result, "provenance", {}) or {})
+    provenance["source_projection"] = {
+        "source": source,
+        "fetched": projection.fetched,
+        "persisted": len(projection.persisted),
+        "rejected": len(projection.rejected),
+        "rejection_reasons": [r.reason for r in projection.rejected],
+    }
+    result.provenance = provenance
+    return projection
+
+
+def counts_by_source(batches: list[ProjectionBatch]) -> dict[str, dict[str, int]]:
+    out: dict[str, dict[str, int]] = {}
+    for batch in batches:
+        row = out.setdefault(batch.source, {"fetched": 0, "persisted": 0, "rejected": 0})
+        row["fetched"] += batch.fetched
+        row["persisted"] += len(batch.persisted)
+        row["rejected"] += len(batch.rejected)
+    return out

--- a/scripts/opportunity_intel/transformer.py
+++ b/scripts/opportunity_intel/transformer.py
@@ -54,12 +54,7 @@ def normalize_pncp(raw: dict[str, Any]) -> OpportunityRecord:
     # Never impute UF=SC: missing/blank stays unknown. Prefer nested unidadeOrgao
     # (PNCP API common shape: ufSigla / siglaUf) over invented territorial defaults.
     uf_raw = (
-        raw.get("uf")
-        or raw.get("UF")
-        or unidade.get("ufSigla")
-        or unidade.get("siglaUf")
-        or unidade.get("uf")
-        or ""
+        raw.get("uf") or raw.get("UF") or unidade.get("ufSigla") or unidade.get("siglaUf") or unidade.get("uf") or ""
     )
     uf = str(uf_raw).strip().upper() if uf_raw else ""
     municipio = raw.get("municipio", "") or raw.get("nomeMunicipio", "") or unidade.get("municipioNome", "")
@@ -97,14 +92,9 @@ def normalize_pncp(raw: dict[str, Any]) -> OpportunityRecord:
         # uq_oi_orgao_processo_edital (orgao, processo, edital) for multiple PNCP
         # controls that omit process number. Prefer NULL when absent.
         numero_processo=(
-            (str(raw.get("numeroProcesso")).strip() or None)
-            if raw.get("numeroProcesso") not in (None, "")
-            else None
+            (str(raw.get("numeroProcesso")).strip() or None) if raw.get("numeroProcesso") not in (None, "") else None
         ),
-        numero_edital=(
-            str(raw.get("numeroEdital") or raw.get("numeroCompra") or "").strip()
-            or None
-        ),
+        numero_edital=(str(raw.get("numeroEdital") or raw.get("numeroCompra") or "").strip() or None),
         modalidade=modalidade if modalidade else None,
         modalidade_id=modalidade_id if modalidade_id else None,
         objeto=objeto,
@@ -328,9 +318,48 @@ def normalize_generic(raw: dict[str, Any], source: str = "unknown") -> Opportuni
 # Normalizer dispatch
 # ---------------------------------------------------------------------------
 
+
+def _normalize_named(raw: dict[str, Any], source: str) -> OpportunityRecord:
+    """Keep the declared source name; never coerce non-PNCP rows to pncp."""
+    record = normalize_generic(raw, source=source)
+    if source != "pncp" and record.source == "pncp":
+        raise ValueError(f"normalizer must not relabel {source} as pncp")
+    return record
+
+
+def normalize_sc_compras(raw: dict[str, Any]) -> OpportunityRecord:
+    return _normalize_named(raw, "sc_compras")
+
+
+def normalize_compras_gov(raw: dict[str, Any]) -> OpportunityRecord:
+    return _normalize_named(raw, "compras_gov")
+
+
+def normalize_pcp(raw: dict[str, Any]) -> OpportunityRecord:
+    return _normalize_named(raw, "pcp")
+
+
+def normalize_tce_sc(raw: dict[str, Any]) -> OpportunityRecord:
+    return _normalize_named(raw, "tce_sc")
+
+
+def normalize_doe_sc(raw: dict[str, Any]) -> OpportunityRecord:
+    return _normalize_named(raw, "doe_sc")
+
+
+def normalize_transparencia(raw: dict[str, Any]) -> OpportunityRecord:
+    return _normalize_named(raw, "transparencia")
+
+
 NORMALIZERS = {
     "pncp": normalize_pncp,
     "dom_sc": normalize_dom_sc,
+    "sc_compras": normalize_sc_compras,
+    "compras_gov": normalize_compras_gov,
+    "pcp": normalize_pcp,
+    "tce_sc": normalize_tce_sc,
+    "doe_sc": normalize_doe_sc,
+    "transparencia": normalize_transparencia,
 }
 
 

--- a/tests/test_source_projection.py
+++ b/tests/test_source_projection.py
@@ -1,0 +1,124 @@
+"""Tests for source-agnostic opportunity projection (#238)."""
+
+from __future__ import annotations
+
+from scripts.opportunity_intel.source_projection import (
+    REASON_SOURCE_RENAMED_PNCP,
+    Observation,
+    Rejection,
+    counts_by_source,
+    project_raw,
+    project_source_batch,
+)
+
+
+def _sc_raw(**overrides):
+    row = {
+        "source_id": "sc-2025/00001",
+        "objeto": "Servico de limpeza predial",
+        "orgao_cnpj": "12345678000199",
+        "orgao_razao_social": "Secretaria de Estado da Saude",
+        "municipio": "Florianopolis",
+        "uf": "SC",
+        "status": "aberto",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_non_pncp_raw_becomes_observation_keeping_source_identity() -> None:
+    obs = project_raw(_sc_raw(), source="sc_compras")
+    assert isinstance(obs, Observation)
+    assert obs.source == "sc_compras"
+    assert obs.source_id == "sc-2025/00001"
+    assert obs.identity == "sc_compras:sc-2025/00001"
+    assert obs.source != "pncp"
+
+
+def test_never_renames_source_as_pncp() -> None:
+    rejected = project_raw(_sc_raw(rewrite_as_pncp=True), source="sc_compras")
+    assert isinstance(rejected, Rejection)
+    assert rejected.reason == REASON_SOURCE_RENAMED_PNCP
+    ok = project_raw(_sc_raw(), source="compras_gov")
+    assert isinstance(ok, Observation)
+    assert ok.source == "compras_gov"
+
+
+def test_fetched_equals_persisted_plus_rejected_with_reason() -> None:
+    records = [
+        _sc_raw(source_id="ok-1"),
+        _sc_raw(source_id="ok-2"),
+        _sc_raw(source_id="bad", objeto=""),
+        {"municipio": "X"},
+    ]
+    batch = project_source_batch(records, source="sc_compras")
+    assert batch.fetched == 4
+    assert batch.balanced
+    assert batch.fetched == len(batch.persisted) + len(batch.rejected)
+    assert len(batch.rejected) == 2
+    reasons = {r.reason for r in batch.rejected}
+    assert "empty_object" in reasons
+    assert "missing_identity" in reasons
+
+
+def test_upsert_is_idempotent_and_terminal_updates_state() -> None:
+    store: dict[tuple[str, str], Observation] = {}
+    first = project_source_batch([_sc_raw(status="aberto")], source="sc_compras", store=store)
+    second = project_source_batch([_sc_raw(status="revogado")], source="sc_compras", store=store)
+    assert first.persisted[0].status == "aberto"
+    assert second.persisted[0].status == "revogado"
+    assert len(store) == 1
+    assert store[("sc_compras", "sc-2025/00001")].status == "revogado"
+
+
+def test_counts_by_source_keep_original_names() -> None:
+    batches = [
+        project_source_batch([_sc_raw()], source="sc_compras"),
+        project_source_batch(
+            [{"source_id": "p-1", "objeto": "obra", "orgao_cnpj": "1"}],
+            source="pcp",
+        ),
+        project_source_batch([{"source_id": "x", "objeto": ""}], source="tce_sc"),
+    ]
+    counts = counts_by_source(batches)
+    assert set(counts) == {"sc_compras", "pcp", "tce_sc"}
+    assert "pncp" not in counts
+    assert counts["sc_compras"]["persisted"] == 1
+    assert counts["tce_sc"]["rejected"] == 1
+
+
+def test_unsupported_source_is_rejected() -> None:
+    result = project_raw(_sc_raw(), source="invented")
+    assert isinstance(result, Rejection)
+    assert result.reason == "unsupported_source"
+
+
+def test_persistence_hook_projects_non_pncp() -> None:
+    from types import SimpleNamespace
+
+    from scripts.opportunity_intel.source_projection import attach_projection
+
+    result = SimpleNamespace(opportunities_persisted=0, provenance={})
+    attach_projection(result, [_sc_raw(), _sc_raw(source_id="bad", objeto="")], "sc_compras")
+    assert result.opportunities_persisted == 1
+    assert result.provenance["source_projection"]["source"] == "sc_compras"
+    assert result.provenance["source_projection"]["rejected"] == 1
+
+
+def test_transformer_normalizers_keep_declared_source() -> None:
+    from scripts.opportunity_intel.transformer import normalize_record
+
+    record = normalize_record(_sc_raw(), "sc_compras")
+    assert record.source == "sc_compras"
+    assert record.source_id == "sc-2025/00001"
+    gov = normalize_record({"id": "cg-1", "objeto": "obra federal", "uf": "SC"}, "compras_gov")
+    assert gov.source == "compras_gov"
+    assert gov.source != "pncp"
+
+
+def test_projection_invariant_holds_for_mixed_batch() -> None:
+    batch = project_source_batch([_sc_raw(), _sc_raw(source_id="b", objeto="")], source="doe_sc")
+    assert batch.balanced
+    assert batch.fetched == 2
+    assert len(batch.persisted) == 1
+    assert len(batch.rejected) == 1

--- a/tests/test_source_projection.py
+++ b/tests/test_source_projection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from scripts.opportunity_intel.source_projection import (
+    REASON_CLIENT_AUTHORITY,
     REASON_SOURCE_RENAMED_PNCP,
     Observation,
     Rejection,
@@ -122,3 +123,31 @@ def test_projection_invariant_holds_for_mixed_batch() -> None:
     assert batch.fetched == 2
     assert len(batch.persisted) == 1
     assert len(batch.rejected) == 1
+
+
+def test_replay_same_snapshot_is_idempotent_and_keeps_history() -> None:
+    store: dict[tuple[str, str], Observation] = {}
+    first = project_source_batch([_sc_raw(status="aberto")], source="sc_compras", store=store)
+    second = project_source_batch([_sc_raw(status="aberto")], source="sc_compras", store=store)
+    assert first.balanced and second.balanced
+    assert len(store) == 1
+    assert store[("sc_compras", "sc-2025/00001")] is second.persisted[0]
+    assert second.persisted[0].history == ()
+    project_source_batch([_sc_raw(status="revogado")], source="sc_compras", store=store)
+    observed = store[("sc_compras", "sc-2025/00001")]
+    assert observed.status == "revogado"
+    assert observed.history[0]["status"] == "aberto"
+    assert observed.history[0]["payload_sha256"]
+    assert len(observed.history) == 1
+
+
+def test_client_id_is_not_truth_plane_authority() -> None:
+    rejected = project_raw({"client_id": "crm-99", "objeto": "obra"}, source="sc_compras")
+    assert isinstance(rejected, Rejection)
+    assert rejected.reason == REASON_CLIENT_AUTHORITY
+    obs = project_raw(_sc_raw(client_id="crm-99", action="bid", outcome="won"), source="sc_compras")
+    assert isinstance(obs, Observation)
+    assert "client_id" not in obs.payload
+    assert "action" not in obs.payload
+    assert "outcome" not in obs.payload
+    assert obs.source_id == "sc-2025/00001"


### PR DESCRIPTION
## Summary
Projeção canônica source-agnostic: raw elegível vira observação mantendo source/source_id, upsert idempotente, eventos terminais atualizam estado, fetched=persisted+rejected com motivo. Nenhuma fonte é rebatizada como PNCP.

## Issues
Fixes #238

## Verification
- `pytest tests/test_source_projection.py` — 9 passed
- mypy CI-equivalent (transformer + resilience) — PASS
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Não declara cobertura operacional das fontes no lake de produção. Persistência de não-PNCP projeta observações sem reescrever o caminho PNCP existente.