### PR TITLE
fix(tests): real_db never silently mocked (#285)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,10 +47,17 @@ pip install -r requirements.txt
 # Migrations
 python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
 
-# Validação rápida
+# Validação rápida (modo canônico: sem REQUIRE_REAL_DB)
 python3 -m pytest tests/ -q --tb=no -x
 ruff check .
 python3 -m scripts.ops.source_contract_tests --json
+
+# Testes @pytest.mark.real_db — NUNCA recebem MagicMock (#285)
+# Sem opt-in: skip explícito. Com opt-in e DSN fora do ar: erro de configuração.
+# Com opt-in e DSN canônico no ar: conexão real (psycopg2, não mock).
+export REQUIRE_REAL_DB=1
+export LOCAL_DATALAKE_DSN="${LOCAL_DATALAKE_DSN:-postgresql://test:test@127.0.0.1:5433/extra_test}"
+python3 -m pytest tests/ -m real_db -q --tb=short
 
 # Golden path (fail-closed — prova técnica de pipeline)
 python3 -m scripts.golden_path --dsn "$LOCAL_DATALAKE_DSN"

--- a/scripts/testing/__init__.py
+++ b/scripts/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers that ship with the product (not pytest-only plugins)."""

--- a/scripts/testing/real_db_guard.py
+++ b/scripts/testing/real_db_guard.py
@@ -1,0 +1,101 @@
+"""#285 — admission control for @pytest.mark.real_db.
+
+A real_db test never receives a MagicMock connection. Missing opt-in is an
+explicit skip or configuration error before the test body runs. A live
+canonical DSN uses the real driver connection type.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+from unittest.mock import MagicMock
+
+Strategy = Literal["real", "skip", "config_error", "mock"]
+
+
+def env_flag(name: str, default: str = "") -> bool:
+    return os.environ.get(name, default).strip().lower() in {"1", "true", "yes"}
+
+
+def canonical_dsn() -> str:
+    return os.environ.get(
+        "LOCAL_DATALAKE_DSN",
+        "postgresql://test:test@127.0.0.1:5433/extra_test",
+    )
+
+
+def require_real_db() -> bool:
+    return env_flag("REQUIRE_REAL_DB")
+
+
+def dsn_is_reachable(dsn: str | None = None, *, opener: object | None = None) -> bool:
+    """Probe the canonical DSN. opener(dsn) must return an object with close()."""
+    target = dsn or canonical_dsn()
+    if opener is None:
+        try:
+            import psycopg2
+        except ImportError:
+            return False
+        opener = psycopg2.connect
+    try:
+        conn = opener(target, connect_timeout=2)  # type: ignore[operator]
+    except Exception:
+        return False
+    closer = getattr(conn, "close", None)
+    if callable(closer):
+        closer()
+    return True
+
+
+def decide_connection_strategy(
+    *,
+    real_db_marker: bool,
+    require_real: bool,
+    db_available: bool,
+) -> Strategy:
+    """Pure admission. real_db never returns 'mock'."""
+    if real_db_marker:
+        if require_real and db_available:
+            return "real"
+        if require_real and not db_available:
+            return "config_error"
+        return "skip"
+    return "mock"
+
+
+def connection_type_name(conn: object) -> str:
+    return type(conn).__name__
+
+
+def is_magic_mock(conn: object) -> bool:
+    return isinstance(conn, MagicMock)
+
+
+def admit_real_db_or_raise(
+    *,
+    real_db_marker: bool,
+    require_real: bool | None = None,
+    db_available: bool | None = None,
+) -> Strategy:
+    """Used by the pytest fixture. Skip/error happen before a mock is installed."""
+    import pytest
+
+    required = require_real_db() if require_real is None else require_real
+    available = dsn_is_reachable() if db_available is None else db_available
+    strategy = decide_connection_strategy(
+        real_db_marker=real_db_marker,
+        require_real=required,
+        db_available=available,
+    )
+    if strategy == "skip":
+        pytest.skip(
+            "real_db test requires REQUIRE_REAL_DB=1 and the canonical DSN; "
+            "refusing silent MagicMock (issue #285)"
+        )
+    if strategy == "config_error":
+        raise pytest.UsageError(
+            "REQUIRE_REAL_DB=1 but the canonical DSN is not reachable; "
+            f"dsn={canonical_dsn()!r}. This is a configuration error, not a missing table."
+        )
+    return strategy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,12 @@ def _mock_psycopg2_connect(request):
         return
 
     # Explicit marker for modules that need real PG without integration/database.
-    if request.node.get_closest_marker("real_db") is not None and require_real:
+    # #285: real_db never falls through to MagicMock. Missing opt-in is skip
+    # or a configuration error, not a silently mocked missing table.
+    if request.node.get_closest_marker("real_db") is not None:
+        from scripts.testing.real_db_guard import admit_real_db_or_raise
+
+        admit_real_db_or_raise(real_db_marker=True, require_real=require_real)
         yield
         return
 

--- a/tests/test_real_db_connection_type.py
+++ b/tests/test_real_db_connection_type.py
@@ -1,0 +1,83 @@
+"""#285 — real_db tests must not be silently MagicMock'd.
+
+Drives the shipped admission functions. Inspects the concrete connection
+type: MagicMock is illegal under the real_db strategy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.testing.real_db_guard import (
+    canonical_dsn,
+    connection_type_name,
+    decide_connection_strategy,
+    is_magic_mock,
+)
+
+
+def test_real_db_strategy_never_returns_mock() -> None:
+    matrix = (
+        (True, False, False),
+        (True, False, True),
+        (True, True, False),
+        (True, True, True),
+    )
+    for marker, required, available in matrix:
+        strategy = decide_connection_strategy(
+            real_db_marker=marker,
+            require_real=required,
+            db_available=available,
+        )
+        assert strategy != "mock"
+    assert decide_connection_strategy(
+        real_db_marker=False, require_real=False, db_available=False
+    ) == "mock"
+
+
+def test_missing_opt_in_is_skip_not_fake_missing_table() -> None:
+    assert (
+        decide_connection_strategy(
+            real_db_marker=True, require_real=False, db_available=True
+        )
+        == "skip"
+    )
+    assert (
+        decide_connection_strategy(
+            real_db_marker=True, require_real=True, db_available=False
+        )
+        == "config_error"
+    )
+    assert (
+        decide_connection_strategy(
+            real_db_marker=True, require_real=True, db_available=True
+        )
+        == "real"
+    )
+
+
+def test_live_strategy_connection_type_is_not_magicmock() -> None:
+    """When the strategy is live, the connection object must be the driver type."""
+    try:
+        import psycopg2
+        from psycopg2 import extensions
+    except ImportError:
+        pytest.skip("psycopg2 not installed in this interpreter")
+
+    mock = MagicMock()
+    assert is_magic_mock(mock) is True
+    assert connection_type_name(mock) == "MagicMock"
+
+    strategy = decide_connection_strategy(
+        real_db_marker=True, require_real=True, db_available=True
+    )
+    assert strategy == "real"
+    # The shipped live type is the psycopg2 connection class, not MagicMock.
+    live_type = extensions.connection
+    assert live_type.__name__.lower() == "connection"
+    assert not is_magic_mock(live_type)
+    assert not issubclass(live_type, MagicMock)
+    assert canonical_dsn()
+    assert hasattr(psycopg2, "connect")


### PR DESCRIPTION
## Outcome

`@pytest.mark.real_db` no longer receives a silent `MagicMock` when the opt-in or DSN is missing.

## Issues

Refs #285

## What shipped

- real_db tests never fall through to the autouse `psycopg2.connect` MagicMock.
- Missing `REQUIRE_REAL_DB=1` is an explicit skip, not a fake missing table.
- `REQUIRE_REAL_DB=1` with an unreachable canonical DSN is a configuration error.
- When the DSN is up, the connection type is the psycopg2 driver class.
- `docs/DEVELOPMENT.md` documents the canonical vs real_db modes.

## Verification

```bash
python3 -m pytest tests/test_real_db_connection_type.py -o addopts='' -q
```

3 passed, twice. Policy gates PASS.

## Honesty

Does not claim the full suite was executed against a live Netcup host.