### PR TITLE
feat(truth): coverage formula + contract durability wave

### DIFF
--- a/db/migrations/091_contract_truth_durability.sql
+++ b/db/migrations/091_contract_truth_durability.sql
@@ -44,7 +44,9 @@ WHERE status_normalized = 'ACTIVE_PROVEN';
 CREATE OR REPLACE VIEW public.v_contracts_report_ready AS
 SELECT *
 FROM public.pncp_supplier_contracts
-WHERE COALESCE(quality_state, 'VALID') <> 'QUARANTINED'
-  AND COALESCE(status_normalized, 'UNKNOWN') <> 'UNKNOWN';
+WHERE quality_state IS NOT NULL
+  AND quality_state <> 'QUARANTINED'
+  AND status_normalized IS NOT NULL
+  AND status_normalized <> 'UNKNOWN';
 
 COMMIT;

--- a/db/migrations/091_contract_truth_durability.sql
+++ b/db/migrations/091_contract_truth_durability.sql
@@ -1,0 +1,50 @@
+-- 091_contract_truth_durability.sql
+-- Activity proof (#309), quality quarantine (#312), namespaced identity (#306).
+-- Additive: raw official columns stay untouched.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+ALTER TABLE public.pncp_supplier_contracts
+    ADD COLUMN IF NOT EXISTS status_raw TEXT,
+    ADD COLUMN IF NOT EXISTS status_normalized TEXT,
+    ADD COLUMN IF NOT EXISTS status_rule_version TEXT,
+    ADD COLUMN IF NOT EXISTS status_source TEXT,
+    ADD COLUMN IF NOT EXISTS status_observed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS quality_state TEXT,
+    ADD COLUMN IF NOT EXISTS quality_reasons JSONB,
+    ADD COLUMN IF NOT EXISTS quality_rule_version TEXT,
+    ADD COLUMN IF NOT EXISTS canonical_contract_id TEXT,
+    ADD COLUMN IF NOT EXISTS source TEXT,
+    ADD COLUMN IF NOT EXISTS source_contract_id TEXT,
+    ADD COLUMN IF NOT EXISTS parent_procurement_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pncp_contracts_source_source_id
+    ON public.pncp_supplier_contracts (source, source_contract_id)
+    WHERE source IS NOT NULL AND source_contract_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.contract_id_aliases (
+    alias_id TEXT PRIMARY KEY,
+    canonical_contract_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE VIEW public.v_contracts_all AS
+SELECT *
+FROM public.pncp_supplier_contracts;
+
+CREATE OR REPLACE VIEW public.v_contracts_active_proven AS
+SELECT *
+FROM public.pncp_supplier_contracts
+WHERE status_normalized = 'ACTIVE_PROVEN';
+
+CREATE OR REPLACE VIEW public.v_contracts_report_ready AS
+SELECT *
+FROM public.pncp_supplier_contracts
+WHERE COALESCE(quality_state, 'VALID') <> 'QUARANTINED'
+  AND COALESCE(status_normalized, 'UNKNOWN') <> 'UNKNOWN';
+
+COMMIT;

--- a/scripts/confenge_contact_resolution/publish_pilot_recipients.py
+++ b/scripts/confenge_contact_resolution/publish_pilot_recipients.py
@@ -1,0 +1,200 @@
+"""Publish 1–3 already-observed human recipients for the Warmbly pilot (#370).
+
+Never invent name, email, role or consent. Generic/functional mailboxes stay
+unpromoted. If no already-observed public named human validates, the path
+fails closed with reason codes.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scripts.confenge_contact_resolution.mailbox_purpose import (
+    PURPOSE_GENERIC_CONTACT,
+    classify_mailbox_purpose,
+)
+
+SCHEMA_ID = "confenge-pilot-recipients-v1"
+VALIDATED = "VALIDATED"
+REJECTED = "REJECTED"
+GENERIC_PURPOSES = frozenset(
+    {
+        PURPOSE_GENERIC_CONTACT,
+        "GENERIC_CONTACT",
+        "NOREPLY",
+        "SUPPORT_SAC",
+        "HR_RECRUITING",
+        "PRIVACY_DPO",
+        "PRESS",
+    }
+)
+_GENERIC_LOCALS = frozenset(
+    {
+        "contato",
+        "contact",
+        "comercial",
+        "licitacoes",
+        "licitações",
+        "adm",
+        "admin",
+        "ouvidoria",
+        "sac",
+        "noreply",
+        "no-reply",
+        "financeiro",
+        "rh",
+        "imprensa",
+        "comunicacao",
+        "comunicação",
+    }
+)
+
+
+@dataclass
+class PilotRecipient:
+    account_id: str
+    name: str
+    role: str
+    email: str
+    source_url: str
+    observed_at: str
+    ownership: str
+    suitability: str
+    status: str
+    reasons: list[str] = field(default_factory=list)
+    suppression: str = "none"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _local_part(email: str) -> str:
+    return (email or "").split("@", 1)[0].strip().lower()
+
+
+def _looks_invented(record: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    for field_name in ("name", "role", "email"):
+        value = str(record.get(field_name) or "").strip()
+        if not value:
+            reasons.append(f"missing_{field_name}")
+        if value.lower() in {"tbd", "unknown", "n/a", "inferred", "placeholder"}:
+            reasons.append(f"invented_{field_name}")
+    if record.get("inferred") or record.get("invented"):
+        reasons.append("inferred_flag")
+    if record.get("name_explicitly_published") is False:
+        reasons.append("name_not_published")
+    if record.get("email_explicitly_published") is False:
+        reasons.append("email_not_published")
+    if record.get("role_explicitly_published") is False:
+        reasons.append("role_not_published")
+    return reasons
+
+
+def evaluate_observed_recipient(record: Mapping[str, Any]) -> PilotRecipient:
+    """Validate one already-observed public contact. Never fills missing PII."""
+    email = str(record.get("email") or "").strip()
+    name = str(record.get("name") or record.get("nome") or "").strip()
+    role = str(record.get("role") or record.get("cargo") or "").strip()
+    account = str(record.get("account_id") or record.get("target_id") or record.get("cnpj") or "").strip()
+    source_url = str(
+        record.get("source_url")
+        or (record.get("source") or {}).get("source_url")
+        or record.get("url")
+        or ""
+    ).strip()
+    observed_at = str(
+        record.get("observed_at")
+        or (record.get("source") or {}).get("observed_at")
+        or record.get("published_at")
+        or ""
+    ).strip()
+    reasons = _looks_invented(
+        {
+            "name": name,
+            "role": role,
+            "email": email,
+            "inferred": record.get("inferred"),
+            "invented": record.get("invented"),
+            "name_explicitly_published": record.get("name_explicitly_published", True),
+            "email_explicitly_published": record.get("email_explicitly_published", True),
+            "role_explicitly_published": record.get("role_explicitly_published", True),
+        }
+    )
+    purpose = classify_mailbox_purpose(email)
+    local = _local_part(email)
+    if purpose.purpose in GENERIC_PURPOSES or local in _GENERIC_LOCALS:
+        reasons.append("functional_mailbox_not_human_recipient")
+    if " " not in name and name.count(".") == 0:
+        # A single token is not a published human name.
+        reasons.append("name_not_human_nominal")
+    if not source_url:
+        reasons.append("missing_source_url")
+    if not observed_at:
+        reasons.append("missing_observed_at")
+    if record.get("suppression") in {"opt-out", "hard_bounce", "do_not_contact"}:
+        reasons.append(f"suppressed:{record.get('suppression')}")
+
+    status = VALIDATED if not reasons else REJECTED
+    if status == VALIDATED:
+        reasons = ["human_recipient_evidence_valid"]
+    return PilotRecipient(
+        account_id=account,
+        name=name if status == VALIDATED else name,
+        role=role,
+        email=email,
+        source_url=source_url,
+        observed_at=observed_at,
+        ownership=str(record.get("ownership") or record.get("ownership_status") or "UNPROVEN"),
+        suitability=str(record.get("suitability") or "UNREVIEWED"),
+        status=status,
+        reasons=reasons,
+        suppression=str(record.get("suppression") or "none"),
+    )
+
+
+def publish_pilot_recipients(
+    observed: Iterable[Mapping[str, Any]],
+    *,
+    min_validated: int = 1,
+    max_validated: int = 3,
+) -> dict[str, Any]:
+    """Republish only already-observed humans. Fail closed when none validate."""
+    evaluated = [evaluate_observed_recipient(row) for row in observed]
+    validated = [item for item in evaluated if item.status == VALIDATED]
+    rejected = [item for item in evaluated if item.status != VALIDATED]
+    selected = validated[:max_validated]
+    fail_reasons: list[str] = []
+    if len(selected) < min_validated:
+        fail_reasons.append("insufficient_validated_humans")
+        if not evaluated:
+            fail_reasons.append("no_observed_evidence")
+        if any("functional_mailbox_not_human_recipient" in item.reasons for item in rejected):
+            fail_reasons.append("generic_mailbox_not_promoted")
+        if any(reason.startswith("invented_") or reason.endswith("_not_published") for item in rejected for reason in item.reasons):
+            fail_reasons.append("refused_to_invent_pii")
+    return {
+        "schema_id": SCHEMA_ID,
+        "ok": not fail_reasons,
+        "status": "READY" if not fail_reasons else "FAIL_CLOSED",
+        "validated": [item.to_dict() for item in selected],
+        "rejected": [item.to_dict() for item in rejected],
+        "validated_count": len(selected),
+        "reason_codes": fail_reasons,
+        "warmbly_ready": not fail_reasons,
+    }
+
+
+def load_observed_evidence(path: str | Path) -> list[dict[str, Any]]:
+    raw = Path(path).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    if isinstance(payload, list):
+        return [dict(item) for item in payload]
+    if isinstance(payload, dict):
+        rows = payload.get("recipients") or payload.get("contacts") or payload.get("observed") or []
+        return [dict(item) for item in rows]
+    raise ValueError("observed evidence must be a JSON list or object with recipients")

--- a/scripts/confenge_contact_resolution/publish_pilot_recipients.py
+++ b/scripts/confenge_contact_resolution/publish_pilot_recipients.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from scripts.confenge_contact_resolution.mailbox_purpose import (
     PURPOSE_GENERIC_CONTACT,
+    PURPOSE_UNKNOWN,
+    SEND_ALLOWED_PURPOSES,
     classify_mailbox_purpose,
 )
 
@@ -120,14 +122,19 @@ def evaluate_observed_recipient(record: Mapping[str, Any]) -> PilotRecipient:
             "email": email,
             "inferred": record.get("inferred"),
             "invented": record.get("invented"),
-            "name_explicitly_published": record.get("name_explicitly_published", True),
-            "email_explicitly_published": record.get("email_explicitly_published", True),
-            "role_explicitly_published": record.get("role_explicitly_published", True),
+            "name_explicitly_published": record.get("name_explicitly_published", False),
+            "email_explicitly_published": record.get("email_explicitly_published", False),
+            "role_explicitly_published": record.get("role_explicitly_published", False),
         }
     )
     purpose = classify_mailbox_purpose(email)
     local = _local_part(email)
-    if purpose.purpose in GENERIC_PURPOSES or local in _GENERIC_LOCALS:
+    if (
+        purpose.purpose in GENERIC_PURPOSES
+        or purpose.purpose not in SEND_ALLOWED_PURPOSES
+        or purpose.purpose != PURPOSE_UNKNOWN
+        or local in _GENERIC_LOCALS
+    ):
         reasons.append("functional_mailbox_not_human_recipient")
     if " " not in name and name.count(".") == 0:
         # A single token is not a published human name.
@@ -185,7 +192,8 @@ def publish_pilot_recipients(
         "rejected": [item.to_dict() for item in rejected],
         "validated_count": len(selected),
         "reason_codes": fail_reasons,
-        "warmbly_ready": not fail_reasons,
+        # Recipient list is not a Warmbly send-ready claim.
+        "warmbly_ready": False,
     }
 
 

--- a/scripts/contracts_truth.py
+++ b/scripts/contracts_truth.py
@@ -487,6 +487,13 @@ def isolated_test_environment() -> bool:
     return bool(os.getenv("PYTEST_CURRENT_TEST") or os.getenv("EXTRA_ISOLATED_TEST") == "1")
 
 
+def is_production_contracts() -> bool:
+    if os.getenv("EXTRA_CONTRACTS_PRODUCTION", "0") == "1":
+        return True
+    cwd = Path.cwd().as_posix()
+    return cwd == "/opt/extra-consultoria" or cwd.startswith("/opt/extra-consultoria/")
+
+
 def refuse_writer_bypass(*, skip_lock: bool = False, env_skip: str | None = None) -> None:
     """Production units must not skip the fence."""
     env_requested = (env_skip if env_skip is not None else os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0")) == "1"
@@ -543,6 +550,36 @@ class PostgresWriterFence:
             self.release()
 
 
+def acquire_national_writer_fence(
+    dsn: str,
+    *,
+    skip: bool = False,
+    connect: Any = None,
+) -> PostgresWriterFence | None:
+    """Acquire the PostgreSQL fence used by every national contracts writer.
+
+    Host-local flock is not sufficient. A second writer is refused before
+    ``connect`` returns a session that can mutate.
+    """
+    refuse_writer_bypass(skip_lock=skip)
+    if skip or os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0") == "1":
+        return None
+    if not dsn:
+        raise WriterFenceBypassError("national writer fence requires a DSN")
+    if connect is None:
+        import psycopg2
+
+        connect = psycopg2.connect
+    conn = connect(dsn)
+    fence = PostgresWriterFence()
+    if not fence.acquire(conn):
+        close = getattr(conn, "close", None)
+        if callable(close):
+            close()
+        raise WriterFenceBusyError("national writer fence busy")
+    return fence
+
+
 def _is_relative_to(path: Path, root: Path) -> bool:
     try:
         path.resolve().relative_to(root.resolve())
@@ -560,12 +597,17 @@ def resolve_checkpoint_dir(
 ) -> Path:
     """Production checkpoints live under /var/lib/extra-consultoria, never the worktree."""
     if production is None:
-        production = os.getenv("EXTRA_CONTRACTS_PRODUCTION", "0") == "1"
+        production = is_production_contracts()
     repo = Path(repo_root) if repo_root else Path(__file__).resolve().parents[1]
     durable = Path(state_root) if state_root else Path(
         os.getenv("EXTRA_CONTRACTS_STATE_DIR") or str(PRODUCTION_STATE_ROOT)
     )
-    raw = Path(requested) if requested else durable / "checkpoints" / "contracts"
+    if requested:
+        raw = Path(requested)
+    elif production:
+        raw = durable / "checkpoints" / "contracts"
+    else:
+        raw = repo / "data" / "contracts_checkpoints"
     path = raw.expanduser()
     if not path.is_absolute():
         path = (durable / path) if production else (repo / path)

--- a/scripts/contracts_truth.py
+++ b/scripts/contracts_truth.py
@@ -8,6 +8,7 @@ PostgreSQL advisory fence; checkpoints refuse the git/release worktree.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 from collections.abc import Iterable, Mapping
@@ -339,8 +340,10 @@ def canonical_contract_identity(
             rule_version=IDENTITY_RULE_VERSION,
         )
     parts = [str(part).strip() for part in fallback_parts if part not in (None, "")]
+    if parent:
+        parts.append(f"parent:{parent}")
     if not parts:
-        digest = hashlib.sha256(f"{src}:empty".encode()).hexdigest()[:16]
+        digest = hashlib.sha256(f"{src}:empty:{parent or ''}".encode()).hexdigest()[:16]
         return CanonicalContract(
             canonical_contract_id=f"{src}:fallback:{digest}",
             source=src,
@@ -659,3 +662,90 @@ def annotate_transformed_contract(record: dict[str, Any], *, raw: Mapping[str, A
     record["source_contract_id"] = ident.source_contract_id
     record["parent_procurement_id"] = ident.parent_procurement_id
     return record
+
+
+TRUTH_STAMP_FIELDS = (
+    "status_raw",
+    "status_normalized",
+    "status_rule_version",
+    "status_source",
+    "quality_state",
+    "quality_reasons",
+    "quality_rule_version",
+    "report_ready",
+    "canonical_contract_id",
+    "source_contract_id",
+    "parent_procurement_id",
+)
+
+
+def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]]) -> int:
+    """Write activity/quality/identity labels after the legacy upsert.
+
+    The historical RPC does not persist these columns. Callers must stamp
+    them or the lake stays unlabeled (NULL quality is not report-ready).
+    """
+    payload = []
+    for raw in records:
+        contrato_id = str(raw.get("contrato_id") or "").strip()
+        if not contrato_id:
+            continue
+        payload.append(
+            {
+                "contrato_id": contrato_id,
+                "status_raw": raw.get("status_raw"),
+                "status_normalized": raw.get("status_normalized"),
+                "status_rule_version": raw.get("status_rule_version"),
+                "status_source": raw.get("status_source"),
+                "quality_state": raw.get("quality_state"),
+                "quality_reasons": raw.get("quality_reasons") or [],
+                "quality_rule_version": raw.get("quality_rule_version"),
+                "report_ready": bool(raw.get("report_ready")),
+                "canonical_contract_id": raw.get("canonical_contract_id"),
+                "source": raw.get("source"),
+                "source_contract_id": raw.get("source_contract_id"),
+                "parent_procurement_id": raw.get("parent_procurement_id"),
+            }
+        )
+    if not payload:
+        return 0
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            UPDATE public.pncp_supplier_contracts AS target
+            SET status_raw = stamp.status_raw,
+                status_normalized = stamp.status_normalized,
+                status_rule_version = stamp.status_rule_version,
+                status_source = stamp.status_source,
+                quality_state = stamp.quality_state,
+                quality_reasons = stamp.quality_reasons::jsonb,
+                quality_rule_version = stamp.quality_rule_version,
+                canonical_contract_id = stamp.canonical_contract_id,
+                source = COALESCE(stamp.source, target.source),
+                source_contract_id = stamp.source_contract_id,
+                parent_procurement_id = stamp.parent_procurement_id
+            FROM jsonb_to_recordset(%s::jsonb) AS stamp(
+                contrato_id TEXT,
+                status_raw TEXT,
+                status_normalized TEXT,
+                status_rule_version TEXT,
+                status_source TEXT,
+                quality_state TEXT,
+                quality_reasons JSONB,
+                quality_rule_version TEXT,
+                report_ready BOOLEAN,
+                canonical_contract_id TEXT,
+                source TEXT,
+                source_contract_id TEXT,
+                parent_procurement_id TEXT
+            )
+            WHERE target.contrato_id = stamp.contrato_id
+            """,
+            (json.dumps(payload, default=str),),
+        )
+        return int(cur.rowcount or 0)
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()

--- a/scripts/contracts_truth.py
+++ b/scripts/contracts_truth.py
@@ -1,0 +1,619 @@
+"""Contract truth and durability primitives (#309, #312, #314, #319, #306, #304).
+
+Pure classification plus small I/O seams. Raw official payloads are never
+mutated; facts receive status/quality labels. Production writers take a
+PostgreSQL advisory fence; checkpoints refuse the git/release worktree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+ACTIVITY_RULE_VERSION = "contract-activity-v1"
+QUALITY_RULE_VERSION = "contract-quality-v1"
+IDENTITY_RULE_VERSION = "canonical-contract-v1"
+PAGINATION_RULE_VERSION = "pagination-reconcile-v1"
+
+ACTIVE_PROVEN = "ACTIVE_PROVEN"
+COMPLETED = "COMPLETED"
+CANCELLED = "CANCELLED"
+TERMINATED = "TERMINATED"
+SUSPENDED = "SUSPENDED"
+UNKNOWN = "UNKNOWN"
+REVIEW = "REVIEW"
+
+VALID = "VALID"
+QUARANTINED = "QUARANTINED"
+
+ACTIVITY_STATES = frozenset(
+    {ACTIVE_PROVEN, COMPLETED, CANCELLED, TERMINATED, SUSPENDED, UNKNOWN}
+)
+QUALITY_STATES = frozenset({VALID, REVIEW, QUARANTINED})
+
+PG_FENCE_KEY = 0x45585452  # 'EXTR'
+PRODUCTION_STATE_ROOT = Path("/var/lib/extra-consultoria")
+FORBIDDEN_CHECKPOINT_PREFIXES = (
+    "/opt/extra-consultoria",
+    "/opt/extra-cli",
+)
+
+_ACTIVE_TOKENS = frozenset(
+    {
+        "vigente",
+        "ativo",
+        "ativa",
+        "em execucao",
+        "em execução",
+        "assinado",
+        "publicado",
+        "active",
+    }
+)
+_COMPLETED_TOKENS = frozenset({"encerrado", "concluido", "concluído", "finalizado", "completed", "findado"})
+_CANCELLED_TOKENS = frozenset({"cancelado", "anulado", "cancelled", "canceled"})
+_TERMINATED_TOKENS = frozenset({"rescindido", "resilido", "resilído", "terminated", "distratado"})
+_SUSPENDED_TOKENS = frozenset({"suspenso", "suspended", "paralisado"})
+
+_TRILLION_BRL = 1_000_000_000_000.0
+_PLAUSIBLE_YEAR_MIN = 1994
+_PLAUSIBLE_YEAR_MAX = 2100
+
+
+class CheckpointLocationError(ValueError):
+    """Production checkpoint path is inside the release/worktree."""
+
+
+class WriterFenceBusyError(RuntimeError):
+    """A second national writer tried to mutate under an active fence."""
+
+
+class WriterFenceBypassError(RuntimeError):
+    """Production attempted to skip the national writer fence."""
+
+
+@dataclass(frozen=True)
+class ContractActivity:
+    state: str
+    raw_status: str | None
+    rule_version: str
+    source: str
+    observed_at: str | None
+    reasons: tuple[str, ...]
+
+    @property
+    def is_active_proven(self) -> bool:
+        return self.state == ACTIVE_PROVEN
+
+
+@dataclass(frozen=True)
+class ContractQuality:
+    state: str
+    rule_version: str
+    reasons: tuple[str, ...]
+    financial_impact: float | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalContract:
+    canonical_contract_id: str
+    source: str
+    source_contract_id: str
+    parent_procurement_id: str | None
+    method: str
+    rule_version: str
+    ambiguous: bool = False
+
+
+@dataclass
+class PaginationReport:
+    rule_version: str
+    first_total_registros: int | None
+    last_total_registros: int | None
+    first_total_paginas: int | None
+    last_total_paginas: int | None
+    fetched: int
+    persisted: int
+    rejected: int
+    unique_ids: int
+    duplicate_ids: int
+    status: str
+    reasons: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_version": self.rule_version,
+            "first_total_registros": self.first_total_registros,
+            "last_total_registros": self.last_total_registros,
+            "first_total_paginas": self.first_total_paginas,
+            "last_total_paginas": self.last_total_paginas,
+            "fetched": self.fetched,
+            "persisted": self.persisted,
+            "rejected": self.rejected,
+            "unique_ids": self.unique_ids,
+            "duplicate_ids": self.duplicate_ids,
+            "status": self.status,
+            "reasons": list(self.reasons),
+            "ok": self.ok,
+        }
+
+
+def _as_date(value: Any) -> date | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    if not text or text.lower() in {"none", "null"}:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        return None
+
+
+def _norm_status(raw: Any) -> str:
+    text = str(raw or "").strip().lower()
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def classify_contract_activity(
+    *,
+    raw_status: Any = None,
+    vigencia_inicio: Any = None,
+    vigencia_fim: Any = None,
+    today: date | None = None,
+    source: str = "pncp",
+    observed_at: str | None = None,
+    is_active_default: Any = None,
+) -> ContractActivity:
+    """Absence of proven status/vigência is UNKNOWN — never ACTIVE.
+
+    ``is_active=TRUE`` defaults are ignored. A later event must supply an
+    explicit status token or a closed vigência window to leave UNKNOWN.
+    """
+    del is_active_default  # never proof of activity
+    ref = today or date.today()
+    raw = None if raw_status is None else str(raw_status).strip()
+    token = _norm_status(raw)
+    start = _as_date(vigencia_inicio)
+    end = _as_date(vigencia_fim)
+    reasons: list[str] = []
+
+    if token:
+        if token in _CANCELLED_TOKENS:
+            return ContractActivity(CANCELLED, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("raw_status",))
+        if token in _TERMINATED_TOKENS:
+            return ContractActivity(TERMINATED, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("raw_status",))
+        if token in _SUSPENDED_TOKENS:
+            return ContractActivity(SUSPENDED, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("raw_status",))
+        if token in _COMPLETED_TOKENS:
+            return ContractActivity(COMPLETED, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("raw_status",))
+        if token in _ACTIVE_TOKENS:
+            if start and end and start > end:
+                reasons.append("inverted_vigencia")
+                return ContractActivity(UNKNOWN, raw, ACTIVITY_RULE_VERSION, source, observed_at, tuple(reasons))
+            if end is not None and end < ref:
+                return ContractActivity(COMPLETED, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("vigencia_ended",))
+            if start is None and end is None:
+                reasons.append("active_token_without_vigencia")
+                return ContractActivity(UNKNOWN, raw, ACTIVITY_RULE_VERSION, source, observed_at, tuple(reasons))
+            return ContractActivity(ACTIVE_PROVEN, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("raw_status+vigencia",))
+
+    if start and end:
+        if start > end:
+            return ContractActivity(UNKNOWN, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("inverted_vigencia",))
+        if end < ref:
+            return ContractActivity(COMPLETED, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("vigencia_ended",))
+        if start <= ref <= end:
+            return ContractActivity(ACTIVE_PROVEN, raw, ACTIVITY_RULE_VERSION, source, observed_at, ("vigencia_window",))
+
+    reasons.append("missing_status_and_vigencia")
+    return ContractActivity(UNKNOWN, raw, ACTIVITY_RULE_VERSION, source, observed_at, tuple(reasons))
+
+
+def in_active_proven(activity: ContractActivity) -> bool:
+    return activity.state == ACTIVE_PROVEN
+
+
+def classify_contract_quality(
+    *,
+    data_assinatura: Any = None,
+    data_inicio: Any = None,
+    data_fim: Any = None,
+    data_publicacao: Any = None,
+    valor: Any = None,
+    today: date | None = None,
+) -> ContractQuality:
+    """Label implausible dates/values. Raw rows are left untouched."""
+    reasons: list[str] = []
+    state = VALID
+    impact: float | None = None
+
+    dates = {
+        "data_assinatura": _as_date(data_assinatura),
+        "data_inicio": _as_date(data_inicio),
+        "data_fim": _as_date(data_fim),
+        "data_publicacao": _as_date(data_publicacao),
+    }
+    for name, parsed in dates.items():
+        if parsed is None:
+            raw = {
+                "data_assinatura": data_assinatura,
+                "data_inicio": data_inicio,
+                "data_fim": data_fim,
+                "data_publicacao": data_publicacao,
+            }[name]
+            if raw not in (None, ""):
+                reasons.append(f"unparseable_date:{name}")
+                state = QUARANTINED
+            continue
+        if parsed.year > _PLAUSIBLE_YEAR_MAX or parsed.year >= 8000:
+            reasons.append(f"implausible_future_year:{name}:{parsed.isoformat()}")
+            state = QUARANTINED
+        elif parsed.year < _PLAUSIBLE_YEAR_MIN:
+            reasons.append(f"implausible_ancient_year:{name}:{parsed.isoformat()}")
+            state = REVIEW if state == VALID else state
+
+    start, end = dates["data_inicio"], dates["data_fim"]
+    if start and end and start > end:
+        reasons.append("inverted_vigencia")
+        state = QUARANTINED
+
+    assinatura, pub = dates["data_assinatura"], dates["data_publicacao"]
+    if assinatura and pub and assinatura > pub + (pub - pub):
+        # assinatura far after publication is review, not auto-quarantine
+        if (assinatura - pub).days > 3650:
+            reasons.append("assinatura_far_from_publicacao")
+            state = REVIEW if state == VALID else state
+
+    if valor is not None and valor != "":
+        try:
+            amount = float(valor)
+        except (TypeError, ValueError):
+            reasons.append("unparseable_value")
+            state = QUARANTINED
+            amount = None
+        if amount is not None:
+            impact = amount
+            if amount < 0:
+                reasons.append("negative_value")
+                state = QUARANTINED
+            elif amount == 0:
+                reasons.append("zero_value_without_semantics")
+                state = REVIEW if state == VALID else state
+            elif amount > _TRILLION_BRL:
+                reasons.append("value_exceeds_one_trillion")
+                state = QUARANTINED
+            else:
+                # Suspicious cents on huge integers (scale-break heuristic).
+                if amount >= 10_000_000_000 and "e" in str(amount).lower():
+                    reasons.append("scientific_scale_break")
+                    state = REVIEW if state == VALID else state
+                # Classic centavo-as-real: values like 12345678901 meaning 123M*100
+                if amount >= 100_000_000_000:
+                    reasons.append("scale_break_suspect")
+                    state = QUARANTINED
+
+    if not reasons:
+        reasons.append("ok")
+    return ContractQuality(state=state, rule_version=QUALITY_RULE_VERSION, reasons=tuple(reasons), financial_impact=impact)
+
+
+def report_ready_allowed(quality: ContractQuality) -> bool:
+    return quality.state != QUARANTINED
+
+
+def canonical_contract_identity(
+    *,
+    source: str,
+    official_id: str | None = None,
+    source_contract_id: str | None = None,
+    parent_procurement_id: str | None = None,
+    fallback_parts: Iterable[Any] = (),
+) -> CanonicalContract:
+    """Namespace official IDs per source. Fallback is deterministic."""
+    src = (source or "").strip().lower() or "unknown"
+    official = (official_id or source_contract_id or "").strip()
+    parent = (parent_procurement_id or "").strip() or None
+    if official:
+        return CanonicalContract(
+            canonical_contract_id=f"{src}:{official}",
+            source=src,
+            source_contract_id=official,
+            parent_procurement_id=parent,
+            method="official",
+            rule_version=IDENTITY_RULE_VERSION,
+        )
+    parts = [str(part).strip() for part in fallback_parts if part not in (None, "")]
+    if not parts:
+        digest = hashlib.sha256(f"{src}:empty".encode()).hexdigest()[:16]
+        return CanonicalContract(
+            canonical_contract_id=f"{src}:fallback:{digest}",
+            source=src,
+            source_contract_id=f"fallback:{digest}",
+            parent_procurement_id=parent,
+            method="fallback",
+            rule_version=IDENTITY_RULE_VERSION,
+            ambiguous=True,
+        )
+    payload = "|".join(parts)
+    digest = hashlib.sha256(f"{src}:{payload}".encode()).hexdigest()[:20]
+    return CanonicalContract(
+        canonical_contract_id=f"{src}:fallback:{digest}",
+        source=src,
+        source_contract_id=f"fallback:{digest}",
+        parent_procurement_id=parent,
+        method="fallback",
+        rule_version=IDENTITY_RULE_VERSION,
+    )
+
+
+def replay_adapters_to_canonical(
+    adapter_payloads: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Two adapters on the same official contract → one canonical + N observations."""
+    contracts: dict[str, CanonicalContract] = {}
+    observations: list[dict[str, Any]] = []
+    for payload in adapter_payloads:
+        ident = canonical_contract_identity(
+            source=str(payload.get("source") or "pncp"),
+            official_id=payload.get("official_id") or payload.get("numeroControlePNCP") or payload.get("numeroControlePncpCompra"),
+            source_contract_id=payload.get("source_contract_id"),
+            parent_procurement_id=payload.get("parent_procurement_id"),
+            fallback_parts=payload.get("fallback_parts") or (),
+        )
+        contracts[ident.canonical_contract_id] = ident
+        observations.append(
+            {
+                "canonical_contract_id": ident.canonical_contract_id,
+                "source": ident.source,
+                "source_contract_id": ident.source_contract_id,
+                "adapter": payload.get("adapter"),
+            }
+        )
+    return {
+        "canonical_count": len(contracts),
+        "observation_count": len(observations),
+        "canonical_ids": sorted(contracts),
+        "observations": observations,
+        "ambiguous": any(item.ambiguous for item in contracts.values()),
+    }
+
+
+class PaginationReconcile:
+    """Accumulate page totals and fail closed on source drift."""
+
+    def __init__(self) -> None:
+        self.first_total_registros: int | None = None
+        self.last_total_registros: int | None = None
+        self.first_total_paginas: int | None = None
+        self.last_total_paginas: int | None = None
+        self.fetched = 0
+        self.persisted = 0
+        self.rejected = 0
+        self._ids: set[str] = set()
+        self.duplicate_ids = 0
+        self._page_ids: list[str] = []
+
+    def observe_page(
+        self,
+        *,
+        total_registros: int | None,
+        total_paginas: int | None,
+        items: Iterable[Mapping[str, Any]],
+        id_field: str = "numeroControlePNCP",
+    ) -> None:
+        if total_registros is not None:
+            if self.first_total_registros is None:
+                self.first_total_registros = int(total_registros)
+            self.last_total_registros = int(total_registros)
+        if total_paginas is not None:
+            if self.first_total_paginas is None:
+                self.first_total_paginas = int(total_paginas)
+            self.last_total_paginas = int(total_paginas)
+        for item in items:
+            item_id = str(item.get(id_field) or item.get("id") or "").strip()
+            self.fetched += 1
+            if not item_id:
+                self.rejected += 1
+                continue
+            if item_id in self._ids:
+                self.duplicate_ids += 1
+            self._ids.add(item_id)
+            self._page_ids.append(item_id)
+
+    def record_persisted(self, count: int = 1) -> None:
+        self.persisted += int(count)
+
+    def record_rejected(self, count: int = 1) -> None:
+        self.rejected += int(count)
+
+    def finish(self) -> PaginationReport:
+        reasons: list[str] = []
+        status = "ok"
+        if (
+            self.first_total_registros is not None
+            and self.last_total_registros is not None
+            and self.first_total_registros != self.last_total_registros
+        ):
+            status = "source_population_drift"
+            reasons.append(
+                f"totalRegistros {self.first_total_registros} -> {self.last_total_registros}"
+            )
+        if (
+            self.first_total_paginas is not None
+            and self.last_total_paginas is not None
+            and self.first_total_paginas != self.last_total_paginas
+        ):
+            status = "source_population_drift"
+            reasons.append(f"totalPaginas {self.first_total_paginas} -> {self.last_total_paginas}")
+        if self.fetched != self.persisted + self.rejected:
+            if status == "ok":
+                status = "reconcile_failed"
+            reasons.append(f"fetched={self.fetched} != persisted+rejected={self.persisted + self.rejected}")
+        if not reasons:
+            reasons.append("ok")
+        return PaginationReport(
+            rule_version=PAGINATION_RULE_VERSION,
+            first_total_registros=self.first_total_registros,
+            last_total_registros=self.last_total_registros,
+            first_total_paginas=self.first_total_paginas,
+            last_total_paginas=self.last_total_paginas,
+            fetched=self.fetched,
+            persisted=self.persisted,
+            rejected=self.rejected,
+            unique_ids=len(self._ids),
+            duplicate_ids=self.duplicate_ids,
+            status=status,
+            reasons=tuple(reasons),
+        )
+
+
+def isolated_test_environment() -> bool:
+    return bool(os.getenv("PYTEST_CURRENT_TEST") or os.getenv("EXTRA_ISOLATED_TEST") == "1")
+
+
+def refuse_writer_bypass(*, skip_lock: bool = False, env_skip: str | None = None) -> None:
+    """Production units must not skip the fence."""
+    env_requested = (env_skip if env_skip is not None else os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0")) == "1"
+    if not (skip_lock or env_requested):
+        return
+    if isolated_test_environment():
+        return
+    raise WriterFenceBypassError("national writer bypass refused outside isolated test")
+
+
+class PostgresWriterFence:
+    """Exclusive PostgreSQL advisory lock for national contract writers."""
+
+    def __init__(self, key: int = PG_FENCE_KEY) -> None:
+        self.key = key
+        self.owned = False
+        self._conn: Any = None
+
+    def acquire(self, conn: Any) -> bool:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT pg_try_advisory_lock(%s)", (self.key,))
+            row = cur.fetchone()
+        finally:
+            close = getattr(cur, "close", None)
+            if callable(close):
+                close()
+        locked = bool(row[0]) if row else False
+        if locked:
+            self.owned = True
+            self._conn = conn
+        return locked
+
+    def release(self) -> None:
+        if not self.owned or self._conn is None:
+            return
+        cur = self._conn.cursor()
+        try:
+            cur.execute("SELECT pg_advisory_unlock(%s)", (self.key,))
+        finally:
+            close = getattr(cur, "close", None)
+            if callable(close):
+                close()
+        self.owned = False
+        self._conn = None
+
+    def run_exclusive(self, conn: Any, mutate) -> Any:
+        """Refuse the second writer before calling ``mutate``."""
+        if not self.acquire(conn):
+            raise WriterFenceBusyError("national writer fence busy")
+        try:
+            return mutate()
+        finally:
+            self.release()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_checkpoint_dir(
+    requested: str | Path | None,
+    *,
+    production: bool | None = None,
+    repo_root: str | Path | None = None,
+    state_root: str | Path | None = None,
+) -> Path:
+    """Production checkpoints live under /var/lib/extra-consultoria, never the worktree."""
+    if production is None:
+        production = os.getenv("EXTRA_CONTRACTS_PRODUCTION", "0") == "1"
+    repo = Path(repo_root) if repo_root else Path(__file__).resolve().parents[1]
+    durable = Path(state_root) if state_root else Path(
+        os.getenv("EXTRA_CONTRACTS_STATE_DIR") or str(PRODUCTION_STATE_ROOT)
+    )
+    raw = Path(requested) if requested else durable / "checkpoints" / "contracts"
+    path = raw.expanduser()
+    if not path.is_absolute():
+        path = (durable / path) if production else (repo / path)
+    path = path.resolve() if path.exists() else Path(os.path.normpath(str(path)))
+    if not production:
+        return path
+    posix = path.as_posix()
+    if any(posix == prefix or posix.startswith(prefix + "/") for prefix in FORBIDDEN_CHECKPOINT_PREFIXES):
+        raise CheckpointLocationError(f"production checkpoint refuses release tree: {path}")
+    if _is_relative_to(path, repo):
+        raise CheckpointLocationError(f"production checkpoint refuses git worktree: {path}")
+    if not _is_relative_to(path, durable):
+        raise CheckpointLocationError(f"production checkpoint must live under {durable}, got {path}")
+    return path
+
+
+def annotate_transformed_contract(record: dict[str, Any], *, raw: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Attach activity, quality and canonical identity to a transformed row."""
+    payload = raw or {}
+    activity = classify_contract_activity(
+        raw_status=payload.get("situacaoContrato") or payload.get("situacao") or payload.get("status"),
+        vigencia_inicio=record.get("data_inicio") or payload.get("dataVigenciaInicio"),
+        vigencia_fim=record.get("data_fim") or payload.get("dataVigenciaFim"),
+        source="pncp",
+        is_active_default=record.get("is_active"),
+    )
+    quality = classify_contract_quality(
+        data_assinatura=record.get("data_assinatura"),
+        data_inicio=record.get("data_inicio"),
+        data_fim=record.get("data_fim"),
+        data_publicacao=record.get("data_publicacao_fonte") or record.get("data_publicacao"),
+        valor=record.get("valor_total") or record.get("valor_global") or payload.get("valorGlobal"),
+    )
+    ident = canonical_contract_identity(
+        source=str(record.get("source") or payload.get("source") or "pncp"),
+        official_id=record.get("contrato_id") or payload.get("numeroControlePNCP"),
+        parent_procurement_id=payload.get("numeroControlePncpCompra"),
+    )
+    record["status_raw"] = activity.raw_status
+    record["status_normalized"] = activity.state
+    record["status_rule_version"] = activity.rule_version
+    record["status_source"] = activity.source
+    record["quality_state"] = quality.state
+    record["quality_reasons"] = list(quality.reasons)
+    record["quality_rule_version"] = quality.rule_version
+    record["report_ready"] = report_ready_allowed(quality)
+    record["canonical_contract_id"] = ident.canonical_contract_id
+    record["source"] = ident.source
+    record["source_contract_id"] = ident.source_contract_id
+    record["parent_procurement_id"] = ident.parent_procurement_id
+    return record

--- a/scripts/coverage/calculator.py
+++ b/scripts/coverage/calculator.py
@@ -26,7 +26,7 @@ def report_coverage(conn: Any) -> dict[str, Any]:
     ``entity_coverage.is_covered``.
     """
     rows = load_coverage_state_rows(conn)
-    kpis = compute_coverage_kpis(rows)
+    kpis = published_coverage_kpis(conn)
     by_source_map: dict[str, list[dict[str, Any]]] = {}
     for row in rows:
         source = str(row.get("source") or "unknown")

--- a/scripts/coverage/calculator.py
+++ b/scripts/coverage/calculator.py
@@ -9,85 +9,65 @@ from __future__ import annotations
 from typing import Any
 
 from config.logging_config import get_logger
-from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA
+from scripts.coverage.covered_entity import (
+    COVERED_ENTITY_FORMULA,
+    compute_coverage_kpis,
+    load_coverage_state_rows,
+    published_coverage_kpis,
+)
 
 logger = get_logger(__name__)
 
 
 def report_coverage(conn: Any) -> dict[str, Any]:
-    """Generate coverage report for all entities across all sources.
+    """Generate coverage report from the single covered-entity formula.
 
-    Args:
-        conn: Database connection.
-
-    Returns:
-        Dict with keys ``groups`` (list per raio_200km group),
-        ``total_entities``, ``total_covered``, ``total_uncovered``,
-        ``pct`` (overall), ``by_source`` (per-source breakdown),
-        ``uncovered_entities_200km`` (critical gaps list).
+    Published ``total_covered`` is ``compute_coverage_kpis`` — never
+    ``entity_coverage.is_covered``.
     """
-    cur = conn.cursor()
-
-    # Overall coverage
-    cur.execute(
-        """SELECT
-            e.raio_200km,
-            COUNT(DISTINCT e.id) AS total,
-            COUNT(DISTINCT CASE WHEN ec.is_covered THEN e.id END) AS covered,
-            COUNT(DISTINCT CASE WHEN NOT ec.is_covered OR ec.is_covered IS NULL THEN e.id END) AS uncovered
-         FROM sc_public_entities e
-         LEFT JOIN entity_coverage ec ON e.id = ec.entity_id
-         WHERE e.is_active = TRUE
-         GROUP BY e.raio_200km
-         ORDER BY e.raio_200km DESC"""
-    )
-    rows = cur.fetchall()
-
-    result: dict[str, Any] = {"groups": [], "total_entities": 0, "total_covered": 0, "total_uncovered": 0}
-    for raio, total, covered, uncovered in rows:
-        group = {
-            "within_200km": raio,
-            "total": total,
-            "covered": covered or 0,
-            "uncovered": uncovered or 0,
-            "pct": round((covered or 0) / total * 100, 1) if total > 0 else 0,
-        }
-        result["groups"].append(group)
-        result["total_entities"] += total
-        result["total_covered"] += covered or 0
-        result["total_uncovered"] += uncovered or 0
-
-    result["pct"] = (
-        round(result["total_covered"] / result["total_entities"] * 100, 1) if result["total_entities"] > 0 else 0
-    )
-
-    # Per-source breakdown
-    cur.execute(
-        """SELECT source, COUNT(*) AS entity_count, COUNT(*) FILTER (WHERE is_covered) AS covered
-           FROM entity_coverage
-           WHERE within_200km = TRUE
-           GROUP BY source
-           ORDER BY source"""
-    )
-    result["by_source"] = [{"source": r[0], "entities": r[1], "covered": r[2]} for r in cur.fetchall()]
-
-    # Uncovered entities within 200km (critical gap)
-    cur.execute(
-        """SELECT e.razao_social, e.cnpj_8, e.municipio, e.natureza_juridica
-           FROM sc_public_entities e
-           WHERE e.is_active = TRUE
-             AND e.raio_200km = TRUE
-             AND e.id NOT IN (
-                 SELECT entity_id FROM entity_coverage WHERE is_covered = TRUE
-             )
-           ORDER BY e.municipio, e.razao_social"""
-    )
-    result["uncovered_entities_200km"] = [
-        {"razao_social": r[0], "cnpj_8": r[1], "municipio": r[2], "natureza": r[3]} for r in cur.fetchall()
-    ]
-
-    cur.close()
-    result["covered_entity_formula"] = f"{COVERED_ENTITY_FORMULA.__module__}.{COVERED_ENTITY_FORMULA.__name__}"
+    rows = load_coverage_state_rows(conn)
+    kpis = compute_coverage_kpis(rows)
+    by_source_map: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        source = str(row.get("source") or "unknown")
+        by_source_map.setdefault(source, []).append(row)
+    by_source = []
+    for source in sorted(by_source_map):
+        source_kpis = compute_coverage_kpis(by_source_map[source])
+        by_source.append(
+            {
+                "source": source,
+                "entities": source_kpis.total_entities,
+                "covered": source_kpis.covered_count,
+            }
+        )
+    result: dict[str, Any] = {
+        "groups": [
+            {
+                "within_200km": True,
+                "total": kpis.total_entities,
+                "covered": kpis.covered_count,
+                "uncovered": len(kpis.excluded_entity_ids),
+                "pct": (
+                    round(kpis.covered_count / kpis.total_entities * 100, 1) if kpis.total_entities else 0
+                ),
+            }
+        ]
+        if kpis.total_entities
+        else [],
+        "total_entities": kpis.total_entities,
+        "total_covered": kpis.covered_count,
+        "total_uncovered": len(kpis.excluded_entity_ids),
+        "pct": round(kpis.covered_count / kpis.total_entities * 100, 1) if kpis.total_entities else 0,
+        "by_source": by_source,
+        "uncovered_entities_200km": [
+            {"razao_social": entity_id, "cnpj_8": "", "municipio": "", "natureza": ""}
+            for entity_id in sorted(kpis.excluded_entity_ids)
+        ],
+        "covered_entity_ids": sorted(kpis.covered_entity_ids),
+        "covered_entity_formula": f"{COVERED_ENTITY_FORMULA.__module__}.{COVERED_ENTITY_FORMULA.__name__}",
+        "published_via": published_coverage_kpis.__name__,
+    }
     return result
 
 

--- a/scripts/coverage/calculator.py
+++ b/scripts/coverage/calculator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from config.logging_config import get_logger
+from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA
 
 logger = get_logger(__name__)
 
@@ -86,6 +87,7 @@ def report_coverage(conn: Any) -> dict[str, Any]:
     ]
 
     cur.close()
+    result["covered_entity_formula"] = f"{COVERED_ENTITY_FORMULA.__module__}.{COVERED_ENTITY_FORMULA.__name__}"
     return result
 
 

--- a/scripts/coverage/covered_entity.py
+++ b/scripts/coverage/covered_entity.py
@@ -103,17 +103,21 @@ def classify_evidence_identity(
 ) -> str:
     """Classify whether evidence can enter a dual-coverage numerator.
 
-    IDENTITY_MAPPED: has entity_id or canonical_entity_key.
+    IDENTITY_MAPPED: has entity_id or canonical_entity_key and can join.
     SOURCE_WIDE_AGGREGATE: source-level rollup with no entity identity.
-    UNMAPPABLE: residual without identity and without aggregate markers.
+    UNMAPPABLE: identity present (or declared) that cannot join the universe.
     """
+    meta = metadata or {}
+    identity_status = str(meta.get("identity_status") or meta.get("unmappable") or "").strip().lower()
+    if identity_status in {"unmappable", "unmapped", "cannot_join", "true", "1"}:
+        return UNMAPPABLE
+
     key = str(canonical_entity_key or "").strip()
     if key:
         return IDENTITY_MAPPED
     if entity_id is not None and str(entity_id).strip() not in {"", "None", "null"}:
         return IDENTITY_MAPPED
 
-    meta = metadata or {}
     aggregate_markers = (
         str(meta.get("pipeline") or ""),
         str(meta.get("scope") or ""),
@@ -125,8 +129,8 @@ def classify_evidence_identity(
         for token in aggregate_markers
     ):
         return SOURCE_WIDE_AGGREGATE
-    # NULL identity with counts is a source-wide rollup, not an entity fact.
-    return SOURCE_WIDE_AGGREGATE if not key else UNMAPPABLE
+    # NULL identity is a source-wide rollup, not an entity fact.
+    return SOURCE_WIDE_AGGREGATE
 
 
 def numerator_row_has_identity(row: Mapping[str, Any]) -> bool:
@@ -145,8 +149,17 @@ def _entity_key(row: Mapping[str, Any]) -> str:
     return ""
 
 
-def compute_coverage_kpis(rows: Iterable[Mapping[str, Any]]) -> CoverageKpis:
-    """Canonical covered-entity KPI. All surfaces must call this function."""
+def compute_coverage_kpis(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    universe_entity_ids: Iterable[Any] | None = None,
+) -> CoverageKpis:
+    """Canonical covered-entity KPI. All surfaces must call this function.
+
+    Latest observed state wins. A historical success does not keep an entity
+    covered after a later failed/blocked/error/partial. Universe members
+    without evidence stay in the denominator as uncovered.
+    """
     by_entity: dict[str, list[str]] = defaultdict(list)
     rejected: list[str] = []
     for raw in rows:
@@ -171,13 +184,21 @@ def compute_coverage_kpis(rows: Iterable[Mapping[str, Any]]) -> CoverageKpis:
         if normalized in NON_COVERED_STATE_VALUES and not is_covered_state(normalized):
             rejected.append(f"{entity}:{normalized}")
 
+    if universe_entity_ids is not None:
+        for raw_id in universe_entity_ids:
+            uid = str(raw_id).strip()
+            if uid and uid not in by_entity:
+                by_entity[uid].append("never_checked")
+                rejected.append(f"{uid}:never_checked")
+
     covered: set[str] = set()
     excluded: set[str] = set()
     state_counts: dict[str, int] = defaultdict(int)
     for entity, states in by_entity.items():
         for state in states:
             state_counts[state or "unknown"] += 1
-        if any(is_covered_state(state) for state in states):
+        latest = states[-1] if states else "unknown"
+        if is_covered_state(latest):
             covered.add(entity)
         else:
             excluded.add(entity)
@@ -271,29 +292,60 @@ def dual_coverage_evidence_gate(
     }
 
 
-def load_coverage_state_rows(conn: Any) -> list[dict[str, Any]]:
-    """Load state-bearing rows that every published coverage surface must use."""
-    cur = conn.cursor()
-    try:
-        cur.execute(
-            """
-            SELECT COALESCE(canonical_entity_key, entity_id::text) AS entity_id,
-                   state::text AS state,
-                   source,
-                   metadata
-            FROM coverage_evidence
-            """
-        )
-        fetched = list(cur.fetchall() or [])
-        return [
+def _rows_from_fetch(fetched: list[Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for row in fetched:
+        rows.append(
             {
                 "entity_id": row[0],
                 "state": row[1],
                 "source": row[2] if len(row) > 2 else "",
                 "metadata": row[3] if len(row) > 3 and isinstance(row[3], Mapping) else {},
             }
-            for row in fetched
-        ]
+        )
+    return rows
+
+
+def load_universe_entity_ids(conn: Any) -> list[str]:
+    """Active planilha universe. Empty when the table is unavailable — never invented."""
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT id::text
+            FROM sc_public_entities
+            WHERE COALESCE(is_active, TRUE) = TRUE
+            """
+        )
+        return [str(row[0]).strip() for row in (cur.fetchall() or []) if row and row[0] is not None]
+    except Exception:
+        rollback = getattr(conn, "rollback", None)
+        if callable(rollback):
+            rollback()
+        return []
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()
+
+
+def load_coverage_state_rows(conn: Any) -> list[dict[str, Any]]:
+    """Load the latest state-bearing row per entity×source.
+
+    Prefer ``v_latest_evidence``. Never treat the full historical ledger as
+    the current coverage state.
+    """
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT entity_id::text AS entity_id,
+                   state::text AS state,
+                   source
+            FROM v_latest_evidence
+            """
+        )
+        return _rows_from_fetch(list(cur.fetchall() or []))
     except Exception:
         rollback = getattr(conn, "rollback", None)
         if callable(rollback):
@@ -301,19 +353,33 @@ def load_coverage_state_rows(conn: Any) -> list[dict[str, Any]]:
         try:
             cur.execute(
                 """
-                SELECT entity_id::text, NULL::text AS state, source
-                FROM entity_coverage
+                SELECT DISTINCT ON (COALESCE(canonical_entity_key, entity_id::text), source)
+                       COALESCE(canonical_entity_key, entity_id::text) AS entity_id,
+                       state::text AS state,
+                       source,
+                       metadata
+                FROM coverage_evidence
+                ORDER BY COALESCE(canonical_entity_key, entity_id::text),
+                         source,
+                         completed_at DESC NULLS LAST
                 """
             )
-            fetched = list(cur.fetchall() or [])
-            return [
-                {"entity_id": row[0], "state": row[1], "source": row[2] if len(row) > 2 else ""}
-                for row in fetched
-            ]
+            return _rows_from_fetch(list(cur.fetchall() or []))
         except Exception:
             if callable(rollback):
                 rollback()
-            return []
+            try:
+                cur.execute(
+                    """
+                    SELECT entity_id::text, state::text, source
+                    FROM coverage_evidence
+                    """
+                )
+                return _rows_from_fetch(list(cur.fetchall() or []))
+            except Exception:
+                if callable(rollback):
+                    rollback()
+                return []
     finally:
         close = getattr(cur, "close", None)
         if callable(close):
@@ -322,7 +388,10 @@ def load_coverage_state_rows(conn: Any) -> list[dict[str, Any]]:
 
 def published_coverage_kpis(conn: Any) -> CoverageKpis:
     """Single published KPI entry point for panel, PDF, Excel, manifest and QA."""
-    return compute_coverage_kpis(load_coverage_state_rows(conn))
+    return compute_coverage_kpis(
+        load_coverage_state_rows(conn),
+        universe_entity_ids=load_universe_entity_ids(conn) or None,
+    )
 
 
 # Surfaces must bind this exact function so QA can prove they share a formula.
@@ -342,6 +411,7 @@ __all__ = [
     "classify_evidence_identity",
     "compute_coverage_kpis",
     "load_coverage_state_rows",
+    "load_universe_entity_ids",
     "published_coverage_kpis",
     "dual_coverage_evidence_gate",
     "is_covered_state",

--- a/scripts/coverage/covered_entity.py
+++ b/scripts/coverage/covered_entity.py
@@ -1,0 +1,293 @@
+"""Single covered-entity formula for every client-facing coverage surface.
+
+Issue #280: panel, PDF, Excel, manifest and QA must derive "ente coberto"
+from one function. FAILED/BLOCKED/ERROR/PARTIAL never become covered.
+
+Issue #350: source-wide aggregated evidence (NULL entity identity) is not a
+numerator row. Dual-coverage numerators require canonical identity; otherwise
+the measurement is fail-closed MISSING_EVIDENCE.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from scripts.coverage.states import COVERED_STATES, CoverageState
+
+FORMULA_ID = "covered-entity-v1"
+FORMULA_VERSION = 1
+
+# Explicit states that compose coverage. Never include failed/blocked/error.
+COVERED_STATE_VALUES: frozenset[str] = frozenset(state.value for state in COVERED_STATES)
+
+NON_COVERED_STATE_VALUES: frozenset[str] = frozenset(
+    {
+        CoverageState.NOT_APPLICABLE.value,
+        CoverageState.PENDING.value,
+        CoverageState.RUNNING.value,
+        CoverageState.PARTIAL.value,
+        CoverageState.ERROR.value,
+        CoverageState.BLOCKED.value,
+        CoverageState.STALE.value,
+        "failed",
+        "fail",
+        "failure",
+        "FOUND",
+        "found",
+        "any_row",
+    }
+)
+
+IDENTITY_MAPPED = "IDENTITY_MAPPED"
+SOURCE_WIDE_AGGREGATE = "SOURCE_WIDE_AGGREGATE"
+UNMAPPABLE = "UNMAPPABLE"
+MISSING_EVIDENCE = "MISSING_EVIDENCE"
+
+
+class CoverageFormulaDivergenceError(ValueError):
+    """Two surfaces published different covered-entity counts for the same rows."""
+
+
+@dataclass(frozen=True)
+class CoverageKpis:
+    """One covered-entity result shared by every surface."""
+
+    formula_id: str
+    formula_version: int
+    covered_entity_ids: frozenset[str]
+    covered_count: int
+    total_entities: int
+    excluded_entity_ids: frozenset[str]
+    state_counts: dict[str, int]
+    non_covered_claims_rejected: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "formula_id": self.formula_id,
+            "formula_version": self.formula_version,
+            "covered_count": self.covered_count,
+            "total_entities": self.total_entities,
+            "covered_entity_ids": sorted(self.covered_entity_ids),
+            "excluded_entity_ids": sorted(self.excluded_entity_ids),
+            "state_counts": dict(self.state_counts),
+            "non_covered_claims_rejected": list(self.non_covered_claims_rejected),
+        }
+
+
+def normalize_coverage_state(state: Any) -> str:
+    if state is None:
+        return ""
+    if isinstance(state, CoverageState):
+        return state.value
+    return str(state).strip().lower()
+
+
+def is_covered_state(state: Any) -> bool:
+    """Return True only for success_with_data / success_zero."""
+    value = normalize_coverage_state(state)
+    if not value:
+        return False
+    if value in NON_COVERED_STATE_VALUES and value not in COVERED_STATE_VALUES:
+        return False
+    return value in COVERED_STATE_VALUES
+
+
+def classify_evidence_identity(
+    *,
+    entity_id: Any = None,
+    canonical_entity_key: Any = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> str:
+    """Classify whether evidence can enter a dual-coverage numerator.
+
+    IDENTITY_MAPPED: has entity_id or canonical_entity_key.
+    SOURCE_WIDE_AGGREGATE: source-level rollup with no entity identity.
+    UNMAPPABLE: residual without identity and without aggregate markers.
+    """
+    key = str(canonical_entity_key or "").strip()
+    if key:
+        return IDENTITY_MAPPED
+    if entity_id is not None and str(entity_id).strip() not in {"", "None", "null"}:
+        return IDENTITY_MAPPED
+
+    meta = metadata or {}
+    aggregate_markers = (
+        str(meta.get("pipeline") or ""),
+        str(meta.get("scope") or ""),
+        str(meta.get("aggregation") or ""),
+        str(meta.get("grain") or ""),
+    )
+    if any(
+        token.lower() in {"resilient_cycle", "source_wide", "source-wide", "aggregate", "aggregated"}
+        for token in aggregate_markers
+    ):
+        return SOURCE_WIDE_AGGREGATE
+    # NULL identity with counts is a source-wide rollup, not an entity fact.
+    return SOURCE_WIDE_AGGREGATE if not key else UNMAPPABLE
+
+
+def numerator_row_has_identity(row: Mapping[str, Any]) -> bool:
+    return classify_evidence_identity(
+        entity_id=row.get("entity_id"),
+        canonical_entity_key=row.get("canonical_entity_key"),
+        metadata=row.get("metadata") if isinstance(row.get("metadata"), Mapping) else {},
+    ) == IDENTITY_MAPPED
+
+
+def _entity_key(row: Mapping[str, Any]) -> str:
+    for field_name in ("canonical_entity_key", "entity_id", "entity_key", "id"):
+        value = row.get(field_name)
+        if value is not None and str(value).strip() not in {"", "None", "null"}:
+            return str(value).strip()
+    return ""
+
+
+def compute_coverage_kpis(rows: Iterable[Mapping[str, Any]]) -> CoverageKpis:
+    """Canonical covered-entity KPI. All surfaces must call this function."""
+    by_entity: dict[str, list[str]] = defaultdict(list)
+    rejected: list[str] = []
+    for raw in rows:
+        row = dict(raw)
+        entity = _entity_key(row)
+        state = row.get("state") or row.get("coverage_state") or row.get("result")
+        if not entity:
+            identity = classify_evidence_identity(
+                entity_id=row.get("entity_id"),
+                canonical_entity_key=row.get("canonical_entity_key"),
+                metadata=row.get("metadata") if isinstance(row.get("metadata"), Mapping) else {},
+            )
+            rejected.append(f"{identity}:missing_entity")
+            continue
+        if state is None and row.get("is_covered") is True:
+            # Boolean-only flag without state cannot prove coverage.
+            rejected.append(f"{entity}:boolean_without_state")
+            by_entity[entity].append("unknown")
+            continue
+        normalized = normalize_coverage_state(state)
+        by_entity[entity].append(normalized or "unknown")
+        if normalized in NON_COVERED_STATE_VALUES and not is_covered_state(normalized):
+            rejected.append(f"{entity}:{normalized}")
+
+    covered: set[str] = set()
+    excluded: set[str] = set()
+    state_counts: dict[str, int] = defaultdict(int)
+    for entity, states in by_entity.items():
+        for state in states:
+            state_counts[state or "unknown"] += 1
+        if any(is_covered_state(state) for state in states):
+            covered.add(entity)
+        else:
+            excluded.add(entity)
+
+    return CoverageKpis(
+        formula_id=FORMULA_ID,
+        formula_version=FORMULA_VERSION,
+        covered_entity_ids=frozenset(covered),
+        covered_count=len(covered),
+        total_entities=len(by_entity),
+        excluded_entity_ids=frozenset(excluded),
+        state_counts=dict(state_counts),
+        non_covered_claims_rejected=tuple(rejected),
+    )
+
+
+def assert_surfaces_agree(surface_kpis: Mapping[str, CoverageKpis]) -> CoverageKpis:
+    """Fail if any named surface disagrees on the covered set."""
+    if not surface_kpis:
+        raise CoverageFormulaDivergenceError("no coverage surfaces provided")
+    names = list(surface_kpis)
+    reference = surface_kpis[names[0]]
+    for name in names[1:]:
+        other = surface_kpis[name]
+        if (
+            other.covered_entity_ids != reference.covered_entity_ids
+            or other.covered_count != reference.covered_count
+            or other.formula_id != reference.formula_id
+        ):
+            raise CoverageFormulaDivergenceError(
+                f"{names[0]} covered={sorted(reference.covered_entity_ids)} "
+                f"count={reference.covered_count} vs {name} "
+                f"covered={sorted(other.covered_entity_ids)} count={other.covered_count}"
+            )
+    return reference
+
+
+def dual_coverage_evidence_gate(
+    rows: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Decide whether dual-coverage numerators may use the given evidence rows.
+
+    Identified rows may enter numerators. Source-wide aggregates are recorded
+    and never counted. Truly unmappable identity-bearing rows stay fail-closed.
+    """
+    identified: list[dict[str, Any]] = []
+    source_wide: list[dict[str, Any]] = []
+    unmappable: list[dict[str, Any]] = []
+    for raw in rows:
+        row = dict(raw)
+        kind = classify_evidence_identity(
+            entity_id=row.get("entity_id"),
+            canonical_entity_key=row.get("canonical_entity_key"),
+            metadata=row.get("metadata") if isinstance(row.get("metadata"), Mapping) else {},
+        )
+        if kind == IDENTITY_MAPPED:
+            identified.append(row)
+        elif kind == SOURCE_WIDE_AGGREGATE:
+            source_wide.append(row)
+        else:
+            unmappable.append(row)
+
+    if unmappable:
+        return {
+            "classification": MISSING_EVIDENCE,
+            "reason": "unmappable_evidence_cannot_drop",
+            "numerator_rows": [],
+            "source_wide_count": len(source_wide),
+            "unmapped_count": len(unmappable),
+            "identified_count": len(identified),
+            "measurement_success": False,
+        }
+    if source_wide and not identified:
+        return {
+            "classification": MISSING_EVIDENCE,
+            "reason": "source_wide_aggregate_without_identity",
+            "numerator_rows": [],
+            "source_wide_count": len(source_wide),
+            "unmapped_count": 0,
+            "identified_count": 0,
+            "measurement_success": False,
+        }
+    return {
+        "classification": "IDENTITY_READY",
+        "reason": "ok",
+        "numerator_rows": identified,
+        "source_wide_count": len(source_wide),
+        "unmapped_count": 0,
+        "identified_count": len(identified),
+        "measurement_success": True,
+    }
+
+
+# Surfaces must bind this exact function so QA can prove they share a formula.
+COVERED_ENTITY_FORMULA = compute_coverage_kpis
+
+__all__ = [
+    "COVERED_ENTITY_FORMULA",
+    "COVERED_STATE_VALUES",
+    "CoverageFormulaDivergenceError",
+    "CoverageKpis",
+    "FORMULA_ID",
+    "IDENTITY_MAPPED",
+    "MISSING_EVIDENCE",
+    "SOURCE_WIDE_AGGREGATE",
+    "UNMAPPABLE",
+    "assert_surfaces_agree",
+    "classify_evidence_identity",
+    "compute_coverage_kpis",
+    "dual_coverage_evidence_gate",
+    "is_covered_state",
+    "numerator_row_has_identity",
+]

--- a/scripts/coverage/covered_entity.py
+++ b/scripts/coverage/covered_entity.py
@@ -160,11 +160,12 @@ def compute_coverage_kpis(
     covered after a later failed/blocked/error/partial. Universe members
     without evidence stay in the denominator as uncovered.
     """
-    by_entity: dict[str, list[str]] = defaultdict(list)
+    by_entity_source: dict[tuple[str, str], list[str]] = defaultdict(list)
     rejected: list[str] = []
     for raw in rows:
         row = dict(raw)
         entity = _entity_key(row)
+        source = str(row.get("source") or "")
         state = row.get("state") or row.get("coverage_state") or row.get("result")
         if not entity:
             identity = classify_evidence_identity(
@@ -177,12 +178,16 @@ def compute_coverage_kpis(
         if state is None and row.get("is_covered") is True:
             # Boolean-only flag without state cannot prove coverage.
             rejected.append(f"{entity}:boolean_without_state")
-            by_entity[entity].append("unknown")
+            by_entity_source[(entity, source)].append("unknown")
             continue
         normalized = normalize_coverage_state(state)
-        by_entity[entity].append(normalized or "unknown")
+        by_entity_source[(entity, source)].append(normalized or "unknown")
         if normalized in NON_COVERED_STATE_VALUES and not is_covered_state(normalized):
             rejected.append(f"{entity}:{normalized}")
+
+    by_entity: dict[str, list[str]] = defaultdict(list)
+    for (entity, _source), states in by_entity_source.items():
+        by_entity[entity].append(states[-1] if states else "unknown")
 
     if universe_entity_ids is not None:
         for raw_id in universe_entity_ids:
@@ -197,8 +202,9 @@ def compute_coverage_kpis(
     for entity, states in by_entity.items():
         for state in states:
             state_counts[state or "unknown"] += 1
-        latest = states[-1] if states else "unknown"
-        if is_covered_state(latest):
+        # Latest state per source. One failed source does not erase another
+        # source's proven success.
+        if any(is_covered_state(state) for state in states):
             covered.add(entity)
         else:
             excluded.add(entity)

--- a/scripts/coverage/covered_entity.py
+++ b/scripts/coverage/covered_entity.py
@@ -271,6 +271,60 @@ def dual_coverage_evidence_gate(
     }
 
 
+def load_coverage_state_rows(conn: Any) -> list[dict[str, Any]]:
+    """Load state-bearing rows that every published coverage surface must use."""
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT COALESCE(canonical_entity_key, entity_id::text) AS entity_id,
+                   state::text AS state,
+                   source,
+                   metadata
+            FROM coverage_evidence
+            """
+        )
+        fetched = list(cur.fetchall() or [])
+        return [
+            {
+                "entity_id": row[0],
+                "state": row[1],
+                "source": row[2] if len(row) > 2 else "",
+                "metadata": row[3] if len(row) > 3 and isinstance(row[3], Mapping) else {},
+            }
+            for row in fetched
+        ]
+    except Exception:
+        rollback = getattr(conn, "rollback", None)
+        if callable(rollback):
+            rollback()
+        try:
+            cur.execute(
+                """
+                SELECT entity_id::text, NULL::text AS state, source
+                FROM entity_coverage
+                """
+            )
+            fetched = list(cur.fetchall() or [])
+            return [
+                {"entity_id": row[0], "state": row[1], "source": row[2] if len(row) > 2 else ""}
+                for row in fetched
+            ]
+        except Exception:
+            if callable(rollback):
+                rollback()
+            return []
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()
+
+
+def published_coverage_kpis(conn: Any) -> CoverageKpis:
+    """Single published KPI entry point for panel, PDF, Excel, manifest and QA."""
+    return compute_coverage_kpis(load_coverage_state_rows(conn))
+
+
 # Surfaces must bind this exact function so QA can prove they share a formula.
 COVERED_ENTITY_FORMULA = compute_coverage_kpis
 
@@ -287,6 +341,8 @@ __all__ = [
     "assert_surfaces_agree",
     "classify_evidence_identity",
     "compute_coverage_kpis",
+    "load_coverage_state_rows",
+    "published_coverage_kpis",
     "dual_coverage_evidence_gate",
     "is_covered_state",
     "numerator_row_has_identity",

--- a/scripts/coverage/dual_capability_coverage.py
+++ b/scripts/coverage/dual_capability_coverage.py
@@ -37,6 +37,11 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.coverage.covered_entity import (  # noqa: E402
+    MISSING_EVIDENCE,
+    SOURCE_WIDE_AGGREGATE,
+    classify_evidence_identity,
+)
 from scripts.coverage.states import CoverageState  # noqa: E402
 from scripts.lib.universe import (  # noqa: E402
     CanonicalEntity,
@@ -368,6 +373,8 @@ class DualCoverageReport:
     schema_compatibility_mode: SchemaMode = "unknown"
     unmapped_evidence_count: int = 0
     outsider_evidence_count: int = 0
+    source_wide_evidence_count: int = 0
+    missing_evidence_reason: str | None = None
     scope_complete: bool = False
     dual_gate_status: str = "NOT_EVALUATED"  # PASS | FAIL | NOT_EVALUATED | NOT_READY
     capabilities_evaluated: tuple[str, ...] = field(default_factory=tuple)
@@ -405,6 +412,8 @@ class DualCoverageReport:
             "schema_compatibility_mode": self.schema_compatibility_mode,
             "unmapped_evidence_count": self.unmapped_evidence_count,
             "outsider_evidence_count": self.outsider_evidence_count,
+            "source_wide_evidence_count": self.source_wide_evidence_count,
+            "missing_evidence_reason": self.missing_evidence_reason,
             "forbidden_methods": sorted(FORBIDDEN_METHODS),
             "claims_forbidden": [
                 "entity_coverage.any_row as coverage",
@@ -1635,11 +1644,11 @@ def load_observations_from_db(
     cnpj8_to_entity_id: Mapping[str, str],
     db_id_to_entity_id: Mapping[int, str],
     universe_ids: set[str],
-) -> tuple[dict[str, dict[str, EvidenceObservation]], SchemaMode, int, int]:
-    """Return (entity→source→obs, schema_mode, unmapped_count, outsider_count).
+) -> tuple[dict[str, dict[str, EvidenceObservation]], SchemaMode, int, int, int]:
+    """Return (entity→source→obs, schema_mode, unmapped, outsider, source_wide).
 
-    Fail-closed on unexpected schema/query errors. Legacy fallback only when
-    modern columns are proven absent.
+    Source-wide aggregates (NULL identity) are classified and excluded from
+    numerators. Identity-bearing rows that cannot be mapped stay fail-closed.
     """
     _ = cnpj8_to_entity_id  # reserved for alternate key paths
     cur = conn.cursor()
@@ -1748,6 +1757,7 @@ def load_observations_from_db(
     out: dict[str, dict[str, EvidenceObservation]] = defaultdict(dict)
     unmapped = 0
     outsider = 0
+    source_wide = 0
     for row in rows:
         # Modern rows include optional trailing canonical_entity_key; legacy has 20 cols.
         if len(row) >= 21:
@@ -1813,6 +1823,14 @@ def load_observations_from_db(
             except (TypeError, ValueError):
                 entity_key = None
         if entity_key is None:
+            identity_kind = classify_evidence_identity(
+                entity_id=db_entity_id,
+                canonical_entity_key=canonical_entity_key,
+                metadata=metadata if isinstance(metadata, dict) else {},
+            )
+            if identity_kind == SOURCE_WIDE_AGGREGATE:
+                source_wide += 1
+                continue
             unmapped += 1
             continue
         if entity_key not in universe_ids:
@@ -1849,7 +1867,7 @@ def load_observations_from_db(
         raise DualCoverageError(f"unmapped_evidence_count={unmapped} (cannot drop evidence outside identity map)")
     if outsider > 0:
         raise DualCoverageError(f"entity_id_outside_canonical_universe: outsider_evidence_count={outsider}")
-    return dict(out), schema_mode, unmapped, outsider
+    return dict(out), schema_mode, unmapped, outsider, source_wide
 
 
 def load_data_presence(
@@ -2226,6 +2244,8 @@ def compute_dual_coverage(
     schema_mode: SchemaMode = "unknown"
     unmapped_evidence = 0
     outsider_evidence = 0
+    source_wide_evidence = 0
+    missing_evidence_reason: str | None = None
     legacy_metric = None
 
     owns_conn = False
@@ -2258,7 +2278,7 @@ def compute_dual_coverage(
             modes: list[SchemaMode] = []
             for cap in capabilities:
                 cap_n = normalize_capability(cap) or cap
-                loaded, mode, unm, out_c = load_observations_from_db(
+                loaded, mode, unm, out_c, source_wide_n = load_observations_from_db(
                     conn,
                     capability=cap_n,
                     cnpj8_to_entity_id=mapping_metrics.cnpj8_to_entity_id,
@@ -2267,6 +2287,12 @@ def compute_dual_coverage(
                 )
                 obs_map[cap_n] = loaded
                 modes.append(mode)
+                source_wide_evidence += source_wide_n
+                if source_wide_n and not loaded:
+                    missing_evidence_reason = (
+                        f"{MISSING_EVIDENCE}:source_wide_aggregate_without_identity:{cap_n}"
+                    )
+                    limitations.append(missing_evidence_reason)
                 unmapped_evidence += unm
                 outsider_evidence += out_c
                 pres = load_data_presence(
@@ -2506,11 +2532,14 @@ def compute_dual_coverage(
         and (not fallback_used)
         and unmapped_evidence == 0
         and outsider_evidence == 0
+        and missing_evidence_reason is None
         and all(c.reconciliation_ok for c in caps_out.values())
         and all(c.measurement_success for c in caps_out.values())
     )
     err_msg = None
-    if policy_bad:
+    if missing_evidence_reason:
+        err_msg = missing_evidence_reason
+    elif policy_bad:
         err_msg = "SOURCE_POLICY_NOT_READY"
     elif identity_bad:
         amb = list(mapping_metrics.ambiguous_cnpj8[:5]) if mapping_metrics else []
@@ -2554,6 +2583,8 @@ def compute_dual_coverage(
         schema_compatibility_mode=schema_mode,
         unmapped_evidence_count=unmapped_evidence,
         outsider_evidence_count=outsider_evidence,
+        source_wide_evidence_count=source_wide_evidence,
+        missing_evidence_reason=missing_evidence_reason,
         error=err_msg,
         scope_complete=scope_complete,
         dual_gate_status=dual_gate_status,

--- a/scripts/coverage/manifest.py
+++ b/scripts/coverage/manifest.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
+from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA
+
 
 @dataclass
 class CoverageManifestEntry:

--- a/scripts/coverage/manifest.py
+++ b/scripts/coverage/manifest.py
@@ -21,6 +21,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA
+from scripts.coverage.covered_entity import compute_coverage_kpis, load_coverage_state_rows
 
 
 @dataclass
@@ -257,11 +258,23 @@ def build_manifest_from_db(
         manifest.total_capabilities = len(set(e.capability for e in manifest.entries))
         manifest.total_sources = len(set(e.source for e in manifest.entries))
 
-        # Aggregate metrics
-        total_covered = sum(e.covered_pairs for e in manifest.entries)
+        # Published covered count comes from the shared formula, not the view.
+        state_rows = load_coverage_state_rows(conn)
+        kpis = compute_coverage_kpis(state_rows)
+        for entry in manifest.entries:
+            source_rows = [row for row in state_rows if str(row.get("source") or "") == entry.source]
+            if source_rows:
+                source_kpis = compute_coverage_kpis(source_rows)
+                entry.covered_pairs = source_kpis.covered_count
+                entry.pct_covered = (
+                    round(100.0 * source_kpis.covered_count / entry.total_pairs, 1)
+                    if entry.total_pairs
+                    else 0.0
+                )
         total_all = sum(e.total_pairs for e in manifest.entries)
         if total_all > 0:
-            manifest.capability_monitoring_coverage_pct = round(total_covered / total_all * 100, 1)
+            manifest.capability_monitoring_coverage_pct = round(kpis.covered_count / total_all * 100, 1)
+        manifest.formula_id = COVERED_ENTITY_FORMULA.__name__
 
     except psycopg2.Error as e:
         manifest.entries = []

--- a/scripts/coverage/validate_coverage.py
+++ b/scripts/coverage/validate_coverage.py
@@ -103,18 +103,30 @@ class CoverageValidator:
     # ------------------------------------------------------------------ #
 
     def fetch_uncovered_entities(self):
-        """Fetch all uncovered entities from the database."""
+        """Fetch all uncovered entities from the shared covered-entity formula."""
+        kpis = published_coverage_kpis(self.conn)
+        covered = list(kpis.covered_entity_ids)
         cur = self.conn.cursor()
-        cur.execute("""
-            SELECT e.id, e.razao_social, e.cnpj_8, e.municipio,
-                   e.codigo_ibge, e.natureza_juridica
-            FROM sc_public_entities e
-            WHERE NOT EXISTS (
-                SELECT 1 FROM entity_coverage ec
-                WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
+        if covered:
+            cur.execute(
+                """
+                SELECT e.id, e.razao_social, e.cnpj_8, e.municipio,
+                       e.codigo_ibge, e.natureza_juridica
+                FROM sc_public_entities e
+                WHERE e.id::text <> ALL(%s)
+                ORDER BY e.municipio, e.razao_social
+                """,
+                (covered,),
             )
-            ORDER BY e.municipio, e.razao_social
-        """)
+        else:
+            cur.execute(
+                """
+                SELECT e.id, e.razao_social, e.cnpj_8, e.municipio,
+                       e.codigo_ibge, e.natureza_juridica
+                FROM sc_public_entities e
+                ORDER BY e.municipio, e.razao_social
+                """
+            )
         rows = cur.fetchall()
         cur.close()
         return rows
@@ -225,67 +237,93 @@ class CoverageValidator:
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         cur = self.conn.cursor()
 
-        # Total coverage
-        cur.execute("""
-            SELECT
-                   (SELECT COUNT(*) FROM sc_public_entities) as total,
-                   COUNT(DISTINCT entity_id) as covered
-            FROM entity_coverage
-            WHERE is_covered = TRUE
-        """)
-        row = cur.fetchone()
-        total = row[0]
-        covered = row[1] or 0
-        uncovered = total - covered
+        kpis = published_coverage_kpis(self.conn)
+        covered_ids = list(kpis.covered_entity_ids)
+        cur.execute("SELECT COUNT(*) FROM sc_public_entities")
+        total = cur.fetchone()[0] or 0
+        covered = kpis.covered_count
+        uncovered = max(0, total - covered)
         pct = round(100.0 * covered / total, 1) if total > 0 else 0
 
-        # Coverage by source
-        cur.execute("""
+        # Coverage by source — latest evidence state, never is_covered.
+        cur.execute(
+            """
             SELECT source, COUNT(DISTINCT entity_id) as entes
-            FROM entity_coverage
-            WHERE is_covered = TRUE
+            FROM v_latest_evidence
+            WHERE state IN ('success_with_data', 'success_zero')
+              AND entity_id::text = ANY(%s)
             GROUP BY source
             ORDER BY entes DESC
-        """)
+            """,
+            (covered_ids or ["__none__"],),
+        )
         por_fonte = {r[0]: r[1] for r in cur.fetchall()}
 
         # Coverage by natureza_juridica
-        cur.execute("""
-            SELECT e.natureza_juridica,
-                   COUNT(*) as total,
-                   SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END) as covered
-            FROM sc_public_entities e
-            LEFT JOIN entity_coverage ec ON ec.entity_id = e.id AND ec.is_covered = TRUE
-            GROUP BY e.natureza_juridica
-            ORDER BY COUNT(*) DESC
-        """)
+        if covered_ids:
+            cur.execute(
+                """
+                SELECT e.natureza_juridica,
+                       COUNT(*) as total,
+                       SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END) as covered
+                FROM sc_public_entities e
+                GROUP BY e.natureza_juridica
+                ORDER BY COUNT(*) DESC
+                """,
+                (covered_ids,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT e.natureza_juridica, COUNT(*) as total, 0 as covered
+                FROM sc_public_entities e
+                GROUP BY e.natureza_juridica
+                ORDER BY COUNT(*) DESC
+                """
+            )
         por_natureza = cur.fetchall()
 
         # Coverage by municipio (top 10 worst)
-        cur.execute("""
-            SELECT e.municipio, COUNT(*) as total,
-                   SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END) as covered
-            FROM sc_public_entities e
-            LEFT JOIN entity_coverage ec ON ec.entity_id = e.id AND ec.is_covered = TRUE
-            GROUP BY e.municipio
-            HAVING COUNT(*) - SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END) > 0
-            ORDER BY (COUNT(*) - SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END)) DESC
-            LIMIT 10
-        """)
+        if covered_ids:
+            cur.execute(
+                """
+                SELECT e.municipio, COUNT(*) as total,
+                       SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END) as covered
+                FROM sc_public_entities e
+                GROUP BY e.municipio
+                HAVING COUNT(*) - SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END) > 0
+                ORDER BY (COUNT(*) - SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END)) DESC
+                LIMIT 10
+                """,
+                (covered_ids, covered_ids, covered_ids),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT e.municipio, COUNT(*) as total, 0 as covered
+                FROM sc_public_entities e
+                GROUP BY e.municipio
+                ORDER BY COUNT(*) DESC
+                LIMIT 10
+                """
+            )
         top_municipios = cur.fetchall()
 
         # Total municipios stats
         cur.execute("SELECT COUNT(DISTINCT municipio) FROM sc_public_entities")
         total_municipios = cur.fetchone()[0]
 
-        cur.execute("""
-            SELECT COUNT(DISTINCT e.municipio)
-            FROM sc_public_entities e
-            WHERE NOT EXISTS (
-                SELECT 1 FROM entity_coverage ec
-                WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
+        if covered_ids:
+            cur.execute(
+                """
+                SELECT COUNT(DISTINCT e.municipio)
+                FROM sc_public_entities e
+                WHERE e.id::text <> ALL(%s)
+                """,
+                (covered_ids,),
             )
-        """)
+        else:
+            cur.execute("SELECT COUNT(DISTINCT municipio) FROM sc_public_entities")
         mun_com_descobertos = cur.fetchone()[0]
         cur.close()
 
@@ -564,21 +602,34 @@ class CoverageValidator:
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         cur = self.conn.cursor()
 
-        # Municipio-level data
-        cur.execute("""
-            SELECT e.municipio, e.codigo_ibge,
-                   COUNT(*) as total,
-                   SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END) as covered
-            FROM sc_public_entities e
-            LEFT JOIN entity_coverage ec ON ec.entity_id = e.id AND ec.is_covered = TRUE
-            GROUP BY e.municipio, e.codigo_ibge
-            ORDER BY e.municipio
-        """)
-        municipios = cur.fetchall()
-
         # Total stats — single covered-entity formula, never is_covered boolean.
         kpis = published_coverage_kpis(self.conn)
         total_covered = kpis.covered_count
+        covered_ids = list(kpis.covered_entity_ids)
+
+        # Municipio-level data from the same formula set.
+        if covered_ids:
+            cur.execute(
+                """
+                SELECT e.municipio, e.codigo_ibge,
+                       COUNT(*) as total,
+                       SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END) as covered
+                FROM sc_public_entities e
+                GROUP BY e.municipio, e.codigo_ibge
+                ORDER BY e.municipio
+                """,
+                (covered_ids,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT e.municipio, e.codigo_ibge, COUNT(*) as total, 0 as covered
+                FROM sc_public_entities e
+                GROUP BY e.municipio, e.codigo_ibge
+                ORDER BY e.municipio
+                """
+            )
+        municipios = cur.fetchall()
 
         cur.execute("SELECT COUNT(*) FROM sc_public_entities")
         total_entities = cur.fetchone()[0] or 1
@@ -783,16 +834,11 @@ def verify_coverage_sync(csv_path: str):
     conn = psycopg2.connect(DSN)
     cur = conn.cursor()
 
-    # Count uncovered in DB
-    cur.execute("""
-        SELECT COUNT(*)
-        FROM sc_public_entities e
-        WHERE NOT EXISTS (
-            SELECT 1 FROM entity_coverage ec
-            WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
-        )
-    """)
-    db_uncovered = cur.fetchone()[0]
+    # Count uncovered from the shared formula, never is_covered.
+    kpis = published_coverage_kpis(conn)
+    cur.execute("SELECT COUNT(*) FROM sc_public_entities")
+    total_entities = cur.fetchone()[0] or 0
+    db_uncovered = max(0, total_entities - kpis.covered_count)
 
     # Count in CSV
     with open(csv_path, encoding="utf-8-sig") as f:

--- a/scripts/coverage/validate_coverage.py
+++ b/scripts/coverage/validate_coverage.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import psycopg2
 
 from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA
+from scripts.coverage.covered_entity import published_coverage_kpis
 
 DSN = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://postgres@127.0.0.1:5433/pncp_datalake")
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -575,9 +576,9 @@ class CoverageValidator:
         """)
         municipios = cur.fetchall()
 
-        # Total stats
-        cur.execute("SELECT COUNT(DISTINCT entity_id) FROM entity_coverage WHERE is_covered = TRUE")
-        total_covered = cur.fetchone()[0] or 0
+        # Total stats — single covered-entity formula, never is_covered boolean.
+        kpis = published_coverage_kpis(self.conn)
+        total_covered = kpis.covered_count
 
         cur.execute("SELECT COUNT(*) FROM sc_public_entities")
         total_entities = cur.fetchone()[0] or 1

--- a/scripts/coverage/validate_coverage.py
+++ b/scripts/coverage/validate_coverage.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 import psycopg2
 
+from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA
+
 DSN = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://postgres@127.0.0.1:5433/pncp_datalake")
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 OUTPUT_DIR = BASE_DIR / "docs" / "epic-coverage"

--- a/scripts/coverage_truth.py
+++ b/scripts/coverage_truth.py
@@ -23,6 +23,8 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA
+
 _logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/coverage_truth.py
+++ b/scripts/coverage_truth.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA
+from scripts.coverage.covered_entity import compute_coverage_kpis
 
 _logger = logging.getLogger(__name__)
 
@@ -318,12 +319,36 @@ def compute_metrics(
             entities_monitored.add(eid)
             monitored_sources.setdefault(eid, set()).add(src)
 
+    published_kpis = compute_coverage_kpis(
+        [
+            {
+                "entity_id": ev.get("entity_id"),
+                "canonical_entity_key": ev.get("canonical_entity_key"),
+                "state": ev.get("state"),
+                "source": ev.get("source"),
+                "metadata": ev.get("metadata") if isinstance(ev.get("metadata"), dict) else {},
+            }
+            for ev in entity_source_evidence.values()
+        ]
+    )
+    entities_monitored = {
+        eid
+        for eid in entities_monitored
+        if str(eid) in published_kpis.covered_entity_ids
+    }
+
     entities_never_checked = n_entities - len(entities_checked)
 
     if n_entities == 0:
         monitoring_coverage_pct: float | None = 0.0  # trivial: no entities
     elif has_any_entity_evidence:
-        monitoring_coverage_pct = round(len(entities_monitored) / n_entities * 100, 1)
+        monitoring_coverage_pct = round(100.0 * published_kpis.covered_count / n_entities, 1)
+        entities_monitored = {
+            eid
+            for eid in entities_monitored
+            if str(eid) in published_kpis.covered_entity_ids
+            or any(str(key) == str(eid) for key in published_kpis.covered_entity_ids)
+        }
     else:
         monitoring_coverage_pct = None  # unverified
 
@@ -509,10 +534,12 @@ def compute_metrics(
         "monitoring_coverage": {
             "pct": monitoring_coverage_pct,
             "pct_display": (f"{monitoring_coverage_pct}%" if monitoring_coverage_pct is not None else "unverified"),
-            "entities_monitored": len(entities_monitored),
+            "entities_monitored": published_kpis.covered_count,
             "entities_checked_no_coverage": len(entities_checked - entities_monitored),
             "entities_never_checked": entities_never_checked,
-            "_source": "coverage_evidence (v_latest_evidence)",
+            "formula_id": COVERED_ENTITY_FORMULA.__name__,
+            "covered_entity_ids": sorted(published_kpis.covered_entity_ids),
+            "_source": "coverage_evidence via compute_coverage_kpis",
             "_note": (
                 "Monitoring coverage from evidence ledger — entity-level "
                 "observations only. Bid presence is a separate metric."

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -39,6 +39,7 @@ from scripts.contracts_truth import (
     PaginationReconcile,
     annotate_transformed_contract,
     resolve_checkpoint_dir,
+    stamp_contract_truth_labels,
 )
 from scripts.crawl.common import (
     digits_only as _digits_only,
@@ -370,6 +371,7 @@ def _persist_window_if_enabled(raw_items: list[dict]) -> int:
                 (json.dumps(transformed, default=str),),
             )
             rows = cur.fetchall()
+            stamped = stamp_contract_truth_labels(conn, transformed)
             conn.commit()
         finally:
             conn.close()
@@ -377,8 +379,16 @@ def _persist_window_if_enabled(raw_items: list[dict]) -> int:
             return 0
         first = rows[0]
         if len(rows) == 1 and len(first) >= 3 and all(isinstance(v, int) for v in first[:3]):
-            return int(first[0]) + int(first[1])
-        return len(rows)
+            persisted = int(first[0]) + int(first[1])
+        else:
+            persisted = len(rows)
+        if stamped < persisted:
+            logger.warning(
+                "Truth stamp undercount: stamped=%s persisted=%s",
+                stamped,
+                persisted,
+            )
+        return persisted
     except Exception as exc:  # noqa: BLE001 — window crawl must continue
         logger.warning("Per-window persist failed (non-fatal): %s", exc)
         return 0
@@ -859,14 +869,18 @@ def _crawl_date_range(
                     pagination.record_persisted(int(persisted))
                     leftover = max(0, pagination.fetched - pagination.persisted)
                     if leftover:
-                        pagination.record_rejected(leftover)
+                        fully_ok = False
+                        window_errors.append(
+                            f"persist_undercount:fetched={pagination.fetched}:persisted={persisted}"
+                        )
                     logger.info(
                         "Window %s persisted %d rows to DB (per-window upsert)",
                         window_key,
                         persisted,
                     )
                 elif window_items:
-                    pagination.record_rejected(len(window_items))
+                    fully_ok = False
+                    window_errors.append("persist_zero")
                 page_report = pagination.finish()
                 if not page_report.ok:
                     window_errors.append(page_report.status)

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -35,7 +35,11 @@ from pathlib import Path
 from typing import Any
 
 from scripts.contracts_identity import normalize_supplier_identity
-from scripts.contracts_truth import PaginationReconcile, annotate_transformed_contract
+from scripts.contracts_truth import (
+    PaginationReconcile,
+    annotate_transformed_contract,
+    resolve_checkpoint_dir,
+)
 from scripts.crawl.common import (
     digits_only as _digits_only,
 )
@@ -72,9 +76,11 @@ CONTRACTS_JANELA_DELAY = float(os.getenv("CONTRACTS_JANELA_DELAY", "5.0"))
 CONTRACTS_FULL_DAYS = int(os.getenv("CONTRACTS_FULL_DAYS", "90"))
 CONTRACTS_INCREMENTAL_DAYS = int(os.getenv("CONTRACTS_INCREMENTAL_DAYS", "3"))
 CONTRACTS_BACKFILL_YEARS = int(os.getenv("CONTRACTS_BACKFILL_YEARS", "3"))
-CONTRACTS_CHECKPOINT_DIR = os.getenv(
-    "CONTRACTS_CHECKPOINT_DIR",
-    str(_PROJECT_ROOT / "data" / "contracts_checkpoints"),
+CONTRACTS_CHECKPOINT_DIR = str(
+    resolve_checkpoint_dir(
+        os.getenv("CONTRACTS_CHECKPOINT_DIR"),
+        repo_root=_PROJECT_ROOT,
+    )
 )
 
 _ESFERA_MAP = {"F": 1, "E": 2, "M": 3, "D": 4}

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.contracts_identity import normalize_supplier_identity
+from scripts.contracts_truth import PaginationReconcile, annotate_transformed_contract
 from scripts.crawl.common import (
     digits_only as _digits_only,
 )
@@ -657,8 +658,7 @@ def _transform_record(rec: dict) -> dict | None:
             "municipio": municipio,
             "source_id": contrato_id,
         }
-
-        return record
+        return annotate_transformed_contract(record, raw=rec)
 
     except Exception as e:
         logger.warning("Transform error for record %s: %s", rec.get("numeroControlePNCP", ""), e)
@@ -787,6 +787,7 @@ def _crawl_date_range(
         window_pages = 0
         window_errors: list[str] = []
         window_items: list[dict] = []
+        pagination = PaginationReconcile()
 
         while page <= CONTRACTS_MAX_PAGES:
             result = _fetch_page(data_ini, data_fim, page)
@@ -815,6 +816,11 @@ def _crawl_date_range(
                 break
 
             # Success with data
+            pagination.observe_page(
+                total_registros=result.total_records,
+                total_paginas=result.total_pages,
+                items=result.items,
+            )
             all_records.extend(result.items)
             window_items.extend(result.items)
             window_records += len(result.items)
@@ -844,14 +850,29 @@ def _crawl_date_range(
                 # Persist immediately so kill mid-run does not drop completed windows.
                 persisted = _persist_window_if_enabled(window_items)
                 if persisted:
+                    pagination.record_persisted(int(persisted))
+                    leftover = max(0, pagination.fetched - pagination.persisted)
+                    if leftover:
+                        pagination.record_rejected(leftover)
                     logger.info(
                         "Window %s persisted %d rows to DB (per-window upsert)",
                         window_key,
                         persisted,
                     )
-                checkpoint.completed_windows.append(window_key)
-                checkpoint.total_windows_completed += 1
-                checkpoint.total_contracts_fetched += window_records
+                elif window_items:
+                    pagination.record_rejected(len(window_items))
+                page_report = pagination.finish()
+                if not page_report.ok:
+                    window_errors.append(page_report.status)
+                    logger.warning("Window %s pagination %s", window_key, page_report.to_dict())
+                    fully_ok = False
+                if fully_ok:
+                    checkpoint.completed_windows.append(window_key)
+                    checkpoint.total_windows_completed += 1
+                    checkpoint.total_contracts_fetched += window_records
+                else:
+                    checkpoint.total_windows_failed += 1
+                    checkpoint.last_error = "; ".join(window_errors[:3])
             else:
                 checkpoint.total_windows_failed += 1
                 checkpoint.last_error = "; ".join(window_errors[:3])

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -16,6 +16,7 @@ from typing import Any
 import requests
 
 from scripts.contracts_identity import normalize_supplier_identity
+from scripts.contracts_truth import canonical_contract_identity
 from scripts.crawl.common import safe_float, safe_int
 from scripts.crawl.dlq_sync import dlq_write
 from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
@@ -838,7 +839,20 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
             str(ano_contrato or ""),
             str(sequencial_contrato or ""),
         ]
-        contrato_id = "|".join(contrato_id_parts) if all(contrato_id_parts) else None
+        official_id = (
+            raw.get("numeroControlePNCP")
+            or raw.get("numeroControlePncp")
+            or numero_controle
+        )
+        ident = canonical_contract_identity(
+            source="pncp",
+            official_id=str(official_id).strip() if official_id else None,
+            parent_procurement_id=str(numero_controle).strip() if numero_controle else None,
+            fallback_parts=contrato_id_parts,
+        )
+        contrato_id = ident.source_contract_id if ident.method == "official" else (
+            "|".join(contrato_id_parts) if all(contrato_id_parts) else ident.source_contract_id
+        )
 
         import hashlib
 
@@ -887,8 +901,11 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
                 "valor_parcela": safe_float(raw.get("valorParcela")),
                 "valor_acumulado": safe_float(raw.get("valorAcumulado")),
                 "content_hash": content_hash,
-                "source": "pncp",
-                "source_id": numero_controle or contrato_id,
+                "source": ident.source,
+                "source_id": ident.source_contract_id,
+                "canonical_contract_id": ident.canonical_contract_id,
+                "source_contract_id": ident.source_contract_id,
+                "parent_procurement_id": ident.parent_procurement_id,
             }
         )
     return transformed

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -839,11 +839,7 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
             str(ano_contrato or ""),
             str(sequencial_contrato or ""),
         ]
-        official_id = (
-            raw.get("numeroControlePNCP")
-            or raw.get("numeroControlePncp")
-            or numero_controle
-        )
+        official_id = raw.get("numeroControlePNCP") or raw.get("numeroControlePncp")
         ident = canonical_contract_identity(
             source="pncp",
             official_id=str(official_id).strip() if official_id else None,

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -265,7 +265,9 @@ def _fetch_page_with_retry(
 
 def _configure_checkpoint_dir(ckpt_dir: str | None) -> str:
     """Point contracts_crawler checkpoint I/O at an isolated directory."""
-    path = ckpt_dir or os.getenv("CONTRACTS_CHECKPOINT_DIR") or DEFAULT_PILOT_CKPT_DIR
+    from scripts.contracts_truth import resolve_checkpoint_dir
+
+    path = str(resolve_checkpoint_dir(ckpt_dir or os.getenv("CONTRACTS_CHECKPOINT_DIR")))
     os.makedirs(path, exist_ok=True)
     os.environ["CONTRACTS_CHECKPOINT_DIR"] = path
     _cc.CONTRACTS_CHECKPOINT_DIR = path

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -41,6 +41,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.contracts_truth import stamp_contract_truth_labels  # noqa: E402
 from scripts.crawl import contracts_crawler as _cc  # noqa: E402
 from scripts.crawl.contracts_crawler import (  # noqa: E402
     CONTRACTS_FULL_DAYS,
@@ -103,12 +104,15 @@ def evaluate_window_completion(
     last_total_pages: int,
     page: int,
     max_pages: int,
+    first_total_registros: int | None = None,
+    last_total_registros: int | None = None,
 ) -> tuple[bool, list[str]]:
     """Decide whether a date window may be marked complete (shipped predicate).
 
     A window is complete only when there are no errors AND pages were fully
     exhausted (or the API returned a legitimate zero on the first page path).
     Hitting ``max_pages`` without exhausting ``total_pages`` is incomplete.
+    Source ``totalRegistros`` drift is not success.
 
     Returns:
         (fully_ok, errors) — errors may be extended with a max-pages message.
@@ -123,6 +127,14 @@ def evaluate_window_completion(
         errors.append(
             f"Hit CONTRACTS_MAX_PAGES={max_pages} before "
             f"total_pages={last_total_pages}; window incomplete"
+        )
+    if (
+        first_total_registros is not None
+        and last_total_registros is not None
+        and first_total_registros != last_total_registros
+    ):
+        errors.append(
+            f"source_population_drift:totalRegistros {first_total_registros} -> {last_total_registros}"
         )
     fully_ok = not errors
     return fully_ok, errors
@@ -454,6 +466,7 @@ def _upsert_batch(conn: Any, rows: list[dict]) -> tuple[int, int]:
             (json.dumps(payload),),
         )
         actions = cur.fetchall()
+        stamp_contract_truth_labels(conn, payload)
         conn.commit()
     except Exception:
         conn.rollback()
@@ -916,6 +929,8 @@ def run_pilot(
 
             pages_exhausted = False
             last_total_pages = 0
+            first_total_registros: int | None = None
+            last_total_registros: int | None = None
             print(f"WINDOW_START {window_key}", flush=True)
             while page <= CONTRACTS_MAX_PAGES:
                 result = _fetch_page_with_retry(data_ini, data_fim, page)
@@ -932,6 +947,12 @@ def run_pilot(
                     break
 
                 last_total_pages = int(result.total_pages or 0)
+                page_total = result.total_records
+                if page_total is not None:
+                    page_total_int = int(page_total)
+                    if first_total_registros is None:
+                        first_total_registros = page_total_int
+                    last_total_registros = page_total_int
                 window_records_raw.extend(result.items)
                 window_pages += 1
                 report["totals"]["pages"] += 1
@@ -1007,6 +1028,8 @@ def run_pilot(
                 last_total_pages=last_total_pages,
                 page=page,
                 max_pages=CONTRACTS_MAX_PAGES,
+                first_total_registros=first_total_registros,
+                last_total_registros=last_total_registros,
             )
             if not fully_ok and any("Hit CONTRACTS_MAX_PAGES" in e for e in window_errors):
                 report["totals"]["page_errors"] += 1

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -33,6 +33,10 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.contracts_truth import (  # noqa: E402
+    refuse_writer_bypass,
+    resolve_checkpoint_dir,
+)
 from scripts.crawl.contracts_checkpoint_contract import (  # noqa: E402
     LOGICAL_JOB_INCREMENTAL,
     archive_checkpoint,
@@ -103,6 +107,17 @@ def main(argv: list[str] | None = None) -> int:
         print("ERROR: --days must be in 1..90 for incremental path", file=sys.stderr)
         return 2
 
+    refuse_writer_bypass(
+        skip_lock=args.skip_lock,
+        env_skip=os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0"),
+    )
+    if args.checkpoint_dir:
+        args.checkpoint_dir = str(
+            resolve_checkpoint_dir(
+                args.checkpoint_dir,
+                production=os.getenv("EXTRA_CONTRACTS_PRODUCTION", "0") == "1",
+            )
+        )
     lock = None
     if not args.skip_lock and os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0") != "1":
         lock = acquire_or_exit(owner_note="run_contracts_incremental")

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -11,7 +11,7 @@ Checkpoint contract (v2):
   * completed windows resume across attempts without foreign-run hard-fail
 
 Lock domain:
-  all writers share ``/run/lock/extra-contracts-writer.lock`` (EXIT 75 if busy).
+  PostgreSQL advisory fence (EXIT 75 if busy). Host-local flock is not used.
 
 Exit codes:
   0 — status=success and zero page/window failures
@@ -34,6 +34,8 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.contracts_truth import (  # noqa: E402
+    WriterFenceBusyError,
+    acquire_national_writer_fence,
     refuse_writer_bypass,
     resolve_checkpoint_dir,
 )
@@ -46,7 +48,7 @@ from scripts.crawl.contracts_checkpoint_contract import (  # noqa: E402
     migrate_meta,
     save_raw,
 )
-from scripts.crawl.contracts_writer_lock import acquire_or_exit  # noqa: E402
+from scripts.crawl.contracts_writer_lock import EXIT_LOCK_BUSY  # noqa: E402
 
 logger = logging.getLogger("contracts_incremental")
 
@@ -111,22 +113,31 @@ def main(argv: list[str] | None = None) -> int:
         skip_lock=args.skip_lock,
         env_skip=os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0"),
     )
-    if args.checkpoint_dir:
-        args.checkpoint_dir = str(
-            resolve_checkpoint_dir(
-                args.checkpoint_dir,
-                production=os.getenv("EXTRA_CONTRACTS_PRODUCTION", "0") == "1",
-            )
+    args.checkpoint_dir = str(
+        resolve_checkpoint_dir(
+            args.checkpoint_dir,
+            repo_root=_PROJECT_ROOT,
         )
-    lock = None
-    if not args.skip_lock and os.getenv("CONTRACTS_SKIP_WRITER_LOCK", "0") != "1":
-        lock = acquire_or_exit(owner_note="run_contracts_incremental")
-
+    )
+    fence = None
+    if args.dsn and not args.dry_run:
+        try:
+            fence = acquire_national_writer_fence(args.dsn, skip=args.skip_lock)
+        except WriterFenceBusyError:
+            print(
+                f"LOCK_BUSY: national writer fence held; exit={EXIT_LOCK_BUSY}",
+                file=sys.stderr,
+            )
+            return EXIT_LOCK_BUSY
     try:
         return _run_incremental(args)
     finally:
-        if lock is not None:
-            lock.release()
+        if fence is not None:
+            fence.release()
+            conn = getattr(fence, "_conn", None)
+            close = getattr(conn, "close", None)
+            if callable(close):
+                close()
 
 
 def _run_incremental(args: argparse.Namespace) -> int:

--- a/scripts/ops/multi_source_open_pack/db_loaders.py
+++ b/scripts/ops/multi_source_open_pack/db_loaders.py
@@ -10,7 +10,9 @@ import csv
 import hashlib
 import json
 import os
+import tempfile
 import uuid
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -36,6 +38,88 @@ class SnapshotReconciliationError(RuntimeError):
 
 class LineageSelectionError(SnapshotReconciliationError):
     """A package row is outside the explicitly selected collection run."""
+
+
+class JsonlSpool(Sequence):
+    """Disk-backed sequence. At most one chunk of items is retained in RAM."""
+
+    def __init__(
+        self,
+        path: Path,
+        count: int,
+        chunk_size: int,
+        factory: Callable[[str], Any],
+    ) -> None:
+        self.path = Path(path)
+        self._count = int(count)
+        self.chunk_size = max(1, int(chunk_size))
+        self._factory = factory
+        self.peak_retained = 0
+        self._cache_start = -1
+        self._cache: list[Any] = []
+
+    def __len__(self) -> int:
+        return self._count
+
+    def __iter__(self):
+        self._cache = []
+        self._cache_start = -1
+        batch: list[Any] = []
+        if self._count == 0 or not self.path.is_file():
+            return
+        with self.path.open(encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                batch.append(self._factory(line))
+                if len(batch) >= self.chunk_size:
+                    self.peak_retained = max(self.peak_retained, len(batch))
+                    yield from batch
+                    batch = []
+            if batch:
+                self.peak_retained = max(self.peak_retained, len(batch))
+                yield from batch
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return [self[i] for i in range(*index.indices(self._count))]
+        if index < 0:
+            index += self._count
+        if index < 0 or index >= self._count:
+            raise IndexError(index)
+        start = (index // self.chunk_size) * self.chunk_size
+        if start != self._cache_start:
+            loaded: list[Any] = []
+            with self.path.open(encoding="utf-8") as handle:
+                for i, line in enumerate(handle):
+                    if i < start:
+                        continue
+                    if i >= start + self.chunk_size:
+                        break
+                    if line.strip():
+                        loaded.append(self._factory(line))
+            self._cache = loaded
+            self._cache_start = start
+            self.peak_retained = max(self.peak_retained, len(loaded))
+        return self._cache[index - start]
+
+
+def _row_from_json(line: str) -> dict[str, Any]:
+    return json.loads(line)
+
+
+def _observation_from_json(line: str) -> SourceObservation:
+    return SourceObservation(**json.loads(line))
+
+
+def _new_spool_path(prefix: str) -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        prefix=f"extra_{prefix}_",
+        suffix=".jsonl",
+        delete=False,
+    )
+    handle.close()
+    return Path(handle.name)
 
 
 @dataclass(frozen=True)
@@ -178,8 +262,8 @@ def _stream_snapshot_rows(
     memory_budget_bytes: int,
     required_lineage_run_id: int | None = None,
     required_external_run_id: str | None = None,
-) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Fetch in bounded DB batches, retaining all rows for exact reconciliation."""
+) -> tuple[JsonlSpool, dict[str, Any]]:
+    """Fetch in bounded DB batches and spool rows; never retain the full population."""
     cursor_name = f"extra_{source}_{uuid.uuid4().hex}"
     try:
         cur = conn.cursor(name=cursor_name)
@@ -187,64 +271,68 @@ def _stream_snapshot_rows(
     except TypeError:
         cur = conn.cursor()
         cursor_mode = "client_fallback"
-    rows: list[dict[str, Any]] = []
+    spool_path = _new_spool_path(source)
     snapshot_id = ""
     eligible_count: int | None = None
     pages_fetched = 0
     estimated_memory_bytes = 0
     seen_ids: set[str] = set()
+    rows_read = 0
+    peak_batch = 0
     try:
         if hasattr(cur, "itersize"):
             cur.itersize = page_size
         cur.execute(sql, params)
-        while True:
-            batch = cur.fetchmany(page_size)
-            if not batch:
-                break
-            pages_fetched += 1
-            for raw_row in batch:
-                row = dict(raw_row)
-                current_count = int(row.pop("_snapshot_eligible_count", 0) or 0)
-                current_snapshot = str(row.pop("_snapshot_id", "") or "")
-                present = bool(row.pop("_snapshot_row_present", True))
-                if eligible_count is None:
-                    eligible_count = current_count
-                    snapshot_id = current_snapshot
-                elif eligible_count != current_count or snapshot_id != current_snapshot:
-                    raise SnapshotReconciliationError(
-                        f"{source}: snapshot metadata changed while streaming"
-                    )
-                if not present:
-                    continue
-                if required_lineage_run_id is not None:
-                    row_lineage = row.get("_lineage_run_id")
-                    if row_lineage is None or int(row_lineage) != required_lineage_run_id:
-                        raise LineageSelectionError(
-                            f"{source}: row id={row.get('id')!r} has lineage "
-                            f"{row_lineage!r}, expected run {required_lineage_run_id}"
+        with spool_path.open("w", encoding="utf-8") as spool:
+            while True:
+                batch = cur.fetchmany(page_size)
+                if not batch:
+                    break
+                pages_fetched += 1
+                peak_batch = max(peak_batch, len(batch))
+                for raw_row in batch:
+                    row = dict(raw_row)
+                    current_count = int(row.pop("_snapshot_eligible_count", 0) or 0)
+                    current_snapshot = str(row.pop("_snapshot_id", "") or "")
+                    present = bool(row.pop("_snapshot_row_present", True))
+                    if eligible_count is None:
+                        eligible_count = current_count
+                        snapshot_id = current_snapshot
+                    elif eligible_count != current_count or snapshot_id != current_snapshot:
+                        raise SnapshotReconciliationError(
+                            f"{source}: snapshot metadata changed while streaming"
                         )
-                    row_external_run = str(row.get("_lineage_external_run_id") or "")
-                    if row_external_run != required_external_run_id:
-                        raise LineageSelectionError(
-                            f"{source}: row id={row.get('id')!r} has external run "
-                            f"{row_external_run!r}, expected {required_external_run_id!r}"
+                    if not present:
+                        continue
+                    if required_lineage_run_id is not None:
+                        row_lineage = row.get("_lineage_run_id")
+                        if row_lineage is None or int(row_lineage) != required_lineage_run_id:
+                            raise LineageSelectionError(
+                                f"{source}: row id={row.get('id')!r} has lineage "
+                                f"{row_lineage!r}, expected run {required_lineage_run_id}"
+                            )
+                        row_external_run = str(row.get("_lineage_external_run_id") or "")
+                        if row_external_run != required_external_run_id:
+                            raise LineageSelectionError(
+                                f"{source}: row id={row.get('id')!r} has external run "
+                                f"{row_external_run!r}, expected {required_external_run_id!r}"
+                            )
+                    row_id = str(row.get("id") or "")
+                    if not row_id or row_id in seen_ids:
+                        raise SnapshotReconciliationError(
+                            f"{source}: missing or duplicate stable id {row_id!r}"
                         )
-                row_id = str(row.get("id") or "")
-                if not row_id or row_id in seen_ids:
-                    raise SnapshotReconciliationError(
-                        f"{source}: missing or duplicate stable id {row_id!r}"
-                    )
-                seen_ids.add(row_id)
-                estimated_memory_bytes += (
-                    len(json.dumps(row, ensure_ascii=False, default=str).encode("utf-8"))
-                    * MEMORY_OVERHEAD_FACTOR
-                )
-                if estimated_memory_bytes > memory_budget_bytes:
-                    raise SnapshotReconciliationError(
-                        f"{source}: estimated memory {estimated_memory_bytes} exceeds "
-                        f"budget {memory_budget_bytes}; use a report-ready projection"
-                    )
-                rows.append(row)
+                    seen_ids.add(row_id)
+                    encoded = json.dumps(row, ensure_ascii=False, default=str)
+                    estimated_memory_bytes += len(encoded.encode("utf-8")) * MEMORY_OVERHEAD_FACTOR
+                    if estimated_memory_bytes > memory_budget_bytes:
+                        raise SnapshotReconciliationError(
+                            f"{source}: estimated memory {estimated_memory_bytes} exceeds "
+                            f"budget {memory_budget_bytes}; use a report-ready projection"
+                        )
+                    spool.write(encoded)
+                    spool.write("\n")
+                    rows_read += 1
     finally:
         close = getattr(cur, "close", None)
         if callable(close):
@@ -254,11 +342,13 @@ def _stream_snapshot_rows(
         raise SnapshotReconciliationError(f"{source}: SQL returned no snapshot metadata")
     if not snapshot_id:
         raise SnapshotReconciliationError(f"{source}: SQL returned an empty snapshot id")
-    if len(rows) != eligible_count:
+    if rows_read != eligible_count:
         raise SnapshotReconciliationError(
-            f"{source}: rows_read={len(rows)} != snapshot_eligible={eligible_count}"
+            f"{source}: rows_read={rows_read} != snapshot_eligible={eligible_count}"
         )
-    return rows, {
+    spool = JsonlSpool(spool_path, rows_read, page_size, _row_from_json)
+    spool.peak_retained = max(spool.peak_retained, peak_batch)
+    return spool, {
         "source": source,
         "snapshot_id": snapshot_id,
         "cursor_mode": cursor_mode,
@@ -266,13 +356,15 @@ def _stream_snapshot_rows(
         "page_size": page_size,
         "pages_fetched": pages_fetched,
         "eligible_count": eligible_count,
-        "rows_read": len(rows),
+        "rows_read": rows_read,
         "duplicate_ids": 0,
         "complete": True,
         "estimated_memory_bytes": estimated_memory_bytes,
         "memory_budget_bytes": memory_budget_bytes,
-        "memory_accounting": "estimated_payload_guard_not_physical_bound",
-        "physical_memory_bounded": False,
+        "memory_accounting": "chunk_spool_physical_bound",
+        "physical_memory_bounded": True,
+        "peak_retained_items": spool.peak_retained,
+        "spool_path": str(spool_path),
         "presentation_truncated": False,
     }
 
@@ -284,7 +376,7 @@ def load_opportunity_intel_snapshot(
     page_size: int = DEFAULT_SNAPSHOT_PAGE_SIZE,
     memory_budget_bytes: int | None = None,
     lineage: OpportunityLineageSelection | None = None,
-) -> tuple[list[SourceObservation], dict[str, Any]]:
+) -> tuple[Sequence[SourceObservation], dict[str, Any]]:
     """Load every eligible opportunity from one reconciled SQL snapshot."""
     if not _table_exists(conn, "opportunity_intel"):
         if lineage is not None:
@@ -410,16 +502,16 @@ def load_opportunity_intel_snapshot(
             "freshness_hours": lineage.freshness_hours,
             "freshness_sla_hours": lineage.freshness_sla_hours,
         }
-    out: list[SourceObservation] = []
-    for r in rows:
-        fonte = _normalize_source_key(str(r.get("source") or "pncp"))
-        ext = r.get("numero_controle_pncp") or r.get("source_id") or str(r.get("id") or "")
-        url = r.get("link_edital") or r.get("source_url") or ""
-        if not url and r.get("numero_controle_pncp"):
-            # PNCP public portal pattern when only control number is known
-            url = f"https://pncp.gov.br/app/editais/{r['numero_controle_pncp']}"
-        out.append(
-            _obs_from_row(
+    obs_path = _new_spool_path("opportunity_obs")
+    written = 0
+    with obs_path.open("w", encoding="utf-8") as handle:
+        for r in rows:
+            fonte = _normalize_source_key(str(r.get("source") or "pncp"))
+            ext = r.get("numero_controle_pncp") or r.get("source_id") or str(r.get("id") or "")
+            url = r.get("link_edital") or r.get("source_url") or ""
+            if not url and r.get("numero_controle_pncp"):
+                url = f"https://pncp.gov.br/app/editais/{r['numero_controle_pncp']}"
+            observation = _obs_from_row(
                 fonte=fonte,
                 fonte_papel=_fonte_papel(fonte),
                 id_externo=str(ext),
@@ -438,8 +530,17 @@ def load_opportunity_intel_snapshot(
                 categoria_ato="edital_aberto",
                 raw=dict(r),
             )
-        )
-    return out, snapshot
+            handle.write(json.dumps(observation.to_dict(), ensure_ascii=False, default=str))
+            handle.write("\n")
+            written += 1
+    page_size = int(snapshot.get("page_size") or DEFAULT_SNAPSHOT_PAGE_SIZE)
+    observations = JsonlSpool(obs_path, written, page_size, _observation_from_json)
+    snapshot["peak_retained_items"] = max(
+        int(snapshot.get("peak_retained_items") or 0),
+        getattr(rows, "peak_retained", 0),
+        observations.peak_retained,
+    )
+    return observations, snapshot
 
 
 def load_opportunity_intel_observations(
@@ -464,7 +565,7 @@ def load_official_acts_snapshot(
     lookback_days: int = 45,
     page_size: int = DEFAULT_SNAPSHOT_PAGE_SIZE,
     memory_budget_bytes: int | None = None,
-) -> tuple[list[SourceObservation], dict[str, Any]]:
+) -> tuple[Sequence[SourceObservation], dict[str, Any]]:
     """Load every eligible official act from one reconciled SQL snapshot."""
     if not _table_exists(conn, "official_acts"):
         return [], {
@@ -502,14 +603,15 @@ def load_official_acts_snapshot(
         page_size=page_size,
         memory_budget_bytes=memory_budget_bytes or _memory_budget_bytes(),
     )
-    out: list[SourceObservation] = []
-    for r in rows:
-        fonte = _normalize_source_key(str(r.get("source") or "ciga_ckan"))
-        if fonte == "pncp":
-            fonte = "ciga_ckan"  # acts table is not PNCP open tenders
-        cat = str(r.get("category") or "publicacao_dom")
-        out.append(
-            _obs_from_row(
+    obs_path = _new_spool_path("official_acts_obs")
+    written = 0
+    with obs_path.open("w", encoding="utf-8") as handle:
+        for r in rows:
+            fonte = _normalize_source_key(str(r.get("source") or "ciga_ckan"))
+            if fonte == "pncp":
+                fonte = "ciga_ckan"  # acts table is not PNCP open tenders
+            cat = str(r.get("category") or "publicacao_dom")
+            observation = _obs_from_row(
                 fonte=fonte if fonte != "unknown" else "ciga_ckan",
                 fonte_papel="required_municipal",
                 id_externo=str(r.get("external_id") or r.get("id") or ""),
@@ -528,8 +630,17 @@ def load_official_acts_snapshot(
                 categoria_ato=cat,
                 raw=dict(r),
             )
-        )
-    return out, snapshot
+            handle.write(json.dumps(observation.to_dict(), ensure_ascii=False, default=str))
+            handle.write("\n")
+            written += 1
+    page_size = int(snapshot.get("page_size") or DEFAULT_SNAPSHOT_PAGE_SIZE)
+    observations = JsonlSpool(obs_path, written, page_size, _observation_from_json)
+    snapshot["peak_retained_items"] = max(
+        int(snapshot.get("peak_retained_items") or 0),
+        getattr(rows, "peak_retained", 0),
+        observations.peak_retained,
+    )
+    return observations, snapshot
 
 
 def load_official_acts_observations(
@@ -642,8 +753,8 @@ def load_all_lake_observations(
     auto_discover_files: bool = True,
     opportunity_lineage: OpportunityLineageSelection | None = None,
     collection_isolated: bool = False,
-) -> tuple[list[SourceObservation], dict[str, Any]]:
-    """Combine lake + optional file artifacts into one observation list."""
+) -> tuple[Sequence[SourceObservation], dict[str, Any]]:
+    """Combine lake + optional file artifacts without retaining the full population."""
     as_of = as_of or date.today()
     meta: dict[str, Any] = {
         "as_of": as_of.isoformat(),
@@ -651,100 +762,124 @@ def load_all_lake_observations(
         "file_artifacts": {},
         "snapshots": {},
     }
-    rows: list[SourceObservation] = []
+    combined_path = _new_spool_path("lake_all")
+    written = 0
+    peak_retained = 0
     effective_memory_budget = memory_budget_bytes or _memory_budget_bytes()
 
-    opp, opp_snapshot = load_opportunity_intel_snapshot(
-        conn,
-        page_size=snapshot_page_size,
-        memory_budget_bytes=effective_memory_budget,
-        lineage=opportunity_lineage,
-    )
-    rows.extend(opp)
-    meta["sources_loaded"]["opportunity_intel"] = len(opp)
-    meta["snapshots"]["opportunity_intel"] = opp_snapshot
-    if opportunity_lineage is not None:
-        persisted = (
-            opportunity_lineage.expected_records
-            if opportunity_lineage.mode == "persisted"
-            else 0
-        )
-        reused = (
-            opportunity_lineage.expected_records
-            if opportunity_lineage.mode == "reused"
-            else 0
-        )
-        meta["lineage_reconciliation"] = {
-            "collection_id": opportunity_lineage.collection_id,
-            "selected_source_run_id": opportunity_lineage.source_run_id,
-            "persisted_records": persisted,
-            "reused_records": reused,
-            "expected_total": persisted + reused,
-            "loaded_total": len(opp),
-            "exact": len(opp) == persisted + reused,
-            "reuse_proof": (
-                opp_snapshot.get("lineage")
-                if opportunity_lineage.mode == "reused"
-                else None
-            ),
-        }
+    def _append_obs(handle, items) -> int:
+        count = 0
+        batch_peak = 0
+        batch = 0
+        for item in items:
+            handle.write(json.dumps(item.to_dict(), ensure_ascii=False, default=str))
+            handle.write("\n")
+            count += 1
+            batch += 1
+            if batch >= snapshot_page_size:
+                batch_peak = max(batch_peak, batch)
+                batch = 0
+        if batch:
+            batch_peak = max(batch_peak, batch)
+        nonlocal peak_retained
+        peak_retained = max(peak_retained, batch_peak, getattr(items, "peak_retained", 0))
+        return count
 
-    if collection_isolated:
-        acts, acts_snapshot = [], {
-            "source": "official_acts",
-            "eligible_count": 0,
-            "rows_read": 0,
-            "complete": True,
-            "excluded": "no selected collection lineage",
-            "presentation_truncated": False,
-        }
-        auto_discover_files = False
-    else:
-        acts, acts_snapshot = load_official_acts_snapshot(
+    with combined_path.open("w", encoding="utf-8") as handle:
+        opp, opp_snapshot = load_opportunity_intel_snapshot(
             conn,
-            lookback_days=ciga_lookback_days,
             page_size=snapshot_page_size,
             memory_budget_bytes=effective_memory_budget,
+            lineage=opportunity_lineage,
         )
-    rows.extend(acts)
-    meta["sources_loaded"]["official_acts"] = len(acts)
-    meta["snapshots"]["official_acts"] = acts_snapshot
+        written += _append_obs(handle, opp)
+        meta["sources_loaded"]["opportunity_intel"] = len(opp)
+        meta["snapshots"]["opportunity_intel"] = opp_snapshot
+        if opportunity_lineage is not None:
+            persisted = (
+                opportunity_lineage.expected_records
+                if opportunity_lineage.mode == "persisted"
+                else 0
+            )
+            reused = (
+                opportunity_lineage.expected_records
+                if opportunity_lineage.mode == "reused"
+                else 0
+            )
+            meta["lineage_reconciliation"] = {
+                "collection_id": opportunity_lineage.collection_id,
+                "selected_source_run_id": opportunity_lineage.source_run_id,
+                "persisted_records": persisted,
+                "reused_records": reused,
+                "expected_total": persisted + reused,
+                "loaded_total": len(opp),
+                "exact": len(opp) == persisted + reused,
+                "reuse_proof": (
+                    opp_snapshot.get("lineage")
+                    if opportunity_lineage.mode == "reused"
+                    else None
+                ),
+            }
 
-    if ciga_path is None and auto_discover_files:
-        ciga_path = discover_ciga_jsonl()
-    if ciga_path and ciga_path.is_file():
-        ciga_rows = load_ciga_observations(ciga_path, as_of, ciga_lookback_days)
-        rows.extend(ciga_rows)
-        meta["sources_loaded"]["ciga_file"] = len(ciga_rows)
-        meta["file_artifacts"]["ciga"] = str(ciga_path)
-        meta["snapshots"]["ciga_file"] = {
-            "eligible_count": len(ciga_rows),
-            "rows_read": len(ciga_rows),
-            "complete": True,
-            "presentation_truncated": False,
-            "estimated_memory_bytes": _estimate_observation_memory(ciga_rows),
-        }
-    else:
-        meta["file_artifacts"]["ciga"] = None
+        if collection_isolated:
+            acts: Sequence[SourceObservation] = []
+            acts_snapshot = {
+                "source": "official_acts",
+                "eligible_count": 0,
+                "rows_read": 0,
+                "complete": True,
+                "excluded": "no selected collection lineage",
+                "presentation_truncated": False,
+            }
+            auto_discover_files = False
+        else:
+            acts, acts_snapshot = load_official_acts_snapshot(
+                conn,
+                lookback_days=ciga_lookback_days,
+                page_size=snapshot_page_size,
+                memory_budget_bytes=effective_memory_budget,
+            )
+        written += _append_obs(handle, acts)
+        meta["sources_loaded"]["official_acts"] = len(acts)
+        meta["snapshots"]["official_acts"] = acts_snapshot
 
-    if sc_path is None and auto_discover_files:
-        sc_path = discover_sc_compras_jsonl()
-    if sc_path and sc_path.is_file():
-        sc_rows = load_sc_compras_observations(sc_path, as_of)
-        rows.extend(sc_rows)
-        meta["sources_loaded"]["sc_compras_file"] = len(sc_rows)
-        meta["file_artifacts"]["sc_compras"] = str(sc_path)
-        meta["snapshots"]["sc_compras_file"] = {
-            "eligible_count": len(sc_rows),
-            "rows_read": len(sc_rows),
-            "complete": True,
-            "presentation_truncated": False,
-            "estimated_memory_bytes": _estimate_observation_memory(sc_rows),
-        }
-    else:
-        meta["file_artifacts"]["sc_compras"] = None
+        if ciga_path is None and auto_discover_files:
+            ciga_path = discover_ciga_jsonl()
+        if ciga_path and ciga_path.is_file():
+            ciga_rows = load_ciga_observations(ciga_path, as_of, ciga_lookback_days)
+            written += _append_obs(handle, ciga_rows)
+            meta["sources_loaded"]["ciga_file"] = len(ciga_rows)
+            meta["file_artifacts"]["ciga"] = str(ciga_path)
+            meta["snapshots"]["ciga_file"] = {
+                "eligible_count": len(ciga_rows),
+                "rows_read": len(ciga_rows),
+                "complete": True,
+                "presentation_truncated": False,
+                "estimated_memory_bytes": _estimate_observation_memory(ciga_rows),
+            }
+        else:
+            meta["file_artifacts"]["ciga"] = None
 
-    meta["total_observations"] = len(rows)
+        if sc_path is None and auto_discover_files:
+            sc_path = discover_sc_compras_jsonl()
+        if sc_path and sc_path.is_file():
+            sc_rows = load_sc_compras_observations(sc_path, as_of)
+            written += _append_obs(handle, sc_rows)
+            meta["sources_loaded"]["sc_compras_file"] = len(sc_rows)
+            meta["file_artifacts"]["sc_compras"] = str(sc_path)
+            meta["snapshots"]["sc_compras_file"] = {
+                "eligible_count": len(sc_rows),
+                "rows_read": len(sc_rows),
+                "complete": True,
+                "presentation_truncated": False,
+                "estimated_memory_bytes": _estimate_observation_memory(sc_rows),
+            }
+        else:
+            meta["file_artifacts"]["sc_compras"] = None
+
+    combined = JsonlSpool(combined_path, written, snapshot_page_size, _observation_from_json)
+    combined.peak_retained = max(combined.peak_retained, peak_retained)
+    meta["total_observations"] = written
     meta["eligible_observations"] = sum(
         int(snapshot.get("eligible_count") or 0)
         for snapshot in meta["snapshots"].values()
@@ -768,13 +903,16 @@ def load_all_lake_observations(
             f"budget={effective_memory_budget}"
         )
     by_fonte: dict[str, int] = {}
-    for o in rows:
-        by_fonte[o.fonte] = by_fonte.get(o.fonte, 0) + 1
+    for observation in combined:
+        by_fonte[observation.fonte] = by_fonte.get(observation.fonte, 0) + 1
     meta["by_fonte"] = by_fonte
-    return rows, meta
+    meta["physical_memory_bounded"] = True
+    meta["peak_retained_items"] = combined.peak_retained
+    return combined, meta
 
 
 __all__ = [
+    "JsonlSpool",
     "discover_ciga_jsonl",
     "discover_sc_compras_jsonl",
     "export_pncp_csv",

--- a/scripts/ops/multi_source_open_pack/db_loaders.py
+++ b/scripts/ops/multi_source_open_pack/db_loaders.py
@@ -61,7 +61,7 @@ class JsonlSpool(Sequence):
     def __len__(self) -> int:
         return self._count
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         self._cache = []
         self._cache_start = -1
         batch: list[Any] = []
@@ -80,7 +80,7 @@ class JsonlSpool(Sequence):
                 self.peak_retained = max(self.peak_retained, len(batch))
                 yield from batch
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int | slice) -> Any:
         if isinstance(index, slice):
             return [self[i] for i in range(*index.indices(self._count))]
         if index < 0:
@@ -105,7 +105,10 @@ class JsonlSpool(Sequence):
 
 
 def _row_from_json(line: str) -> dict[str, Any]:
-    return json.loads(line)
+    payload = json.loads(line)
+    if not isinstance(payload, dict):
+        raise TypeError("spool row must be a JSON object")
+    return payload
 
 
 def _observation_from_json(line: str) -> SourceObservation:
@@ -283,7 +286,7 @@ def _stream_snapshot_rows(
         if hasattr(cur, "itersize"):
             cur.itersize = page_size
         cur.execute(sql, params)
-        with spool_path.open("w", encoding="utf-8") as spool:
+        with spool_path.open("w", encoding="utf-8") as spool_fh:
             while True:
                 batch = cur.fetchmany(page_size)
                 if not batch:
@@ -330,8 +333,8 @@ def _stream_snapshot_rows(
                             f"{source}: estimated memory {estimated_memory_bytes} exceeds "
                             f"budget {memory_budget_bytes}; use a report-ready projection"
                         )
-                    spool.write(encoded)
-                    spool.write("\n")
+                    spool_fh.write(encoded)
+                    spool_fh.write("\n")
                     rows_read += 1
     finally:
         close = getattr(cur, "close", None)
@@ -549,7 +552,7 @@ def load_opportunity_intel_observations(
     statuses: tuple[str, ...] = ("open", "upcoming"),
     page_size: int = DEFAULT_SNAPSHOT_PAGE_SIZE,
     memory_budget_bytes: int | None = None,
-) -> list[SourceObservation]:
+) -> Sequence[SourceObservation]:
     observations, _snapshot = load_opportunity_intel_snapshot(
         conn,
         statuses=statuses,
@@ -649,7 +652,7 @@ def load_official_acts_observations(
     lookback_days: int = 45,
     page_size: int = DEFAULT_SNAPSHOT_PAGE_SIZE,
     memory_budget_bytes: int | None = None,
-) -> list[SourceObservation]:
+) -> Sequence[SourceObservation]:
     observations, _snapshot = load_official_acts_snapshot(
         conn,
         lookback_days=lookback_days,
@@ -767,7 +770,7 @@ def load_all_lake_observations(
     peak_retained = 0
     effective_memory_budget = memory_budget_bytes or _memory_budget_bytes()
 
-    def _append_obs(handle, items) -> int:
+    def _append_obs(handle: Any, items: Any) -> int:
         count = 0
         batch_peak = 0
         batch = 0

--- a/scripts/reports/coverage_weekly.py
+++ b/scripts/reports/coverage_weekly.py
@@ -36,6 +36,8 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA  # noqa: E402
+
 DSN = os.getenv(
     "LOCAL_DATALAKE_DSN",
     "postgresql://postgres@127.0.0.1:5433/pncp_datalake",

--- a/scripts/reports/coverage_weekly.py
+++ b/scripts/reports/coverage_weekly.py
@@ -108,71 +108,77 @@ def fetch_coverage_data(report_date: date) -> dict[str, Any]:
     data["total_uncovered"] = max(0, int(data["total_entities"] or 0) - kpis.covered_count)
     data["covered_entity_formula"] = f"{COVERED_ENTITY_FORMULA.__module__}.{COVERED_ENTITY_FORMULA.__name__}"
     data["covered_entity_ids"] = sorted(kpis.covered_entity_ids)
+    covered_ids = data["covered_entity_ids"] or ["__none__"]
 
-    # --- Coverage by source ---
-    data["summary"] = query("""
+    # --- Coverage by source (latest evidence, formula-covered set) ---
+    data["summary"] = query(
+        """
         SELECT
-            ec.source,
+            ev.source,
             COUNT(*) AS total_tracked,
-            SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END) AS covered,
-            ROUND(100.0 * SUM(CASE WHEN ec.is_covered THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0), 1) AS pct
-        FROM entity_coverage ec
-        WHERE EXISTS (
-            SELECT 1 FROM sc_public_entities e WHERE e.id = ec.entity_id AND e.is_active = TRUE
-        )
-        GROUP BY ec.source
+            SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END) AS covered,
+            ROUND(
+                100.0 * SUM(CASE WHEN e.id::text = ANY(%s) THEN 1 ELSE 0 END)
+                / NULLIF(COUNT(*), 0),
+                1
+            ) AS pct
+        FROM v_latest_evidence ev
+        JOIN sc_public_entities e ON e.id = ev.entity_id AND e.is_active = TRUE
+        GROUP BY ev.source
         ORDER BY pct DESC
-    """)
+        """,
+        (covered_ids, covered_ids),
+    )
 
     # --- Gaps (uncovered entities) ---
-    data["gaps"] = query("""
+    data["gaps"] = query(
+        """
         SELECT e.razao_social, e.municipio, e.natureza_juridica, e.cnpj_8, e.uf
         FROM sc_public_entities e
         WHERE e.is_active = TRUE
-          AND NOT EXISTS (
-              SELECT 1 FROM entity_coverage ec
-              WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
-          )
+          AND e.id::text <> ALL(%s)
         ORDER BY e.municipio, e.razao_social
-    """)
+        """,
+        (covered_ids,),
+    )
 
     # --- Gaps by municipio ---
-    data["gaps_by_municipio"] = query("""
+    data["gaps_by_municipio"] = query(
+        """
         SELECT
             e.municipio,
             COUNT(*) AS total_entes,
-            COUNT(*) FILTER (WHERE NOT EXISTS (
-                SELECT 1 FROM entity_coverage ec
-                WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
-            )) AS entes_descobertos,
-            ROUND(100.0 * COUNT(*) FILTER (WHERE NOT EXISTS (
-                SELECT 1 FROM entity_coverage ec
-                WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
-            )) / NULLIF(COUNT(*), 0), 1) AS pct_gap
+            COUNT(*) FILTER (WHERE e.id::text <> ALL(%s)) AS entes_descobertos,
+            ROUND(
+                100.0 * COUNT(*) FILTER (WHERE e.id::text <> ALL(%s)) / NULLIF(COUNT(*), 0),
+                1
+            ) AS pct_gap
         FROM sc_public_entities e
         WHERE e.is_active = TRUE
         GROUP BY e.municipio
         ORDER BY entes_descobertos DESC
-    """)
+        """,
+        (covered_ids, covered_ids),
+    )
 
     # --- Gaps by natureza juridica ---
-    data["gaps_by_natureza"] = query("""
+    data["gaps_by_natureza"] = query(
+        """
         SELECT
             e.natureza_juridica,
             COUNT(*) AS total_entes,
-            COUNT(*) FILTER (WHERE NOT EXISTS (
-                SELECT 1 FROM entity_coverage ec
-                WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
-            )) AS entes_descobertos,
-            ROUND(100.0 * COUNT(*) FILTER (WHERE NOT EXISTS (
-                SELECT 1 FROM entity_coverage ec
-                WHERE ec.entity_id = e.id AND ec.is_covered = TRUE
-            )) / NULLIF(COUNT(*), 0), 1) AS pct_gap
+            COUNT(*) FILTER (WHERE e.id::text <> ALL(%s)) AS entes_descobertos,
+            ROUND(
+                100.0 * COUNT(*) FILTER (WHERE e.id::text <> ALL(%s)) / NULLIF(COUNT(*), 0),
+                1
+            ) AS pct_gap
         FROM sc_public_entities e
         WHERE e.is_active = TRUE
         GROUP BY e.natureza_juridica
         ORDER BY entes_descobertos DESC
-    """)
+        """,
+        (covered_ids, covered_ids),
+    )
 
     # --- Trend (last 4 weeks) ---
     data["trend"] = query(

--- a/scripts/reports/coverage_weekly.py
+++ b/scripts/reports/coverage_weekly.py
@@ -36,7 +36,10 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from scripts.coverage.covered_entity import COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA  # noqa: E402
+from scripts.coverage.covered_entity import (  # noqa: E402
+    COVERED_ENTITY_FORMULA as COVERED_ENTITY_FORMULA,
+)
+from scripts.coverage.covered_entity import published_coverage_kpis  # noqa: E402
 
 DSN = os.getenv(
     "LOCAL_DATALAKE_DSN",
@@ -100,15 +103,11 @@ def fetch_coverage_data(report_date: date) -> dict[str, Any]:
     rows = query("SELECT COUNT(*) AS total FROM sc_public_entities WHERE is_active = TRUE")
     data["total_entities"] = rows[0]["total"] if rows else 0
 
-    # --- Total covered (at least one source) ---
-    rows = query("""
-        SELECT COUNT(DISTINCT entity_id) AS covered
-        FROM entity_coverage ec
-        WHERE ec.is_covered = TRUE
-          AND EXISTS (SELECT 1 FROM sc_public_entities e WHERE e.id = ec.entity_id AND e.is_active = TRUE)
-    """)
-    data["total_covered"] = rows[0]["covered"] if rows else 0
-    data["total_uncovered"] = data["total_entities"] - data["total_covered"]
+    kpis = published_coverage_kpis(get_conn())
+    data["total_covered"] = kpis.covered_count
+    data["total_uncovered"] = max(0, int(data["total_entities"] or 0) - kpis.covered_count)
+    data["covered_entity_formula"] = f"{COVERED_ENTITY_FORMULA.__module__}.{COVERED_ENTITY_FORMULA.__name__}"
+    data["covered_entity_ids"] = sorted(kpis.covered_entity_ids)
 
     # --- Coverage by source ---
     data["summary"] = query("""

--- a/tests/test_contract_activity_and_quality.py
+++ b/tests/test_contract_activity_and_quality.py
@@ -1,0 +1,113 @@
+"""#309 UNKNOWN vs ACTIVE_PROVEN and #312 date/value quarantine."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from scripts.contracts_truth import (
+    ACTIVE_PROVEN,
+    QUARANTINED,
+    REVIEW,
+    UNKNOWN,
+    VALID,
+    annotate_transformed_contract,
+    classify_contract_activity,
+    classify_contract_quality,
+    in_active_proven,
+    report_ready_allowed,
+)
+from scripts.crawl import contracts_crawler as cc
+
+
+def test_missing_status_is_unknown_and_not_active_proven() -> None:
+    activity = classify_contract_activity(
+        raw_status=None,
+        vigencia_inicio=None,
+        vigencia_fim=None,
+        is_active_default=True,
+        today=date(2026, 8, 13),
+    )
+    assert activity.state == UNKNOWN
+    assert in_active_proven(activity) is False
+    assert "missing_status_and_vigencia" in activity.reasons
+
+
+def test_proven_vigencia_window_is_active_proven() -> None:
+    activity = classify_contract_activity(
+        raw_status="vigente",
+        vigencia_inicio="2026-01-01",
+        vigencia_fim="2026-12-31",
+        today=date(2026, 8, 13),
+    )
+    assert activity.state == ACTIVE_PROVEN
+    assert in_active_proven(activity) is True
+
+
+def test_year_8406_and_inverted_vigencia_are_quarantined() -> None:
+    year_8406 = classify_contract_quality(
+        data_assinatura="8406-05-16",
+        data_inicio="2026-01-01",
+        data_fim="2026-12-31",
+        valor=1000,
+        today=date(2026, 8, 13),
+    )
+    assert year_8406.state == QUARANTINED
+    assert any("8406" in reason for reason in year_8406.reasons)
+    assert report_ready_allowed(year_8406) is False
+
+    inverted = classify_contract_quality(
+        data_inicio="2026-12-31",
+        data_fim="2026-01-01",
+        valor=1000,
+        today=date(2026, 8, 13),
+    )
+    assert inverted.state == QUARANTINED
+    assert "inverted_vigencia" in inverted.reasons
+
+    ancient = classify_contract_quality(data_assinatura="1890-01-01", valor=10)
+    assert ancient.state == REVIEW
+
+    negative = classify_contract_quality(valor=-1)
+    assert negative.state == QUARANTINED
+    assert "negative_value" in negative.reasons
+
+    trillion = classify_contract_quality(valor=1_000_000_000_001)
+    assert trillion.state == QUARANTINED
+    assert "value_exceeds_one_trillion" in trillion.reasons
+
+    ok = classify_contract_quality(
+        data_assinatura="2026-05-16",
+        data_inicio="2026-05-16",
+        data_fim="2027-05-15",
+        valor=150_000.50,
+        today=date(2026, 8, 13),
+    )
+    assert ok.state == VALID
+    assert report_ready_allowed(ok) is True
+
+
+def test_transform_record_attaches_unknown_and_quarantine_on_live_path() -> None:
+    raw = {
+        "numeroControlePNCP": "11111111000191-1-000001/2026",
+        "orgaoEntidade": {"cnpj": "11111111000191", "razaoSocial": "ORGAO X"},
+        "unidadeOrgao": {"ufSigla": "SC", "municipioNome": "FLORIANOPOLIS", "nomeUnidade": "PMF"},
+        "niFornecedor": "22222222000100",
+        "tipoPessoa": "PJ",
+        "nomeRazaoSocialFornecedor": "FORNECEDOR Y",
+        "objetoContrato": "Pavimentacao",
+        "valorGlobal": 2000,
+        "dataAssinatura": "8406-05-16",
+        "dataVigenciaInicio": "2026-12-01",
+        "dataVigenciaFim": "2026-01-01",
+    }
+    record = cc._transform_record(raw)
+    assert record is not None
+    assert record["status_normalized"] == UNKNOWN
+    assert record["quality_state"] == QUARANTINED
+    assert record["report_ready"] is False
+    assert record["canonical_contract_id"].startswith("pncp:")
+    assert "11111111000191-1-000001/2026" in record["canonical_contract_id"]
+    # Raw official fields remain as parsed; quality is a label, not a rewrite.
+    assert record["data_assinatura"] is not None
+    annotated = annotate_transformed_contract(dict(record), raw=raw)
+    assert annotated["quality_state"] == QUARANTINED

--- a/tests/test_contract_durability.py
+++ b/tests/test_contract_durability.py
@@ -1,0 +1,182 @@
+"""#314 fence, #319 checkpoint location, #306 identity, #304 pagination."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.contracts_truth import (
+    CheckpointLocationError,
+    PaginationReconcile,
+    PostgresWriterFence,
+    WriterFenceBusyError,
+    WriterFenceBypassError,
+    canonical_contract_identity,
+    refuse_writer_bypass,
+    replay_adapters_to_canonical,
+    resolve_checkpoint_dir,
+)
+
+
+class _FakeAdvisoryConn:
+    """Minimal connection that implements pg_try_advisory_lock / unlock."""
+
+    held: set[int] = set()
+
+    def __init__(self) -> None:
+        self.mutations = 0
+        self.statements: list[str] = []
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+
+class _FakeCursor:
+    def __init__(self, conn: _FakeAdvisoryConn) -> None:
+        self.conn = conn
+        self._result: tuple[bool, ...] | None = None
+
+    def execute(self, sql: str, params=None) -> None:
+        self.conn.statements.append(sql)
+        key = int(params[0]) if params else 0
+        if "pg_try_advisory_lock" in sql:
+            if key in _FakeAdvisoryConn.held:
+                self._result = (False,)
+            else:
+                _FakeAdvisoryConn.held.add(key)
+                self._result = (True,)
+        elif "pg_advisory_unlock" in sql:
+            _FakeAdvisoryConn.held.discard(key)
+            self._result = (True,)
+        else:
+            self.conn.mutations += 1
+            self._result = (True,)
+
+    def fetchone(self):
+        return self._result
+
+    def close(self) -> None:
+        return None
+
+
+def test_second_writer_is_refused_before_mutation() -> None:
+    _FakeAdvisoryConn.held.clear()
+    fence_a = PostgresWriterFence()
+    fence_b = PostgresWriterFence()
+    conn_a = _FakeAdvisoryConn()
+    conn_b = _FakeAdvisoryConn()
+    mutated: list[str] = []
+    assert fence_a.acquire(conn_a) is True
+
+    def _mutate() -> None:
+        mutated.append("wrote")
+        conn_b.cursor().execute("INSERT INTO pncp_supplier_contracts VALUES (1)")
+
+    with pytest.raises(WriterFenceBusyError):
+        fence_b.run_exclusive(conn_b, _mutate)
+    assert mutated == []
+    assert conn_b.mutations == 0
+    fence_a.release()
+    fence_b.run_exclusive(conn_b, _mutate)
+    assert mutated == ["wrote"]
+
+
+def test_production_bypass_is_refused_outside_isolated_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("EXTRA_ISOLATED_TEST", raising=False)
+    with pytest.raises(WriterFenceBypassError):
+        refuse_writer_bypass(skip_lock=True)
+    monkeypatch.setenv("EXTRA_ISOLATED_TEST", "1")
+    refuse_writer_bypass(skip_lock=True)
+
+
+def test_production_checkpoint_path_is_outside_repo(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    durable = tmp_path / "var" / "lib" / "extra-consultoria"
+    (durable / "checkpoints").mkdir(parents=True)
+    inside = resolve_checkpoint_dir(
+        "data/contracts_checkpoints/incremental",
+        production=False,
+        repo_root=repo,
+        state_root=durable,
+    )
+    assert inside == (repo / "data/contracts_checkpoints/incremental")
+    with pytest.raises(CheckpointLocationError, match="worktree"):
+        resolve_checkpoint_dir(
+            repo / "data" / "contracts_checkpoints",
+            production=True,
+            repo_root=repo,
+            state_root=durable,
+        )
+    with pytest.raises(CheckpointLocationError, match="release tree"):
+        resolve_checkpoint_dir(
+            "/opt/extra-consultoria/data/contracts_checkpoints",
+            production=True,
+            repo_root=repo,
+            state_root=durable,
+        )
+    ok = resolve_checkpoint_dir(
+        durable / "checkpoints" / "contracts",
+        production=True,
+        repo_root=repo,
+        state_root=durable,
+    )
+    assert str(ok).startswith(str(durable))
+    assert "opt/extra-consultoria" not in str(ok)
+
+
+def test_two_adapters_replay_to_one_canonical_and_two_observations() -> None:
+    official = "12345678000199-1-000010/2026"
+    crawler = canonical_contract_identity(source="pncp", official_id=official)
+    adapter = canonical_contract_identity(
+        source="pncp",
+        official_id=official,
+        parent_procurement_id="compra-1",
+        fallback_parts=["12345678000199", "2026", "10"],
+    )
+    assert crawler.canonical_contract_id == adapter.canonical_contract_id
+    assert crawler.canonical_contract_id == f"pncp:{official}"
+    replayed = replay_adapters_to_canonical(
+        [
+            {"adapter": "contracts_crawler", "source": "pncp", "official_id": official},
+            {
+                "adapter": "pncp_crawler_adapter",
+                "source": "pncp",
+                "official_id": official,
+                "fallback_parts": ["12345678000199", "2026", "10"],
+            },
+        ]
+    )
+    assert replayed["canonical_count"] == 1
+    assert replayed["observation_count"] == 2
+    other_source = canonical_contract_identity(source="compras_gov", official_id=official)
+    assert other_source.canonical_contract_id != crawler.canonical_contract_id
+
+
+def test_pagination_reconciles_and_drift_is_not_success() -> None:
+    ok = PaginationReconcile()
+    ok.observe_page(
+        total_registros=2,
+        total_paginas=1,
+        items=[
+            {"numeroControlePNCP": "a"},
+            {"numeroControlePNCP": "b"},
+        ],
+    )
+    ok.record_persisted(2)
+    report = ok.finish()
+    assert report.ok is True
+    assert report.fetched == report.persisted + report.rejected
+
+    drift = PaginationReconcile()
+    drift.observe_page(total_registros=80, total_paginas=8, items=[{"numeroControlePNCP": "1"}])
+    drift.observe_page(total_registros=95, total_paginas=10, items=[{"numeroControlePNCP": "2"}])
+    drift.record_persisted(2)
+    drifted = drift.finish()
+    assert drifted.ok is False
+    assert drifted.status == "source_population_drift"
+    assert drifted.fetched == drifted.persisted + drifted.rejected

--- a/tests/test_contract_durability.py
+++ b/tests/test_contract_durability.py
@@ -7,16 +7,19 @@ from pathlib import Path
 import pytest
 
 from scripts.contracts_truth import (
+    PG_FENCE_KEY,
     CheckpointLocationError,
     PaginationReconcile,
     PostgresWriterFence,
     WriterFenceBusyError,
     WriterFenceBypassError,
+    acquire_national_writer_fence,
     canonical_contract_identity,
     refuse_writer_bypass,
     replay_adapters_to_canonical,
     resolve_checkpoint_dir,
 )
+from scripts.crawl.contracts_writer_lock import EXIT_LOCK_BUSY
 
 
 class _FakeAdvisoryConn:
@@ -155,6 +158,86 @@ def test_two_adapters_replay_to_one_canonical_and_two_observations() -> None:
     assert replayed["observation_count"] == 2
     other_source = canonical_contract_identity(source="compras_gov", official_id=official)
     assert other_source.canonical_contract_id != crawler.canonical_contract_id
+
+
+def test_incremental_writer_uses_pg_fence_before_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from scripts.crawl import run_contracts_incremental as inc
+
+    monkeypatch.delenv("CONTRACTS_SKIP_WRITER_LOCK", raising=False)
+    ran: list[str] = []
+    monkeypatch.setattr(inc, "_run_incremental", lambda args: ran.append("ran") or 0)
+
+    def _connect(_dsn: str) -> _FakeAdvisoryConn:
+        return _FakeAdvisoryConn()
+
+    monkeypatch.setattr("psycopg2.connect", _connect)
+    _FakeAdvisoryConn.held.clear()
+    out = tmp_path / "out.json"
+    rc = inc.main(
+        [
+            "--dsn",
+            "postgresql://fence/test",
+            "--days",
+            "7",
+            "--checkpoint-dir",
+            str(tmp_path / "ckpt"),
+            "--output-json",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    assert ran == ["ran"]
+    assert PG_FENCE_KEY not in _FakeAdvisoryConn.held
+
+    ran.clear()
+    _FakeAdvisoryConn.held.add(PG_FENCE_KEY)
+    rc_busy = inc.main(
+        [
+            "--dsn",
+            "postgresql://fence/test",
+            "--days",
+            "7",
+            "--checkpoint-dir",
+            str(tmp_path / "ckpt"),
+            "--output-json",
+            str(out),
+        ]
+    )
+    assert rc_busy == EXIT_LOCK_BUSY
+    assert ran == []
+
+
+def test_acquire_national_writer_fence_is_the_shipped_lock() -> None:
+    _FakeAdvisoryConn.held.clear()
+    fence = acquire_national_writer_fence("postgresql://x", connect=lambda _dsn: _FakeAdvisoryConn())
+    assert fence is not None
+    assert fence.owned is True
+    fence.release()
+
+
+def test_production_default_checkpoint_refuses_worktree_and_release_tree(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "data" / "contracts_checkpoints").mkdir(parents=True)
+    with pytest.raises(CheckpointLocationError, match="worktree"):
+        resolve_checkpoint_dir(
+            repo / "data" / "contracts_checkpoints",
+            production=True,
+            repo_root=repo,
+        )
+    with pytest.raises(CheckpointLocationError, match="release tree"):
+        resolve_checkpoint_dir(
+            "/opt/extra-consultoria/data/contracts_checkpoints",
+            production=True,
+            repo_root=repo,
+        )
+    production_default = resolve_checkpoint_dir(None, production=True, repo_root=repo)
+    assert str(production_default).startswith("/var/lib/extra-consultoria")
+    from scripts.crawl import contracts_crawler as crawler
+
+    assert "resolve_checkpoint_dir" in Path(crawler.__file__).read_text(encoding="utf-8")
 
 
 def test_pagination_reconciles_and_drift_is_not_success() -> None:

--- a/tests/test_contract_durability.py
+++ b/tests/test_contract_durability.py
@@ -240,6 +240,77 @@ def test_production_default_checkpoint_refuses_worktree_and_release_tree(tmp_pat
     assert "resolve_checkpoint_dir" in Path(crawler.__file__).read_text(encoding="utf-8")
 
 
+def test_stamp_contract_truth_labels_writes_quality_not_null_valid() -> None:
+    from scripts.contracts_truth import stamp_contract_truth_labels
+
+    statements: list[str] = []
+
+    class _Conn:
+        def cursor(self):
+            return self
+
+        def execute(self, sql, params=None):
+            statements.append(sql)
+            self.rowcount = 1
+            assert "quality_state = stamp.quality_state" in sql
+            assert "COALESCE(quality_state, 'VALID')" not in sql
+            payload = __import__("json").loads(params[0])
+            assert payload[0]["quality_state"] == "QUARANTINED"
+            assert payload[0]["status_normalized"] == "UNKNOWN"
+
+        def close(self) -> None:
+            return None
+
+    stamped = stamp_contract_truth_labels(
+        _Conn(),
+        [
+            {
+                "contrato_id": "11111111000191-1-000001/2026",
+                "status_normalized": "UNKNOWN",
+                "quality_state": "QUARANTINED",
+                "canonical_contract_id": "pncp:11111111000191-1-000001/2026",
+            }
+        ],
+    )
+    assert stamped == 1
+    assert statements
+
+
+def test_purchase_id_is_not_official_contract_id() -> None:
+    ident = canonical_contract_identity(
+        source="pncp",
+        official_id=None,
+        parent_procurement_id="12345678000199-1-000010/2026",
+        fallback_parts=["12345678000199", "2026", "10"],
+    )
+    assert ident.method == "fallback"
+    assert not ident.canonical_contract_id.endswith("12345678000199-1-000010/2026")
+    assert ident.parent_procurement_id == "12345678000199-1-000010/2026"
+
+
+def test_pilot_window_drift_is_not_complete() -> None:
+    from scripts.crawl.run_contracts_90d_pilot import evaluate_window_completion
+
+    fully_ok, errors = evaluate_window_completion(
+        [],
+        pages_exhausted=True,
+        last_total_pages=2,
+        page=2,
+        max_pages=10,
+        first_total_registros=80,
+        last_total_registros=95,
+    )
+    assert fully_ok is False
+    assert any("source_population_drift" in err for err in errors)
+
+
+def test_report_ready_view_does_not_treat_null_quality_as_valid() -> None:
+    sql = Path("db/migrations/091_contract_truth_durability.sql").read_text(encoding="utf-8")
+    assert "COALESCE(quality_state, 'VALID')" not in sql
+    assert "quality_state IS NOT NULL" in sql
+    assert "status_normalized IS NOT NULL" in sql
+
+
 def test_pagination_reconciles_and_drift_is_not_success() -> None:
     ok = PaginationReconcile()
     ok.observe_page(

--- a/tests/test_contracts_crawler.py
+++ b/tests/test_contracts_crawler.py
@@ -206,6 +206,18 @@ class TestTransformRecord:
             "uf",
             "municipio",
             "source_id",
+            "status_raw",
+            "status_normalized",
+            "status_rule_version",
+            "status_source",
+            "quality_state",
+            "quality_reasons",
+            "quality_rule_version",
+            "report_ready",
+            "canonical_contract_id",
+            "source",
+            "source_contract_id",
+            "parent_procurement_id",
         }
         assert set(result.keys()) == expected_fields, (
             f"Field mismatch. Extra: {set(result.keys()) - expected_fields}. "

--- a/tests/test_coverage_calculator.py
+++ b/tests/test_coverage_calculator.py
@@ -1,7 +1,6 @@
 """Unit tests for scripts/coverage/calculator.py.
 
-Tests cover the report_coverage and print_coverage_report functions
-using mocked database connections.
+Published KPIs come from compute_coverage_kpis, never is_covered COUNT.
 """
 
 from __future__ import annotations
@@ -9,162 +8,80 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from scripts.coverage.calculator import print_coverage_report, report_coverage
-
-# ---------------------------------------------------------------------------
-# report_coverage
-# ---------------------------------------------------------------------------
+from scripts.coverage.covered_entity import compute_coverage_kpis
 
 
-def _make_mock_conn(
-    groups: list[tuple],
-    by_source: list[tuple],
-    uncovered: list[tuple],
-) -> MagicMock:
-    """Create a mock connection with three pre-defined query results.
-
-    Args:
-        groups: Rows for the groups query (raio, total, covered, uncovered).
-        by_source: Rows for the by_source query (source, count, covered).
-        uncovered: Rows for uncovered entities query
-            (razao_social, cnpj_8, municipio, natureza_juridica).
-    """
+def _make_mock_conn(state_rows: list[tuple]) -> MagicMock:
     conn = MagicMock()
     cursor = conn.cursor.return_value
-
-    # Mock cursor.__enter__ for context manager usage
     conn.cursor.return_value.__enter__.return_value = cursor
-
-    # We use side_effect to return different results on successive
-    # cursor.fetchall() calls
-    cursor.fetchall.side_effect = [groups, by_source, uncovered]
-    # Mock description for first query
-    # (description is only needed for returned cursors, which we don't use here)
+    cursor.fetchall.return_value = state_rows
     return conn
 
 
 class TestReportCoverage:
     def test_all_entities_covered(self):
-        """Return 100% coverage when all entities are covered."""
-        conn = _make_mock_conn(
-            groups=[(True, 10, 10, 0)],
-            by_source=[("pncp", 10, 10)],
-            uncovered=[],
+        rows = [(f"e{i}", "success_with_data", "pncp", {}) for i in range(10)]
+        result = report_coverage(_make_mock_conn(rows))
+        expected = compute_coverage_kpis(
+            [{"entity_id": r[0], "state": r[1], "source": r[2]} for r in rows]
         )
-
-        result = report_coverage(conn)
-
+        assert result["total_covered"] == expected.covered_count == 10
         assert result["total_entities"] == 10
-        assert result["total_covered"] == 10
-        assert result["total_uncovered"] == 0
         assert result["pct"] == 100.0
-        assert len(result["groups"]) == 1
-        assert result["groups"][0]["pct"] == 100.0
 
-    def test_partial_coverage(self):
-        """Return correct percentage when some entities are uncovered."""
-        conn = _make_mock_conn(
-            groups=[(True, 20, 12, 8)],
-            by_source=[("dom_sc", 20, 12)],
-            uncovered=[],
+    def test_partial_coverage_ignores_blocked(self):
+        rows = [(f"e{i}", "success_with_data", "dom_sc", {}) for i in range(12)]
+        rows += [(f"b{i}", "blocked", "dom_sc", {}) for i in range(8)]
+        result = report_coverage(_make_mock_conn(rows))
+        expected = compute_coverage_kpis(
+            [{"entity_id": r[0], "state": r[1], "source": r[2]} for r in rows]
         )
-
-        result = report_coverage(conn)
-
-        assert result["total_entities"] == 20
-        assert result["total_covered"] == 12
+        assert result["total_covered"] == expected.covered_count == 12
+        assert result["total_uncovered"] == 8
         assert result["pct"] == 60.0
+        assert "b0" not in result["covered_entity_ids"]
 
     def test_zero_entities(self):
-        """Handle zero entities gracefully."""
-        conn = _make_mock_conn(
-            groups=[],
-            by_source=[],
-            uncovered=[],
-        )
-
-        result = report_coverage(conn)
-
+        result = report_coverage(_make_mock_conn([]))
         assert result["total_entities"] == 0
         assert result["total_covered"] == 0
         assert result["pct"] == 0.0
         assert result["groups"] == []
         assert result["by_source"] == []
 
-    def test_both_radius_groups(self):
-        """Handle both within_200km and outside groups."""
-        conn = _make_mock_conn(
-            groups=[
-                (True, 15, 12, 3),
-                (False, 5, 2, 3),
-            ],
-            by_source=[("pncp", 15, 12)],
-            uncovered=[],
-        )
+    def test_failed_and_blocked_never_published_as_covered(self):
+        rows = [
+            ("ok", "success_zero", "pncp", {}),
+            ("bad", "failed", "pncp", {}),
+            ("blk", "blocked", "pncp", {}),
+        ]
+        result = report_coverage(_make_mock_conn(rows))
+        assert result["total_covered"] == 1
+        assert result["covered_entity_ids"] == ["ok"]
 
-        result = report_coverage(conn)
+    def test_uncovered_list_uses_formula_exclusions(self):
+        rows = [
+            ("covered", "success_with_data", "pncp", {}),
+            ("gap", "error", "pncp", {}),
+        ]
+        result = report_coverage(_make_mock_conn(rows))
+        assert any(item["razao_social"] == "gap" for item in result["uncovered_entities_200km"])
 
-        assert len(result["groups"]) == 2
-        assert result["groups"][0]["within_200km"] is True
-        assert result["groups"][1]["within_200km"] is False
-        assert result["total_entities"] == 20
-        assert result["total_covered"] == 14
-
-    def test_uncovered_within_200km(self):
-        """Report uncovered entities within 200km radius."""
-        conn = _make_mock_conn(
-            groups=[(True, 5, 3, 2)],
-            by_source=[("pncp", 5, 3)],
-            uncovered=[
-                ("Prefeitura de Sao Jose", "87654321", "Sao Jose", "PREFEITURA"),
-                ("Prefeitura de Palhoca", "99887766", "Palhoca", "PREFEITURA"),
-            ],
-        )
-
-        result = report_coverage(conn)
-
-        assert len(result["uncovered_entities_200km"]) == 2
-        assert result["uncovered_entities_200km"][0]["razao_social"] == "Prefeitura de Sao Jose"
-
-    def test_no_uncovered_within_200km(self):
-        """Return empty list when all 200km entities are covered."""
-        conn = _make_mock_conn(
-            groups=[(True, 10, 10, 0)],
-            by_source=[("pncp", 10, 10)],
-            uncovered=[],
-        )
-
-        result = report_coverage(conn)
-
-        assert result["uncovered_entities_200km"] == []
-
-    def test_by_source_breakdown(self):
-        """Provide per-source coverage breakdown."""
-        conn = _make_mock_conn(
-            groups=[(True, 30, 25, 5)],
-            by_source=[
-                ("pncp", 20, 18),
-                ("dom_sc", 10, 7),
-            ],
-            uncovered=[],
-        )
-
-        result = report_coverage(conn)
-
-        assert len(result["by_source"]) == 2
-        assert result["by_source"][0]["source"] == "pncp"
-        assert result["by_source"][0]["covered"] == 18
-        assert result["by_source"][1]["source"] == "dom_sc"
-        assert result["by_source"][1]["covered"] == 7
-
-
-# ---------------------------------------------------------------------------
-# print_coverage_report
-# ---------------------------------------------------------------------------
+    def test_by_source_breakdown_uses_formula(self):
+        rows = [
+            ("a", "success_with_data", "pncp", {}),
+            ("b", "blocked", "pncp", {}),
+            ("c", "success_zero", "dom_sc", {}),
+        ]
+        result = report_coverage(_make_mock_conn(rows))
+        by_source = {item["source"]: item for item in result["by_source"]}
+        assert by_source["pncp"]["covered"] == 1
+        assert by_source["dom_sc"]["covered"] == 1
 
 
 class TestPrintCoverageReport:
     def test_logs_coverage_summary(self, caplog):
-        """Log coverage report with correct values."""
         result = {
             "groups": [
                 {"within_200km": True, "total": 10, "covered": 8, "uncovered": 2, "pct": 80.0},
@@ -186,7 +103,6 @@ class TestPrintCoverageReport:
         assert any("10" in msg for msg in caplog.messages)
 
     def test_warns_on_uncovered(self, caplog):
-        """Log warning when uncovered entities exist within 200km."""
         result = {
             "groups": [
                 {"within_200km": True, "total": 10, "covered": 6, "uncovered": 4, "pct": 60.0},
@@ -209,7 +125,6 @@ class TestPrintCoverageReport:
         assert any("SEM COBERTURA" in msg for msg in caplog.messages)
 
     def test_no_warning_when_all_covered(self, caplog):
-        """No warning logged when all entities are covered."""
         result = {
             "groups": [
                 {"within_200km": True, "total": 5, "covered": 5, "uncovered": 0, "pct": 100.0},
@@ -228,10 +143,9 @@ class TestPrintCoverageReport:
             print_coverage_report(result)
 
         warning_logs = [m for m in caplog.messages if "SEM COBERTURA" in m]
-        assert len(warning_logs) == 0, "Expected no WARNING about uncovered entities"
+        assert len(warning_logs) == 0
 
     def test_empty_result_does_not_crash(self, caplog):
-        """Empty/dummy result does not crash the logger."""
         result = {
             "groups": [],
             "total_entities": 0,
@@ -241,7 +155,5 @@ class TestPrintCoverageReport:
             "by_source": [],
             "uncovered_entities_200km": [],
         }
-
-        # Should not raise any exception
         print_coverage_report(result)
         assert True

--- a/tests/test_coverage_formula_and_identity.py
+++ b/tests/test_coverage_formula_and_identity.py
@@ -1,0 +1,145 @@
+"""#280 unified covered-entity formula and #350 dual-coverage identity."""
+
+from __future__ import annotations
+
+import pytest
+
+import scripts.coverage.calculator as coverage_calculator
+import scripts.coverage.manifest as coverage_manifest
+import scripts.coverage.validate_coverage as coverage_panel
+import scripts.coverage_truth as coverage_qa
+import scripts.reports.coverage_weekly as coverage_weekly
+from scripts.coverage.covered_entity import (
+    COVERED_ENTITY_FORMULA,
+    MISSING_EVIDENCE,
+    CoverageFormulaDivergenceError,
+    assert_surfaces_agree,
+    classify_evidence_identity,
+    compute_coverage_kpis,
+    dual_coverage_evidence_gate,
+    is_covered_state,
+)
+
+FIXTURE_ROWS = [
+    {"entity_id": "e-ok-data", "state": "success_with_data"},
+    {"entity_id": "e-ok-zero", "state": "success_zero"},
+    {"entity_id": "e-blocked", "state": "blocked"},
+    {"entity_id": "e-failed", "state": "failed"},
+    {"entity_id": "e-error", "state": "error"},
+    {"entity_id": "e-partial", "state": "partial"},
+    {"entity_id": "e-boolean-only", "is_covered": True},
+]
+
+
+def test_surfaces_share_one_covered_entity_formula() -> None:
+    assert coverage_calculator.COVERED_ENTITY_FORMULA is COVERED_ENTITY_FORMULA
+    assert coverage_weekly.COVERED_ENTITY_FORMULA is COVERED_ENTITY_FORMULA
+    assert coverage_panel.COVERED_ENTITY_FORMULA is COVERED_ENTITY_FORMULA
+    assert coverage_manifest.COVERED_ENTITY_FORMULA is COVERED_ENTITY_FORMULA
+    assert coverage_qa.COVERED_ENTITY_FORMULA is COVERED_ENTITY_FORMULA
+    kpis = {
+        "panel": coverage_panel.COVERED_ENTITY_FORMULA(FIXTURE_ROWS),
+        "pdf": coverage_weekly.COVERED_ENTITY_FORMULA(FIXTURE_ROWS),
+        "excel": coverage_weekly.COVERED_ENTITY_FORMULA(FIXTURE_ROWS),
+        "manifest": coverage_manifest.COVERED_ENTITY_FORMULA(FIXTURE_ROWS),
+        "qa": coverage_qa.COVERED_ENTITY_FORMULA(FIXTURE_ROWS),
+    }
+    agreed = assert_surfaces_agree(kpis)
+    assert agreed.covered_entity_ids == frozenset({"e-ok-data", "e-ok-zero"})
+    assert agreed.covered_count == 2
+    assert "e-blocked" in agreed.excluded_entity_ids
+    assert "e-failed" in agreed.excluded_entity_ids
+    assert "e-boolean-only" in agreed.excluded_entity_ids
+
+
+def test_failed_and_blocked_never_count_as_covered() -> None:
+    assert is_covered_state("failed") is False
+    assert is_covered_state("blocked") is False
+    assert is_covered_state("error") is False
+    assert is_covered_state("success_with_data") is True
+    kpis = compute_coverage_kpis(FIXTURE_ROWS)
+    assert "e-blocked" not in kpis.covered_entity_ids
+    assert "e-failed" not in kpis.covered_entity_ids
+
+
+def test_disagreeing_surfaces_fail_the_gate() -> None:
+    panel = compute_coverage_kpis(FIXTURE_ROWS)
+    matrix = compute_coverage_kpis(
+        [{"entity_id": "e-ok-data", "state": "success_with_data"}]
+    )
+    with pytest.raises(CoverageFormulaDivergenceError, match="panel"):
+        assert_surfaces_agree({"panel": panel, "matrix": matrix})
+
+
+def test_source_wide_aggregate_is_missing_evidence_not_a_numerator() -> None:
+    rows = [
+        {
+            "id": 3,
+            "entity_id": None,
+            "canonical_entity_key": None,
+            "source": "pncp",
+            "data_type": "bids",
+            "state": "success_with_data",
+            "run_id": 22,
+            "count_obtained": 800,
+            "count_persisted": 800,
+            "metadata": {"pipeline": "resilient_cycle"},
+        }
+    ]
+    assert classify_evidence_identity(
+        entity_id=None,
+        canonical_entity_key=None,
+        metadata={"pipeline": "resilient_cycle"},
+    ) == "SOURCE_WIDE_AGGREGATE"
+    gate = dual_coverage_evidence_gate(rows)
+    assert gate["classification"] == MISSING_EVIDENCE
+    assert gate["measurement_success"] is False
+    assert gate["numerator_rows"] == []
+    assert gate["reason"] == "source_wide_aggregate_without_identity"
+
+
+def test_identified_rows_enter_numerators_source_wide_does_not() -> None:
+    rows = [
+        {
+            "entity_id": None,
+            "canonical_entity_key": None,
+            "metadata": {"pipeline": "resilient_cycle"},
+            "state": "success_with_data",
+        },
+        {
+            "entity_id": 10,
+            "canonical_entity_key": "ent-10",
+            "state": "success_with_data",
+        },
+    ]
+    gate = dual_coverage_evidence_gate(rows)
+    assert gate["measurement_success"] is True
+    assert gate["source_wide_count"] == 1
+    assert gate["identified_count"] == 1
+    assert len(gate["numerator_rows"]) == 1
+    assert gate["numerator_rows"][0]["canonical_entity_key"] == "ent-10"
+
+
+def test_unmappable_identity_bearing_row_is_not_silently_dropped() -> None:
+    # A row with a key that classify treats as mapped stays in identified;
+    # residual without identity and without aggregate markers is source-wide.
+    # True drop-protection is the fail-closed unmapped path when identity is
+    # present but cannot join the universe — exercised via dual_coverage gate
+    # when we force UNMAPPABLE by monkeypatch.
+    from scripts.coverage import covered_entity as ce
+
+    original = ce.classify_evidence_identity
+
+    def _force_unmappable(**kwargs):
+        if kwargs.get("entity_id") == "ghost":
+            return ce.UNMAPPABLE
+        return original(**kwargs)
+
+    ce.classify_evidence_identity = _force_unmappable  # type: ignore[method-assign]
+    try:
+        gate = dual_coverage_evidence_gate([{"entity_id": "ghost", "state": "success_with_data"}])
+        assert gate["classification"] == MISSING_EVIDENCE
+        assert gate["reason"] == "unmappable_evidence_cannot_drop"
+        assert gate["numerator_rows"] == []
+    finally:
+        ce.classify_evidence_identity = original  # type: ignore[method-assign]

--- a/tests/test_coverage_formula_and_identity.py
+++ b/tests/test_coverage_formula_and_identity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 import scripts.coverage.calculator as coverage_calculator
@@ -9,6 +11,7 @@ import scripts.coverage.manifest as coverage_manifest
 import scripts.coverage.validate_coverage as coverage_panel
 import scripts.coverage_truth as coverage_qa
 import scripts.reports.coverage_weekly as coverage_weekly
+from scripts.coverage.calculator import report_coverage
 from scripts.coverage.covered_entity import (
     COVERED_ENTITY_FORMULA,
     MISSING_EVIDENCE,
@@ -19,6 +22,7 @@ from scripts.coverage.covered_entity import (
     dual_coverage_evidence_gate,
     is_covered_state,
 )
+from scripts.coverage_truth import compute_metrics
 
 FIXTURE_ROWS = [
     {"entity_id": "e-ok-data", "state": "success_with_data"},
@@ -118,6 +122,58 @@ def test_identified_rows_enter_numerators_source_wide_does_not() -> None:
     assert gate["identified_count"] == 1
     assert len(gate["numerator_rows"]) == 1
     assert gate["numerator_rows"][0]["canonical_entity_key"] == "ent-10"
+
+
+def test_published_surfaces_call_formula_not_is_covered() -> None:
+    state_rows = [
+        ("ok", "success_with_data", "pncp", {}),
+        ("blk", "blocked", "pncp", {}),
+        ("fail", "failed", "pncp", {}),
+    ]
+    conn = MagicMock()
+    conn.cursor.return_value.fetchall.return_value = state_rows
+    published = report_coverage(conn)
+    expected = compute_coverage_kpis(
+        [{"entity_id": r[0], "state": r[1], "source": r[2]} for r in state_rows]
+    )
+    assert published["total_covered"] == expected.covered_count == 1
+    assert published["covered_entity_ids"] == ["ok"]
+
+    qa = compute_metrics(
+        entities=[
+            {"id": 1, "razao_social": "A"},
+            {"id": 2, "razao_social": "B"},
+            {"id": 3, "razao_social": "C"},
+        ],
+        coverage=[],
+        evidence=[
+            {"entity_id": 1, "source": "pncp", "state": "success_with_data"},
+            {"entity_id": 2, "source": "pncp", "state": "blocked"},
+            {"entity_id": 3, "source": "pncp", "state": "failed"},
+        ],
+        source_health=[],
+        contract_presence={},
+        radius_km=200,
+    )
+    assert qa["monitoring_coverage"]["entities_monitored"] == 1
+    assert "1" in qa["monitoring_coverage"]["covered_entity_ids"]
+
+    kpis = compute_coverage_kpis(
+        [{"entity_id": r[0], "state": r[1], "source": r[2]} for r in state_rows]
+    )
+
+    def _fake_query(sql, params=None):
+        if "COUNT(*) AS total" in sql:
+            return [{"total": 3}]
+        return []
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(coverage_weekly, "query", _fake_query)
+    monkeypatch.setattr(coverage_weekly, "published_coverage_kpis", lambda _conn: kpis)
+    monkeypatch.setattr(coverage_weekly, "get_conn", lambda: conn)
+    weekly = coverage_weekly.fetch_coverage_data(__import__("datetime").date(2026, 8, 13))
+    monkeypatch.undo()
+    assert weekly["total_covered"] == 1
 
 
 def test_unmappable_identity_bearing_row_is_not_silently_dropped() -> None:

--- a/tests/test_coverage_formula_and_identity.py
+++ b/tests/test_coverage_formula_and_identity.py
@@ -177,25 +177,41 @@ def test_published_surfaces_call_formula_not_is_covered() -> None:
 
 
 def test_unmappable_identity_bearing_row_is_not_silently_dropped() -> None:
-    # A row with a key that classify treats as mapped stays in identified;
-    # residual without identity and without aggregate markers is source-wide.
-    # True drop-protection is the fail-closed unmapped path when identity is
-    # present but cannot join the universe — exercised via dual_coverage gate
-    # when we force UNMAPPABLE by monkeypatch.
-    from scripts.coverage import covered_entity as ce
+    gate = dual_coverage_evidence_gate(
+        [
+            {
+                "entity_id": "ghost",
+                "state": "success_with_data",
+                "metadata": {"identity_status": "unmappable"},
+            }
+        ]
+    )
+    assert classify_evidence_identity(
+        entity_id="ghost",
+        metadata={"identity_status": "unmappable"},
+    ) == "UNMAPPABLE"
+    assert gate["classification"] == MISSING_EVIDENCE
+    assert gate["reason"] == "unmappable_evidence_cannot_drop"
+    assert gate["numerator_rows"] == []
 
-    original = ce.classify_evidence_identity
 
-    def _force_unmappable(**kwargs):
-        if kwargs.get("entity_id") == "ghost":
-            return ce.UNMAPPABLE
-        return original(**kwargs)
+def test_latest_state_not_historical_success_keeps_entity_covered() -> None:
+    kpis = compute_coverage_kpis(
+        [
+            {"entity_id": "e1", "state": "success_with_data"},
+            {"entity_id": "e1", "state": "failed"},
+        ]
+    )
+    assert "e1" not in kpis.covered_entity_ids
+    assert kpis.covered_count == 0
 
-    ce.classify_evidence_identity = _force_unmappable  # type: ignore[method-assign]
-    try:
-        gate = dual_coverage_evidence_gate([{"entity_id": "ghost", "state": "success_with_data"}])
-        assert gate["classification"] == MISSING_EVIDENCE
-        assert gate["reason"] == "unmappable_evidence_cannot_drop"
-        assert gate["numerator_rows"] == []
-    finally:
-        ce.classify_evidence_identity = original  # type: ignore[method-assign]
+
+def test_universe_members_without_evidence_stay_in_denominator() -> None:
+    kpis = compute_coverage_kpis(
+        [{"entity_id": "e-ok", "state": "success_with_data"}],
+        universe_entity_ids=["e-ok", "e-never", "e-also-never"],
+    )
+    assert kpis.covered_count == 1
+    assert kpis.total_entities == 3
+    assert kpis.covered_count / kpis.total_entities < 0.95
+    assert "e-never" in kpis.excluded_entity_ids

--- a/tests/test_coverage_formula_and_identity.py
+++ b/tests/test_coverage_formula_and_identity.py
@@ -198,12 +198,23 @@ def test_unmappable_identity_bearing_row_is_not_silently_dropped() -> None:
 def test_latest_state_not_historical_success_keeps_entity_covered() -> None:
     kpis = compute_coverage_kpis(
         [
-            {"entity_id": "e1", "state": "success_with_data"},
-            {"entity_id": "e1", "state": "failed"},
+            {"entity_id": "e1", "source": "pncp", "state": "success_with_data"},
+            {"entity_id": "e1", "source": "pncp", "state": "failed"},
         ]
     )
     assert "e1" not in kpis.covered_entity_ids
     assert kpis.covered_count == 0
+
+
+def test_failed_source_does_not_erase_other_source_success() -> None:
+    kpis = compute_coverage_kpis(
+        [
+            {"entity_id": "1", "source": "pncp", "state": "success_zero"},
+            {"entity_id": "1", "source": "dom_sc", "state": "connection_failed"},
+        ]
+    )
+    assert "1" in kpis.covered_entity_ids
+    assert kpis.covered_count == 1
 
 
 def test_universe_members_without_evidence_stay_in_denominator() -> None:

--- a/tests/test_coverage_manifest.py
+++ b/tests/test_coverage_manifest.py
@@ -164,13 +164,14 @@ class TestBuildManifestFromDb:
             ("errored", None, None, None, None, None, None),
             ("last_check_at", None, None, None, None, None, None),
         ]
-        cursor.fetchall.return_value = [
-            ("open_tenders", "pncp", 100, 90, 90.0, 80, 10, 5, 0, 2, 1, 2, None),
+        cursor.fetchall.side_effect = [
+            [("open_tenders", "pncp", 100, 90, 90.0, 80, 10, 5, 0, 2, 1, 2, None)],
+            [("e1", "success_with_data", "pncp", {}), ("e2", "blocked", "pncp", {})],
         ]
 
         manifest = build_manifest_from_db(conn)
         assert len(manifest.entries) == 1
         assert manifest.entries[0].capability == "open_tenders"
-        assert manifest.entries[0].pct_covered == 90.0
+        assert manifest.entries[0].covered_pairs == 1
         assert manifest.entries[0].with_data == 80
         assert manifest.entries[0].blocked == 2

--- a/tests/test_dual_capability_coverage.py
+++ b/tests/test_dual_capability_coverage.py
@@ -814,7 +814,7 @@ def test_identity_unresolved_fails_measurement(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(
         dcc,
         "load_observations_from_db",
-        lambda conn, **kwargs: ({}, "modern", 0, 0),
+        lambda conn, **kwargs: ({}, "modern", 0, 0, 0),
     )
     monkeypatch.setattr(
         dcc,
@@ -937,7 +937,7 @@ def test_cap_measurement_false_when_identity_unresolved(monkeypatch: pytest.Monk
             return None
 
     monkeypatch.setattr(dcc, "map_db_entities", lambda conn, universe: fake)
-    monkeypatch.setattr(dcc, "load_observations_from_db", lambda conn, **k: ({}, "modern", 0, 0))
+    monkeypatch.setattr(dcc, "load_observations_from_db", lambda conn, **k: ({}, "modern", 0, 0, 0))
     monkeypatch.setattr(
         dcc, "load_data_presence", lambda *a, **k: PresenceLoadResult(status="no_rows", entity_ids=set())
     )

--- a/tests/test_live_data_fail_closed.py
+++ b/tests/test_live_data_fail_closed.py
@@ -126,7 +126,8 @@ def test_incremental_uses_logical_job_contract_and_reset(tmp_path: Path) -> None
     assert "logical_job_id" in src or "LOGICAL_JOB_INCREMENTAL" in src
     assert "--reset-checkpoint" in src
     assert "archive_checkpoint" in src
-    assert "acquire_or_exit" in src or "contracts_writer_lock" in src
+    assert "acquire_national_writer_fence" in src
+    assert "acquire_or_exit" not in src
     # campaign mismatch still fail-closed via migrate_meta
     contract = Path("scripts/crawl/contracts_checkpoint_contract.py").read_text(
         encoding="utf-8"

--- a/tests/test_pilot_recipient_publish.py
+++ b/tests/test_pilot_recipient_publish.py
@@ -1,0 +1,67 @@
+"""#370 publish only already-observed public human recipients."""
+
+from __future__ import annotations
+
+from scripts.confenge_contact_resolution.publish_pilot_recipients import (
+    VALIDATED,
+    publish_pilot_recipients,
+)
+
+# Already-observed public evidence (same chain used by the send-ready fixture).
+# Nothing here is invented at publish time.
+OBSERVED_HUMAN = {
+    "account_id": "cnpj:11222333000181",
+    "name": "Maria de Souza",
+    "role": "Diretora Comercial",
+    "email": "maria.souza@empresa-target.com.br",
+    "source_url": "https://empresa-target.com.br/equipe",
+    "observed_at": "2026-08-13T12:00:00Z",
+    "email_explicitly_published": True,
+    "name_explicitly_published": True,
+    "role_explicitly_published": True,
+    "ownership": "COMPANY_OWNED",
+    "suitability": "CONFENGE_REAJUSTE",
+}
+
+GENERIC_MAILBOX = {
+    "account_id": "cnpj:11222333000181",
+    "name": "",
+    "role": "",
+    "email": "contato@empresa-target.com.br",
+    "source_url": "https://empresa-target.com.br/contato",
+    "observed_at": "2026-08-13T12:00:00Z",
+    "email_explicitly_published": True,
+}
+
+INVENTED = {
+    "account_id": "cnpj:000",
+    "name": "placeholder",
+    "role": "inferred",
+    "email": "n/a",
+    "invented": True,
+}
+
+
+def test_publish_validates_observed_human_and_rejects_generic() -> None:
+    result = publish_pilot_recipients([OBSERVED_HUMAN, GENERIC_MAILBOX])
+    assert result["ok"] is True
+    assert result["validated_count"] == 1
+    assert result["validated"][0]["status"] == VALIDATED
+    assert result["validated"][0]["name"] == "Maria de Souza"
+    assert result["validated"][0]["email"] == "maria.souza@empresa-target.com.br"
+    assert result["validated"][0]["source_url"].startswith("https://")
+    assert result["validated"][0]["observed_at"]
+    assert any(
+        "functional_mailbox_not_human_recipient" in item["reasons"]
+        for item in result["rejected"]
+    )
+
+
+def test_publish_fails_closed_without_inventing_pii() -> None:
+    result = publish_pilot_recipients([GENERIC_MAILBOX, INVENTED])
+    assert result["ok"] is False
+    assert result["warmbly_ready"] is False
+    assert result["validated"] == []
+    assert "insufficient_validated_humans" in result["reason_codes"]
+    assert "generic_mailbox_not_promoted" in result["reason_codes"]
+    assert "refused_to_invent_pii" in result["reason_codes"]

--- a/tests/test_pilot_recipient_publish.py
+++ b/tests/test_pilot_recipient_publish.py
@@ -65,3 +65,35 @@ def test_publish_fails_closed_without_inventing_pii() -> None:
     assert "insufficient_validated_humans" in result["reason_codes"]
     assert "generic_mailbox_not_promoted" in result["reason_codes"]
     assert "refused_to_invent_pii" in result["reason_codes"]
+
+
+def test_publish_requires_explicit_publication_flags() -> None:
+    unattested = {
+        "account_id": "cnpj:11222333000181",
+        "name": "Maria de Souza",
+        "role": "Diretora Comercial",
+        "email": "maria.souza@empresa-target.com.br",
+        "source_url": "https://empresa-target.com.br/equipe",
+        "observed_at": "2026-08-13T12:00:00Z",
+    }
+    result = publish_pilot_recipients([unattested])
+    assert result["ok"] is False
+    assert result["validated"] == []
+    assert "refused_to_invent_pii" in result["reason_codes"]
+
+
+def test_publish_rejects_role_mailbox_and_never_claims_warmbly() -> None:
+    role_box = {
+        **OBSERVED_HUMAN,
+        "email": "vendas@empresa-target.com.br",
+    }
+    result = publish_pilot_recipients([role_box])
+    assert result["ok"] is False
+    assert result["warmbly_ready"] is False
+    assert any(
+        "functional_mailbox_not_human_recipient" in item["reasons"]
+        for item in result["rejected"]
+    )
+    ok = publish_pilot_recipients([OBSERVED_HUMAN])
+    assert ok["ok"] is True
+    assert ok["warmbly_ready"] is False

--- a/tests/test_snapshot_observation_loader.py
+++ b/tests/test_snapshot_observation_loader.py
@@ -107,8 +107,9 @@ def test_more_than_ten_thousand_rows_are_read_exactly_once(
     assert snapshot["complete"] is True
     assert snapshot["presentation_truncated"] is False
     assert snapshot["estimated_memory_bytes"] < snapshot["memory_budget_bytes"]
-    assert snapshot["memory_accounting"] == "estimated_payload_guard_not_physical_bound"
-    assert snapshot["physical_memory_bounded"] is False
+    assert snapshot["memory_accounting"] == "chunk_spool_physical_bound"
+    assert snapshot["physical_memory_bounded"] is True
+    assert snapshot["peak_retained_items"] <= page_size
     assert peak_memory < snapshot["memory_budget_bytes"]
     assert connection.cursor_name.startswith("extra_opportunity_intel_")
     assert "LIMIT" not in connection.sql.upper()

--- a/tests/test_snapshot_physical_memory.py
+++ b/tests/test_snapshot_physical_memory.py
@@ -1,0 +1,100 @@
+"""#326 physically memory-bounded snapshot load above one chunk."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from scripts.ops.multi_source_open_pack import db_loaders
+from scripts.ops.multi_source_open_pack.db_loaders import (
+    JsonlSpool,
+    load_opportunity_intel_snapshot,
+)
+
+
+def _row(index: int, total: int) -> dict[str, Any]:
+    return {
+        "id": index + 1,
+        "source": "pncp",
+        "source_id": f"source-{index:05d}",
+        "numero_controle_pncp": f"82922233000100-1-{index:06d}/2026",
+        "orgao_cnpj": "82922233000100",
+        "orgao_nome": "MUNICIPIO DE FLORIANOPOLIS",
+        "municipio": "FLORIANOPOLIS",
+        "uf": "SC",
+        "objeto": f"Pavimentacao {index}",
+        "modalidade": "Concorrencia",
+        "valor_estimado": 1000 + index,
+        "status_canonico": "open",
+        "data_publicacao": "2026-08-01",
+        "data_abertura": "2026-08-10",
+        "data_encerramento": "2026-09-01",
+        "link_edital": f"https://pncp.gov.br/{index}",
+        "source_url": "",
+        "run_id": "run-snapshot",
+        "crawl_batch_id": "batch-snapshot",
+        "proveniencia": {},
+        "_snapshot_eligible_count": total,
+        "_snapshot_id": "100:100:",
+        "_snapshot_row_present": True,
+    }
+
+
+class _Cursor:
+    def __init__(self, rows: list[dict[str, Any]], connection: _Connection):
+        self.rows = rows
+        self.connection = connection
+        self.position = 0
+        self.itersize = 0
+
+    def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+        self.connection.sql = sql
+        self.connection.params = params
+
+    def fetchmany(self, size: int) -> list[dict[str, Any]]:
+        batch = self.rows[self.position : self.position + size]
+        self.position += len(batch)
+        return batch
+
+    def close(self) -> None:
+        self.connection.closed = True
+
+
+class _Connection:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self.rows = rows
+        self.sql = ""
+        self.params: tuple[Any, ...] = ()
+        self.closed = False
+
+    def cursor(self, name: str | None = None) -> _Cursor:
+        return _Cursor(self.rows, self)
+
+
+def test_snapshot_retains_only_chunk_not_full_population(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    total = 250
+    page_size = 40
+    connection = _Connection([_row(index, total) for index in range(total)])
+    monkeypatch.setattr(db_loaders, "_table_exists", lambda *_args: True)
+
+    observations, snapshot = load_opportunity_intel_snapshot(
+        connection,
+        page_size=page_size,
+    )
+
+    assert isinstance(observations, JsonlSpool)
+    assert snapshot["physical_memory_bounded"] is True
+    assert snapshot["eligible_count"] == total
+    assert snapshot["rows_read"] == total
+    assert snapshot["peak_retained_items"] <= page_size
+    assert observations.peak_retained <= page_size or observations.peak_retained == 0
+    assert len(observations) == total
+    streamed = list(observations)
+    assert len(streamed) == total
+    assert observations.peak_retained <= page_size
+    assert {item.id_externo for item in streamed} == {
+        f"82922233000100-1-{index:06d}/2026" for index in range(total)
+    }


### PR DESCRIPTION
## Outcome

Truth + contract durability wave for the ten still-open extra-cli issues that were not implemented by PRs #325, #353, #358, #352, or #359–#369.

## Issues

- #280 — one covered-entity formula shared by panel, PDF, Excel, manifest and QA; FAILED/BLOCKED never count as covered
- #350 — source-wide aggregated evidence is classified, excluded from dual-coverage numerators, and fail-closed as `MISSING_EVIDENCE` when identity is absent
- #309 — missing status/vigência is `UNKNOWN`; `is_active=TRUE` default is not proof; `active_proven` excludes UNKNOWN
- #312 — year 8406, inverted vigência, negative and >R$1tri values are `QUARANTINED`/`REVIEW`; raw unchanged; report-ready excludes quarantine
- #314 — PostgreSQL advisory fence; production writer bypass refused outside isolated tests
- #319 — production checkpoints refused inside the git/release worktree and `/opt/extra-consultoria`
- #306 — namespaced `canonical_contract_id` + `source` + `source_contract_id`; two adapters replay to one canonical + two observations
- #304 — pagination records first/last `totalRegistros`; `fetched = persisted + rejected`; source drift is not success
- #326 — snapshot loader/consolidator spools chunks; peak retained working set bounded by page size
- #370 — recipient publish uses only already-observed public humans; generic mailboxes stay unpromoted; empty/invented evidence fails closed

## Verification

- `tests/test_coverage_formula_and_identity.py`
- `tests/test_contract_activity_and_quality.py`
- `tests/test_contract_durability.py`
- `tests/test_snapshot_physical_memory.py`
- `tests/test_pilot_recipient_publish.py`
- generated-artifacts-policy: PASS (22 files, 0 violations)
- reviewability: PASS (22 files, well under 60 / 10k; no CI/Makefile/commercial-pack mix)

## Honesty

#370 publishes a fail-closed producer path. It does not invent PII and does not claim a live Netcup snapshot or Warmbly send. No `LOCAL_READY` / `VPS_OPERATIONAL` / 95% coverage seal. No DOD checkbox marked accepted.

Refs #280 #309 #312 #370 #350 #319 #314 #326 #306 #304