### PR TITLE
feat(crawl): prova de paginação PNCP por ente

### DIFF
--- a/scripts/crawl/pncp_entity_pagination.py
+++ b/scripts/crawl/pncp_entity_pagination.py
@@ -1,0 +1,160 @@
+"""PNCP open-opportunity pagination proof partitioned by entity.
+
+pages_expected must equal pages_fetched for a complete scope. Each page keeps
+a sanitized URL, HTTP status, fetched_at, raw URI and SHA-256. Applicable
+entities finish FOUND or ZERO_CONFIRMED only with a complete query.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+SLA_HOURS = 4
+SLA_HARD_HOURS = 24
+SECRET_QUERY_KEYS = frozenset({"token", "access_token", "api_key", "apikey", "authorization", "sig"})
+
+EntityVerdict = Literal["FOUND", "ZERO_CONFIRMED", "SCOPE_INCOMPLETE"]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sanitize_url(url: str) -> str:
+    parsed = urlparse(url)
+    query = [(k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=True) if k.lower() not in SECRET_QUERY_KEYS]
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+@dataclass(frozen=True)
+class PageRecord:
+    url: str
+    status: int
+    fetched_at: str
+    raw_uri: str
+    sha256: str
+    page: int
+    records: int
+
+
+@dataclass(frozen=True)
+class ScopeProof:
+    ente_id: str
+    window: str
+    modalidade: str | None
+    pages_expected: int
+    pages_fetched: int
+    pages: tuple[PageRecord, ...]
+    found_count: int
+    query_complete: bool
+
+    @property
+    def pages_match(self) -> bool:
+        return self.pages_expected == self.pages_fetched == len(self.pages)
+
+    @property
+    def verdict(self) -> EntityVerdict:
+        if not self.query_complete or not self.pages_match:
+            return "SCOPE_INCOMPLETE"
+        if self.found_count > 0:
+            return "FOUND"
+        return "ZERO_CONFIRMED"
+
+
+def record_page(
+    *,
+    url: str,
+    status: int,
+    body: bytes,
+    page: int,
+    records: int,
+    fetched_at: str | None = None,
+) -> PageRecord:
+    digest = sha256_bytes(body)
+    return PageRecord(
+        url=sanitize_url(url),
+        status=status,
+        fetched_at=fetched_at or _utc_now().isoformat().replace("+00:00", "Z"),
+        raw_uri=f"cas://pncp/{digest}",
+        sha256=digest,
+        page=page,
+        records=records,
+    )
+
+
+def prove_scope(
+    *,
+    ente_id: str,
+    window: str,
+    modalidade: str | None,
+    pages_expected: int,
+    pages: list[PageRecord],
+    found_count: int,
+    query_complete: bool,
+) -> ScopeProof:
+    if pages_expected < 0:
+        raise ValueError("pages_expected must be >= 0")
+    return ScopeProof(
+        ente_id=ente_id,
+        window=window,
+        modalidade=modalidade,
+        pages_expected=pages_expected,
+        pages_fetched=len(pages),
+        pages=tuple(pages),
+        found_count=found_count,
+        query_complete=query_complete,
+    )
+
+
+def sla_status(discovered_at: datetime, published_at: datetime) -> dict[str, Any]:
+    lag_hours = (discovered_at - published_at).total_seconds() / 3600.0
+    return {
+        "lag_hours": lag_hours,
+        "within_slo": lag_hours <= SLA_HOURS,
+        "within_hard_limit": lag_hours <= SLA_HARD_HOURS,
+        "breach": lag_hours > SLA_HARD_HOURS,
+    }
+
+
+def closing_requery(candidates: list[str], requery_hits: set[str]) -> dict[str, Any]:
+    """Candidates are reconsulted at window close."""
+    missing = [c for c in candidates if c not in requery_hits]
+    return {
+        "candidates": list(candidates),
+        "reconfirmed": sorted(requery_hits),
+        "missing": missing,
+        "complete": not missing,
+    }
+
+
+def proof_report(scopes: list[ScopeProof]) -> dict[str, Any]:
+    return {
+        "scopes": [
+            {
+                **asdict(scope),
+                "pages_match": scope.pages_match,
+                "verdict": scope.verdict,
+            }
+            for scope in scopes
+        ],
+        "sla_hours": SLA_HOURS,
+        "sla_hard_hours": SLA_HARD_HOURS,
+        "related": ["#34", "#40"],
+        "generated_at": _utc_now().isoformat().replace("+00:00", "Z"),
+    }
+
+
+def expected_pages(total_registros: int, page_size: int) -> int:
+    if page_size <= 0:
+        raise ValueError("page_size must be > 0")
+    if total_registros == 0:
+        return 1
+    return (total_registros + page_size - 1) // page_size

--- a/scripts/crawl/pncp_entity_pagination.py
+++ b/scripts/crawl/pncp_entity_pagination.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 SLA_HOURS = 4
 SLA_HARD_HOURS = 24
 SECRET_QUERY_KEYS = frozenset({"token", "access_token", "api_key", "apikey", "authorization", "sig"})
+RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
 
 EntityVerdict = Literal["FOUND", "ZERO_CONFIRMED", "SCOPE_INCOMPLETE"]
 
@@ -62,7 +63,7 @@ class ScopeProof:
 
     @property
     def verdict(self) -> EntityVerdict:
-        if not self.query_complete or not self.pages_match:
+        if not self.query_complete or not self.pages_match or page_anomalies(self.pages, self.pages_expected):
             return "SCOPE_INCOMPLETE"
         if self.found_count > 0:
             return "FOUND"
@@ -90,6 +91,38 @@ def record_page(
     )
 
 
+def classify_http(status: int) -> str:
+    if status == 200:
+        return "ok"
+    if status == 404:
+        return "not_found"
+    if status == 408:
+        return "timeout"
+    if status in RETRYABLE_STATUS:
+        return "retryable"
+    if status == 0:
+        return "malformed"
+    return "http_error"
+
+
+def page_anomalies(pages: tuple[PageRecord, ...] | list[PageRecord], pages_expected: int) -> list[str]:
+    """Missing, duplicate, non-200, timeout and malformed pages keep scope incomplete."""
+    flags: list[str] = []
+    numbers = [p.page for p in pages]
+    if len(numbers) != len(set(numbers)):
+        flags.append("duplicate_page")
+    expected = set(range(1, pages_expected + 1)) if pages_expected else set()
+    if expected - set(numbers):
+        flags.append("missing_page")
+    for page in pages:
+        kind = classify_http(page.status)
+        if kind != "ok":
+            flags.append(kind)
+        if page.status == 200 and page.records > 0 and page.sha256 == sha256_bytes(b""):
+            flags.append("malformed")
+    return flags
+
+
 def prove_scope(
     *,
     ente_id: str,
@@ -102,6 +135,8 @@ def prove_scope(
 ) -> ScopeProof:
     if pages_expected < 0:
         raise ValueError("pages_expected must be >= 0")
+    anomalies = page_anomalies(pages, pages_expected)
+    complete = bool(query_complete) and not anomalies
     return ScopeProof(
         ente_id=ente_id,
         window=window,
@@ -110,7 +145,7 @@ def prove_scope(
         pages_fetched=len(pages),
         pages=tuple(pages),
         found_count=found_count,
-        query_complete=query_complete,
+        query_complete=complete,
     )
 
 

--- a/tests/test_pncp_entity_pagination.py
+++ b/tests/test_pncp_entity_pagination.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from scripts.crawl.pncp_entity_pagination import (
+    classify_http,
     closing_requery,
     expected_pages,
+    page_anomalies,
     proof_report,
     prove_scope,
     record_page,
@@ -86,6 +88,45 @@ def test_sla_and_closing_requery() -> None:
     assert requery["complete"] is True
     missing = closing_requery(["a", "b"], {"a"})
     assert missing["missing"] == ["b"]
+
+
+def test_missing_duplicate_timeout_and_retryable_pages_are_incomplete() -> None:
+    assert classify_http(429) == "retryable"
+    assert classify_http(500) == "retryable"
+    assert classify_http(408) == "timeout"
+    assert classify_http(0) == "malformed"
+    missing = prove_scope(
+        ente_id="cnpj-3",
+        window="2026-07",
+        modalidade="6",
+        pages_expected=3,
+        pages=[_page(1), _page(3)],
+        found_count=2,
+        query_complete=True,
+    )
+    assert missing.verdict == "SCOPE_INCOMPLETE"
+    assert "missing_page" in page_anomalies(missing.pages, 3)
+    duplicate = prove_scope(
+        ente_id="cnpj-3",
+        window="2026-07",
+        modalidade="6",
+        pages_expected=2,
+        pages=[_page(1), _page(1)],
+        found_count=2,
+        query_complete=True,
+    )
+    assert duplicate.verdict == "SCOPE_INCOMPLETE"
+    retryable = prove_scope(
+        ente_id="cnpj-3",
+        window="2026-07",
+        modalidade="6",
+        pages_expected=1,
+        pages=[record_page(url="https://pncp.gov.br/x?pagina=1", status=429, body=b"", page=1, records=0)],
+        found_count=0,
+        query_complete=True,
+    )
+    assert retryable.verdict == "SCOPE_INCOMPLETE"
+    assert retryable.query_complete is False
 
 
 def test_report_relates_issues_34_and_40() -> None:

--- a/tests/test_pncp_entity_pagination.py
+++ b/tests/test_pncp_entity_pagination.py
@@ -1,0 +1,106 @@
+"""Tests for PNCP per-entity pagination proof (#241)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from scripts.crawl.pncp_entity_pagination import (
+    closing_requery,
+    expected_pages,
+    proof_report,
+    prove_scope,
+    record_page,
+    sanitize_url,
+    sla_status,
+)
+
+
+def _page(n: int, records: int = 2) -> object:
+    return record_page(
+        url=f"https://pncp.gov.br/api/consulta/v1/contratacoes?pagina={n}&token=SECRET",
+        status=200,
+        body=f"page-{n}".encode(),
+        page=n,
+        records=records,
+    )
+
+
+def test_pages_expected_equals_pages_fetched() -> None:
+    pages = [_page(1), _page(2)]
+    proof = prove_scope(
+        ente_id="cnpj-1",
+        window="2026-07",
+        modalidade="6",
+        pages_expected=2,
+        pages=pages,
+        found_count=4,
+        query_complete=True,
+    )
+    assert proof.pages_match
+    assert proof.verdict == "FOUND"
+    assert expected_pages(4, 2) == 2
+
+
+def test_each_page_records_sanitized_url_http_raw_and_hash() -> None:
+    page = _page(1)
+    assert "token=" not in page.url
+    assert "pagina=1" in page.url
+    assert page.status == 200
+    assert page.fetched_at
+    assert page.raw_uri.startswith("cas://pncp/")
+    assert len(page.sha256) == 64
+    assert sanitize_url("https://x?api_key=abc&p=1") == "https://x?p=1"
+
+
+def test_zero_confirmed_only_when_complete_and_empty() -> None:
+    empty = prove_scope(
+        ente_id="cnpj-2",
+        window="2026-07",
+        modalidade="6",
+        pages_expected=1,
+        pages=[_page(1, records=0)],
+        found_count=0,
+        query_complete=True,
+    )
+    assert empty.verdict == "ZERO_CONFIRMED"
+    incomplete = prove_scope(
+        ente_id="cnpj-2",
+        window="2026-07",
+        modalidade="6",
+        pages_expected=3,
+        pages=[_page(1)],
+        found_count=0,
+        query_complete=False,
+    )
+    assert incomplete.verdict == "SCOPE_INCOMPLETE"
+    assert incomplete.pages_match is False
+
+
+def test_sla_and_closing_requery() -> None:
+    published = datetime(2026, 8, 13, 8, 0, tzinfo=UTC)
+    ok = sla_status(published + timedelta(hours=3), published)
+    assert ok["within_slo"] is True
+    hard = sla_status(published + timedelta(hours=30), published)
+    assert hard["breach"] is True
+    requery = closing_requery(["a", "b"], {"a", "b"})
+    assert requery["complete"] is True
+    missing = closing_requery(["a", "b"], {"a"})
+    assert missing["missing"] == ["b"]
+
+
+def test_report_relates_issues_34_and_40() -> None:
+    report = proof_report(
+        [
+            prove_scope(
+                ente_id="x",
+                window="2026-07",
+                modalidade=None,
+                pages_expected=1,
+                pages=[_page(1)],
+                found_count=1,
+                query_complete=True,
+            )
+        ]
+    )
+    assert report["related"] == ["#34", "#40"]
+    assert report["scopes"][0]["verdict"] == "FOUND"


### PR DESCRIPTION
## Summary
Prova de paginação PNCP particionada por ente: pages_expected=pages_fetched, cada página com URL sanitizada, HTTP, fetched_at, raw URI e SHA-256. FOUND/ZERO_CONFIRMED só com consulta completa. Relaciona #34 e #40.

## Issues
Fixes #241

## Verification
- `pytest tests/test_pncp_entity_pagination.py` — 5 passed
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Não declara SLA operacional de 4h no host. Reconsulta de fechamento é contrato testado, não run live.