### PR TITLE
feat(ops): gate fail-closed de deploy e soak na VPS

### DIFF
--- a/scripts/ops/deploy_soak_gate.py
+++ b/scripts/ops/deploy_soak_gate.py
@@ -12,7 +12,8 @@ from datetime import UTC, datetime
 from typing import Any, Literal
 
 PENDING_HUMAN = "PENDING_HUMAN"
-FORBIDDEN_CLAIMS = frozenset({"VPS_OPERATIONAL", "LOCAL_READY", "95%"})
+FORBIDDEN_CLAIMS = frozenset({"VPS_OPERATIONAL", "95%"})
+EVIDENCE_TIERS = ("CODE_READY", "LOCAL_READY", "DEPLOYED", "SOAK_PASSED", "VPS_OPERATIONAL")
 PILOT_REQUIRED = ("pagination", "dedup", "raw", "documents", "replay")
 SoakVerdict = Literal["PENDING_HUMAN", "ABORT"]
 
@@ -33,6 +34,8 @@ class DeployDecision:
     approved_sha: str | None = None
     claims: list[str] = field(default_factory=list)
     gates: list[GateResult] = field(default_factory=list)
+    achieved_tiers: list[str] = field(default_factory=list)
+    ceiling: str = "NONE"
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -42,6 +45,8 @@ class DeployDecision:
             "implanted_sha": self.implanted_sha,
             "approved_sha": self.approved_sha,
             "claims": list(self.claims),
+            "achieved_tiers": list(self.achieved_tiers),
+            "ceiling": self.ceiling,
             "gates": [asdict(g) for g in self.gates],
             "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         }
@@ -104,6 +109,31 @@ def evaluate_soak(*, backup_restore: bool, freshness_ok: bool, days: int) -> Gat
     return GateResult("soak", True, "7d_backup_freshness")
 
 
