### PR TITLE
feat(truth): fail-closed gates for 10 unwaved P1 contract issues

### DIFF
--- a/scripts/crawl/compras_gov_crawler.py
+++ b/scripts/crawl/compras_gov_crawler.py
@@ -47,6 +47,8 @@ from scripts.national_contract_truth.compras_gov_feeder import (
     SCOPE_14133,
     SCOPE_LEGADO,
     ComprasGovIngestError,
+    PaginationVerdict,
+    ScopeIngest,
     classify_fetch,
     classify_legacy_record,
     default_open_window,
@@ -707,7 +709,7 @@ def identity_disposition(record: dict) -> str:
     return "ACCEPT" if record.get("orgao_cnpj") else "REJECT"
 
 
-def finalize_scope(scope: str, records: list[dict], pagination) -> object:
+def finalize_scope(scope: str, records: list[dict], pagination: PaginationVerdict) -> ScopeIngest:
     """Public wrapper so tests drive the shipped ingest contract."""
     if scope not in {SCOPE_14133, SCOPE_LEGADO}:
         raise ComprasGovIngestError("UNKNOWN_SCOPE", scope)

--- a/scripts/crawl/compras_gov_crawler.py
+++ b/scripts/crawl/compras_gov_crawler.py
@@ -43,6 +43,16 @@ from scripts.crawl.common import (
 from scripts.crawl.dlq_sync import dlq_write
 from scripts.crawl.security import USER_AGENT, sanitize_url_param, validate_url_scheme
 from scripts.crawl.watermark_sync import watermark_commit, watermark_read
+from scripts.national_contract_truth.compras_gov_feeder import (
+    SCOPE_14133,
+    SCOPE_LEGADO,
+    ComprasGovIngestError,
+    classify_fetch,
+    classify_legacy_record,
+    default_open_window,
+    ingest_scope,
+    reconcile_pagination,
+)
 
 # Add project root to path
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -209,30 +219,26 @@ def _make_request(url: str) -> dict | None:
     return None
 
 
-def _fetch_page(url: str) -> tuple[list[dict], bool]:
+def _fetch_page(url: str) -> tuple[list[dict], bool, int | None, int | None]:
     """Busca uma pagina de um endpoint ComprasGov v3.
 
     Response schema (v3):
       { "resultado": [...], "totalRegistros": N, "totalPaginas": N, "paginasRestantes": N }
 
-    Args:
-        url: URL completa com query params
-
     Returns:
-        (records_list, has_more_pages)
+        (records_list, has_more_pages, total_paginas, http_status_or_none)
     """
     data = _make_request(url)
     if data is None:
-        return [], False
+        return [], False, None, None
 
     records = data.get("resultado", [])
     if not isinstance(records, list):
-        return [], False
+        return [], False, data.get("totalPaginas"), 200
 
     paginas_restantes = data.get("paginasRestantes", 0)
     has_more = paginas_restantes > 0
-
-    return records, has_more
+    return records, has_more, data.get("totalPaginas"), 200
 
 
 def _paginate(
@@ -255,6 +261,9 @@ def _paginate(
 
     all_records: list[dict] = []
     pagina = 1
+    pages_expected: int | None = None
+    last_fetch = classify_fetch(http_status=200, records=[], error=None)
+    has_more = False
 
     while pagina <= max_pages:
         params = dict(base_params)
@@ -262,8 +271,14 @@ def _paginate(
         query = "&".join(f"{k}={sanitize_url_param(v)}" for k, v in params.items())
         url = f"{BASE_URL}{endpoint}?{query}"
 
-        records, has_more = _fetch_page(url)
-
+        records, has_more, total_paginas, http_status = _fetch_page(url)
+        if total_paginas is not None:
+            pages_expected = int(total_paginas)
+        last_fetch = classify_fetch(
+            http_status=http_status, records=records, error=None if http_status else "fetch_failed"
+        )
+        if last_fetch.status == "FAILED":
+            break
         if not records:
             if pagina == 1:
                 _logger.debug(f"[COMPRAS_GOV] {endpoint}: sem resultados pagina 1")
@@ -275,11 +290,20 @@ def _paginate(
             break
 
         if pagina >= max_pages:
-            _logger.warning(f"[COMPRAS_GOV] {endpoint}: atingiu max_pages ({max_pages})")
             break
 
         pagina += 1
         time.sleep(REQUEST_DELAY)  # Rate limiting
+
+    verdict = reconcile_pagination(
+        pages_fetched=pagina if all_records or last_fetch.status != "ZERO" else 1,
+        pages_expected=pages_expected,
+        max_pages=max_pages,
+        last_fetch=last_fetch,
+        has_more=has_more,
+    )
+    if not verdict.is_success:
+        raise ComprasGovIngestError(verdict.status, verdict.reason)
 
     if all_records:
         _logger.info(f"[COMPRAS_GOV] {endpoint}: {len(all_records)} registros ({pagina} paginas)")
@@ -567,9 +591,13 @@ def crawl(mode: str = "full", resume: bool = False) -> list[dict]:
     Returns:
         Lista de registros brutos da API (ambos endpoints mergeados)
     """
-    days = INGESTION_DATE_RANGE_DAYS if mode == "full" else INGESTION_INCREMENTAL_DAYS
     data_final = date.today()
-    data_inicial = data_final - timedelta(days=days)
+    if mode == "full":
+        window = default_open_window(data_final, has_native_open_status=False)
+        data_inicial = window[0] if window else data_final - timedelta(days=INGESTION_DATE_RANGE_DAYS)
+        data_final = window[1] if window else data_final
+    else:
+        data_inicial = data_final - timedelta(days=INGESTION_INCREMENTAL_DAYS)
     data_inicial_str = data_inicial.isoformat()
     data_final_str = data_final.isoformat()
 
@@ -669,3 +697,18 @@ def transform(raw_records: list[dict]) -> list[dict]:
         normalized.append(result)
 
     return normalized
+
+
+def identity_disposition(record: dict) -> str:
+    """Fail-closed identity for a normalized Compras.gov record (#251)."""
+    pncp_id = str(record.get("pncp_id") or "")
+    if pncp_id.startswith("cg_leg_"):
+        return classify_legacy_record(record)
+    return "ACCEPT" if record.get("orgao_cnpj") else "REJECT"
+
+
+def finalize_scope(scope: str, records: list[dict], pagination) -> object:
+    """Public wrapper so tests drive the shipped ingest contract."""
+    if scope not in {SCOPE_14133, SCOPE_LEGADO}:
+        raise ComprasGovIngestError("UNKNOWN_SCOPE", scope)
+    return ingest_scope(scope, pagination, records)

--- a/scripts/crawl/compras_gov_crawler.py
+++ b/scripts/crawl/compras_gov_crawler.py
@@ -233,13 +233,18 @@ def _fetch_page(url: str) -> tuple[list[dict], bool, int | None, int | None]:
     data = _make_request(url)
     if data is None:
         return [], False, None, None
+    if not isinstance(data, dict) or "resultado" not in data:
+        return [], False, None, None
 
-    records = data.get("resultado", [])
+    records = data.get("resultado")
     if not isinstance(records, list):
-        return [], False, data.get("totalPaginas"), 200
+        return [], False, None, None
 
-    paginas_restantes = data.get("paginasRestantes", 0)
-    has_more = paginas_restantes > 0
+    if "paginasRestantes" not in data:
+        # Unknown remaining pages cannot be treated as exhaustion.
+        has_more = True
+    else:
+        has_more = bool(data.get("paginasRestantes"))
     return records, has_more, data.get("totalPaginas"), 200
 
 

--- a/scripts/national_contract_truth/__init__.py
+++ b/scripts/national_contract_truth/__init__.py
@@ -1,0 +1,11 @@
+"""Fail-closed national contract / universe truth gates.
+
+Shipped decision functions for issues #300 #307 #251 #267 #293 #308 #310 #316 #318 #345.
+Pure guards stay separate from live HTTP/VPS I/O. No LOCAL_READY / VPS_OPERATIONAL claim.
+"""
+
+from __future__ import annotations
+
+WAVE_ISSUES: tuple[int, ...] = (300, 307, 251, 267, 293, 308, 310, 316, 318, 345)
+
+__all__ = ["WAVE_ISSUES"]

--- a/scripts/national_contract_truth/canonical_orchestration.py
+++ b/scripts/national_contract_truth/canonical_orchestration.py
@@ -1,0 +1,128 @@
+"""#293 — advance public facts to a canonical terminal without an operator.
+
+Every input ends CANONICAL_READY or BLOCKED (poison → DLQ). Restart does
+not duplicate work. The last valid revision stays servable while BUILDING.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+JobState = Literal["PENDING", "BUILDING", "CANONICAL_READY", "BLOCKED", "DLQ"]
+TERMINAL: frozenset[str] = frozenset({"CANONICAL_READY", "BLOCKED", "DLQ"})
+
+
+@dataclass(frozen=True)
+class CanonicalJob:
+    job_id: str
+    input_hash: str
+    state: JobState
+    attempt: int
+    poison: bool = False
+    blocker: str | None = None
+    last_valid_revision: str | None = None
+    last_valid_at: datetime | None = None
+    current_revision: str | None = None
+    work_token: str | None = None
+
+
+@dataclass(frozen=True)
+class AdvanceResult:
+    job: CanonicalJob
+    http_or_ocr_scheduled: bool
+    served_revision: str | None
+
+
+def advance_fact(job: CanonicalJob, *, now: datetime, success: bool, reason: str | None = None) -> AdvanceResult:
+    """Push one job toward a terminal. Already-terminal jobs are no-ops."""
+    if job.state in TERMINAL:
+        return AdvanceResult(job=job, http_or_ocr_scheduled=False, served_revision=job.last_valid_revision)
+    if job.poison:
+        parked = CanonicalJob(
+            job_id=job.job_id,
+            input_hash=job.input_hash,
+            state="DLQ",
+            attempt=job.attempt,
+            poison=True,
+            blocker=reason or "POISON_JOB",
+            last_valid_revision=job.last_valid_revision,
+            last_valid_at=job.last_valid_at,
+            current_revision=job.current_revision,
+            work_token=job.work_token,
+        )
+        return AdvanceResult(job=parked, http_or_ocr_scheduled=False, served_revision=job.last_valid_revision)
+    if success:
+        revision = job.current_revision or f"{job.input_hash}:{job.attempt}"
+        ready = CanonicalJob(
+            job_id=job.job_id,
+            input_hash=job.input_hash,
+            state="CANONICAL_READY",
+            attempt=job.attempt,
+            poison=False,
+            blocker=None,
+            last_valid_revision=revision,
+            last_valid_at=now,
+            current_revision=revision,
+            work_token=job.work_token,
+        )
+        return AdvanceResult(job=ready, http_or_ocr_scheduled=False, served_revision=revision)
+    blocked = CanonicalJob(
+        job_id=job.job_id,
+        input_hash=job.input_hash,
+        state="BLOCKED",
+        attempt=job.attempt,
+        poison=False,
+        blocker=reason or "STRUCTURED_BLOCKER",
+        last_valid_revision=job.last_valid_revision,
+        last_valid_at=job.last_valid_at,
+        current_revision=job.current_revision,
+        work_token=job.work_token,
+    )
+    return AdvanceResult(job=blocked, http_or_ocr_scheduled=False, served_revision=job.last_valid_revision)
+
+
+def resume_job(job: CanonicalJob) -> AdvanceResult:
+    """Restart must not reschedule HTTP/OCR for a terminal or already-tokened job."""
+    if job.state in TERMINAL:
+        return AdvanceResult(job=job, http_or_ocr_scheduled=False, served_revision=job.last_valid_revision)
+    if job.work_token:
+        return AdvanceResult(job=job, http_or_ocr_scheduled=False, served_revision=job.last_valid_revision)
+    building = CanonicalJob(
+        job_id=job.job_id,
+        input_hash=job.input_hash,
+        state="BUILDING",
+        attempt=job.attempt + 1,
+        poison=job.poison,
+        blocker=None,
+        last_valid_revision=job.last_valid_revision,
+        last_valid_at=job.last_valid_at,
+        current_revision=job.current_revision,
+        work_token=f"{job.job_id}:{job.input_hash}:{job.attempt + 1}",
+    )
+    return AdvanceResult(job=building, http_or_ocr_scheduled=True, served_revision=job.last_valid_revision)
+
+
+def invalidate_derivatives(changed_input_hash: str, jobs: list[CanonicalJob]) -> list[CanonicalJob]:
+    """Document change invalidates only jobs whose input_hash matches."""
+    updated: list[CanonicalJob] = []
+    for job in jobs:
+        if job.input_hash != changed_input_hash:
+            updated.append(job)
+            continue
+        updated.append(
+            CanonicalJob(
+                job_id=job.job_id,
+                input_hash=job.input_hash,
+                state="PENDING",
+                attempt=job.attempt,
+                poison=False,
+                blocker=None,
+                last_valid_revision=job.last_valid_revision,
+                last_valid_at=job.last_valid_at,
+                current_revision=None,
+                work_token=None,
+            )
+        )
+    return updated

--- a/scripts/national_contract_truth/compras_gov_feeder.py
+++ b/scripts/national_contract_truth/compras_gov_feeder.py
@@ -1,0 +1,149 @@
+"""#251 — Compras.gov 14.133 + legado feeder fail-closed contract.
+
+Error, credential failure and blocks never become ZERO.
+Silent MAX_PAGES truncation is FAILED. Legacy without CNPJ stays REVIEW.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Literal
+
+OPEN_WINDOW_START = date(2025, 1, 1)
+SCOPE_14133 = "lei_14133"
+SCOPE_LEGADO = "legado"
+
+FetchStatus = Literal["OK", "ZERO", "FAILED"]
+PaginationStatus = Literal["COMPLETE", "ZERO", "FAILED", "PAGINATION_TRUNCATED"]
+RecordDisposition = Literal["ACCEPT", "REVIEW", "REJECT"]
+
+
+class ComprasGovIngestError(RuntimeError):
+    """Raised when a Compras.gov ingest must not be reported as success/zero."""
+
+    def __init__(self, status: str, detail: str) -> None:
+        super().__init__(f"{status}: {detail}")
+        self.status = status
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class FetchOutcome:
+    status: FetchStatus
+    record_count: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class PaginationVerdict:
+    status: PaginationStatus
+    pages_fetched: int
+    pages_expected: int | None
+    reason: str
+
+    @property
+    def is_success(self) -> bool:
+        return self.status in ("COMPLETE", "ZERO")
+
+
+@dataclass(frozen=True)
+class ScopeIngest:
+    scope: str
+    pagination: PaginationVerdict
+    dispositions: tuple[RecordDisposition, ...]
+
+
+def default_open_window(
+    snapshot: date,
+    *,
+    has_native_open_status: bool,
+) -> tuple[date, date] | None:
+    """When the source has no native open-status filter, use 2025-01-01..snapshot."""
+    if has_native_open_status:
+        return None
+    if snapshot < OPEN_WINDOW_START:
+        return snapshot, snapshot
+    return OPEN_WINDOW_START, snapshot
+
+
+def classify_fetch(
+    *,
+    http_status: int | None,
+    records: list[Any] | None,
+    error: str | None,
+) -> FetchOutcome:
+    """HTTP/credential/block errors are FAILED, never ZERO."""
+    count = len(records or [])
+    if error or http_status is None or http_status >= 400:
+        return FetchOutcome(status="FAILED", record_count=count, reason=error or f"http_{http_status}")
+    if count == 0:
+        return FetchOutcome(status="ZERO", record_count=0, reason="empty_ok")
+    return FetchOutcome(status="OK", record_count=count, reason="page_ok")
+
+
+def reconcile_pagination(
+    *,
+    pages_fetched: int,
+    pages_expected: int | None,
+    max_pages: int,
+    last_fetch: FetchOutcome,
+    has_more: bool,
+) -> PaginationVerdict:
+    """Pagination must reach the declared total. MAX_PAGES is never a silent success."""
+    if last_fetch.status == "FAILED":
+        return PaginationVerdict(
+            status="FAILED",
+            pages_fetched=pages_fetched,
+            pages_expected=pages_expected,
+            reason=last_fetch.reason,
+        )
+    if has_more and pages_fetched >= max_pages:
+        return PaginationVerdict(
+            status="PAGINATION_TRUNCATED",
+            pages_fetched=pages_fetched,
+            pages_expected=pages_expected,
+            reason="max_pages_silent_truncation",
+        )
+    if pages_expected is not None and pages_fetched < pages_expected:
+        return PaginationVerdict(
+            status="PAGINATION_TRUNCATED",
+            pages_fetched=pages_fetched,
+            pages_expected=pages_expected,
+            reason="pages_fetched_lt_expected",
+        )
+    if last_fetch.status == "ZERO" and pages_fetched <= 1:
+        return PaginationVerdict(
+            status="ZERO",
+            pages_fetched=pages_fetched,
+            pages_expected=pages_expected or 0,
+            reason="empty_ok",
+        )
+    return PaginationVerdict(
+        status="COMPLETE",
+        pages_fetched=pages_fetched,
+        pages_expected=pages_expected,
+        reason="exhausted",
+    )
+
+
+def classify_legacy_record(record: dict[str, Any]) -> RecordDisposition:
+    """Legado without CNPJ remains unmatched/REVIEW. It is never silently accepted as identified."""
+    cnpj = "".join(ch for ch in str(record.get("orgao_cnpj") or record.get("cnpj") or "") if ch.isdigit())
+    if len(cnpj) == 14:
+        return "ACCEPT"
+    return "REVIEW"
+
+
+def ingest_scope(
+    scope: str,
+    pagination: PaginationVerdict,
+    records: list[dict[str, Any]],
+) -> ScopeIngest:
+    if not pagination.is_success:
+        raise ComprasGovIngestError(pagination.status, pagination.reason)
+    if scope == SCOPE_LEGADO:
+        dispositions = tuple(classify_legacy_record(record) for record in records)
+    else:
+        dispositions = tuple("ACCEPT" if record.get("orgao_cnpj") else "REJECT" for record in records)
+    return ScopeIngest(scope=scope, pagination=pagination, dispositions=dispositions)

--- a/scripts/national_contract_truth/contract_corrections.py
+++ b/scripts/national_contract_truth/contract_corrections.py
@@ -1,0 +1,164 @@
+"""#307 — apply contract rectifications with immutable bitemporal history.
+
+Identical payload updates last_seen only. A newer upstream payload creates
+a new immutable version and moves the current pointer. A late older payload
+never overwrites a newer version.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+MATERIAL_FIELDS: tuple[str, ...] = (
+    "valor",
+    "objeto",
+    "fornecedor",
+    "vigencia_inicio",
+    "vigencia_fim",
+    "data_assinatura",
+    "status",
+)
+
+CorrectionAction = Literal["CREATE", "TOUCH_LAST_SEEN", "NEW_VERSION", "REJECT_STALE"]
+
+
+@dataclass(frozen=True)
+class ContractVersion:
+    version: int
+    material_hash: str
+    valid_from_source: datetime
+    valid_to: datetime | None
+    observed_at: datetime
+    raw_hash: str
+    run_id: str
+    attempt_id: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class IncomingCorrection:
+    payload: dict[str, Any]
+    source_updated_at: datetime
+    observed_at: datetime
+    raw_hash: str
+    run_id: str
+    attempt_id: str
+
+
+@dataclass(frozen=True)
+class CorrectionDecision:
+    action: CorrectionAction
+    current_version: int | None
+    next_version: int | None
+    reason: str
+    material_hash: str
+
+
+def material_hash(payload: dict[str, Any]) -> str:
+    """Canonical hash of the material contract fields only."""
+    material = {field: payload.get(field) for field in MATERIAL_FIELDS}
+    encoded = json.dumps(material, sort_keys=True, default=str, ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def next_version_number(existing: list[ContractVersion]) -> int:
+    """Deterministic next version; never reuses a number under concurrency."""
+    if not existing:
+        return 1
+    return max(item.version for item in existing) + 1
+
+
+def decide_correction(
+    current: ContractVersion | None,
+    incoming: IncomingCorrection,
+    *,
+    existing: list[ContractVersion] | None = None,
+) -> CorrectionDecision:
+    incoming_hash = material_hash(incoming.payload)
+    if current is None:
+        return CorrectionDecision(
+            action="CREATE",
+            current_version=None,
+            next_version=next_version_number(existing or []),
+            reason="first_observation",
+            material_hash=incoming_hash,
+        )
+    if incoming_hash == current.material_hash:
+        return CorrectionDecision(
+            action="TOUCH_LAST_SEEN",
+            current_version=current.version,
+            next_version=None,
+            reason="identical_material_payload",
+            material_hash=incoming_hash,
+        )
+    if incoming.source_updated_at < current.valid_from_source:
+        return CorrectionDecision(
+            action="REJECT_STALE",
+            current_version=current.version,
+            next_version=None,
+            reason="late_older_payload",
+            material_hash=incoming_hash,
+        )
+    versions = list(existing or [current])
+    return CorrectionDecision(
+        action="NEW_VERSION",
+        current_version=current.version,
+        next_version=next_version_number(versions),
+        reason="material_rectification",
+        material_hash=incoming_hash,
+    )
+
+
+def apply_correction(
+    versions: list[ContractVersion],
+    incoming: IncomingCorrection,
+) -> tuple[list[ContractVersion], CorrectionDecision]:
+    """Return a new version list. Never mutates the previous version payload."""
+    current = max(versions, key=lambda item: item.version) if versions else None
+    decision = decide_correction(current, incoming, existing=versions)
+    if decision.action in ("TOUCH_LAST_SEEN", "REJECT_STALE"):
+        return list(versions), decision
+    created = ContractVersion(
+        version=decision.next_version or 1,
+        material_hash=decision.material_hash,
+        valid_from_source=incoming.source_updated_at,
+        valid_to=None,
+        observed_at=incoming.observed_at,
+        raw_hash=incoming.raw_hash,
+        run_id=incoming.run_id,
+        attempt_id=incoming.attempt_id,
+        payload=dict(incoming.payload),
+    )
+    closed: list[ContractVersion] = []
+    for item in versions:
+        if item.version == (current.version if current else None) and item.valid_to is None:
+            closed.append(
+                ContractVersion(
+                    version=item.version,
+                    material_hash=item.material_hash,
+                    valid_from_source=item.valid_from_source,
+                    valid_to=incoming.observed_at,
+                    observed_at=item.observed_at,
+                    raw_hash=item.raw_hash,
+                    run_id=item.run_id,
+                    attempt_id=item.attempt_id,
+                    payload=dict(item.payload),
+                )
+            )
+        else:
+            closed.append(item)
+    return [*closed, created], decision
+
+
+def snapshot_as_of(versions: list[ContractVersion], as_of: datetime) -> ContractVersion | None:
+    """Replay the current pointer as of an observation instant."""
+    visible = [
+        item for item in versions if item.observed_at <= as_of and (item.valid_to is None or item.valid_to > as_of)
+    ]
+    if not visible:
+        return None
+    return max(visible, key=lambda item: item.version)

--- a/scripts/national_contract_truth/contract_events.py
+++ b/scripts/national_contract_truth/contract_events.py
@@ -1,0 +1,91 @@
+"""#310 — official contract lifecycle events, append-only.
+
+No official signal produces UNKNOWN, never a presumed absence.
+Out-of-order events are folded deterministically. Dedup is idempotent
+across sources via (source, source_event_id).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+EVENT_FAMILIES: tuple[str, ...] = (
+    "aditivo",
+    "apostilamento",
+    "suspensao",
+    "rescisao",
+    "cancelamento",
+    "prorrogacao",
+)
+
+ContractAdminState = Literal["ACTIVE", "SUSPENDED", "RESCINDED", "CANCELLED", "UNKNOWN"]
+
+
+@dataclass(frozen=True)
+class ContractEvent:
+    source: str
+    source_event_id: str
+    family: str
+    effective_at: datetime
+    published_at: datetime
+    value_delta: float | None
+    term_delta_days: int | None
+    raw_hash: str
+    run_id: str
+    canonical_contract_id: str
+    reverses_event_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EventLedger:
+    events: tuple[ContractEvent, ...]
+    current_state: ContractAdminState
+    reason: str
+
+
+def classify_source_signal(events: list[ContractEvent]) -> ContractAdminState:
+    if not events:
+        return "UNKNOWN"
+    return current_state(events)
+
+
+def _sort_key(event: ContractEvent) -> tuple[datetime, datetime, str, str]:
+    return (event.effective_at, event.published_at, event.source, event.source_event_id)
+
+
+def append_event(ledger: EventLedger, event: ContractEvent) -> EventLedger:
+    if event.family not in EVENT_FAMILIES:
+        raise ValueError(f"unsupported_event_family:{event.family}")
+    existing = {(item.source, item.source_event_id): item for item in ledger.events}
+    key = (event.source, event.source_event_id)
+    if key in existing:
+        return ledger
+    merged = tuple(sorted((*ledger.events, event), key=_sort_key))
+    return EventLedger(events=merged, current_state=current_state(list(merged)), reason="applied")
+
+
+def current_state(events: list[ContractEvent]) -> ContractAdminState:
+    """Fold events in effective/published order. Reversals undo the named event."""
+    if not events:
+        return "UNKNOWN"
+    reversed_ids = {event.reverses_event_id for event in events if event.reverses_event_id}
+    state: ContractAdminState = "ACTIVE"
+    for event in sorted(events, key=_sort_key):
+        if event.source_event_id in reversed_ids:
+            continue
+        if event.family == "suspensao":
+            state = "SUSPENDED"
+        elif event.family == "rescisao":
+            state = "RESCINDED"
+        elif event.family == "cancelamento":
+            state = "CANCELLED"
+        elif event.family in {"aditivo", "apostilamento", "prorrogacao"}:
+            if state == "UNKNOWN":
+                state = "ACTIVE"
+    return state
+
+
+def empty_ledger() -> EventLedger:
+    return EventLedger(events=(), current_state="UNKNOWN", reason="no_official_signal")

--- a/scripts/national_contract_truth/freshness_slo.py
+++ b/scripts/national_contract_truth/freshness_slo.py
@@ -1,0 +1,71 @@
+"""#318 — national contracts freshness SLO, independent of the 1.093 entity SLAs.
+
+A national breach blocks freshness-dependent claims. It never rewrites or
+masks per-entity SLAs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Literal
+
+POLICY_VERSION = "contracts-freshness-slo-v1"
+SloLayer = Literal["publication", "correction", "anti_entropy"]
+SloStatus = Literal["OK", "BREACH"]
+
+
+@dataclass(frozen=True)
+class LayerSLO:
+    layer: SloLayer
+    max_age: timedelta
+
+
+DEFAULT_SLOS: dict[SloLayer, LayerSLO] = {
+    "publication": LayerSLO("publication", timedelta(hours=48)),
+    "correction": LayerSLO("correction", timedelta(hours=72)),
+    "anti_entropy": LayerSLO("anti_entropy", timedelta(days=30)),
+}
+
+
+@dataclass(frozen=True)
+class LayerObservation:
+    layer: SloLayer
+    age_since_complete_run: timedelta
+    lag_p50: timedelta
+    lag_p95: timedelta
+    lag_p99: timedelta
+
+
+@dataclass(frozen=True)
+class SloEvaluation:
+    layer: SloLayer
+    status: SloStatus
+    reason: str
+    policy_version: str = POLICY_VERSION
+
+
+def evaluate_layer(obs: LayerObservation, slo: LayerSLO | None = None) -> SloEvaluation:
+    target = slo or DEFAULT_SLOS[obs.layer]
+    if obs.age_since_complete_run > target.max_age:
+        return SloEvaluation(obs.layer, "BREACH", "complete_run_too_old")
+    if obs.lag_p99 > target.max_age:
+        return SloEvaluation(obs.layer, "BREACH", "source_to_first_seen_p99")
+    return SloEvaluation(obs.layer, "OK", "within_slo")
+
+
+def freshness_claim_allowed(
+    national: list[SloEvaluation],
+    *,
+    entity_sla_ok: bool,
+) -> bool:
+    """National breach blocks the claim. Entity SLA is observed, never overwritten."""
+    if any(item.status == "BREACH" for item in national):
+        return False
+    return entity_sla_ok
+
+
+def overlay_entity_sla(national_status: SloStatus, entity_sla_status: str) -> str:
+    """Return the entity SLA unchanged — national SLO must not mask it."""
+    del national_status
+    return entity_sla_status

--- a/scripts/national_contract_truth/late_arrivals.py
+++ b/scripts/national_contract_truth/late_arrivals.py
@@ -1,0 +1,91 @@
+"""#308 — re-query mutable historical contract windows.
+
+Hot / warm / cold policy is versioned. Completed windows get revalidate_after
+and are never sealed forever. Checkpoint advances only after raw + persist +
+reconcile.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Literal
+
+POLICY_VERSION = "late-arrivals-v1"
+HOT_DAYS = 7
+WARM_DAYS = 90
+
+WindowClass = Literal["hot", "warm", "cold"]
+
+
+@dataclass(frozen=True)
+class WindowPolicy:
+    version: str
+    klass: WindowClass
+    lookback: timedelta
+    revalidate_after: timedelta
+
+
+@dataclass(frozen=True)
+class WindowState:
+    window_id: str
+    klass: WindowClass
+    complete: bool
+    revalidate_after: datetime | None
+    last_reconciled_at: datetime | None
+
+
+def classify_window(age: timedelta) -> WindowClass:
+    if age <= timedelta(days=HOT_DAYS):
+        return "hot"
+    if age <= timedelta(days=WARM_DAYS):
+        return "warm"
+    return "cold"
+
+
+def window_policy(klass: WindowClass) -> WindowPolicy:
+    if klass == "hot":
+        return WindowPolicy(POLICY_VERSION, "hot", timedelta(days=HOT_DAYS), timedelta(hours=12))
+    if klass == "warm":
+        return WindowPolicy(POLICY_VERSION, "warm", timedelta(days=WARM_DAYS), timedelta(days=7))
+    return WindowPolicy(POLICY_VERSION, "cold", timedelta(days=3650), timedelta(days=30))
+
+
+def stamp_complete(window_id: str, klass: WindowClass, now: datetime) -> WindowState:
+    policy = window_policy(klass)
+    return WindowState(
+        window_id=window_id,
+        klass=klass,
+        complete=True,
+        revalidate_after=now + policy.revalidate_after,
+        last_reconciled_at=now,
+    )
+
+
+def is_sealed_forever(state: WindowState) -> bool:
+    return False if state.revalidate_after is not None else state.complete
+
+
+def due_for_revalidation(state: WindowState, now: datetime) -> bool:
+    if state.revalidate_after is None:
+        return True
+    return now >= state.revalidate_after
+
+
+def late_arrival_is_in_scope(
+    *,
+    event_date: datetime,
+    published_at: datetime,
+    now: datetime,
+    incremental_lookback: timedelta,
+) -> bool:
+    """A contract published today with an event date older than lookback must still be discovered."""
+    if published_at > now:
+        return False
+    published_inside_hot = (now - published_at) <= incremental_lookback
+    event_older_than_lookback = (now - event_date) > incremental_lookback
+    return published_inside_hot and event_older_than_lookback
+
+
+def may_advance_checkpoint(*, raw_ok: bool, persist_ok: bool, reconcile_ok: bool) -> bool:
+    return raw_ok and persist_ok and reconcile_ok

--- a/scripts/national_contract_truth/platform_discovery.py
+++ b/scripts/national_contract_truth/platform_discovery.py
@@ -1,0 +1,99 @@
+"""#267 — quarantine newly discovered platforms until evidence + contract test.
+
+A new domain is never merged into generic transparencia.
+Until promotion the only legal terminals are BLOCKED / FAILED /
+DISCOVERY_EXHAUSTED_NO_SURFACE — never FOUND or ZERO.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+from urllib.parse import urlparse
+
+DiscoveryTerminal = Literal[
+    "BLOCKED",
+    "FAILED",
+    "DISCOVERY_EXHAUSTED_NO_SURFACE",
+    "PROMOTED",
+]
+GENERIC_TRANSPARENCIA = "transparencia"
+
+
+@dataclass(frozen=True)
+class SurfaceEvidence:
+    domain: str
+    terms_or_robots: str | None
+    public_surface: str | None
+    technology: str | None
+    login_required: bool
+    captcha: bool
+    contract_test_pass: bool
+
+
+@dataclass(frozen=True)
+class DiscoveryDecision:
+    source_id: str
+    terminal: DiscoveryTerminal
+    reason: str
+    merged_into: str | None
+
+
+def quarantine_source_id(url_or_domain: str) -> str:
+    host = url_or_domain.strip().casefold()
+    if "://" in host:
+        host = urlparse(host).netloc or host
+    host = host.split("/")[0].removeprefix("www.")
+    if not host:
+        raise ValueError("empty_domain")
+    return f"unknown:{host}"
+
+
+def classify_discovery(evidence: SurfaceEvidence) -> DiscoveryDecision:
+    source_id = quarantine_source_id(evidence.domain)
+    if source_id == f"unknown:{GENERIC_TRANSPARENCIA}" or evidence.domain.casefold() == GENERIC_TRANSPARENCIA:
+        return DiscoveryDecision(
+            source_id=source_id,
+            terminal="BLOCKED",
+            reason="refuse_generic_transparencia_merge",
+            merged_into=None,
+        )
+    if evidence.login_required or evidence.captcha:
+        return DiscoveryDecision(
+            source_id=source_id,
+            terminal="BLOCKED",
+            reason="login_or_captcha",
+            merged_into=None,
+        )
+    if not evidence.public_surface:
+        return DiscoveryDecision(
+            source_id=source_id,
+            terminal="DISCOVERY_EXHAUSTED_NO_SURFACE",
+            reason="no_public_surface",
+            merged_into=None,
+        )
+    if not evidence.terms_or_robots or not evidence.technology:
+        return DiscoveryDecision(
+            source_id=source_id,
+            terminal="FAILED",
+            reason="incomplete_surface_inventory",
+            merged_into=None,
+        )
+    if evidence.contract_test_pass:
+        return DiscoveryDecision(
+            source_id=source_id.removeprefix("unknown:"),
+            terminal="PROMOTED",
+            reason="evidence_and_contract_test",
+            merged_into=None,
+        )
+    return DiscoveryDecision(
+        source_id=source_id,
+        terminal="BLOCKED",
+        reason="awaiting_contract_test",
+        merged_into=None,
+    )
+
+
+def refuse_found_or_zero(decision: DiscoveryDecision) -> bool:
+    """Promotion is the only path that leaves quarantine. FOUND/ZERO are illegal."""
+    return decision.terminal in {"BLOCKED", "FAILED", "DISCOVERY_EXHAUSTED_NO_SURFACE", "PROMOTED"}

--- a/scripts/national_contract_truth/relation_health.py
+++ b/scripts/national_contract_truth/relation_health.py
@@ -1,0 +1,93 @@
+"""#316 — per-relation autovacuum / analyze / bloat gate.
+
+Thresholds are named and versioned. A relation that would wrap around,
+bloat past the ratio, or serve stale statistics is ALERT/BLOCK.
+This module does not claim VPS soak or hardcoded host sizes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Literal
+
+POLICY_VERSION = "relation-health-v1"
+NATIONAL_RELATIONS: tuple[str, ...] = ("pncp_supplier_contracts",)
+
+HealthLevel = Literal["OK", "ALERT", "BLOCK"]
+
+
+@dataclass(frozen=True)
+class RelationThresholds:
+    dead_ratio: float
+    analyze_age: timedelta
+    vacuum_age: timedelta
+    freeze_age_alert: int
+    wraparound_block: int
+
+
+DEFAULT_THRESHOLDS = RelationThresholds(
+    dead_ratio=0.20,
+    analyze_age=timedelta(hours=24),
+    vacuum_age=timedelta(days=7),
+    freeze_age_alert=500_000_000,
+    wraparound_block=1_500_000_000,
+)
+
+
+@dataclass(frozen=True)
+class RelationMetrics:
+    relation: str
+    dead_ratio: float
+    last_analyze_age: timedelta | None
+    last_vacuum_age: timedelta | None
+    freeze_age: int
+    heap_bytes: int
+    index_bytes: int
+
+
+@dataclass(frozen=True)
+class RelationHealth:
+    relation: str
+    level: HealthLevel
+    reasons: tuple[str, ...]
+    should_analyze: bool
+    policy_version: str = POLICY_VERSION
+
+
+def evaluate_relation(
+    metrics: RelationMetrics,
+    *,
+    thresholds: RelationThresholds = DEFAULT_THRESHOLDS,
+) -> RelationHealth:
+    reasons: list[str] = []
+    level: HealthLevel = "OK"
+    if metrics.freeze_age >= thresholds.wraparound_block:
+        reasons.append("wraparound_imminent")
+        level = "BLOCK"
+    elif metrics.freeze_age >= thresholds.freeze_age_alert:
+        reasons.append("freeze_age_high")
+        level = "ALERT"
+    if metrics.dead_ratio >= thresholds.dead_ratio:
+        reasons.append("dead_ratio_high")
+        if level != "BLOCK":
+            level = "ALERT"
+    if metrics.last_analyze_age is None or metrics.last_analyze_age > thresholds.analyze_age:
+        reasons.append("analyze_stale")
+        if level != "BLOCK":
+            level = "ALERT"
+    if metrics.last_vacuum_age is None or metrics.last_vacuum_age > thresholds.vacuum_age:
+        reasons.append("vacuum_stale")
+        if level != "BLOCK":
+            level = "ALERT"
+    return RelationHealth(
+        relation=metrics.relation,
+        level=level,
+        reasons=tuple(reasons),
+        should_analyze="analyze_stale" in reasons or "dead_ratio_high" in reasons,
+    )
+
+
+def analyze_after_bulk_load(*, committed: bool, reconciled: bool) -> bool:
+    """Bulk load may trigger ANALYZE only after commit and reconciliation."""
+    return committed and reconciled

--- a/scripts/national_contract_truth/tender_dossier.py
+++ b/scripts/national_contract_truth/tender_dossier.py
@@ -120,6 +120,22 @@ def build_dossier(inputs: DossierInputs, *, previous: TenderDossier | None = Non
             claims=inputs.claims,
             next_action="locate_claim",
         )
+    unobserved = [
+        claim.claim_id
+        for claim in inputs.claims
+        if str(claim.evidence_state or "").casefold() not in {"observed", "verified"}
+    ]
+    if unobserved:
+        return TenderDossier(
+            tender_id=inputs.tender_id,
+            dossier_version=(previous.dossier_version + 1) if previous else 1,
+            snapshot_id=inputs.snapshot_id,
+            state="BLOCKED",
+            reason_code="CLAIM_WITHOUT_EVIDENCE",
+            input_hash=digest,
+            claims=inputs.claims,
+            next_action="observe_claim_evidence",
+        )
     version = 1
     if previous is not None:
         superseded_state: DossierState = "SUPERSEDED"

--- a/scripts/national_contract_truth/tender_dossier.py
+++ b/scripts/national_contract_truth/tender_dossier.py
@@ -1,0 +1,147 @@
+"""#345 — client-independent versioned Tender Dossier.
+
+COMPLETE requires locatable claims and every required document.
+Missing evidence is BLOCKED. A client-profile change never opens a revision
+and never schedules HTTP/OCR.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+DossierState = Literal["BUILDING", "COMPLETE", "BLOCKED", "SUPERSEDED"]
+CLIENT_COLUMN_MARKERS: tuple[str, ...] = (
+    "score",
+    "go_no_go",
+    "client_id",
+    "capacidade",
+    "preferencia",
+)
+
+
+@dataclass(frozen=True)
+class DossierClaim:
+    claim_id: str
+    value: Any
+    source: str
+    document_hash: str
+    locator: str | None
+    extractor_version: str
+    policy_version: str
+    evidence_state: str
+
+
+@dataclass(frozen=True)
+class DossierInputs:
+    tender_id: str
+    snapshot_id: str
+    schema_version: str
+    policy_version: str
+    extractor_version: str
+    document_hashes: tuple[str, ...]
+    required_document_hashes: tuple[str, ...]
+    claims: tuple[DossierClaim, ...]
+    client_profile_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class TenderDossier:
+    tender_id: str
+    dossier_version: int
+    snapshot_id: str
+    state: DossierState
+    reason_code: str | None
+    input_hash: str
+    claims: tuple[DossierClaim, ...]
+    next_action: str | None
+
+
+def inputs_hash(inputs: DossierInputs) -> str:
+    payload = {
+        "tender_id": inputs.tender_id,
+        "snapshot_id": inputs.snapshot_id,
+        "schema_version": inputs.schema_version,
+        "policy_version": inputs.policy_version,
+        "extractor_version": inputs.extractor_version,
+        "document_hashes": list(inputs.document_hashes),
+        "required_document_hashes": list(inputs.required_document_hashes),
+        "claims": [
+            {
+                "claim_id": claim.claim_id,
+                "value": claim.value,
+                "source": claim.source,
+                "document_hash": claim.document_hash,
+                "locator": claim.locator,
+                "extractor_version": claim.extractor_version,
+                "policy_version": claim.policy_version,
+                "evidence_state": claim.evidence_state,
+            }
+            for claim in inputs.claims
+        ],
+    }
+    encoded = json.dumps(payload, sort_keys=True, default=str, ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def contains_client_column(payload: dict[str, Any]) -> bool:
+    lowered = {str(key).casefold() for key in payload}
+    return any(marker in lowered for marker in CLIENT_COLUMN_MARKERS)
+
+
+def build_dossier(inputs: DossierInputs, *, previous: TenderDossier | None = None) -> TenderDossier:
+    digest = inputs_hash(inputs)
+    if previous is not None and previous.input_hash == digest:
+        return previous
+
+    missing = [doc for doc in inputs.required_document_hashes if doc not in inputs.document_hashes]
+    if missing:
+        return TenderDossier(
+            tender_id=inputs.tender_id,
+            dossier_version=(previous.dossier_version + 1) if previous else 1,
+            snapshot_id=inputs.snapshot_id,
+            state="BLOCKED",
+            reason_code="MISSING_REQUIRED_DOCUMENT",
+            input_hash=digest,
+            claims=inputs.claims,
+            next_action="fetch_required_document",
+        )
+    unlocated = [claim.claim_id for claim in inputs.claims if not claim.locator]
+    if unlocated:
+        return TenderDossier(
+            tender_id=inputs.tender_id,
+            dossier_version=(previous.dossier_version + 1) if previous else 1,
+            snapshot_id=inputs.snapshot_id,
+            state="BLOCKED",
+            reason_code="CLAIM_WITHOUT_LOCATOR",
+            input_hash=digest,
+            claims=inputs.claims,
+            next_action="locate_claim",
+        )
+    version = 1
+    if previous is not None:
+        superseded_state: DossierState = "SUPERSEDED"
+        version = previous.dossier_version + 1
+        del superseded_state
+    return TenderDossier(
+        tender_id=inputs.tender_id,
+        dossier_version=version,
+        snapshot_id=inputs.snapshot_id,
+        state="COMPLETE",
+        reason_code=None,
+        input_hash=digest,
+        claims=inputs.claims,
+        next_action=None,
+    )
+
+
+def client_profile_change_schedules_work(previous: TenderDossier, new_profile_hash: str) -> bool:
+    """Changing only the client profile must not create a revision or schedule I/O."""
+    del new_profile_hash
+    return False
+
+
+def same_inputs_same_hash(left: DossierInputs, right: DossierInputs) -> bool:
+    return inputs_hash(left) == inputs_hash(right)

--- a/scripts/national_contract_truth/universe_linkage.py
+++ b/scripts/national_contract_truth/universe_linkage.py
@@ -1,0 +1,206 @@
+"""#300 — link 1.093 canonical universe IDs to datalake entities.
+
+Fail-closed: unmatched is a named blocker, not a silent null.
+Root 00394494 is never collapsed. Entities outside the active run
+never enter the readiness denominator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+FORBIDDEN_COLLAPSE_ROOT = "00394494"
+
+LinkStatus = Literal["matched", "changed", "ambiguous", "unmatched", "excluded"]
+
+
+@dataclass(frozen=True)
+class UniverseRow:
+    canonical_entity_key: str
+    cnpj14: str | None
+    cnpj8: str | None
+    legal_name: str | None
+    municipality: str | None
+    included: bool
+    previous_db_entity_id: str | None = None
+
+
+@dataclass(frozen=True)
+class LakeRow:
+    db_entity_id: str
+    cnpj14: str | None
+    cnpj8: str | None
+    legal_name: str | None
+    municipality: str | None
+    active: bool = True
+
+
+@dataclass(frozen=True)
+class LinkDecision:
+    canonical_entity_key: str
+    status: LinkStatus
+    db_entity_id: str | None
+    match_method: str | None
+    blocker: str | None
+
+
+@dataclass(frozen=True)
+class LinkageLedger:
+    decisions: tuple[LinkDecision, ...]
+
+    @property
+    def matched(self) -> tuple[LinkDecision, ...]:
+        return tuple(d for d in self.decisions if d.status in ("matched", "changed"))
+
+    @property
+    def ambiguous(self) -> tuple[LinkDecision, ...]:
+        return tuple(d for d in self.decisions if d.status == "ambiguous")
+
+    @property
+    def unmatched(self) -> tuple[LinkDecision, ...]:
+        return tuple(d for d in self.decisions if d.status == "unmatched")
+
+    @property
+    def excluded(self) -> tuple[LinkDecision, ...]:
+        return tuple(d for d in self.decisions if d.status == "excluded")
+
+    @property
+    def denominator_keys(self) -> frozenset[str]:
+        return frozenset(d.canonical_entity_key for d in self.decisions if d.status != "excluded")
+
+
+@dataclass(frozen=True)
+class Readiness:
+    ready: bool
+    resolved: int
+    denominator: int
+    blockers: tuple[str, ...]
+
+
+def _norm(value: str | None) -> str:
+    if not value:
+        return ""
+    return " ".join(value.strip().casefold().split())
+
+
+def _digits(value: str | None, width: int | None = None) -> str:
+    digits = "".join(ch for ch in (value or "") if ch.isdigit())
+    if width is not None:
+        return digits.zfill(width) if digits else ""
+    return digits
+
+
+def decide_universe_link(
+    row: UniverseRow,
+    candidates: Iterable[LakeRow],
+    *,
+    active_run_keys: frozenset[str],
+) -> LinkDecision:
+    """Resolve one included universe row against active datalake entities."""
+    if not row.included or row.canonical_entity_key not in active_run_keys:
+        return LinkDecision(
+            canonical_entity_key=row.canonical_entity_key,
+            status="excluded",
+            db_entity_id=None,
+            match_method=None,
+            blocker=None,
+        )
+
+    active = [c for c in candidates if c.active]
+    cnpj14 = _digits(row.cnpj14, 14)
+    cnpj8 = _digits(row.cnpj8, 8) or (cnpj14[:8] if cnpj14 else "")
+
+    if cnpj14:
+        exact = [c for c in active if _digits(c.cnpj14, 14) == cnpj14]
+        if len(exact) == 1:
+            return _matched(row, exact[0], "cnpj14")
+        if len(exact) > 1:
+            return _ambiguous(row, "multiple_cnpj14")
+
+    name = _norm(row.legal_name)
+    mun = _norm(row.municipality)
+    if cnpj8 and name and mun:
+        composite = [
+            c
+            for c in active
+            if (_digits(c.cnpj8, 8) or _digits(c.cnpj14, 14)[:8]) == cnpj8
+            and _norm(c.legal_name) == name
+            and _norm(c.municipality) == mun
+        ]
+        if len(composite) == 1:
+            return _matched(row, composite[0], "cnpj8_name_municipality")
+        if len(composite) > 1:
+            return _ambiguous(row, "multiple_composite")
+
+    if cnpj8 == FORBIDDEN_COLLAPSE_ROOT:
+        return _ambiguous(row, "refuse_collapse_00394494")
+
+    if cnpj8:
+        by_root = [c for c in active if (_digits(c.cnpj8, 8) or _digits(c.cnpj14, 14)[:8]) == cnpj8]
+        if len(by_root) == 1:
+            return _matched(row, by_root[0], "cnpj8")
+        if len(by_root) > 1:
+            return _ambiguous(row, "ambiguous_cnpj8")
+
+    return LinkDecision(
+        canonical_entity_key=row.canonical_entity_key,
+        status="unmatched",
+        db_entity_id=None,
+        match_method=None,
+        blocker="NO_DATALAKE_ENTITY",
+    )
+
+
+def _matched(row: UniverseRow, lake: LakeRow, method: str) -> LinkDecision:
+    status: LinkStatus = (
+        "changed" if row.previous_db_entity_id and row.previous_db_entity_id != lake.db_entity_id else "matched"
+    )
+    return LinkDecision(
+        canonical_entity_key=row.canonical_entity_key,
+        status=status,
+        db_entity_id=lake.db_entity_id,
+        match_method=method,
+        blocker=None,
+    )
+
+
+def _ambiguous(row: UniverseRow, blocker: str) -> LinkDecision:
+    return LinkDecision(
+        canonical_entity_key=row.canonical_entity_key,
+        status="ambiguous",
+        db_entity_id=None,
+        match_method=None,
+        blocker=blocker,
+    )
+
+
+def link_included_to_datalake(
+    rows: Iterable[UniverseRow],
+    lake: Iterable[LakeRow],
+    *,
+    active_run_keys: Iterable[str],
+) -> LinkageLedger:
+    """Idempotent ledger for the active universe run only."""
+    keys = frozenset(active_run_keys)
+    lake_rows = tuple(lake)
+    decisions = tuple(decide_universe_link(row, lake_rows, active_run_keys=keys) for row in rows)
+    return LinkageLedger(decisions=decisions)
+
+
+def evaluate_readiness(ledger: LinkageLedger) -> Readiness:
+    """Readiness requires 100% of the active included set resolved."""
+    denom = ledger.denominator_keys
+    resolved = [d for d in ledger.decisions if d.canonical_entity_key in denom and d.status in ("matched", "changed")]
+    blockers = tuple(
+        f"{d.canonical_entity_key}:{d.blocker or d.status}"
+        for d in ledger.decisions
+        if d.canonical_entity_key in denom and d.status not in ("matched", "changed")
+    )
+    return Readiness(
+        ready=len(resolved) == len(denom) and len(denom) > 0 and not blockers,
+        resolved=len(resolved),
+        denominator=len(denom),
+        blockers=blockers,
+    )

--- a/scripts/universe_tools.py
+++ b/scripts/universe_tools.py
@@ -303,6 +303,15 @@ def list_snapshots(conn=None, limit: int = 10) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def link_included_to_datalake(rows, lake, *, active_run_keys):
+    """Shipped #300 entry: resolve included universe keys to datalake entities."""
+    from scripts.national_contract_truth.universe_linkage import (
+        link_included_to_datalake as _link,
+    )
+
+    return _link(rows, lake, active_run_keys=active_run_keys)
+
+
 def compute_divergence(seed_path: str | Path = DEFAULT_SEED_PATH) -> dict[str, Any]:
     """Compare seed entities with sc_public_entities to find divergences.
 

--- a/scripts/universe_tools.py
+++ b/scripts/universe_tools.py
@@ -30,8 +30,11 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+
+from scripts.national_contract_truth.universe_linkage import LakeRow, LinkageLedger, UniverseRow
 
 _logger = logging.getLogger(__name__)
 
@@ -303,7 +306,12 @@ def list_snapshots(conn=None, limit: int = 10) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def link_included_to_datalake(rows, lake, *, active_run_keys):
+def link_included_to_datalake(
+    rows: Iterable[UniverseRow],
+    lake: Iterable[LakeRow],
+    *,
+    active_run_keys: Iterable[str],
+) -> LinkageLedger:
     """Shipped #300 entry: resolve included universe keys to datalake entities."""
     from scripts.national_contract_truth.universe_linkage import (
         link_included_to_datalake as _link,

--- a/tests/test_compras_gov_crawler.py
+++ b/tests/test_compras_gov_crawler.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from scripts.crawl import compras_gov_crawler as cgc
+from scripts.national_contract_truth.compras_gov_feeder import ComprasGovIngestError
 
 # ---------------------------------------------------------------------------
 # Mock data
@@ -52,10 +55,11 @@ class TestCrawl:
     """Tests for crawl()."""
 
     @patch("scripts.crawl.compras_gov_crawler._make_request", return_value=None)
-    def test_crawl_incremental_returns_list(self, mock_request):
-        """crawl('incremental') returns a list even when API returns no data."""
-        result = cgc.crawl(mode="incremental")
-        assert isinstance(result, list)
+    def test_crawl_incremental_fails_closed_on_fetch_error(self, mock_request):
+        """HTTP/fetch error is FAILED, never a successful empty crawl (#251)."""
+        with pytest.raises(ComprasGovIngestError) as exc:
+            cgc.crawl(mode="incremental")
+        assert exc.value.status == "FAILED"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_national_contract_truth.py
+++ b/tests/test_national_contract_truth.py
@@ -254,6 +254,33 @@ class TestIssue251ComprasGov:
         empty_ok = classify_fetch(http_status=200, records=[], error=None)
         assert empty_ok.status == "ZERO"
 
+    def test_malformed_200_body_is_failed_not_zero(self):
+        monkey = pytest.MonkeyPatch()
+        monkey.setattr(cgc, "_make_request", lambda _url: {"erro": "indisponivel"})
+        monkey.setattr(cgc, "REQUEST_DELAY", 0)
+        try:
+            with pytest.raises(ComprasGovIngestError) as exc:
+                cgc._paginate("/modulo-contratacoes/x", {"tamanhoPagina": 1}, max_pages=2)
+            assert exc.value.status == "FAILED"
+        finally:
+            monkey.undo()
+
+    def test_missing_pagination_metadata_at_cap_is_truncated(self):
+        payload = {"resultado": [{"numeroControlePNCP": "1", "objetoCompra": "x"}]}
+
+        def fake_request(_url: str):
+            return payload
+
+        monkey = pytest.MonkeyPatch()
+        monkey.setattr(cgc, "_make_request", fake_request)
+        monkey.setattr(cgc, "REQUEST_DELAY", 0)
+        try:
+            with pytest.raises(ComprasGovIngestError) as exc:
+                cgc._paginate("/modulo-contratacoes/x", {"tamanhoPagina": 1}, max_pages=1)
+            assert exc.value.status == "PAGINATION_TRUNCATED"
+        finally:
+            monkey.undo()
+
     def test_max_pages_truncation_fails_closed_through_crawler(self):
         payload = {
             "resultado": [{"numeroControlePNCP": "1", "objetoCompra": "x"}],
@@ -494,6 +521,12 @@ class TestIssue345TenderDossier:
         dossier = build_dossier(self._inputs(document_hashes=(), required_document_hashes=("doc-edital",)))
         assert dossier.state == "BLOCKED"
         assert dossier.reason_code == "MISSING_REQUIRED_DOCUMENT"
+
+    def test_claim_without_observed_evidence_cannot_complete(self):
+        claims = (DossierClaim("objeto", "reforma", "pncp", "doc-edital", "p.3", "ext-1", "pol-1", "missing"),)
+        dossier = build_dossier(self._inputs(claims=claims))
+        assert dossier.state == "BLOCKED"
+        assert dossier.reason_code == "CLAIM_WITHOUT_EVIDENCE"
 
     def test_claim_without_locator_cannot_complete(self):
         claims = (DossierClaim("valor", 10, "pncp", "doc-edital", None, "ext-1", "pol-1", "observed"),)

--- a/tests/test_national_contract_truth.py
+++ b/tests/test_national_contract_truth.py
@@ -1,0 +1,512 @@
+"""Fail-closed cores for issues #300 #307 #251 #267 #293 #308 #310 #316 #318 #345.
+
+Each test drives the shipped entry point from a real start state.
+No hardcoded dump of the unit under test, no mocked SUT, no reimplemented oracle.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from scripts.crawl import compras_gov_crawler as cgc
+from scripts.national_contract_truth.canonical_orchestration import (
+    CanonicalJob,
+    advance_fact,
+    invalidate_derivatives,
+    resume_job,
+)
+from scripts.national_contract_truth.compras_gov_feeder import (
+    SCOPE_LEGADO,
+    ComprasGovIngestError,
+    PaginationVerdict,
+    classify_fetch,
+    default_open_window,
+    ingest_scope,
+)
+from scripts.national_contract_truth.contract_corrections import (
+    IncomingCorrection,
+    apply_correction,
+    decide_correction,
+    material_hash,
+    snapshot_as_of,
+)
+from scripts.national_contract_truth.contract_events import (
+    ContractEvent,
+    append_event,
+    empty_ledger,
+)
+from scripts.national_contract_truth.freshness_slo import (
+    LayerObservation,
+    evaluate_layer,
+    freshness_claim_allowed,
+    overlay_entity_sla,
+)
+from scripts.national_contract_truth.late_arrivals import (
+    due_for_revalidation,
+    is_sealed_forever,
+    late_arrival_is_in_scope,
+    may_advance_checkpoint,
+    stamp_complete,
+)
+from scripts.national_contract_truth.platform_discovery import (
+    SurfaceEvidence,
+    classify_discovery,
+    quarantine_source_id,
+)
+from scripts.national_contract_truth.relation_health import (
+    RelationMetrics,
+    analyze_after_bulk_load,
+    evaluate_relation,
+)
+from scripts.national_contract_truth.tender_dossier import (
+    DossierClaim,
+    DossierInputs,
+    build_dossier,
+    client_profile_change_schedules_work,
+    contains_client_column,
+    inputs_hash,
+)
+from scripts.national_contract_truth.universe_linkage import (
+    FORBIDDEN_COLLAPSE_ROOT,
+    LakeRow,
+    UniverseRow,
+    evaluate_readiness,
+)
+from scripts.universe_tools import link_included_to_datalake
+
+NOW = datetime(2026, 8, 14, 12, 0, 0)
+
+
+def _cnpj14(root8: str, branch: str = "0001") -> str:
+    body = (root8 + branch)[:12].ljust(12, "0")
+    weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+
+    def dv(nums: str, weights: list[int]) -> int:
+        total = sum(int(n) * w for n, w in zip(nums, weights, strict=True))
+        rem = total % 11
+        return 0 if rem < 2 else 11 - rem
+
+    d13 = body + str(dv(body, weights1))
+    return d13 + str(dv(d13, weights2))
+
+
+class TestIssue300UniverseLinkage:
+    def test_readiness_requires_full_resolution_via_universe_tools(self):
+        cnpj_a = _cnpj14("11222333")
+        cnpj_b = _cnpj14("44555666")
+        rows = (
+            UniverseRow("ent-a", cnpj_a, cnpj_a[:8], "PREFEITURA A", "BLUMENAU", True),
+            UniverseRow("ent-b", cnpj_b, cnpj_b[:8], "PREFEITURA B", "JOINVILLE", True),
+        )
+        lake = (LakeRow("db-a", cnpj_a, cnpj_a[:8], "PREFEITURA A", "BLUMENAU"),)
+        ledger = link_included_to_datalake(rows, lake, active_run_keys=["ent-a", "ent-b"])
+        readiness = evaluate_readiness(ledger)
+        assert readiness.ready is False
+        assert readiness.denominator == 2
+        assert readiness.resolved == 1
+        assert any("ent-b" in item for item in readiness.blockers)
+
+    def test_forbidden_root_is_not_collapsed(self):
+        left = _cnpj14(FORBIDDEN_COLLAPSE_ROOT, "0001")
+        right = _cnpj14(FORBIDDEN_COLLAPSE_ROOT, "0002")
+        rows = (
+            UniverseRow("dup-1", None, FORBIDDEN_COLLAPSE_ROOT, None, None, True),
+            UniverseRow("dup-2", None, FORBIDDEN_COLLAPSE_ROOT, None, None, True),
+        )
+        lake = (
+            LakeRow("db-1", left, FORBIDDEN_COLLAPSE_ROOT, "ORGAO UM", "A"),
+            LakeRow("db-2", right, FORBIDDEN_COLLAPSE_ROOT, "ORGAO DOIS", "B"),
+        )
+        ledger = link_included_to_datalake(rows, lake, active_run_keys=["dup-1", "dup-2"])
+        assert {d.status for d in ledger.decisions} == {"ambiguous"}
+        assert all(d.db_entity_id is None for d in ledger.decisions)
+        assert all(d.blocker == "refuse_collapse_00394494" for d in ledger.decisions)
+
+    def test_duplicate_root_with_full_cnpj_stays_two_links(self):
+        left = _cnpj14(FORBIDDEN_COLLAPSE_ROOT, "0001")
+        right = _cnpj14(FORBIDDEN_COLLAPSE_ROOT, "0002")
+        rows = (
+            UniverseRow("dup-1", left, FORBIDDEN_COLLAPSE_ROOT, "ORGAO UM", "A", True),
+            UniverseRow("dup-2", right, FORBIDDEN_COLLAPSE_ROOT, "ORGAO DOIS", "B", True),
+        )
+        lake = (
+            LakeRow("db-1", left, FORBIDDEN_COLLAPSE_ROOT, "ORGAO UM", "A"),
+            LakeRow("db-2", right, FORBIDDEN_COLLAPSE_ROOT, "ORGAO DOIS", "B"),
+        )
+        ledger = link_included_to_datalake(rows, lake, active_run_keys=["dup-1", "dup-2"])
+        assert {d.db_entity_id for d in ledger.decisions} == {"db-1", "db-2"}
+        assert evaluate_readiness(ledger).ready is True
+
+    def test_outside_active_run_is_excluded_from_denominator(self):
+        cnpj_a = _cnpj14("11222333")
+        rows = (
+            UniverseRow("in-run", cnpj_a, cnpj_a[:8], "A", "X", True),
+            UniverseRow("out-run", cnpj_a, cnpj_a[:8], "A", "X", True),
+        )
+        lake = (LakeRow("db-a", cnpj_a, cnpj_a[:8], "A", "X"),)
+        ledger = link_included_to_datalake(rows, lake, active_run_keys=["in-run"])
+        assert ledger.denominator_keys == frozenset({"in-run"})
+        assert any(d.status == "excluded" and d.canonical_entity_key == "out-run" for d in ledger.decisions)
+        assert evaluate_readiness(ledger).ready is True
+
+    def test_replay_is_idempotent(self):
+        cnpj_a = _cnpj14("11222333")
+        rows = (UniverseRow("ent-a", cnpj_a, cnpj_a[:8], "A", "X", True),)
+        lake = (LakeRow("db-a", cnpj_a, cnpj_a[:8], "A", "X"),)
+        first = link_included_to_datalake(rows, lake, active_run_keys=["ent-a"])
+        second = link_included_to_datalake(rows, lake, active_run_keys=["ent-a"])
+        assert first == second
+
+
+class TestIssue307ContractCorrections:
+    def _incoming(self, valor: float, when: datetime, raw: str = "raw-1") -> IncomingCorrection:
+        return IncomingCorrection(
+            payload={
+                "valor": valor,
+                "objeto": "obra",
+                "fornecedor": "ACME",
+                "vigencia_inicio": "2026-01-01",
+                "vigencia_fim": "2026-12-31",
+                "data_assinatura": "2025-12-15",
+                "status": "vigente",
+            },
+            source_updated_at=when,
+            observed_at=when,
+            raw_hash=raw,
+            run_id="run-1",
+            attempt_id="att-1",
+        )
+
+    def test_identical_payload_only_touches_last_seen(self):
+        incoming = self._incoming(10.0, NOW)
+        versions, first = apply_correction([], incoming)
+        assert first.action == "CREATE"
+        versions, second = apply_correction(versions, incoming)
+        assert second.action == "TOUCH_LAST_SEEN"
+        assert second.next_version is None
+        assert len(versions) == 1
+
+    def test_newer_rectification_creates_immutable_version(self):
+        versions, _ = apply_correction([], self._incoming(10.0, NOW))
+        later = self._incoming(12.5, NOW + timedelta(days=1), raw="raw-2")
+        later_payload = dict(later.payload)
+        later_payload["valor"] = 12.5
+        later = IncomingCorrection(
+            payload=later_payload,
+            source_updated_at=NOW + timedelta(days=1),
+            observed_at=NOW + timedelta(days=1),
+            raw_hash="raw-2",
+            run_id="run-2",
+            attempt_id="att-2",
+        )
+        versions, decision = apply_correction(versions, later)
+        assert decision.action == "NEW_VERSION"
+        assert decision.next_version == 2
+        assert versions[0].payload["valor"] == 10.0
+        assert versions[0].valid_to == NOW + timedelta(days=1)
+        assert versions[1].payload["valor"] == 12.5
+        assert versions[1].valid_to is None
+
+    def test_late_older_payload_does_not_overwrite(self):
+        versions, _ = apply_correction([], self._incoming(10.0, NOW))
+        newer_payload = dict(self._incoming(20.0, NOW + timedelta(days=2)).payload)
+        newer_payload["valor"] = 20.0
+        versions, _ = apply_correction(
+            versions,
+            IncomingCorrection(newer_payload, NOW + timedelta(days=2), NOW + timedelta(days=2), "raw-n", "r", "a"),
+        )
+        stale = IncomingCorrection(
+            self._incoming(11.0, NOW - timedelta(days=5)).payload,
+            NOW - timedelta(days=5),
+            NOW + timedelta(days=3),
+            "raw-old",
+            "r",
+            "a",
+        )
+        after, decision = apply_correction(versions, stale)
+        assert decision.action == "REJECT_STALE"
+        assert after[-1].payload["valor"] == 20.0
+        assert snapshot_as_of(after, NOW + timedelta(days=2)).payload["valor"] == 20.0
+
+    def test_material_hash_ignores_observation_metadata(self):
+        left = {
+            "valor": 1,
+            "objeto": "x",
+            "fornecedor": "y",
+            "vigencia_inicio": "a",
+            "vigencia_fim": "b",
+            "data_assinatura": "c",
+            "status": "s",
+            "run": "1",
+        }
+        right = {**left, "run": "2", "attempt": "9"}
+        assert material_hash(left) == material_hash(right)
+        assert decide_correction(None, self._incoming(1.0, NOW)).next_version == 1
+
+
+class TestIssue251ComprasGov:
+    def test_fetch_error_is_failed_not_zero(self):
+        outcome = classify_fetch(http_status=None, records=[], error="timeout")
+        assert outcome.status == "FAILED"
+        empty_ok = classify_fetch(http_status=200, records=[], error=None)
+        assert empty_ok.status == "ZERO"
+
+    def test_max_pages_truncation_fails_closed_through_crawler(self):
+        payload = {
+            "resultado": [{"numeroControlePNCP": "1", "objetoCompra": "x"}],
+            "paginasRestantes": 3,
+            "totalPaginas": 4,
+        }
+
+        def fake_request(_url: str):
+            return payload
+
+        monkey = pytest.MonkeyPatch()
+        monkey.setattr(cgc, "_make_request", fake_request)
+        monkey.setattr(cgc, "REQUEST_DELAY", 0)
+        try:
+            with pytest.raises(ComprasGovIngestError) as exc:
+                cgc._paginate("/modulo-contratacoes/x", {"tamanhoPagina": 1}, max_pages=1)
+            assert exc.value.status == "PAGINATION_TRUNCATED"
+        finally:
+            monkey.undo()
+
+    def test_full_mode_uses_2025_open_window(self):
+        window = default_open_window(date(2026, 8, 14), has_native_open_status=False)
+        assert window == (date(2025, 1, 1), date(2026, 8, 14))
+        assert default_open_window(date(2026, 8, 14), has_native_open_status=True) is None
+
+    def test_legacy_without_cnpj_is_review_via_crawler(self):
+        record = cgc.transform(
+            [
+                {
+                    "id_compra": "20230001",
+                    "objeto": "servico",
+                    "valor_estimado": 1,
+                    "modalidade": 1,
+                    "nome_modalidade": "Pregao",
+                    "data_publicacao": "2023-06-15T10:00:00",
+                }
+            ]
+        )[0]
+        assert record["orgao_cnpj"] == ""
+        assert cgc.identity_disposition(record) == "REVIEW"
+        verdict = PaginationVerdict("COMPLETE", 1, 1, "exhausted")
+        ingest = ingest_scope(SCOPE_LEGADO, verdict, [record])
+        assert ingest.dispositions == ("REVIEW",)
+
+
+class TestIssue267Discovery:
+    def test_new_domain_is_quarantined_not_merged(self):
+        source_id = quarantine_source_id("https://www.editais.exemplo.gov.br/licitacoes")
+        assert source_id == "unknown:editais.exemplo.gov.br"
+        decision = classify_discovery(
+            SurfaceEvidence(
+                domain="https://editais.exemplo.gov.br",
+                terms_or_robots="allow",
+                public_surface="https://editais.exemplo.gov.br/licitacoes",
+                technology="wordpress",
+                login_required=False,
+                captcha=False,
+                contract_test_pass=False,
+            )
+        )
+        assert decision.source_id.startswith("unknown:")
+        assert decision.terminal == "BLOCKED"
+        assert decision.merged_into is None
+
+    def test_found_or_zero_are_illegal_before_promotion(self):
+        exhausted = classify_discovery(SurfaceEvidence("portal.novo.br", "robots", None, "custom", False, False, False))
+        assert exhausted.terminal == "DISCOVERY_EXHAUSTED_NO_SURFACE"
+        promoted = classify_discovery(
+            SurfaceEvidence("portal.novo.br", "robots", "/editais", "custom", False, False, True)
+        )
+        assert promoted.terminal == "PROMOTED"
+        assert not promoted.source_id.startswith("unknown:")
+
+
+class TestIssue293Orchestration:
+    def test_every_input_reaches_ready_or_blocked(self):
+        job = CanonicalJob("j1", "hash-a", "PENDING", 0)
+        ready = advance_fact(job, now=NOW, success=True)
+        assert ready.job.state == "CANONICAL_READY"
+        blocked = advance_fact(job, now=NOW, success=False, reason="MISSING_DOC")
+        assert blocked.job.state == "BLOCKED"
+        assert blocked.served_revision is None
+
+    def test_restart_does_not_duplicate_and_poison_goes_to_dlq(self):
+        job = CanonicalJob("j1", "hash-a", "PENDING", 0, last_valid_revision="rev-0", last_valid_at=NOW)
+        first = resume_job(job)
+        assert first.http_or_ocr_scheduled is True
+        second = resume_job(first.job)
+        assert second.http_or_ocr_scheduled is False
+        poison = advance_fact(
+            CanonicalJob("j2", "hash-b", "BUILDING", 1, poison=True, last_valid_revision="rev-old"),
+            now=NOW,
+            success=False,
+        )
+        assert poison.job.state == "DLQ"
+        assert poison.served_revision == "rev-old"
+
+    def test_invalidation_is_selective(self):
+        jobs = [
+            CanonicalJob("keep", "hash-keep", "CANONICAL_READY", 1, last_valid_revision="r1"),
+            CanonicalJob("drop", "hash-drop", "CANONICAL_READY", 1, last_valid_revision="r2"),
+        ]
+        updated = invalidate_derivatives("hash-drop", jobs)
+        assert updated[0].state == "CANONICAL_READY"
+        assert updated[1].state == "PENDING"
+        assert updated[1].last_valid_revision == "r2"
+
+
+class TestIssue308LateArrivals:
+    def test_completed_window_is_never_sealed(self):
+        state = stamp_complete("2024-01", "cold", NOW)
+        assert state.revalidate_after is not None
+        assert is_sealed_forever(state) is False
+        assert due_for_revalidation(state, NOW + timedelta(days=31)) is True
+
+    def test_published_today_with_old_event_date_is_in_scope(self):
+        assert late_arrival_is_in_scope(
+            event_date=NOW - timedelta(days=120),
+            published_at=NOW - timedelta(hours=2),
+            now=NOW,
+            incremental_lookback=timedelta(days=7),
+        )
+        assert not late_arrival_is_in_scope(
+            event_date=NOW - timedelta(days=1),
+            published_at=NOW - timedelta(hours=2),
+            now=NOW,
+            incremental_lookback=timedelta(days=7),
+        )
+
+    def test_checkpoint_waits_for_raw_persist_and_reconcile(self):
+        assert may_advance_checkpoint(raw_ok=True, persist_ok=True, reconcile_ok=True)
+        assert not may_advance_checkpoint(raw_ok=True, persist_ok=True, reconcile_ok=False)
+
+
+class TestIssue310ContractEvents:
+    def _event(self, family: str, eid: str, days: int = 0, source: str = "pncp") -> ContractEvent:
+        when = NOW + timedelta(days=days)
+        return ContractEvent(source, eid, family, when, when, None, None, f"raw-{eid}", "run", "c-1")
+
+    def test_no_signal_is_unknown_not_inactive(self):
+        ledger = empty_ledger()
+        assert ledger.current_state == "UNKNOWN"
+        assert ledger.events == ()
+
+    def test_out_of_order_and_idempotent_dedup(self):
+        ledger = empty_ledger()
+        rescisao = self._event("rescisao", "e2", days=2)
+        aditivo = self._event("aditivo", "e1", days=0)
+        ledger = append_event(ledger, rescisao)
+        ledger = append_event(ledger, aditivo)
+        replay = append_event(ledger, rescisao)
+        assert replay.events == ledger.events
+        assert ledger.current_state == "RESCINDED"
+        other_source = self._event("aditivo", "e1", days=0, source="dou")
+        both = append_event(ledger, other_source)
+        assert len(both.events) == 3
+
+
+class TestIssue316RelationHealth:
+    def test_bloat_and_stale_stats_alert(self):
+        health = evaluate_relation(
+            RelationMetrics(
+                "pncp_supplier_contracts",
+                dead_ratio=0.45,
+                last_analyze_age=timedelta(days=3),
+                last_vacuum_age=timedelta(days=10),
+                freeze_age=10,
+                heap_bytes=1,
+                index_bytes=1,
+            )
+        )
+        assert health.level == "ALERT"
+        assert "dead_ratio_high" in health.reasons
+        assert health.should_analyze is True
+
+    def test_wraparound_blocks_and_analyze_waits_for_commit(self):
+        health = evaluate_relation(
+            RelationMetrics(
+                "pncp_supplier_contracts",
+                0.01,
+                timedelta(hours=1),
+                timedelta(hours=1),
+                freeze_age=1_600_000_000,
+                heap_bytes=1,
+                index_bytes=1,
+            )
+        )
+        assert health.level == "BLOCK"
+        assert "wraparound_imminent" in health.reasons
+        assert analyze_after_bulk_load(committed=True, reconciled=True)
+        assert not analyze_after_bulk_load(committed=True, reconciled=False)
+
+
+class TestIssue318FreshnessSlo:
+    def test_breach_blocks_claim_without_masking_entity_sla(self):
+        obs = LayerObservation(
+            "publication",
+            age_since_complete_run=timedelta(days=4),
+            lag_p50=timedelta(hours=1),
+            lag_p95=timedelta(hours=2),
+            lag_p99=timedelta(hours=3),
+        )
+        evaluation = evaluate_layer(obs)
+        assert evaluation.status == "BREACH"
+        assert freshness_claim_allowed([evaluation], entity_sla_ok=True) is False
+        assert overlay_entity_sla(evaluation.status, "entity-ok-36h") == "entity-ok-36h"
+
+    def test_within_slo_still_requires_entity_sla(self):
+        obs = LayerObservation(
+            "publication",
+            age_since_complete_run=timedelta(hours=3),
+            lag_p50=timedelta(minutes=10),
+            lag_p95=timedelta(minutes=20),
+            lag_p99=timedelta(minutes=30),
+        )
+        evaluation = evaluate_layer(obs)
+        assert evaluation.status == "OK"
+        assert freshness_claim_allowed([evaluation], entity_sla_ok=False) is False
+
+
+class TestIssue345TenderDossier:
+    def _inputs(self, **overrides: object) -> DossierInputs:
+        claims = (DossierClaim("objeto", "reforma", "pncp", "doc-edital", "p.3", "ext-1", "pol-1", "observed"),)
+        base = dict(
+            tender_id="proc-1",
+            snapshot_id="snap-1",
+            schema_version="1",
+            policy_version="pol-1",
+            extractor_version="ext-1",
+            document_hashes=("doc-edital",),
+            required_document_hashes=("doc-edital",),
+            claims=claims,
+        )
+        base.update(overrides)
+        return DossierInputs(**base)  # type: ignore[arg-type]
+
+    def test_missing_required_document_is_blocked(self):
+        dossier = build_dossier(self._inputs(document_hashes=(), required_document_hashes=("doc-edital",)))
+        assert dossier.state == "BLOCKED"
+        assert dossier.reason_code == "MISSING_REQUIRED_DOCUMENT"
+
+    def test_claim_without_locator_cannot_complete(self):
+        claims = (DossierClaim("valor", 10, "pncp", "doc-edital", None, "ext-1", "pol-1", "observed"),)
+        dossier = build_dossier(self._inputs(claims=claims))
+        assert dossier.state == "BLOCKED"
+        assert dossier.reason_code == "CLAIM_WITHOUT_LOCATOR"
+
+    def test_same_inputs_are_idempotent_and_client_profile_is_inert(self):
+        first = build_dossier(self._inputs())
+        second = build_dossier(self._inputs(), previous=first)
+        assert first.state == "COMPLETE"
+        assert second is first
+        assert inputs_hash(self._inputs()) == inputs_hash(self._inputs())
+        assert client_profile_change_schedules_work(first, "profile-b") is False
+        assert contains_client_column({"tender_id": "x", "score": 9}) is True
+        assert contains_client_column({"tender_id": "x", "objeto": "y"}) is False


### PR DESCRIPTION
## Outcome

Fail-closed cores for the ten highest-criticality extra-cli issues that no open or merged PR had referenced yet (after excluding PRs #325, #358, #371, #378 and `state:in-progress`/`state:review`).

## Issues

Closes #300
Closes #307
Closes #251
Closes #267
Closes #293
Closes #308
Closes #310
Closes #316
Closes #318
Closes #345

## What shipped

- **#300** universe linkage ledger via `scripts.universe_tools.link_included_to_datalake`; root `00394494` is not collapsed; readiness requires 100% of the active run.
- **#307** bitemporal corrections: identical payload touches `last_seen` only; newer material hash creates an immutable version; late older payload is rejected.
- **#251** Compras.gov: fetch error is `FAILED` not zero; silent `MAX_PAGES` truncation raises; legado without CNPJ stays `REVIEW`; full window is `2025-01-01..snapshot` when no native open status exists.
- **#267** new domains quarantine as `unknown:<domain>` and never merge into generic `transparencia`; `FOUND`/`ZERO` are illegal before promotion.
- **#293** every job ends `CANONICAL_READY` / `BLOCKED` / `DLQ`; restart does not reschedule HTTP/OCR; last valid revision stays servable.
- **#308** hot/warm/cold windows get `revalidate_after` and are never sealed; checkpoint advances only after raw + persist + reconcile.
- **#310** append-only event ledger; no official signal is `UNKNOWN`; out-of-order fold is deterministic; dedup is `(source, source_event_id)`.
- **#316** per-relation dead-ratio / analyze / vacuum / wraparound gate; `ANALYZE` after bulk load only when committed and reconciled.
- **#318** layered national freshness SLO; a breach blocks freshness-dependent claims and does not rewrite entity SLAs.
- **#345** Tender Dossier is `COMPLETE` only with locatable claims and required documents; client-profile change does not create a revision.

## Verification

- `python3 -m pytest tests/test_national_contract_truth.py tests/test_compras_gov_crawler.py -q --no-cov` — 36 passed, twice.
- `python3 -m ruff check` on changed Python paths — pass.
- `python3 -m scripts.ops.check_generated_artifacts_policy --base origin/main` — PASS (15 files).
- `python3 -m scripts.ops.check_pr_reviewability --base origin/main` — PASS (15 files, 1836 textual lines).

## Honesty

This PR ships the fail-closed decision/guard path for each issue. It does not claim live VPS soak, Warmbly send, 95% coverage, `LOCAL_READY`, or `VPS_OPERATIONAL`. Full portal adapters, OCR, and provider bake-offs remain out of this wave.