### PR TITLE
fix(truth-plane): persist provenance and reject-all zero proof

### DIFF
--- a/scripts/crawl/pncp_contracts_backfill.py
+++ b/scripts/crawl/pncp_contracts_backfill.py
@@ -159,6 +159,14 @@ def zero_proof(job: WindowJob) -> dict[str, Any]:
         return {"ente_id": job.ente_id, "verdict": "SCOPE_INCOMPLETE", "count": len(job.persisted)}
     if job.persisted:
         return {"ente_id": job.ente_id, "verdict": "FOUND", "count": len(job.persisted)}
+    if job.fetched > 0 or job.rejected:
+        return {
+            "ente_id": job.ente_id,
+            "verdict": "REJECTED_ALL",
+            "count": 0,
+            "fetched": job.fetched,
+            "rejected": len(job.rejected),
+        }
     return {"ente_id": job.ente_id, "verdict": "ZERO_CONFIRMED", "count": 0}
 
 

--- a/scripts/crawl/resilience/persistence.py
+++ b/scripts/crawl/resilience/persistence.py
@@ -32,6 +32,26 @@ class PersistResult:
         return not self.errors
 
 
+def finalize_persist_provenance(
+    result: PersistResult,
+    *,
+    request_scope: str,
+    ingestion_run_id: Any,
+    inbound: dict[str, Any],
+) -> PersistResult:
+    """Keep source_projection when persist() rebuilds provenance."""
+    projected = (result.provenance or {}).get("source_projection")
+    merged: dict[str, Any] = {
+        "request_scope": request_scope,
+        "ingestion_run_id": ingestion_run_id,
+        **dict(inbound or {}),
+    }
+    if projected:
+        merged["source_projection"] = projected
+    result.provenance = merged
+    return result
+
+
 class PersistenceBackend(Protocol):
     def persist_canonical(
         self,
@@ -105,6 +125,7 @@ class InMemoryPersistence:
 
     def __init__(self) -> None:
         self.rows: dict[str, dict[str, Any]] = {}
+        self.observations: dict[tuple[str, str], Any] = {}
         self.runs: list[dict[str, Any]] = []
         self.fail_mode: str | None = None
         self.call_count = 0
@@ -161,6 +182,16 @@ class InMemoryPersistence:
             content_max_timestamp=extract_content_max_timestamp(source, records),
             provenance={"request_scope": request_scope, "run_id": run_id, **provenance},
         )
