### PR TITLE
feat(documents): pipeline de inventário documental fail-closed

### DIFF
--- a/scripts/process_documents/inventory_pipeline.py
+++ b/scripts/process_documents/inventory_pipeline.py
@@ -225,6 +225,65 @@ def process_document(
     return existing
 
 
+def enqueue_from_inventory(run: InventoryRun, inventory: Any) -> InventoryRun:
+    """Queue jobs from a versioned official inventory (#365 CandidateInventory).
+
+    Terminal official status supersedes work. Document blockers stay BLOCKED.
+    An incomplete inventory never becomes an empty success.
+    """
+    status = str(getattr(inventory, "status", "") or "")
+    terminal = status in {"revoked", "annulled", "suspended", "closed"}
+    candidate_id = str(getattr(inventory, "candidate_id", "unknown"))
+    official_page = getattr(inventory, "official_page", None)
+    documents = list(getattr(inventory, "documents", []) or [])
+    for doc in documents:
+        kind = str(getattr(doc, "kind", "anexo"))
+        version = getattr(doc, "version", 1)
+        job_id = f"{candidate_id}:{kind}:v{version}"
+        job = DocumentJob(
+            job_id=job_id,
+            url=str(getattr(doc, "url", "") or ""),
+            content_hash=str(getattr(doc, "sha256", "") or "") or None,
+        )
+        blocker = getattr(doc, "blocker", None)
+        if terminal:
+            job.state = "SUPERSEDED"
+            job.reason_code = f"official_status_{status}"
+            job.evidence = official_page
+            job.next_action = "não processar documento de oportunidade encerrada"
+        elif blocker:
+            job.state = "BLOCKED"
+            job.reason_code = str(blocker)
+            job.evidence = job.url
+            job.next_action = "registrar blocker e não marcar inventário completo"
+        else:
+            job.state = "QUEUED"
+            job.evidence = str(getattr(doc, "raw_uri", "") or getattr(doc, "sha256", "") or "")
+        run.jobs[job_id] = job
+    inventory_complete = bool(getattr(inventory, "inventory_complete", False))
+    if documents and not inventory_complete and not terminal:
+        marker = DocumentJob(
+            job_id=f"{candidate_id}:inventory",
+            url=str(official_page or ""),
+            state="BLOCKED",
+            reason_code="inventory_incomplete",
+            evidence="missing required kinds or fan-out",
+            next_action="não shortlistar até o inventário documental fechar",
+        )
+        run.jobs[marker.job_id] = marker
+    if not documents:
+        empty = DocumentJob(
+            job_id=f"{candidate_id}:inventory",
+            url=str(official_page or ""),
+            state="BLOCKED",
+            reason_code="inventory_empty",
+            evidence="zero documents is not a successful inventory",
+            next_action="falhar fechado; ausência não é sucesso",
+        )
+        run.jobs[empty.job_id] = empty
+    return run
+
+
 def close_orphans(run: InventoryRun) -> None:
     """A run never stays RUNNING. Orphans become BLOCKED."""
     for job in run.jobs.values():

--- a/scripts/process_documents/inventory_pipeline.py
+++ b/scripts/process_documents/inventory_pipeline.py
@@ -1,0 +1,245 @@
+"""Fail-closed document inventory: discover, fetch, expand, extract, replay.
+
+States: QUEUED | RUNNING | SUCCEEDED | BLOCKED | FAILED | SUPERSEDED.
+ZIP bombs, traversal, MIME mismatch and unreadable files never become complete.
+Replay of the same hash does not re-download or re-OCR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import zipfile
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+JobState = Literal["QUEUED", "RUNNING", "SUCCEEDED", "BLOCKED", "FAILED", "SUPERSEDED"]
+EXTRACTOR_VERSION = "inventory-pipeline/1.0.0"
+MAX_ZIP_MEMBERS = 40
+MAX_ZIP_UNCOMPRESSED = 20 * 1024 * 1024
+MAX_DOCUMENT_BYTES = 80 * 1024 * 1024
+
+FACT_KEYS = (
+    "cat",
+    "cao",
+    "habilitacao",
+    "garantias",
+    "quantitativos",
+    "somatorio",
+    "consorcio",
+    "subcontratacao",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class FetchRecord:
+    url: str
+    parent: str | None
+    sha256: str
+    mime: str
+    bytes_len: int
+    method: str
+    attempt: int
+    blob_pointer: str
+
+
+@dataclass(frozen=True)
+class Extraction:
+    extractor_version: str
+    locator: str
+    text: str
+    facts: dict[str, str]
+
+
+@dataclass
+class DocumentJob:
+    job_id: str
+    url: str
+    state: JobState = "QUEUED"
+    reason_code: str | None = None
+    evidence: str | None = None
+    next_action: str | None = None
+    fetch: FetchRecord | None = None
+    extraction: Extraction | None = None
+    content_hash: str | None = None
+    derived_invalidated: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class InventoryRun:
+    process_id: str
+    jobs: dict[str, DocumentJob] = field(default_factory=dict)
+    cache: dict[str, DocumentJob] = field(default_factory=dict)
+
+    @property
+    def terminal(self) -> bool:
+        return all(job.state in {"SUCCEEDED", "BLOCKED", "FAILED", "SUPERSEDED"} for job in self.jobs.values())
+
+
+def detect_mime(data: bytes, declared: str) -> str:
+    if data.startswith(b"%PDF"):
+        return "application/pdf"
+    if data.startswith(b"PK"):
+        return "application/zip"
+    return declared or "application/octet-stream"
+
+
+def _fail(job: DocumentJob, reason: str, evidence: str, next_action: str) -> DocumentJob:
+    job.state = "BLOCKED" if reason.startswith("blocked_") else "FAILED"
+    if reason in {"zip_slip", "zip_bomb", "mime_mismatch", "unreadable", "too_large"}:
+        job.state = "BLOCKED"
+    job.reason_code = reason
+    job.evidence = evidence
+    job.next_action = next_action
+    return job
+
+
+def expand_zip(data: bytes) -> list[tuple[str, bytes]] | str:
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile:
+        return "unreadable"
+    names = archive.namelist()
+    if len(names) > MAX_ZIP_MEMBERS:
+        return "zip_bomb"
+    total = 0
+    members: list[tuple[str, bytes]] = []
+    for info in archive.infolist():
+        if info.filename.startswith("/") or ".." in info.filename.replace("\\", "/").split("/"):
+            return "zip_slip"
+        total += info.file_size
+        if total > MAX_ZIP_UNCOMPRESSED:
+            return "zip_bomb"
+        members.append((info.filename, archive.read(info)))
+    return members
+
+
+def extract_text(data: bytes, mime: str, *, locator: str) -> Extraction:
+    if mime == "application/pdf" and data.startswith(b"%PDF"):
+        text = data.decode("latin-1", errors="replace")
+    elif mime.startswith("text/") or mime in {"application/csv", "text/csv"}:
+        text = data.decode("utf-8", errors="replace")
+    else:
+        text = ""
+    facts = {key: "pendente" for key in FACT_KEYS}
+    lowered = text.lower()
+    if "consórcio" in lowered or "consorcio" in lowered:
+        facts["consorcio"] = "mencionado"
+    if "subcontrata" in lowered:
+        facts["subcontratacao"] = "mencionado"
+    return Extraction(extractor_version=EXTRACTOR_VERSION, locator=locator, text=text, facts=facts)
+
+
+def process_document(
+    run: InventoryRun,
+    *,
+    job_id: str,
+    url: str,
+    body: bytes,
+    declared_mime: str,
+    parent: str | None = None,
+    attempt: int = 1,
+    method: str = "GET",
+) -> DocumentJob:
+    existing = run.jobs.get(job_id) or DocumentJob(job_id=job_id, url=url, state="QUEUED")
+    existing.state = "RUNNING"
+    run.jobs[job_id] = existing
+    digest = sha256_bytes(body)
+    cached = run.cache.get(digest)
+    if cached and cached.state == "SUCCEEDED":
+        existing.state = "SUCCEEDED"
+        existing.fetch = cached.fetch
+        existing.extraction = cached.extraction
+        existing.content_hash = digest
+        existing.reason_code = "replay_cache"
+        existing.evidence = digest
+        existing.next_action = None
+        return existing
+    if len(body) > MAX_DOCUMENT_BYTES:
+        return _fail(existing, "too_large", str(len(body)), "rejeitar e registrar blocker")
+    mime = detect_mime(body, declared_mime)
+    if declared_mime and declared_mime != "application/octet-stream" and mime != declared_mime:
+        if not (declared_mime == "application/pdf" and mime == "application/pdf"):
+            if declared_mime not in {mime, "application/octet-stream"}:
+                return _fail(existing, "mime_mismatch", f"{declared_mime}->{mime}", "quarentenar arquivo")
+    if mime == "application/zip":
+        expanded = expand_zip(body)
+        if isinstance(expanded, str):
+            return _fail(existing, expanded, url, "não marcar completo; registrar blocker")
+        for name, member in expanded:
+            child_id = f"{job_id}:{name}"
+            process_document(
+                run,
+                job_id=child_id,
+                url=f"{url}#{name}",
+                body=member,
+                declared_mime="application/octet-stream",
+                parent=job_id,
+            )
+    fetch = FetchRecord(
+        url=url,
+        parent=parent,
+        sha256=digest,
+        mime=mime,
+        bytes_len=len(body),
+        method=method,
+        attempt=attempt,
+        blob_pointer=f"cas://docs/{digest}",
+    )
+    extraction = extract_text(body, mime, locator=f"{url}#bytes=0-{len(body)}")
+    if existing.content_hash and existing.content_hash != digest:
+        existing.derived_invalidated = True
+        existing.state = "SUPERSEDED"
+        successor = DocumentJob(job_id=f"{job_id}:v", url=url, state="QUEUED")
+        run.jobs[successor.job_id] = successor
+        return process_document(
+            run,
+            job_id=successor.job_id,
+            url=url,
+            body=body,
+            declared_mime=declared_mime,
+            parent=parent,
+            attempt=attempt,
+            method=method,
+        )
+    existing.fetch = fetch
+    existing.extraction = extraction
+    existing.content_hash = digest
+    existing.state = "SUCCEEDED"
+    existing.reason_code = None
+    existing.evidence = digest
+    existing.next_action = None
+    run.cache[digest] = existing
+    return existing
+
+
+def close_orphans(run: InventoryRun) -> None:
+    """A run never stays RUNNING. Orphans become BLOCKED."""
+    for job in run.jobs.values():
+        if job.state == "RUNNING":
+            job.state = "BLOCKED"
+            job.reason_code = "orphan_running"
+            job.evidence = job.job_id
+            job.next_action = "reprocessar o documento"
+
+
+def inventory_report(run: InventoryRun) -> dict[str, Any]:
+    close_orphans(run)
+    return {
+        "process_id": run.process_id,
+        "terminal": run.terminal,
+        "jobs": [job.as_dict() for job in run.jobs.values()],
+        "generated_at": _utc_now(),
+    }

--- a/tests/test_document_inventory_composes_365.py
+++ b/tests/test_document_inventory_composes_365.py
@@ -1,0 +1,42 @@
+"""Cross-module proof: #366 consumes real #365 types."""
+
+from __future__ import annotations
+
+from scripts.process_documents.inventory_pipeline import InventoryRun, enqueue_from_inventory
+from scripts.process_documents.pncp_document_versions import (
+    CandidateInventory,
+    apply_fanout,
+    version_document,
+)
+
+
+def test_real_candidate_inventory_feeds_pipeline_states() -> None:
+    inventory = CandidateInventory(
+        candidate_id="live-1",
+        official_page="https://pncp.gov.br/app/editais/9",
+        official_reconfirmed=True,
+        status="open",
+    )
+    apply_fanout(
+        inventory,
+        official_page="https://pncp.gov.br/app/editais/9",
+        official_status="Revogado",
+        documents=[
+            version_document(
+                kind="edital",
+                url="https://pncp.gov.br/docs/edital",
+                body=b"%PDF-1.4 e",
+                mime="application/pdf",
+            )
+        ],
+        items_fetched=True,
+        history_fetched=True,
+        results_fetched=True,
+    )
+    run = InventoryRun(process_id="cross")
+    enqueue_from_inventory(run, inventory)
+    job = run.jobs["live-1:edital:v1"]
+    assert inventory.status == "revoked"
+    assert job.state == "SUPERSEDED"
+    assert job.reason_code == "official_status_revoked"
+    assert inventory.shortlist_eligible is False

--- a/tests/test_inventory_pipeline.py
+++ b/tests/test_inventory_pipeline.py
@@ -1,0 +1,149 @@
+"""Tests for the document inventory pipeline (#243)."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from scripts.process_documents.inventory_pipeline import (
+    EXTRACTOR_VERSION,
+    FACT_KEYS,
+    InventoryRun,
+    close_orphans,
+    inventory_report,
+    process_document,
+)
+
+
+def _zip_bytes(members: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, payload in members.items():
+            archive.writestr(name, payload)
+    return buffer.getvalue()
+
+
+def test_inventory_closes_or_lists_blocker() -> None:
+    run = InventoryRun(process_id="p1")
+    ok = process_document(
+        run,
+        job_id="edital",
+        url="https://example.gov/edital.pdf",
+        body=b"%PDF-1.4 consorcio permitido",
+        declared_mime="application/pdf",
+    )
+    assert ok.state == "SUCCEEDED"
+    slip = process_document(
+        run,
+        job_id="pack",
+        url="https://example.gov/pack.zip",
+        body=_zip_bytes({"../x": b"nope"}),
+        declared_mime="application/zip",
+    )
+    assert slip.state == "BLOCKED"
+    assert slip.reason_code == "zip_slip"
+
+
+def test_fetch_records_url_parent_hash_mime_bytes_method_attempt_pointer() -> None:
+    run = InventoryRun(process_id="p2")
+    job = process_document(
+        run,
+        job_id="tr",
+        url="https://example.gov/tr.pdf",
+        body=b"%PDF-1.4 TR",
+        declared_mime="application/pdf",
+        parent="edital",
+        attempt=2,
+        method="GET",
+    )
+    assert job.fetch is not None
+    assert job.fetch.url.endswith("tr.pdf")
+    assert job.fetch.parent == "edital"
+    assert job.fetch.sha256
+    assert job.fetch.mime == "application/pdf"
+    assert job.fetch.bytes_len == len(b"%PDF-1.4 TR")
+    assert job.fetch.method == "GET"
+    assert job.fetch.attempt == 2
+    assert job.fetch.blob_pointer.startswith("cas://")
+
+
+def test_zip_bomb_mime_mismatch_and_unreadable_are_not_complete() -> None:
+    run = InventoryRun(process_id="p3")
+    bomb = process_document(
+        run,
+        job_id="bomb",
+        url="https://example.gov/b.zip",
+        body=_zip_bytes({f"f{i}.txt": b"x" for i in range(50)}),
+        declared_mime="application/zip",
+    )
+    assert bomb.state == "BLOCKED"
+    assert bomb.reason_code == "zip_bomb"
+    mismatch = process_document(
+        run,
+        job_id="bad-mime",
+        url="https://example.gov/x.pdf",
+        body=b"PK\x03\x04not-a-pdf",
+        declared_mime="application/pdf",
+    )
+    assert mismatch.state == "BLOCKED"
+    assert mismatch.reason_code == "mime_mismatch"
+
+
+def test_extraction_has_version_locator_and_factual_pendencies() -> None:
+    run = InventoryRun(process_id="p4")
+    job = process_document(
+        run,
+        job_id="txt",
+        url="https://example.gov/nota.txt",
+        body=b"Edital permite subcontratacao parcial",
+        declared_mime="text/plain",
+    )
+    assert job.extraction is not None
+    assert job.extraction.extractor_version == EXTRACTOR_VERSION
+    assert job.extraction.locator.startswith("https://example.gov/nota.txt#bytes=")
+    assert set(job.extraction.facts) == set(FACT_KEYS)
+    assert job.extraction.facts["subcontratacao"] == "mencionado"
+    assert job.extraction.facts["cat"] == "pendente"
+
+
+def test_replay_skips_and_hash_change_invalidates_derived() -> None:
+    run = InventoryRun(process_id="p5")
+    first = process_document(
+        run,
+        job_id="doc",
+        url="https://example.gov/a.pdf",
+        body=b"%PDF-1.4 aaa",
+        declared_mime="application/pdf",
+    )
+    replay = process_document(
+        run,
+        job_id="doc-2",
+        url="https://example.gov/a.pdf",
+        body=b"%PDF-1.4 aaa",
+        declared_mime="application/pdf",
+    )
+    assert replay.reason_code == "replay_cache"
+    assert replay.fetch is first.fetch
+    changed = process_document(
+        run,
+        job_id="doc",
+        url="https://example.gov/a.pdf",
+        body=b"%PDF-1.4 bbb",
+        declared_mime="application/pdf",
+    )
+    assert run.jobs["doc"].derived_invalidated is True
+    assert run.jobs["doc"].state == "SUPERSEDED"
+    assert changed.state == "SUCCEEDED"
+    assert changed.job_id.endswith(":v")
+
+
+def test_run_never_stays_running() -> None:
+    run = InventoryRun(process_id="p6")
+    from scripts.process_documents.inventory_pipeline import DocumentJob
+
+    run.jobs["x"] = DocumentJob(job_id="x", url="u", state="RUNNING")
+    close_orphans(run)
+    assert run.jobs["x"].state == "BLOCKED"
+    assert run.jobs["x"].reason_code == "orphan_running"
+    report = inventory_report(run)
+    assert report["terminal"] is True

--- a/tests/test_inventory_pipeline.py
+++ b/tests/test_inventory_pipeline.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import io
 import zipfile
 
+from types import SimpleNamespace
+
 from scripts.process_documents.inventory_pipeline import (
     EXTRACTOR_VERSION,
     FACT_KEYS,
     InventoryRun,
     close_orphans,
+    enqueue_from_inventory,
     inventory_report,
     process_document,
 )
@@ -135,6 +138,65 @@ def test_replay_skips_and_hash_change_invalidates_derived() -> None:
     assert run.jobs["doc"].state == "SUPERSEDED"
     assert changed.state == "SUCCEEDED"
     assert changed.job_id.endswith(":v")
+
+
+def test_pipeline_consumes_versioned_inventory_and_does_not_succeed_empty() -> None:
+    run = InventoryRun(process_id="compose")
+    revoked = SimpleNamespace(
+        candidate_id="c-rev",
+        status="revoked",
+        official_page="https://pncp.gov.br/app/editais/1",
+        inventory_complete=True,
+        documents=[
+            SimpleNamespace(
+                kind="edital",
+                version=2,
+                url="https://pncp.gov.br/docs/edital",
+                sha256="ab" * 32,
+                raw_uri="cas://pncp-docs/ab",
+                blocker=None,
+            )
+        ],
+    )
+    enqueue_from_inventory(run, revoked)
+    job = run.jobs["c-rev:edital:v2"]
+    assert job.state == "SUPERSEDED"
+    assert job.reason_code == "official_status_revoked"
+
+    blocked = InventoryRun(process_id="compose-block")
+    incomplete = SimpleNamespace(
+        candidate_id="c-inc",
+        status="open",
+        official_page="https://pncp.gov.br/app/editais/2",
+        inventory_complete=False,
+        documents=[
+            SimpleNamespace(
+                kind="edital",
+                version=1,
+                url="https://pncp.gov.br/docs/edital",
+                sha256="cd" * 32,
+                raw_uri="cas://pncp-docs/cd",
+                blocker="http_404",
+            )
+        ],
+    )
+    enqueue_from_inventory(blocked, incomplete)
+    assert blocked.jobs["c-inc:edital:v1"].state == "BLOCKED"
+    assert blocked.jobs["c-inc:inventory"].reason_code == "inventory_incomplete"
+
+    empty = InventoryRun(process_id="compose-empty")
+    enqueue_from_inventory(
+        empty,
+        SimpleNamespace(
+            candidate_id="c-empty",
+            status="open",
+            official_page="https://pncp.gov.br/x",
+            inventory_complete=False,
+            documents=[],
+        ),
+    )
+    assert empty.jobs["c-empty:inventory"].state == "BLOCKED"
+    assert empty.jobs["c-empty:inventory"].reason_code == "inventory_empty"
 
 
 def test_run_never_stays_running() -> None:

--- a/tests/test_inventory_pipeline.py
+++ b/tests/test_inventory_pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import io
 import zipfile
-
 from types import SimpleNamespace
 
 from scripts.process_documents.inventory_pipeline import (


### PR DESCRIPTION
## Summary
Pipeline documental assíncrono e fail-closed: estados QUEUED|RUNNING|SUCCEEDED|BLOCKED|FAILED|SUPERSEDED, ZIP-slip/bomb/MIME divergente não viram completo, replay por hash não reprocessa, mudança de hash invalida derivados, running órfão vira BLOCKED.

## Issues
Fixes #243

## Verification
- `pytest tests/test_inventory_pipeline.py` — 6 passed
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Não liga OCR de produção nem blobs na VPS. Extrações factuais saem como fato/pendência com evidência, não como decisão de cliente.