### PR TITLE
feat(inference): provider-agnostic durable jobs (#347)

### DIFF
--- a/scripts/inference_runtime/__init__.py
+++ b/scripts/inference_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-agnostic durable inference jobs (#347)."""

--- a/scripts/inference_runtime/jobs.py
+++ b/scripts/inference_runtime/jobs.py
@@ -257,6 +257,9 @@ class JobStore:
 
 
 def submit(store: JobStore, spec: JobSpec, *, job_id: str) -> InferenceJob:
+    existing_id = store.by_idempotency.get(spec.key)
+    if existing_id is not None:
+        return store.get(existing_id)
     queued = InferenceJob(
         job_id=job_id,
         idempotency_key=spec.key,

--- a/scripts/inference_runtime/jobs.py
+++ b/scripts/inference_runtime/jobs.py
@@ -1,0 +1,443 @@
+"""#347 — asynchronous, auditable, provider-agnostic inference jobs.
+
+Domain contract is independent of OpenAI/Anthropic/DeepSeek/Gemini/Bedrock.
+A job survives restart and ends SUCCEEDED, BLOCKED or DLQ. Invalid schema,
+missing evidence or low confidence never promote a fact into a dossier.
+
+This is the durable job contract. It does not migrate to Bedrock, run a
+provider bake-off, or authorize human GO.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, Literal, Protocol
+
+SCHEMA_VERSION = "inference-job/1.0"
+TERMINAL: frozenset[str] = frozenset({"SUCCEEDED", "BLOCKED", "DLQ"})
+JobState = Literal["QUEUED", "RUNNING", "SUCCEEDED", "BLOCKED", "DLQ"]
+
+DEFAULT_CONFIDENCE_GATE = 0.70
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_BUDGET_TOKENS = 8_000
+
+
+class InferenceRuntimeError(ValueError):
+    """Fail-closed inference contract error."""
+
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_payload(obj: Any) -> str:
+    return hashlib.sha256(_canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+def idempotency_key(
+    *,
+    input_hash: str,
+    task: str,
+    prompt_version: str,
+    schema_version: str,
+    policy_version: str,
+) -> str:
+    if not all((input_hash, task, prompt_version, schema_version, policy_version)):
+        raise InferenceRuntimeError("idempotency material is incomplete")
+    return sha256_payload(
+        {
+            "input_hash": input_hash,
+            "task": task,
+            "prompt_version": prompt_version,
+            "schema_version": schema_version,
+            "policy_version": policy_version,
+        }
+    )
+
+
+@dataclass(frozen=True)
+class EvidenceLocator:
+    document_id: str
+    chunk_id: str | None = None
+    locator: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    task: str
+    input_payload: dict[str, Any]
+    output_schema: dict[str, Any]
+    prompt_version: str
+    schema_version: str
+    policy_version: str
+    confidence_gate: float = DEFAULT_CONFIDENCE_GATE
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS
+    budget_tokens: int = DEFAULT_BUDGET_TOKENS
+
+    @property
+    def input_hash(self) -> str:
+        return sha256_payload(self.input_payload)
+
+    @property
+    def key(self) -> str:
+        return idempotency_key(
+            input_hash=self.input_hash,
+            task=self.task,
+            prompt_version=self.prompt_version,
+            schema_version=self.schema_version,
+            policy_version=self.policy_version,
+        )
+
+
+@dataclass(frozen=True)
+class Attempt:
+    attempt_no: int
+    provider: str
+    model: str
+    prompt_version: str
+    schema_version: str
+    policy_version: str
+    status: Literal["SUCCEEDED", "FAILED", "TIMEOUT", "RATE_LIMITED", "UNAVAILABLE"]
+    tokens_in: int
+    tokens_out: int
+    cost_usd: float
+    latency_ms: int
+    fallback_reason: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InferenceJob:
+    job_id: str
+    idempotency_key: str
+    spec: JobSpec
+    state: JobState
+    attempts: tuple[Attempt, ...] = ()
+    output: dict[str, Any] | None = None
+    evidence: tuple[EvidenceLocator, ...] = ()
+    confidence: float | None = None
+    blocker: str | None = None
+    next_action: str | None = None
+    promoted: bool = False
+    revision: int = 0
+    tokens_used: int = 0
+    cost_usd: float = 0.0
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "job_id": self.job_id,
+            "idempotency_key": self.idempotency_key,
+            "state": self.state,
+            "attempts": [a.as_dict() for a in self.attempts],
+            "output": self.output,
+            "evidence": [e.as_dict() for e in self.evidence],
+            "confidence": self.confidence,
+            "blocker": self.blocker,
+            "next_action": self.next_action,
+            "promoted": self.promoted,
+            "revision": self.revision,
+            "tokens_used": self.tokens_used,
+            "cost_usd": self.cost_usd,
+            "provider_contract": "agnostic",
+        }
+
+
+class Provider(Protocol):
+    name: str
+    model: str
+
+    def infer(self, spec: JobSpec) -> dict[str, Any]:
+        """Return output, evidence, confidence, usage. May raise ProviderError."""
+
+
+class ProviderError(RuntimeError):
+    def __init__(self, status: str, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+class FakeProvider:
+    """Deterministic in-process provider for contract tests."""
+
+    name = "fake"
+    model = "fake-extract-v1"
+
+    def __init__(self, *, output: dict[str, Any] | None = None, fail: str | None = None) -> None:
+        self._output = output
+        self._fail = fail
+
+    def infer(self, spec: JobSpec) -> dict[str, Any]:
+        if self._fail:
+            raise ProviderError(self._fail, f"fake provider {self._fail}")
+        if self._output is not None:
+            return dict(self._output)
+        return {
+            "output": {"summary": spec.input_payload.get("text", ""), "task": spec.task},
+            "evidence": [{"document_id": "doc-1", "chunk_id": "c0", "locator": "p1"}],
+            "confidence": 0.91,
+            "tokens_in": 12,
+            "tokens_out": 8,
+            "cost_usd": 0.0,
+            "latency_ms": 4,
+        }
+
+
+class EchoProvider:
+    """Second opt-in adapter. Same domain contract, different provider name."""
+
+    name = "echo"
+    model = "echo-v1"
+
+    def infer(self, spec: JobSpec) -> dict[str, Any]:
+        return {
+            "output": {"echo": spec.input_payload, "task": spec.task},
+            "evidence": [{"document_id": "doc-echo", "locator": "body"}],
+            "confidence": 0.80,
+            "tokens_in": 6,
+            "tokens_out": 6,
+            "cost_usd": 0.0,
+            "latency_ms": 1,
+        }
+
+
+def validate_against_schema(output: dict[str, Any], schema: dict[str, Any]) -> tuple[bool, str | None]:
+    """Minimal required-object schema check. Missing required fields fail closed."""
+    if schema.get("type", "object") != "object":
+        return False, "schema_type_not_object"
+    if not isinstance(output, dict):
+        return False, "output_not_object"
+    required = schema.get("required") or []
+    for key in required:
+        if key not in output:
+            return False, f"missing_required:{key}"
+    properties = schema.get("properties") or {}
+    for key, value in output.items():
+        declared = properties.get(key)
+        if declared is None:
+            continue
+        expected = declared.get("type")
+        if expected == "string" and not isinstance(value, str):
+            return False, f"type:{key}:string"
+        if expected == "number" and not isinstance(value, (int, float)):
+            return False, f"type:{key}:number"
+        if expected == "object" and not isinstance(value, dict):
+            return False, f"type:{key}:object"
+        if expected == "array" and not isinstance(value, list):
+            return False, f"type:{key}:array"
+    return True, None
+
+
+@dataclass
+class JobStore:
+    """In-memory durable store used by tests and as the persist contract."""
+
+    jobs: dict[str, InferenceJob] = field(default_factory=dict)
+    by_idempotency: dict[str, str] = field(default_factory=dict)
+
+    def put(self, job: InferenceJob) -> InferenceJob:
+        existing_id = self.by_idempotency.get(job.idempotency_key)
+        if existing_id is not None and existing_id != job.job_id:
+            return self.jobs[existing_id]
+        self.jobs[job.job_id] = job
+        self.by_idempotency[job.idempotency_key] = job.job_id
+        return job
+
+    def get(self, job_id: str) -> InferenceJob:
+        return self.jobs[job_id]
+
+
+def submit(store: JobStore, spec: JobSpec, *, job_id: str) -> InferenceJob:
+    queued = InferenceJob(
+        job_id=job_id,
+        idempotency_key=spec.key,
+        spec=spec,
+        state="QUEUED",
+    )
+    return store.put(queued)
+
+
+def _park(job: InferenceJob, state: JobState, blocker: str, next_action: str) -> InferenceJob:
+    return replace(
+        job,
+        state=state,
+        blocker=blocker,
+        next_action=next_action,
+        promoted=False,
+    )
+
+
+def run_job(store: JobStore, job_id: str, provider: Provider) -> InferenceJob:
+    job = store.get(job_id)
+    if job.state in TERMINAL:
+        return job
+    if job.tokens_used >= job.spec.budget_tokens:
+        parked = _park(job, "BLOCKED", "BUDGET_EXHAUSTED", "raise budget or shrink input")
+        return store.put(parked)
+
+    running = replace(job, state="RUNNING")
+    store.put(running)
+    attempt_no = len(running.attempts) + 1
+    try:
+        raw = provider.infer(running.spec)
+        attempt = Attempt(
+            attempt_no=attempt_no,
+            provider=provider.name,
+            model=provider.model,
+            prompt_version=running.spec.prompt_version,
+            schema_version=running.spec.schema_version,
+            policy_version=running.spec.policy_version,
+            status="SUCCEEDED",
+            tokens_in=int(raw.get("tokens_in") or 0),
+            tokens_out=int(raw.get("tokens_out") or 0),
+            cost_usd=float(raw.get("cost_usd") or 0.0),
+            latency_ms=int(raw.get("latency_ms") or 0),
+        )
+        output = raw.get("output")
+        if not isinstance(output, dict):
+            done = _park(
+                replace(running, attempts=running.attempts + (attempt,)),
+                "BLOCKED",
+                "OUTPUT_NOT_OBJECT",
+                "repair provider adapter; do not promote",
+            )
+            return store.put(done)
+        ok, reason = validate_against_schema(output, running.spec.output_schema)
+        locators = tuple(
+            EvidenceLocator(
+                document_id=str(item["document_id"]),
+                chunk_id=item.get("chunk_id"),
+                locator=item.get("locator"),
+            )
+            for item in (raw.get("evidence") or [])
+            if isinstance(item, dict) and item.get("document_id")
+        )
+        confidence = raw.get("confidence")
+        tokens = running.tokens_used + attempt.tokens_in + attempt.tokens_out
+        cost = running.cost_usd + attempt.cost_usd
+        updated = replace(
+            running,
+            attempts=running.attempts + (attempt,),
+            tokens_used=tokens,
+            cost_usd=cost,
+        )
+        if not ok:
+            return store.put(
+                _park(updated, "BLOCKED", f"SCHEMA_INVALID:{reason}", "reject output; do not write dossier fact")
+            )
+        if not locators:
+            return store.put(
+                _park(updated, "BLOCKED", "MISSING_EVIDENCE", "link document locators before promotion")
+            )
+        if confidence is None or float(confidence) < running.spec.confidence_gate:
+            return store.put(
+                _park(updated, "BLOCKED", "CONFIDENCE_GATE", "human review or richer evidence")
+            )
+        succeeded = replace(
+            updated,
+            state="SUCCEEDED",
+            output=output,
+            evidence=locators,
+            confidence=float(confidence),
+            blocker=None,
+            next_action=None,
+            promoted=True,
+            revision=updated.revision + 1,
+        )
+        return store.put(succeeded)
+    except ProviderError as exc:
+        status = exc.status if exc.status in {"FAILED", "TIMEOUT", "RATE_LIMITED", "UNAVAILABLE"} else "FAILED"
+        attempt = Attempt(
+            attempt_no=attempt_no,
+            provider=provider.name,
+            model=provider.model,
+            prompt_version=running.spec.prompt_version,
+            schema_version=running.spec.schema_version,
+            policy_version=running.spec.policy_version,
+            status=status,  # type: ignore[arg-type]
+            tokens_in=0,
+            tokens_out=0,
+            cost_usd=0.0,
+            latency_ms=0,
+            error=exc.message,
+            fallback_reason=status,
+        )
+        updated = replace(running, attempts=running.attempts + (attempt,))
+        if attempt_no >= running.spec.max_attempts or status == "UNAVAILABLE":
+            state: JobState = "DLQ" if status in {"UNAVAILABLE", "FAILED"} and attempt_no >= running.spec.max_attempts else "BLOCKED"
+            if status == "UNAVAILABLE":
+                state = "BLOCKED"
+            parked = _park(
+                updated,
+                state,
+                f"PROVIDER_{status}",
+                "retry with fallback provider or park for operator",
+            )
+            return store.put(parked)
+        queued = replace(updated, state="QUEUED", blocker=f"PROVIDER_{status}", next_action="retry")
+        return store.put(queued)
+
+
+def restart(store: JobStore, job_id: str) -> InferenceJob:
+    """Process restart: persisted job is unchanged; terminal jobs stay terminal."""
+    return store.get(job_id)
+
+
+def replay(store: JobStore, job_id: str, provider: Provider) -> InferenceJob:
+    """Replay preserves the previous result and creates a new auditable revision."""
+    job = store.get(job_id)
+    if job.state != "SUCCEEDED" or job.output is None:
+        raise InferenceRuntimeError("replay requires a previously succeeded job")
+    previous = job
+    reset = replace(job, state="QUEUED", promoted=False)
+    store.put(reset)
+    rerun = run_job(store, job_id, provider)
+    if rerun.state == "SUCCEEDED":
+        return store.put(replace(rerun, revision=previous.revision + 1, output=rerun.output))
+    # Failed replay keeps the last valid output servable.
+    return store.put(
+        replace(
+            rerun,
+            output=previous.output,
+            evidence=previous.evidence,
+            confidence=previous.confidence,
+            revision=previous.revision,
+            promoted=False,
+        )
+    )
+
+
+def job_ledger(job: InferenceJob) -> dict[str, Any]:
+    """Queryable per-job audit: tokens, cost, versions, latency, attempts."""
+    return {
+        "job_id": job.job_id,
+        "state": job.state,
+        "provider_attempts": [
+            {
+                "provider": a.provider,
+                "model": a.model,
+                "prompt_version": a.prompt_version,
+                "schema_version": a.schema_version,
+                "policy_version": a.policy_version,
+                "tokens_in": a.tokens_in,
+                "tokens_out": a.tokens_out,
+                "cost_usd": a.cost_usd,
+                "latency_ms": a.latency_ms,
+                "status": a.status,
+                "fallback_reason": a.fallback_reason,
+            }
+            for a in job.attempts
+        ],
+        "tokens_used": job.tokens_used,
+        "cost_usd": job.cost_usd,
+        "promoted": job.promoted,
+    }

--- a/tests/test_inference_runtime.py
+++ b/tests/test_inference_runtime.py
@@ -67,6 +67,12 @@ def test_same_idempotency_key_does_not_duplicate_promoted_output() -> None:
     again = run_job(store, "job-a", FakeProvider())
     assert len(again.attempts) == 1
     assert again.tokens_used == store.get("job-a").tokens_used
+    # Same job_id after success must not wipe the promoted result.
+    resubmit = submit(store, spec, job_id="job-a")
+    assert resubmit.job_id == "job-a"
+    assert resubmit.state == "SUCCEEDED"
+    assert resubmit.promoted is True
+    assert len(resubmit.attempts) == 1
 
 
 def test_invalid_schema_missing_evidence_or_low_confidence_not_promoted() -> None:

--- a/tests/test_inference_runtime.py
+++ b/tests/test_inference_runtime.py
@@ -1,0 +1,186 @@
+"""Tests for #347 durable provider-agnostic inference jobs.
+
+Drives the shipped JobStore / submit / run_job / replay entry points.
+No mocked SUT. Fake and Echo providers are real adapters behind the contract.
+"""
+
+from __future__ import annotations
+
+from scripts.inference_runtime.jobs import (
+    TERMINAL,
+    EchoProvider,
+    FakeProvider,
+    JobSpec,
+    JobStore,
+    idempotency_key,
+    job_ledger,
+    replay,
+    restart,
+    run_job,
+    submit,
+)
+
+
+def _spec(**overrides: object) -> JobSpec:
+    payload = {
+        "task": "extract_requirements",
+        "input_payload": {"text": "Prazo de 30 dias."},
+        "output_schema": {
+            "type": "object",
+            "required": ["summary"],
+            "properties": {"summary": {"type": "string"}, "task": {"type": "string"}},
+        },
+        "prompt_version": "p1",
+        "schema_version": "s1",
+        "policy_version": "pol1",
+    }
+    payload.update(overrides)
+    return JobSpec(**payload)  # type: ignore[arg-type]
+
+
+def test_job_survives_restart_and_ends_terminal_with_attempts() -> None:
+    store = JobStore()
+    spec = _spec()
+    job = submit(store, spec, job_id="job-1")
+    assert job.state == "QUEUED"
+    after = restart(store, "job-1")
+    assert after.job_id == "job-1"
+    assert after.idempotency_key == spec.key
+    done = run_job(store, "job-1", FakeProvider())
+    assert done.state == "SUCCEEDED"
+    assert done.state in TERMINAL
+    assert done.attempts
+    assert done.promoted is True
+    assert restart(store, "job-1").state == "SUCCEEDED"
+
+
+def test_same_idempotency_key_does_not_duplicate_promoted_output() -> None:
+    store = JobStore()
+    spec = _spec()
+    first = submit(store, spec, job_id="job-a")
+    run_job(store, "job-a", FakeProvider())
+    second = submit(store, spec, job_id="job-b")
+    assert second.job_id == first.job_id == "job-a"
+    assert len(store.jobs) == 1
+    assert store.get("job-a").promoted is True
+    # Re-running a terminal job is a no-op: no extra cost or new promotion.
+    again = run_job(store, "job-a", FakeProvider())
+    assert len(again.attempts) == 1
+    assert again.tokens_used == store.get("job-a").tokens_used
+
+
+def test_invalid_schema_missing_evidence_or_low_confidence_not_promoted() -> None:
+    store = JobStore()
+    spec = _spec()
+    submit(store, spec, job_id="schema")
+    bad_schema = run_job(
+        store,
+        "schema",
+        FakeProvider(output={"output": {"nope": 1}, "evidence": [{"document_id": "d"}], "confidence": 0.99}),
+    )
+    assert bad_schema.state == "BLOCKED"
+    assert bad_schema.promoted is False
+    assert bad_schema.blocker and bad_schema.blocker.startswith("SCHEMA_INVALID")
+
+    store2 = JobStore()
+    submit(store2, spec, job_id="evidence")
+    no_ev = run_job(
+        store2,
+        "evidence",
+        FakeProvider(output={"output": {"summary": "x"}, "evidence": [], "confidence": 0.99}),
+    )
+    assert no_ev.state == "BLOCKED"
+    assert no_ev.blocker == "MISSING_EVIDENCE"
+    assert no_ev.promoted is False
+
+    store3 = JobStore()
+    submit(store3, spec, job_id="conf")
+    low = run_job(
+        store3,
+        "conf",
+        FakeProvider(
+            output={
+                "output": {"summary": "x"},
+                "evidence": [{"document_id": "d"}],
+                "confidence": 0.1,
+            }
+        ),
+    )
+    assert low.state == "BLOCKED"
+    assert low.blocker == "CONFIDENCE_GATE"
+    assert low.promoted is False
+
+
+def test_provider_swap_keeps_domain_contract() -> None:
+    spec = _spec(
+        output_schema={
+            "type": "object",
+            "required": ["echo"],
+            "properties": {"echo": {"type": "object"}, "task": {"type": "string"}},
+        }
+    )
+    store = JobStore()
+    submit(store, spec, job_id="echo")
+    done = run_job(store, "echo", EchoProvider())
+    assert done.state == "SUCCEEDED"
+    assert done.attempts[0].provider == "echo"
+    ledger = job_ledger(done)
+    assert ledger["provider_attempts"][0]["model"] == "echo-v1"
+    assert ledger["provider_attempts"][0]["prompt_version"] == "p1"
+    assert "tokens_used" in ledger
+    # Domain job fields do not mention a mandatory vendor.
+    dumped = done.as_dict()
+    assert dumped["provider_contract"] == "agnostic"
+
+
+def test_timeout_and_unavailable_follow_limited_policy() -> None:
+    store = JobStore()
+    spec = _spec(max_attempts=2)
+    submit(store, spec, job_id="to")
+    first = run_job(store, "to", FakeProvider(fail="TIMEOUT"))
+    assert first.state == "QUEUED"
+    assert first.attempts[0].status == "TIMEOUT"
+    second = run_job(store, "to", FakeProvider(fail="TIMEOUT"))
+    assert second.state in TERMINAL
+    assert second.blocker == "PROVIDER_TIMEOUT"
+
+    store2 = JobStore()
+    submit(store2, spec, job_id="down")
+    down = run_job(store2, "down", FakeProvider(fail="UNAVAILABLE"))
+    assert down.state == "BLOCKED"
+    assert down.blocker == "PROVIDER_UNAVAILABLE"
+    assert down.next_action
+
+
+def test_replay_preserves_previous_result_and_adds_revision() -> None:
+    store = JobStore()
+    spec = _spec()
+    submit(store, spec, job_id="rp")
+    first = run_job(store, "rp", FakeProvider())
+    assert first.revision == 1
+    replayed = replay(store, "rp", FakeProvider())
+    assert replayed.state == "SUCCEEDED"
+    assert replayed.revision == 2
+    assert replayed.output == first.output
+    failed = replay(
+        store,
+        "rp",
+        FakeProvider(output={"output": {"summary": "x"}, "evidence": [], "confidence": 0.99}),
+    )
+    assert failed.output == first.output
+    assert failed.promoted is False
+
+
+def test_idempotency_key_is_stable_and_changes_with_policy() -> None:
+    spec = _spec()
+    same = _spec()
+    other = _spec(policy_version="pol2")
+    assert spec.key == same.key
+    assert spec.key != other.key
+    assert spec.key == idempotency_key(
+        input_hash=spec.input_hash,
+        task=spec.task,
+        prompt_version=spec.prompt_version,
+        schema_version=spec.schema_version,
+        policy_version=spec.policy_version,
+    )


### PR DESCRIPTION
## Outcome

Durable, asynchronous, provider-agnostic inference job contract.

## Issues

Refs #347

Does **not** auto-close: no live provider bake-off, no Bedrock migration, no representative corpus benchmark.

## What shipped

- Jobs persist across restart and terminate in `SUCCEEDED|BLOCKED|DLQ` with attempt history.
- Idempotency key is `input_hash + task + prompt/schema/policy version`; the same key does not duplicate cost or a promoted output.
- Output off-schema, without evidence, or below the confidence gate is never promoted as a dossier fact.
- Fake and Echo adapters share the same domain contract; swapping provider does not change job fields.
- Tokens, cost, model/provider/prompt/schema versions and latency are queryable per job.
- 429/timeout retry with a limited policy; total unavailability is an actionable `BLOCKED`.
- Replay keeps the previous result and adds an auditable revision.

## Verification

```bash
python3 -m pytest tests/test_inference_runtime.py -o addopts='' -q
```

7 passed, twice. Policy gates PASS.

## Honesty

No claim that a real vendor is better. No Bedrock Agents. No human GO.