+        if source != "pncp" and records:
+            from scripts.opportunity_intel.source_projection import apply_source_projection
+
+            apply_source_projection(result, records, source, store=self.observations)
+            finalize_persist_provenance(
+                result,
+                request_scope=request_scope,
+                ingestion_run_id=result.ingestion_run_id,
+                inbound={"run_id": run_id, **provenance},
+            )
         self.runs.append(
             {
                 "source": source,
@@ -293,9 +324,9 @@ class PostgresPersistence:
                 result.opportunities_persisted = _persist_engineering_opportunities(conn, opportunities)
             elif records:
                 # Non-PNCP sources keep their own source_id. Never rewrite as PNCP.
-                from scripts.opportunity_intel.source_projection import attach_projection
+                from scripts.opportunity_intel.source_projection import apply_source_projection
 
-                attach_projection(result, records, source)
+                apply_source_projection(result, records, source)
 
             # Project resilience-aware source evidence (migration 054 columns when present).
             self._project_resilience_evidence(
@@ -324,7 +355,12 @@ class PostgresPersistence:
             )
             conn.commit()
             result.content_max_timestamp = extract_content_max_timestamp(source, records)
-            result.provenance = {"request_scope": request_scope, "ingestion_run_id": db_run_id, **provenance}
+            finalize_persist_provenance(
+                result,
+                request_scope=request_scope,
+                ingestion_run_id=db_run_id,
+                inbound=provenance,
+            )
             return result
         except Exception as exc:
             try:

--- a/scripts/opportunity_intel/source_projection.py
+++ b/scripts/opportunity_intel/source_projection.py
@@ -271,20 +271,33 @@ def project_source_batch(
     return batch
 
 
-def attach_projection(result: Any, records: list[dict[str, Any]], source: str) -> ProjectionBatch:
-    """Hook used by resilience persistence for every non-PNCP source."""
-    projection = project_source_batch(records, source=source)
-    result.opportunities_persisted = len(projection.persisted)
+def apply_source_projection(
+    result: Any,
+    records: list[dict[str, Any]],
+    source: str,
+    store: dict[tuple[str, str], Observation] | None = None,
+) -> ProjectionBatch:
+    """Project non-PNCP records into an observation store. Count is store writes."""
+    observation_store = store if store is not None else {}
+    projection = project_source_batch(records, source=source, store=observation_store)
+    unique_keys = {obs.upsert_key() for obs in projection.persisted}
+    result.opportunities_persisted = len(unique_keys)
     provenance = dict(getattr(result, "provenance", {}) or {})
     provenance["source_projection"] = {
         "source": source,
         "fetched": projection.fetched,
-        "persisted": len(projection.persisted),
+        "persisted": len(unique_keys),
         "rejected": len(projection.rejected),
+        "store_size": len(observation_store),
         "rejection_reasons": [r.reason for r in projection.rejected],
     }
     result.provenance = provenance
     return projection
+
+
+def attach_projection(result: Any, records: list[dict[str, Any]], source: str) -> ProjectionBatch:
+    """Hook used by resilience persistence for every non-PNCP source."""
+    return apply_source_projection(result, records, source)
 
 
 def counts_by_source(batches: list[ProjectionBatch]) -> dict[str, dict[str, int]]:

--- a/tests/test_pncp_contracts_backfill.py
+++ b/tests/test_pncp_contracts_backfill.py
@@ -90,6 +90,29 @@ def test_zero_proof_and_freshness_require_complete_window() -> None:
     assert zero_proof(incomplete)["verdict"] == "SCOPE_INCOMPLETE"
 
 
+def test_zero_proof_does_not_confirm_zero_when_all_rows_rejected() -> None:
+    job = WindowJob(ente_id="e3b", window_start="2025-01-01", window_end="2025-01-31")
+    ingest_window(
+        job,
+        pages=[_page(1)],
+        rows=[
+            {"contract_id": "bad", "value_kind": "foo", "amount": 1, "raw_uri": "x", "sha256": "y"},
+            {"contract_id": "nope", "value_kind": "pago", "amount": 1, "raw_uri": "", "sha256": ""},
+        ],
+        query_complete=True,
+        persist_ok=True,
+    )
+    assert job.status == "complete"
+    assert job.fetched == 2
+    assert job.persisted == []
+    assert len(job.rejected) == 2
+    proof = zero_proof(job)
+    assert proof["verdict"] == "REJECTED_ALL"
+    assert proof["verdict"] != "ZERO_CONFIRMED"
+    assert proof["fetched"] == 2
+    assert proof["rejected"] == 2
+
+
 def test_buyer_intel_uses_only_rows_with_provenance() -> None:
     job = WindowJob(ente_id="e4", window_start="2025-01-01", window_end="2025-12-31")
     ingest_window(

--- a/tests/test_source_projection.py
+++ b/tests/test_source_projection.py
@@ -94,6 +94,53 @@ def test_unsupported_source_is_rejected() -> None:
     assert result.reason == "unsupported_source"
 
 
+def test_persist_canonical_keeps_source_projection_on_the_returned_result() -> None:
+    from scripts.crawl.resilience.persistence import (
+        InMemoryPersistence,
+        PersistResult,
+        finalize_persist_provenance,
+    )
+
+    backend = InMemoryPersistence()
+    kwargs = {
+        "source": "sc_compras",
+        "records": [_sc_raw()],
+        "run_id": "run-1",
+        "request_scope": "sc:test",
+        "date_from": None,
+        "date_to": None,
+        "provenance": {"endpoint": "https://example.test/sc"},
+        "fetch_status": "success",
+        "pages_fetched": 1,
+        "pages_expected": 1,
+    }
+    first = backend.persist_canonical(**kwargs)
+    assert first.opportunities_persisted == 1
+    assert first.provenance["source_projection"]["source"] == "sc_compras"
+    assert first.provenance["source_projection"]["persisted"] == 1
+    assert ("sc_compras", "sc-2025/00001") in backend.observations
+    assert backend.observations[("sc_compras", "sc-2025/00001")].source != "pncp"
+    second = backend.persist_canonical(**kwargs)
+    assert second.provenance.get("source_projection", {}).get("source") == "sc_compras"
+    assert len(backend.observations) == 1
+    overwritten = PersistResult(provenance={"source_projection": {"source": "sc_compras", "persisted": 1}})
+    finalize_persist_provenance(
+        overwritten,
+        request_scope="sc:test",
+        ingestion_run_id=99,
+        inbound={"endpoint": "https://example.test/sc"},
+    )
+    assert overwritten.provenance["source_projection"]["source"] == "sc_compras"
+    assert overwritten.provenance["ingestion_run_id"] == 99
+    import inspect
+
+    from scripts.crawl.resilience.persistence import PostgresPersistence
+
+    postgres_src = inspect.getsource(PostgresPersistence.persist_canonical)
+    assert "finalize_persist_provenance" in postgres_src
+    assert "apply_source_projection" in postgres_src
+
+
 def test_persistence_hook_projects_non_pncp() -> None:
     from types import SimpleNamespace
 


### PR DESCRIPTION
Closeout of the #359–#368 campaign. One transversal fix that cannot live on the already-merged heads.

- `persist_canonical` keeps `source_projection` after rebuilding provenance.
- In-memory persist writes observations to a store; `opportunities_persisted` is that store count.
- `zero_proof` returns `REJECTED_ALL` when fetched>0 and persisted==0.

Not a new capability wave. No #370–#378 follow-ups.