### PR TITLE
feat(crawl): contrato de escopo e prova por ente do SC Compras

### DIFF
--- a/scripts/crawl/sc_compras_scope.py
+++ b/scripts/crawl/sc_compras_scope.py
@@ -1,0 +1,158 @@
+"""SC Compras collection contract: pagination proof and per-entity verdicts.
+
+FOUND / ZERO_CONFIRMED are emitted only after a complete query. A snapshot hash
+change invalidates an incompatible checkpoint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+SLA_HOURS = 24
+WINDOW_START = "2025-01-01"
+
+EntityVerdict = Literal["FOUND", "ZERO_CONFIRMED", "SCOPE_INCOMPLETE"]
+
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_payload(obj: Any) -> str:
+    return hashlib.sha256(_canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def digits_only(value: str) -> str:
+    return re.sub(r"\D+", "", value or "")
+
+
+def normalize_orgao(*, nome: str, cnpj: str, municipio: str) -> dict[str, str]:
+    cnpj14 = digits_only(cnpj)
+    if cnpj and len(cnpj14) != 14:
+        raise ValueError(f"cnpj_invalido:{cnpj}")
+    return {
+        "orgao_nome": " ".join((nome or "").split()),
+        "orgao_cnpj": cnpj14,
+        "municipio": " ".join((municipio or "").split()),
+    }
+
+
+@dataclass(frozen=True)
+class CountProof:
+    total_elementos: int
+    pages: int
+    chunks: int
+    persisted: int
+    rejected: int
+    page_size: int
+
+    @property
+    def balanced(self) -> bool:
+        return self.persisted + self.rejected == self.total_elementos
+
+    @property
+    def pages_match(self) -> bool:
+        expected = (self.total_elementos + self.page_size - 1) // self.page_size if self.page_size else 0
+        return self.pages == expected and self.chunks == self.pages
+
+
+def reconcile_counts(
+    *,
+    total_elementos: int,
+    pages: int,
+    chunks: int,
+    persisted: int,
+    rejected: int,
+    page_size: int = 10,
+) -> CountProof:
+    if min(total_elementos, pages, chunks, persisted, rejected, page_size) < 0:
+        raise ValueError("counts must be non-negative")
+    proof = CountProof(total_elementos, pages, chunks, persisted, rejected, page_size)
+    if not proof.balanced:
+        raise ValueError(f"count_mismatch: persisted({persisted})+rejected({rejected})!=total({total_elementos})")
+    if not proof.pages_match:
+        raise ValueError(f"pagination_mismatch: pages={pages} chunks={chunks} total={total_elementos} size={page_size}")
+    return proof
+
+
+def entity_verdict(*, query_complete: bool, found_count: int) -> EntityVerdict:
+    if not query_complete:
+        return "SCOPE_INCOMPLETE"
+    if found_count > 0:
+        return "FOUND"
+    return "ZERO_CONFIRMED"
+
+
+def checkpoint_compatible(previous_snapshot_hash: str, current_snapshot_hash: str) -> bool:
+    if not previous_snapshot_hash or not current_snapshot_hash:
+        return False
+    return previous_snapshot_hash == current_snapshot_hash
+
+
+def invalidate_checkpoint(previous_snapshot_hash: str, current_snapshot_hash: str) -> str:
+    if checkpoint_compatible(previous_snapshot_hash, current_snapshot_hash):
+        return "keep"
+    return "invalidate"
+
+
+@dataclass(frozen=True)
+class EntityProof:
+    ente_id: str
+    orgao: dict[str, str]
+    verdict: EntityVerdict
+    found_count: int
+    raw_sha256: str
+    query_complete: bool
+
+
+def prove_entities(
+    rows: list[dict[str, Any]],
+    universe: list[dict[str, Any]],
+    *,
+    snapshot: dict[str, Any],
+    previous_checkpoint_hash: str | None,
+    query_complete_by_ente: dict[str, bool],
+) -> dict[str, Any]:
+    snapshot_hash = sha256_payload(snapshot)
+    checkpoint = invalidate_checkpoint(previous_checkpoint_hash or "", snapshot_hash)
+    by_ente: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        row_ente = str(row.get("ente_id") or row.get("orgao_cnpj") or "")
+        by_ente.setdefault(row_ente, []).append(row)
+    proofs: list[EntityProof] = []
+    for entity in universe:
+        ente_id = str(entity["ente_id"])
+        complete = bool(query_complete_by_ente.get(ente_id))
+        found = by_ente.get(ente_id, [])
+        orgao = normalize_orgao(
+            nome=str(entity.get("nome") or ""),
+            cnpj=str(entity.get("cnpj") or ""),
+            municipio=str(entity.get("municipio") or ""),
+        )
+        proofs.append(
+            EntityProof(
+                ente_id=ente_id,
+                orgao=orgao,
+                verdict=entity_verdict(query_complete=complete, found_count=len(found)),
+                found_count=len(found),
+                raw_sha256=sha256_payload(found),
+                query_complete=complete,
+            )
+        )
+    return {
+        "snapshot_hash": snapshot_hash,
+        "checkpoint": checkpoint,
+        "sla_hours": SLA_HOURS,
+        "window_start": WINDOW_START,
+        "entities": [asdict(p) for p in proofs],
+        "generated_at": _utc_now(),
+    }

--- a/tests/test_sc_compras_scope.py
+++ b/tests/test_sc_compras_scope.py
@@ -1,0 +1,81 @@
+"""Tests for the SC Compras scope contract (#240)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.crawl.sc_compras_scope import (
+    checkpoint_compatible,
+    entity_verdict,
+    invalidate_checkpoint,
+    normalize_orgao,
+    prove_entities,
+    reconcile_counts,
+    sha256_payload,
+)
+
+
+def test_counts_reconcile_and_reject_drift() -> None:
+    proof = reconcile_counts(
+        total_elementos=20,
+        pages=2,
+        chunks=2,
+        persisted=18,
+        rejected=2,
+        page_size=10,
+    )
+    assert proof.balanced
+    assert proof.pages_match
+    with pytest.raises(ValueError, match="count_mismatch"):
+        reconcile_counts(total_elementos=20, pages=2, chunks=2, persisted=10, rejected=2, page_size=10)
+    with pytest.raises(ValueError, match="pagination_mismatch"):
+        reconcile_counts(total_elementos=20, pages=1, chunks=1, persisted=20, rejected=0, page_size=10)
+
+
+def test_orgao_cnpj_municipio_are_normalized() -> None:
+    orgao = normalize_orgao(
+        nome="  Secretaria   da Saude ",
+        cnpj="12.345.678/0001-99",
+        municipio=" Florianopolis ",
+    )
+    assert orgao["orgao_cnpj"] == "12345678000199"
+    assert orgao["orgao_nome"] == "Secretaria da Saude"
+    assert orgao["municipio"] == "Florianopolis"
+    with pytest.raises(ValueError, match="cnpj_invalido"):
+        normalize_orgao(nome="X", cnpj="123", municipio="Y")
+
+
+def test_found_and_zero_require_complete_query() -> None:
+    assert entity_verdict(query_complete=False, found_count=4) == "SCOPE_INCOMPLETE"
+    assert entity_verdict(query_complete=True, found_count=2) == "FOUND"
+    assert entity_verdict(query_complete=True, found_count=0) == "ZERO_CONFIRMED"
+
+
+def test_snapshot_change_invalidates_checkpoint() -> None:
+    snap_a = sha256_payload({"ano": 2025, "total": 2610})
+    snap_b = sha256_payload({"ano": 2025, "total": 2611})
+    assert checkpoint_compatible(snap_a, snap_a) is True
+    assert checkpoint_compatible(snap_a, snap_b) is False
+    assert invalidate_checkpoint(snap_a, snap_b) == "invalidate"
+    assert invalidate_checkpoint(snap_a, snap_a) == "keep"
+
+
+def test_entity_proof_hashes_raw_and_respects_completeness() -> None:
+    report = prove_entities(
+        rows=[{"ente_id": "e1", "objeto": "obra"}],
+        universe=[
+            {"ente_id": "e1", "nome": "Pref A", "cnpj": "12345678000199", "municipio": "A"},
+            {"ente_id": "e2", "nome": "Pref B", "cnpj": "12345678000198", "municipio": "B"},
+            {"ente_id": "e3", "nome": "Pref C", "cnpj": "12345678000197", "municipio": "C"},
+        ],
+        snapshot={"pages": 53, "total": 2610},
+        previous_checkpoint_hash="old",
+        query_complete_by_ente={"e1": True, "e2": True, "e3": False},
+    )
+    by_id = {e["ente_id"]: e for e in report["entities"]}
+    assert by_id["e1"]["verdict"] == "FOUND"
+    assert by_id["e2"]["verdict"] == "ZERO_CONFIRMED"
+    assert by_id["e3"]["verdict"] == "SCOPE_INCOMPLETE"
+    assert report["checkpoint"] == "invalidate"
+    assert by_id["e1"]["raw_sha256"]
+    assert report["sla_hours"] == 24


### PR DESCRIPTION
## Summary
Contrato de coleta SC Compras: reconcilia total_elementos/páginas/chunks/persistidos/rejeitados, normaliza órgão/CNPJ/município, emite FOUND/ZERO_CONFIRMED só com query completa e invalida checkpoint quando o snapshot muda.

## Issues
Fixes #240

## Verification
- `pytest tests/test_sc_compras_scope.py` — 5 passed
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Não reexecuta o crawl live das 53 páginas. Freshness ≤24h é SLO do contrato, não prova de host.