+def evidence_tiers(
+    *,
+    preflight: GateResult,
+    sha: GateResult,
+    pilot: GateResult,
+    reboot: GateResult,
+    soak: GateResult,
+    local_ready_evidence: bool,
+) -> list[str]:
+    """Evidence-gated ladder. VPS_OPERATIONAL is never automated."""
+    achieved: list[str] = []
+    if not preflight.passed:
+        return achieved
+    achieved.append("CODE_READY")
+    if local_ready_evidence:
+        achieved.append("LOCAL_READY")
+    if sha.passed:
+        achieved.append("DEPLOYED")
+    else:
+        return achieved
+    if pilot.passed and reboot.passed and soak.passed:
+        achieved.append("SOAK_PASSED")
+    return achieved
+
+
 def decide_deploy(
     *,
     test_exit: int,
@@ -118,6 +148,7 @@ def decide_deploy(
     freshness_ok: bool,
     soak_days: int,
     requested_claims: list[str] | None = None,
+    local_ready_evidence: bool = False,
 ) -> DeployDecision:
     decision = DeployDecision(
         state=PENDING_HUMAN,
@@ -138,11 +169,21 @@ def decide_deploy(
     if failed:
         decision.abort = True
         decision.reasons = [f"{g.name}:{g.detail}" for g in failed]
-    illegal = [c for c in (requested_claims or []) if c in FORBIDDEN_CLAIMS]
+    illegal = [c for c in (requested_claims or []) if c in FORBIDDEN_CLAIMS or c == "VPS_OPERATIONAL"]
     if illegal:
         decision.abort = True
         decision.reasons.append(f"forbidden_claim:{illegal[0]}")
-    # State never auto-promotes.
+    preflight, sha, pilot, reboot, soak = gates
+    decision.achieved_tiers = evidence_tiers(
+        preflight=preflight,
+        sha=sha,
+        pilot=pilot,
+        reboot=reboot,
+        soak=soak,
+        local_ready_evidence=local_ready_evidence,
+    )
+    decision.ceiling = decision.achieved_tiers[-1] if decision.achieved_tiers else "NONE"
+    # Automation never claims VPS_OPERATIONAL; human remains the promoter.
     decision.state = PENDING_HUMAN
     decision.claims = []
     return decision

--- a/scripts/ops/deploy_soak_gate.py
+++ b/scripts/ops/deploy_soak_gate.py
@@ -1,0 +1,148 @@
+"""Fail-closed deploy and soak gate for VPS operation.
+
+Test/crawl failures abort the deploy. The implanted SHA must equal the SHA
+approved in CI. No automation may declare VPS_OPERATIONAL; the state remains
+PENDING_HUMAN.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+PENDING_HUMAN = "PENDING_HUMAN"
+FORBIDDEN_CLAIMS = frozenset({"VPS_OPERATIONAL", "LOCAL_READY", "95%"})
+PILOT_REQUIRED = ("pagination", "dedup", "raw", "documents", "replay")
+SoakVerdict = Literal["PENDING_HUMAN", "ABORT"]
+
+
+@dataclass(frozen=True)
+class GateResult:
+    name: str
+    passed: bool
+    detail: str
+
+
+@dataclass
+class DeployDecision:
+    state: str
+    abort: bool
+    reasons: list[str] = field(default_factory=list)
+    implanted_sha: str | None = None
+    approved_sha: str | None = None
+    claims: list[str] = field(default_factory=list)
+    gates: list[GateResult] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state,
+            "abort": self.abort,
+            "reasons": list(self.reasons),
+            "implanted_sha": self.implanted_sha,
+            "approved_sha": self.approved_sha,
+            "claims": list(self.claims),
+            "gates": [asdict(g) for g in self.gates],
+            "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        }
+
+
+def command_is_masked(command: str) -> bool:
+    """Scripts that swallow pytest/crawl failures with `|| true` are illegal."""
+    compact = " ".join(command.split())
+    return "|| true" in compact or "||true" in compact
+
+
+def sha_matches(implanted_sha: str, approved_sha: str) -> bool:
+    if not implanted_sha or not approved_sha:
+        return False
+    return implanted_sha.lower() == approved_sha.lower()
+
+
+def evaluate_preflight(
+    *,
+    test_exit: int,
+    crawl_exit: int,
+    commands: list[str],
+) -> GateResult:
+    masked = [cmd for cmd in commands if command_is_masked(cmd)]
+    if masked:
+        return GateResult("preflight", False, f"masked_failure:{masked[0]}")
+    if test_exit != 0:
+        return GateResult("preflight", False, f"test_exit={test_exit}")
+    if crawl_exit != 0:
+        return GateResult("preflight", False, f"crawl_exit={crawl_exit}")
+    return GateResult("preflight", True, "tests_and_crawls_passed")
+
+
+def evaluate_sha(implanted_sha: str, approved_sha: str) -> GateResult:
+    if sha_matches(implanted_sha, approved_sha):
+        return GateResult("sha", True, implanted_sha)
+    return GateResult("sha", False, f"{implanted_sha}!={approved_sha}")
+
+
+def evaluate_pilot(proven: set[str]) -> GateResult:
+    missing = [item for item in PILOT_REQUIRED if item not in proven]
+    if missing:
+        return GateResult("pilot", False, f"missing:{','.join(missing)}")
+    return GateResult("pilot", True, "pagination,dedup,raw,documents,replay")
+
+
+def evaluate_reboot(leases_recovered: bool, jobs_recovered: bool) -> GateResult:
+    if leases_recovered and jobs_recovered:
+        return GateResult("reboot", True, "leases_and_jobs_recovered")
+    return GateResult("reboot", False, "recovery_incomplete")
+
+
+def evaluate_soak(*, backup_restore: bool, freshness_ok: bool, days: int) -> GateResult:
+    if days < 7:
+        return GateResult("soak", False, f"days={days}<7")
+    if not backup_restore:
+        return GateResult("soak", False, "backup_restore_unproven")
+    if not freshness_ok:
+        return GateResult("soak", False, "freshness_unproven")
+    return GateResult("soak", True, "7d_backup_freshness")
+
+
+def decide_deploy(
+    *,
+    test_exit: int,
+    crawl_exit: int,
+    commands: list[str],
+    implanted_sha: str,
+    approved_sha: str,
+    pilot_proven: set[str],
+    leases_recovered: bool,
+    jobs_recovered: bool,
+    backup_restore: bool,
+    freshness_ok: bool,
+    soak_days: int,
+    requested_claims: list[str] | None = None,
+) -> DeployDecision:
+    decision = DeployDecision(
+        state=PENDING_HUMAN,
+        abort=False,
+        implanted_sha=implanted_sha,
+        approved_sha=approved_sha,
+        claims=[],
+    )
+    gates = [
+        evaluate_preflight(test_exit=test_exit, crawl_exit=crawl_exit, commands=commands),
+        evaluate_sha(implanted_sha, approved_sha),
+        evaluate_pilot(pilot_proven),
+        evaluate_reboot(leases_recovered, jobs_recovered),
+        evaluate_soak(backup_restore=backup_restore, freshness_ok=freshness_ok, days=soak_days),
+    ]
+    decision.gates = gates
+    failed = [g for g in gates if not g.passed]
+    if failed:
+        decision.abort = True
+        decision.reasons = [f"{g.name}:{g.detail}" for g in failed]
+    illegal = [c for c in (requested_claims or []) if c in FORBIDDEN_CLAIMS]
+    if illegal:
+        decision.abort = True
+        decision.reasons.append(f"forbidden_claim:{illegal[0]}")
+    # State never auto-promotes.
+    decision.state = PENDING_HUMAN
+    decision.claims = []
+    return decision

--- a/tests/test_deploy_soak_gate.py
+++ b/tests/test_deploy_soak_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from scripts.ops.deploy_soak_gate import (
+    EVIDENCE_TIERS,
     FORBIDDEN_CLAIMS,
     PENDING_HUMAN,
     command_is_masked,
@@ -82,3 +83,25 @@ def test_state_stays_pending_human_and_never_claims_vps_operational() -> None:
     payload = clean.as_dict()
     assert payload["state"] == PENDING_HUMAN
     assert "VPS_OPERATIONAL" not in payload["claims"]
+    assert "VPS_OPERATIONAL" not in payload["achieved_tiers"]
+    assert payload["ceiling"] == "SOAK_PASSED"
+    assert payload["achieved_tiers"] == ["CODE_READY", "DEPLOYED", "SOAK_PASSED"]
+
+
+def test_evidence_tiers_are_distinct_and_never_auto_vps() -> None:
+    assert EVIDENCE_TIERS == (
+        "CODE_READY",
+        "LOCAL_READY",
+        "DEPLOYED",
+        "SOAK_PASSED",
+        "VPS_OPERATIONAL",
+    )
+    code_only = decide_deploy(**_ok_kwargs(test_exit=1))
+    assert code_only.ceiling == "NONE"
+    assert code_only.achieved_tiers == []
+    local = decide_deploy(**_ok_kwargs(local_ready_evidence=True, soak_days=1))
+    assert "CODE_READY" in local.achieved_tiers
+    assert "LOCAL_READY" in local.achieved_tiers
+    assert local.ceiling == "DEPLOYED"
+    assert "SOAK_PASSED" not in local.achieved_tiers
+    assert "VPS_OPERATIONAL" not in local.achieved_tiers

--- a/tests/test_deploy_soak_gate.py
+++ b/tests/test_deploy_soak_gate.py
@@ -1,0 +1,84 @@
+"""Tests for the fail-closed deploy/soak gate (#248)."""
+
+from __future__ import annotations
+
+from scripts.ops.deploy_soak_gate import (
+    FORBIDDEN_CLAIMS,
+    PENDING_HUMAN,
+    command_is_masked,
+    decide_deploy,
+    evaluate_preflight,
+    sha_matches,
+)
+
+
+def _ok_kwargs(**overrides):
+    kwargs = {
+        "test_exit": 0,
+        "crawl_exit": 0,
+        "commands": ["pytest tests/ -q", "python -m scripts.crawl.monitor --source pncp --mode smoke"],
+        "implanted_sha": "abc123def",
+        "approved_sha": "abc123def",
+        "pilot_proven": {"pagination", "dedup", "raw", "documents", "replay"},
+        "leases_recovered": True,
+        "jobs_recovered": True,
+        "backup_restore": True,
+        "freshness_ok": True,
+        "soak_days": 7,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_masked_pytest_or_true_aborts_deploy() -> None:
+    assert command_is_masked("pytest tests/ || true") is True
+    gate = evaluate_preflight(test_exit=0, crawl_exit=0, commands=["pytest || true"])
+    assert gate.passed is False
+    decision = decide_deploy(**_ok_kwargs(commands=["pytest tests/ || true"]))
+    assert decision.abort is True
+    assert any("masked_failure" in r for r in decision.reasons)
+
+
+def test_failed_test_or_crawl_aborts() -> None:
+    tests = decide_deploy(**_ok_kwargs(test_exit=1))
+    assert tests.abort is True
+    assert any("test_exit" in r for r in tests.reasons)
+    crawl = decide_deploy(**_ok_kwargs(crawl_exit=2))
+    assert crawl.abort is True
+
+
+def test_sha_implanted_must_equal_ci_approved() -> None:
+    assert sha_matches("ABC", "abc") is True
+    mismatch = decide_deploy(**_ok_kwargs(implanted_sha="deadbeef", approved_sha="cafebabe"))
+    assert mismatch.abort is True
+    assert any("sha:" in r for r in mismatch.reasons)
+
+
+def test_pilot_requires_pagination_dedup_raw_documents_replay() -> None:
+    missing = decide_deploy(**_ok_kwargs(pilot_proven={"pagination", "dedup"}))
+    assert missing.abort is True
+    assert "documents" in missing.reasons[0] or any("pilot" in r for r in missing.reasons)
+
+
+def test_reboot_and_soak_are_required() -> None:
+    reboot = decide_deploy(**_ok_kwargs(leases_recovered=False))
+    assert reboot.abort is True
+    soak = decide_deploy(**_ok_kwargs(soak_days=3))
+    assert soak.abort is True
+    freshness = decide_deploy(**_ok_kwargs(freshness_ok=False))
+    assert freshness.abort is True
+
+
+def test_state_stays_pending_human_and_never_claims_vps_operational() -> None:
+    decision = decide_deploy(**_ok_kwargs(), requested_claims=["VPS_OPERATIONAL"])
+    assert decision.state == PENDING_HUMAN
+    assert "VPS_OPERATIONAL" in FORBIDDEN_CLAIMS
+    assert decision.abort is True
+    assert any("forbidden_claim" in r for r in decision.reasons)
+    clean = decide_deploy(**_ok_kwargs())
+    assert clean.state == PENDING_HUMAN
+    assert clean.abort is False
+    assert clean.claims == []
+    payload = clean.as_dict()
+    assert payload["state"] == PENDING_HUMAN
+    assert "VPS_OPERATIONAL" not in payload["claims"]


### PR DESCRIPTION
## Summary
Gate de deploy/soak fail-closed: falha de teste/crawl aborta, `|| true` é ilegal, SHA implantado deve igualar o SHA aprovado no CI, piloto exige paginação/dedup/raw/documentos/replay, reboot recupera leases/jobs. Estado permanece PENDING_HUMAN.

## Issues
Fixes #248

## Verification
- `pytest tests/test_deploy_soak_gate.py` — 6 passed
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Nenhuma automação declara `VPS_OPERATIONAL`. Host de record ≠ operacional.