### PR TITLE
feat(crawl): backfill incremental de contratos PNCP por ente

### DIFF
--- a/scripts/crawl/pncp_contracts_backfill.py
+++ b/scripts/crawl/pncp_contracts_backfill.py
@@ -101,6 +101,11 @@ def ingest_window(
 ) -> WindowJob:
     job.pages = list(pages)
     job.fetched = len(rows)
+    job.persisted = []
+    job.rejected = []
+    job.error = None
+    job.checkpoint_after_persist = False
+    job.status = None
     if any(p.retryable and p.status != 200 for p in pages) and not query_complete:
         job.status = "failed"
         job.error = "retryable_http"

--- a/scripts/crawl/pncp_contracts_backfill.py
+++ b/scripts/crawl/pncp_contracts_backfill.py
@@ -1,0 +1,186 @@
+"""Per-entity / per-window PNCP contracts backfill.
+
+Each window ends complete or failed. Pagination, raw URI, hashes and
+obtained/rejected/persisted reconcile. Values distinguish estimado,
+homologado, contratado and pago. Buyer intelligence only uses rows with
+provenance. 429/5xx are retryable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+WINDOW_START = "2025-01-01"
+RETRYABLE = frozenset({408, 429, 500, 502, 503, 504})
+VALUE_KINDS = ("estimado", "homologado", "contratado", "pago")
+WindowStatus = Literal["complete", "failed"]
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class PageEvidence:
+    page: int
+    url: str
+    status: int
+    raw_uri: str
+    sha256: str
+    records: int
+    retryable: bool
+
+
+@dataclass(frozen=True)
+class ContractObservation:
+    ente_id: str
+    contract_id: str
+    value_kind: str
+    amount: float
+    provenance: dict[str, Any]
+
+
+@dataclass
+class WindowJob:
+    ente_id: str
+    window_start: str
+    window_end: str
+    status: WindowStatus | None = None
+    checkpoint_after_persist: bool = False
+    pages: list[PageEvidence] = field(default_factory=list)
+    persisted: list[ContractObservation] = field(default_factory=list)
+    rejected: list[dict[str, str]] = field(default_factory=list)
+    fetched: int = 0
+    error: str | None = None
+
+    @property
+    def balanced(self) -> bool:
+        return self.fetched == len(self.persisted) + len(self.rejected)
+
+
+def classify_value(kind: str, amount: Any) -> tuple[str, float] | str:
+    key = (kind or "").strip().lower()
+    if key not in VALUE_KINDS:
+        return "unknown_value_kind"
+    try:
+        number = float(amount)
+    except (TypeError, ValueError):
+        return "invalid_amount"
+    if number < 0:
+        return "negative_amount"
+    return key, number
+
+
+def record_page(*, page: int, url: str, status: int, body: bytes, records: int) -> PageEvidence:
+    digest = sha256_bytes(body)
+    return PageEvidence(
+        page=page,
+        url=url,
+        status=status,
+        raw_uri=f"cas://pncp-contracts/{digest}",
+        sha256=digest,
+        records=records,
+        retryable=status in RETRYABLE,
+    )
+
+
+def ingest_window(
+    job: WindowJob,
+    *,
+    pages: list[PageEvidence],
+    rows: list[dict[str, Any]],
+    query_complete: bool,
+    persist_ok: bool,
+) -> WindowJob:
+    job.pages = list(pages)
+    job.fetched = len(rows)
+    if any(p.retryable and p.status != 200 for p in pages) and not query_complete:
+        job.status = "failed"
+        job.error = "retryable_http"
+        job.checkpoint_after_persist = False
+        return job
+    if not query_complete:
+        job.status = "failed"
+        job.error = "scope_incomplete"
+        return job
+    if not persist_ok:
+        job.status = "failed"
+        job.error = "persist_failed"
+        job.checkpoint_after_persist = False
+        return job
+    for row in rows:
+        classified = classify_value(str(row.get("value_kind") or ""), row.get("amount"))
+        if isinstance(classified, str):
+            job.rejected.append({"contract_id": str(row.get("contract_id") or ""), "reason": classified})
+            continue
+        kind, amount = classified
+        provenance = {
+            "page": row.get("page"),
+            "raw_uri": row.get("raw_uri"),
+            "sha256": row.get("sha256"),
+            "source": "pncp_contratos",
+        }
+        if not provenance["raw_uri"] or not provenance["sha256"]:
+            job.rejected.append({"contract_id": str(row.get("contract_id") or ""), "reason": "missing_provenance"})
+            continue
+        job.persisted.append(
+            ContractObservation(
+                ente_id=job.ente_id,
+                contract_id=str(row["contract_id"]),
+                value_kind=kind,
+                amount=amount,
+                provenance=provenance,
+            )
+        )
+    if not job.balanced:
+        job.status = "failed"
+        job.error = "count_mismatch"
+        return job
+    job.status = "complete"
+    job.checkpoint_after_persist = True
+    job.error = None
+    return job
+
+
+def zero_proof(job: WindowJob) -> dict[str, Any]:
+    if job.status != "complete":
+        return {"ente_id": job.ente_id, "verdict": "SCOPE_INCOMPLETE", "count": len(job.persisted)}
+    if job.persisted:
+        return {"ente_id": job.ente_id, "verdict": "FOUND", "count": len(job.persisted)}
+    return {"ente_id": job.ente_id, "verdict": "ZERO_CONFIRMED", "count": 0}
+
+
+def buyer_intel_rows(jobs: list[WindowJob]) -> list[ContractObservation]:
+    """Buyer intelligence uses only persisted rows that carry provenance."""
+    rows: list[ContractObservation] = []
+    for job in jobs:
+        for item in job.persisted:
+            if item.provenance.get("raw_uri") and item.provenance.get("sha256"):
+                rows.append(item)
+    return rows
+
+
+def job_report(job: WindowJob) -> dict[str, Any]:
+    return {
+        "ente_id": job.ente_id,
+        "window_start": job.window_start,
+        "window_end": job.window_end,
+        "status": job.status,
+        "checkpoint_after_persist": job.checkpoint_after_persist,
+        "fetched": job.fetched,
+        "persisted": len(job.persisted),
+        "rejected": len(job.rejected),
+        "balanced": job.balanced,
+        "zero": zero_proof(job),
+        "pages": [asdict(p) for p in job.pages],
+        "error": job.error,
+        "policy_window_start": WINDOW_START,
+        "generated_at": _utc_now(),
+    }

--- a/tests/test_pncp_contracts_backfill.py
+++ b/tests/test_pncp_contracts_backfill.py
@@ -108,3 +108,18 @@ def test_buyer_intel_uses_only_rows_with_provenance() -> None:
     report = job_report(job)
     assert report["status"] == "complete"
     assert report["policy_window_start"] == "2025-01-01"
+
+
+def test_replay_same_window_is_idempotent_and_never_checkpoints_before_persist() -> None:
+    job = WindowJob(ente_id="e5", window_start="2025-01-01", window_end="2025-01-31")
+    rows = [_row("c-replay", "contratado", 99.0)]
+    ingest_window(job, pages=[_page(1)], rows=rows, query_complete=True, persist_ok=True)
+    ingest_window(job, pages=[_page(1)], rows=rows, query_complete=True, persist_ok=True)
+    assert job.status == "complete"
+    assert len(job.persisted) == 1
+    assert job.balanced
+    blocked = WindowJob(ente_id="e5", window_start="2025-01-01", window_end="2025-01-31")
+    ingest_window(blocked, pages=[_page(1)], rows=rows, query_complete=True, persist_ok=False)
+    assert blocked.status == "failed"
+    assert blocked.checkpoint_after_persist is False
+    assert blocked.persisted == []

--- a/tests/test_pncp_contracts_backfill.py
+++ b/tests/test_pncp_contracts_backfill.py
@@ -1,0 +1,110 @@
+"""Tests for per-entity PNCP contracts backfill (#249)."""
+
+from __future__ import annotations
+
+from scripts.crawl.pncp_contracts_backfill import (
+    VALUE_KINDS,
+    WindowJob,
+    buyer_intel_rows,
+    classify_value,
+    ingest_window,
+    job_report,
+    record_page,
+    zero_proof,
+)
+
+
+def _page(n: int, status: int = 200) -> object:
+    return record_page(
+        page=n,
+        url=f"https://pncp.gov.br/api/consulta/v1/contratos?pagina={n}",
+        status=status,
+        body=f"p{n}".encode(),
+        records=1,
+    )
+
+
+def _row(contract_id: str, kind: str, amount: float, page: int = 1) -> dict:
+    return {
+        "contract_id": contract_id,
+        "value_kind": kind,
+        "amount": amount,
+        "page": page,
+        "raw_uri": f"cas://pncp-contracts/{contract_id}",
+        "sha256": "a" * 64,
+    }
+
+
+def test_window_ends_complete_or_failed_with_checkpoint_after_persist() -> None:
+    job = WindowJob(ente_id="e1", window_start="2025-01-01", window_end="2025-01-31")
+    ingest_window(
+        job,
+        pages=[_page(1)],
+        rows=[_row("c1", "contratado", 1000.0)],
+        query_complete=True,
+        persist_ok=True,
+    )
+    assert job.status == "complete"
+    assert job.checkpoint_after_persist is True
+    failed = WindowJob(ente_id="e1", window_start="2025-01-01", window_end="2025-01-31")
+    ingest_window(failed, pages=[_page(1, status=429)], rows=[], query_complete=False, persist_ok=False)
+    assert failed.status == "failed"
+    assert failed.error == "retryable_http"
+    assert failed.checkpoint_after_persist is False
+
+
+def test_pagination_raw_hash_and_counts_reconcile() -> None:
+    page = _page(1)
+    assert page.raw_uri.startswith("cas://")
+    assert len(page.sha256) == 64
+    job = WindowJob(ente_id="e2", window_start="2025-01-01", window_end="2025-03-31")
+    ingest_window(
+        job,
+        pages=[page],
+        rows=[
+            _row("ok", "estimado", 10.0),
+            {"contract_id": "bad", "value_kind": "foo", "amount": 1, "raw_uri": "x", "sha256": "y"},
+        ],
+        query_complete=True,
+        persist_ok=True,
+    )
+    assert job.fetched == 2
+    assert len(job.persisted) == 1
+    assert len(job.rejected) == 1
+    assert job.balanced
+    assert job.rejected[0]["reason"] == "unknown_value_kind"
+
+
+def test_value_kinds_are_distinct() -> None:
+    assert set(VALUE_KINDS) == {"estimado", "homologado", "contratado", "pago"}
+    assert classify_value("Homologado", "15.5") == ("homologado", 15.5)
+    assert classify_value("pago", -1) == "negative_amount"
+
+
+def test_zero_proof_and_freshness_require_complete_window() -> None:
+    empty = WindowJob(ente_id="e3", window_start="2025-01-01", window_end="2025-01-31")
+    ingest_window(empty, pages=[_page(1)], rows=[], query_complete=True, persist_ok=True)
+    assert zero_proof(empty)["verdict"] == "ZERO_CONFIRMED"
+    incomplete = WindowJob(ente_id="e3", window_start="2025-01-01", window_end="2025-01-31")
+    ingest_window(incomplete, pages=[], rows=[], query_complete=False, persist_ok=True)
+    assert zero_proof(incomplete)["verdict"] == "SCOPE_INCOMPLETE"
+
+
+def test_buyer_intel_uses_only_rows_with_provenance() -> None:
+    job = WindowJob(ente_id="e4", window_start="2025-01-01", window_end="2025-12-31")
+    ingest_window(
+        job,
+        pages=[_page(1)],
+        rows=[
+            _row("with", "pago", 50.0),
+            {"contract_id": "nope", "value_kind": "pago", "amount": 1, "raw_uri": "", "sha256": ""},
+        ],
+        query_complete=True,
+        persist_ok=True,
+    )
+    intel = buyer_intel_rows([job])
+    assert [item.contract_id for item in intel] == ["with"]
+    assert intel[0].provenance["source"] == "pncp_contratos"
+    report = job_report(job)
+    assert report["status"] == "complete"
+    assert report["policy_window_start"] == "2025-01-01"


### PR DESCRIPTION
## Summary
Jobs de contratos PNCP por ente/janela: complete ou failed, checkpoint só após persistência, paginação/raw/hash, reconciliação fetched=persisted+rejected, valores estimado/homologado/contratado/pago, prova de zero e buyer-intel somente com proveniência.

## Issues
Fixes #249

## Verification
- `pytest tests/test_pncp_contracts_backfill.py` — 5 passed
- reviewability e generated-artifacts-policy — PASS

## Truth ceiling
Não executa backfill nacional live desde 2025-01-01. 429/5xx são retomáveis no contrato; não há claim de freshness de produção.