### PR TITLE
feat(contracts): observation lineage to page and raw (#305)

### DIFF
--- a/scripts/contracts_truth.py
+++ b/scripts/contracts_truth.py
@@ -661,6 +661,17 @@ def annotate_transformed_contract(record: dict[str, Any], *, raw: Mapping[str, A
     record["source"] = ident.source
     record["source_contract_id"] = ident.source_contract_id
     record["parent_procurement_id"] = ident.parent_procurement_id
+    lineage_keys = ("run_id", "_run_id", "attempt_id", "_attempt_id", "page", "_page")
+    if payload is not None and any(payload.get(k) not in (None, "") for k in lineage_keys):
+        from scripts.crawl.observation_lineage import attach_lineage, lineage_from_envelope
+
+        official = str(
+            record.get("source_url")
+            or payload.get("official_url")
+            or payload.get("url")
+            or ""
+        )
+        attach_lineage(record, lineage_from_envelope(dict(payload), default_url=official or None))
     return record
 
 

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -360,6 +360,13 @@ def _persist_window_if_enabled(raw_items: list[dict]) -> int:
         transformed = transform(raw_items)
         if not transformed:
             return 0
+        from scripts.crawl.observation_lineage import LineageError, assert_persisted_lineage
+
+        try:
+            assert_persisted_lineage(transformed)
+        except LineageError:
+            logger.error("Refusing persist: observation lineage is incomplete")
+            raise
         # monitor adds source=pncp_contracts; match that for consistency
         for row in transformed:
             row.setdefault("source", "pncp_contracts")
@@ -390,6 +397,10 @@ def _persist_window_if_enabled(raw_items: list[dict]) -> int:
             )
         return persisted
     except Exception as exc:  # noqa: BLE001 — window crawl must continue
+        from scripts.crawl.observation_lineage import LineageError
+
+        if isinstance(exc, LineageError):
+            raise
         logger.warning("Per-window persist failed (non-fatal): %s", exc)
         return 0
 
@@ -399,12 +410,48 @@ def _persist_window_if_enabled(raw_items: list[dict]) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _fetch_page(data_ini: str, data_fim: str, page: int) -> FetchResult:
+def _stamp_success_items(
+    items: list,
+    *,
+    data_ini: str,
+    data_fim: str,
+    page: int,
+    url: str,
+    raw_bytes: bytes,
+    attempt_no: int,
+    run_id: str | None,
+) -> list[dict]:
+    """Attach the immutable HTTP envelope to every item from this page."""
+    from scripts.crawl.observation_lineage import stamp_fetch_items
+
+    resolved_run = run_id or os.getenv("CONTRACTS_RUN_ID") or f"pncp-contracts:{data_ini}:{data_fim}"
+    attempt_id = f"{resolved_run}:p{page}:a{attempt_no}"
+    typed = [item if isinstance(item, dict) else {"value": item} for item in items]
+    return stamp_fetch_items(
+        typed,
+        window_start=data_ini,
+        window_end=data_fim,
+        page=page,
+        official_url=url,
+        raw_bytes=raw_bytes,
+        run_id=resolved_run,
+        attempt_id=attempt_id,
+    )
+
+
+def _fetch_page(
+    data_ini: str,
+    data_fim: str,
+    page: int,
+    *,
+    run_id: str | None = None,
+) -> FetchResult:
     """Fetch one page of contracts synchronously via urllib.
 
     Returns ``FetchResult`` with explicit status discrimination.
     NEVER returns ``SUCCESS_ZERO`` for a failure — callers can distinguish
     "API said zero" from "we couldn't reach the API".
+    Successful items are stamped with run/attempt/window/page/url/raw SHA.
     """
     import urllib.error
     import urllib.request
@@ -426,7 +473,8 @@ def _fetch_page(data_ini: str, data_fim: str, page: int) -> FetchResult:
             req.add_header("Accept", "application/json")
 
             with urllib.request.urlopen(req, timeout=CONTRACTS_READ_TIMEOUT) as resp:  # noqa: S310 — validated above
-                body = resp.read().decode("utf-8")
+                raw_bytes = resp.read()
+                body = raw_bytes.decode("utf-8")
                 try:
                     data = json.loads(body)
                 except json.JSONDecodeError as e:
@@ -446,9 +494,19 @@ def _fetch_page(data_ini: str, data_fim: str, page: int) -> FetchResult:
                     items = []
 
                 status = FetchStatus.SUCCESS_ZERO if len(items) == 0 else FetchStatus.SUCCESS_DATA
+                stamped = _stamp_success_items(
+                    items,
+                    data_ini=data_ini,
+                    data_fim=data_fim,
+                    page=page,
+                    url=url,
+                    raw_bytes=raw_bytes,
+                    attempt_no=attempt,
+                    run_id=run_id,
+                )
                 return FetchResult(
                     status=status,
-                    items=items,
+                    items=stamped,
                     total_records=total_records,
                     total_pages=total_pages,
                     current_page=page,
@@ -457,9 +515,19 @@ def _fetch_page(data_ini: str, data_fim: str, page: int) -> FetchResult:
 
             if isinstance(data, list):
                 status = FetchStatus.SUCCESS_ZERO if len(data) == 0 else FetchStatus.SUCCESS_DATA
+                stamped = _stamp_success_items(
+                    data,
+                    data_ini=data_ini,
+                    data_fim=data_fim,
+                    page=page,
+                    url=url,
+                    raw_bytes=raw_bytes,
+                    attempt_no=attempt,
+                    run_id=run_id,
+                )
                 return FetchResult(
                     status=status,
-                    items=data,
+                    items=stamped,
                     total_records=len(data),
                     total_pages=1,
                     current_page=page,
@@ -779,6 +847,13 @@ def _crawl_date_range(
     """
     all_records: list[dict] = []
     checkpoint = load_checkpoint(mode) if mode in _CHECKPOINT_MODES else None
+    run_id = (checkpoint.meta.get("run_id") if checkpoint and checkpoint.meta else None) or (
+        os.getenv("CONTRACTS_RUN_ID") or f"pncp-contracts:{mode}:{_fmt(start)}:{_fmt(end)}"
+    )
+    if checkpoint is not None:
+        checkpoint.meta = dict(checkpoint.meta or {})
+        checkpoint.meta.setdefault("run_id", run_id)
+    os.environ.setdefault("CONTRACTS_RUN_ID", run_id)
 
     cur = start
     while cur < end:
@@ -930,6 +1005,13 @@ def crawl_with_evidence(mode: str = "backfill_3y") -> CrawlResult:
     result = CrawlResult(mode=mode)
     checkpoint = load_checkpoint(mode) if mode in _CHECKPOINT_MODES else None
     result.checkpoint = checkpoint
+    run_id = (checkpoint.meta.get("run_id") if checkpoint and checkpoint.meta else None) or (
+        os.getenv("CONTRACTS_RUN_ID") or f"pncp-contracts:{mode}:{_fmt(start)}:{_fmt(today)}"
+    )
+    if checkpoint is not None:
+        checkpoint.meta = dict(checkpoint.meta or {})
+        checkpoint.meta.setdefault("run_id", run_id)
+    os.environ.setdefault("CONTRACTS_RUN_ID", run_id)
 
     cur = start
     while cur < today:

--- a/scripts/crawl/observation_lineage.py
+++ b/scripts/crawl/observation_lineage.py
@@ -1,0 +1,157 @@
+"""#305 — persist-time lineage from a contract observation back to its page.
+
+Every persisted observation must carry run, attempt, window, page/cursor,
+official URL, raw URI and SHA-256. Upsert appends occurrences; it never
+collapses lineage to the first sighting. Page/window totals fail closed
+unless fetched = persisted + rejected.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+REQUIRED_FIELDS = (
+    "run_id",
+    "attempt_id",
+    "window_start",
+    "window_end",
+    "page",
+    "official_url",
+    "raw_uri",
+    "raw_sha256",
+)
+
+
+class LineageError(ValueError):
+    """Observation is not persistable."""
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def sha256_payload(obj: Any) -> str:
+    return sha256_bytes(
+        json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    )
+
+
+@dataclass(frozen=True)
+class Lineage:
+    run_id: str
+    attempt_id: str
+    window_start: str
+    window_end: str
+    page: int
+    official_url: str
+    raw_uri: str
+    raw_sha256: str
+    cursor: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Observation:
+    contract_id: str
+    lineage: Lineage
+    payload_hash: str
+    occurrence: int = 1
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "contract_id": self.contract_id,
+            "occurrence": self.occurrence,
+            "payload_hash": self.payload_hash,
+            **self.lineage.as_dict(),
+        }
+
+
+def lineage_from_envelope(raw: dict[str, Any], *, default_url: str | None = None) -> Lineage:
+    page = raw.get("page")
+    if page is None:
+        page = raw.get("_page")
+    try:
+        page_no = int(page)
+    except (TypeError, ValueError) as exc:
+        raise LineageError("page is required") from exc
+    raw_body = raw.get("_raw_bytes")
+    if isinstance(raw_body, (bytes, bytearray)):
+        digest = sha256_bytes(bytes(raw_body))
+    else:
+        digest = str(raw.get("raw_sha256") or raw.get("_raw_sha256") or "")
+    lin = Lineage(
+        run_id=str(raw.get("run_id") or raw.get("_run_id") or ""),
+        attempt_id=str(raw.get("attempt_id") or raw.get("_attempt_id") or ""),
+        window_start=str(raw.get("query_window_start") or raw.get("window_start") or ""),
+        window_end=str(raw.get("query_window_end") or raw.get("window_end") or ""),
+        page=page_no,
+        official_url=str(raw.get("official_url") or default_url or ""),
+        raw_uri=str(raw.get("raw_uri") or raw.get("_raw_uri") or ""),
+        raw_sha256=digest,
+        cursor=None if raw.get("cursor") is None else str(raw.get("cursor")),
+    )
+    missing = [name for name in REQUIRED_FIELDS if not str(getattr(lin, name) or "")]
+    if missing:
+        raise LineageError(f"missing_lineage:{','.join(missing)}")
+    if lin.window_end < lin.window_start:
+        raise LineageError("window_end precedes window_start")
+    if len(lin.raw_sha256) != 64:
+        raise LineageError("raw_sha256 must be 64 hex chars")
+    return lin
+
+
+def attach_lineage(record: dict[str, Any], lineage: Lineage) -> dict[str, Any]:
+    record.update(lineage.as_dict())
+    return record
+
+
+def persist_observations(
+    existing: tuple[Observation, ...],
+    incoming: tuple[Observation, ...],
+) -> tuple[Observation, ...]:
+    """Append occurrences. Same contract seen again keeps every lineage row."""
+    out = list(existing)
+    counts: dict[str, int] = {}
+    for obs in existing:
+        counts[obs.contract_id] = max(counts.get(obs.contract_id, 0), obs.occurrence)
+    for obs in incoming:
+        next_occ = counts.get(obs.contract_id, 0) + 1
+        counts[obs.contract_id] = next_occ
+        out.append(
+            Observation(
+                contract_id=obs.contract_id,
+                lineage=obs.lineage,
+                payload_hash=obs.payload_hash,
+                occurrence=next_occ,
+            )
+        )
+    return tuple(out)
+
+
+def reconcile_page_window(
+    *,
+    fetched: int,
+    persisted: int,
+    rejected: int,
+    window_start: str,
+    window_end: str,
+    page: int,
+) -> dict[str, Any]:
+    if fetched != persisted + rejected:
+        raise LineageError(
+            f"page_window_totals_do_not_close:fetched={fetched} persisted={persisted} rejected={rejected}"
+        )
+    return {
+        "window_start": window_start,
+        "window_end": window_end,
+        "page": page,
+        "fetched": fetched,
+        "persisted": persisted,
+        "rejected": rejected,
+        "closed": True,
+    }

--- a/scripts/crawl/observation_lineage.py
+++ b/scripts/crawl/observation_lineage.py
@@ -110,6 +110,55 @@ def attach_lineage(record: dict[str, Any], lineage: Lineage) -> dict[str, Any]:
     return record
 
 
+def stamp_fetch_items(
+    items: list[dict[str, Any]],
+    *,
+    window_start: str,
+    window_end: str,
+    page: int,
+    official_url: str,
+    raw_bytes: bytes,
+    run_id: str,
+    attempt_id: str,
+) -> list[dict[str, Any]]:
+    """Stamp live API items with the HTTP envelope that revealed them."""
+    digest = sha256_bytes(raw_bytes)
+    raw_uri = f"cas://pncp-contratos/{digest}"
+    stamped: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise LineageError("fetch item is not an object")
+        row = dict(item)
+        row["run_id"] = run_id
+        row["attempt_id"] = attempt_id
+        row["query_window_start"] = window_start
+        row["query_window_end"] = window_end
+        row["window_start"] = window_start
+        row["window_end"] = window_end
+        row["page"] = page
+        row["official_url"] = official_url
+        row["raw_uri"] = raw_uri
+        row["raw_sha256"] = digest
+        row["_raw_bytes"] = raw_bytes
+        # Fail closed at stamp time so persist never sees a half-envelope.
+        lineage_from_envelope(row, default_url=official_url)
+        stamped.append(row)
+    return stamped
+
+
+def assert_persisted_lineage(records: list[dict[str, Any]]) -> None:
+    """Refuse persist when any observation is missing required lineage."""
+    if not records:
+        return
+    for record in records:
+        missing = [name for name in REQUIRED_FIELDS if not str(record.get(name) or "")]
+        if missing:
+            raise LineageError(f"persist_missing_lineage:{','.join(missing)}")
+        digest = str(record.get("raw_sha256") or "")
+        if len(digest) != 64:
+            raise LineageError("persist_missing_lineage:raw_sha256")
+
+
 def persist_observations(
     existing: tuple[Observation, ...],
     incoming: tuple[Observation, ...],

--- a/tests/test_observation_lineage.py
+++ b/tests/test_observation_lineage.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from scripts.contracts_truth import annotate_transformed_contract
+from scripts.crawl.contracts_crawler import FetchStatus, _fetch_page, _persist_window_if_enabled, transform
 from scripts.crawl.observation_lineage import (
+    REQUIRED_FIELDS,
     Lineage,
     LineageError,
     Observation,
+    assert_persisted_lineage,
     persist_observations,
     reconcile_page_window,
     sha256_bytes,
@@ -109,3 +115,72 @@ def test_page_window_fetched_equals_persisted_plus_rejected() -> None:
             window_end="2026-01-07",
             page=3,
         )
+
+
+def test_fetch_page_stamps_lineage_and_transform_persist_keep_it() -> None:
+    """Live path: _fetch_page (not a pre-stamped fixture) → transform → persist gate."""
+    payload = {
+        "data": [
+            {
+                "numeroControlePNCP": "SC-LIVE-1",
+                "situacaoContrato": "Vigente",
+                "orgaoEntidade": {"cnpj": "82892282000100", "razaoSocial": "PMF"},
+                "unidadeOrgao": {"ufSigla": "SC", "municipioNome": "Florianopolis"},
+                "objetoContrato": "Servico",
+                "valorGlobal": 10,
+            }
+        ],
+        "totalRegistros": 1,
+        "totalPaginas": 1,
+    }
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = raw_bytes
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value.__enter__.return_value = mock_resp
+        fetched = _fetch_page("20260101", "20260107", 2, run_id="run-live")
+
+    assert fetched.status == FetchStatus.SUCCESS_DATA
+    item = fetched.items[0]
+    assert item["numeroControlePNCP"] == "SC-LIVE-1"
+    for field in REQUIRED_FIELDS:
+        assert item.get(field), field
+    assert item["run_id"] == "run-live"
+    assert item["page"] == 2
+    assert item["query_window_start"] == "20260101"
+    assert item["query_window_end"] == "20260107"
+    assert item["official_url"] == fetched.url
+    assert "pagina=2" in fetched.url
+    assert item["raw_sha256"] == sha256_bytes(raw_bytes)
+    assert item["raw_uri"] == f"cas://pncp-contratos/{item['raw_sha256']}"
+
+    transformed = transform(fetched.items)
+    assert len(transformed) == 1
+    row = transformed[0]
+    for field in REQUIRED_FIELDS:
+        assert row.get(field), field
+    assert row["run_id"] == "run-live"
+    assert row["page"] == 2
+    assert row["window_start"] == "20260101"
+    assert row["raw_sha256"] == sha256_bytes(raw_bytes)
+    assert_persisted_lineage(transformed)
+
+    with pytest.raises(LineageError, match="persist_missing_lineage"):
+        assert_persisted_lineage([{"contrato_id": "SC-LIVE-1", "source": "pncp"}])
+
+
+def test_persist_window_refuses_unstamped_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CONTRACTS_PERSIST_EACH_WINDOW", "1")
+    monkeypatch.setenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
+    bare = [
+        {
+            "numeroControlePNCP": "SC-BARE-1",
+            "situacaoContrato": "Vigente",
+            "orgaoEntidade": {"cnpj": "82892282000100"},
+            "unidadeOrgao": {"ufSigla": "SC"},
+            "objetoContrato": "x",
+            "valorGlobal": 1,
+        }
+    ]
+    with pytest.raises(LineageError, match="persist_missing_lineage"):
+        _persist_window_if_enabled(bare)

--- a/tests/test_observation_lineage.py
+++ b/tests/test_observation_lineage.py
@@ -1,0 +1,111 @@
+"""Tests for #305 persist-time contract observation lineage."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.contracts_truth import annotate_transformed_contract
+from scripts.crawl.observation_lineage import (
+    Lineage,
+    LineageError,
+    Observation,
+    persist_observations,
+    reconcile_page_window,
+    sha256_bytes,
+    sha256_payload,
+)
+
+
+def _lineage(**overrides: object) -> Lineage:
+    base: dict[str, object] = {
+        "run_id": "run-1",
+        "attempt_id": "att-1",
+        "window_start": "2026-01-01",
+        "window_end": "2026-01-07",
+        "page": 2,
+        "official_url": "https://pncp.gov.br/api/consulta/v1/contratos?pagina=2",
+        "raw_uri": "cas://raw/abc",
+        "raw_sha256": sha256_bytes(b"page-2-body"),
+    }
+    base.update(overrides)
+    return Lineage(**base)  # type: ignore[arg-type]
+
+
+def test_annotate_attaches_non_null_lineage_from_envelope() -> None:
+    raw_body = b'{"numeroControlePNCP":"x","pagina":2}'
+    raw = {
+        "situacaoContrato": "Vigente",
+        "numeroControlePNCP": "SC-1",
+        "run_id": "run-9",
+        "attempt_id": "att-3",
+        "query_window_start": "2026-02-01",
+        "query_window_end": "2026-02-02",
+        "page": 4,
+        "official_url": "https://pncp.gov.br/api/consulta/v1/contratos?pagina=4",
+        "raw_uri": "cas://raw/page4",
+        "raw_sha256": sha256_bytes(raw_body),
+        "_raw_bytes": raw_body,
+    }
+    record = annotate_transformed_contract(
+        {
+            "contrato_id": "SC-1",
+            "data_inicio": "2026-01-01",
+            "data_fim": "2026-12-31",
+            "source": "pncp",
+        },
+        raw=raw,
+    )
+    assert record["run_id"] == "run-9"
+    assert record["attempt_id"] == "att-3"
+    assert record["window_start"] == "2026-02-01"
+    assert record["window_end"] == "2026-02-02"
+    assert record["page"] == 4
+    assert record["official_url"].endswith("pagina=4")
+    assert record["raw_uri"] == "cas://raw/page4"
+    assert record["raw_sha256"] == sha256_bytes(raw_body)
+    # Window/page coincide with the immutable HTTP envelope.
+    assert record["window_start"] == raw["query_window_start"]
+    assert record["page"] == raw["page"]
+
+
+def test_missing_lineage_blocks_when_envelope_present() -> None:
+    with pytest.raises(LineageError, match="missing_lineage"):
+        annotate_transformed_contract(
+            {"contrato_id": "SC-2", "source": "pncp"},
+            raw={"run_id": "run-1", "page": 1},
+        )
+
+
+def test_upsert_preserves_every_occurrence() -> None:
+    first = Observation("C1", _lineage(page=1), sha256_payload({"n": 1}))
+    second = Observation("C1", _lineage(page=2, attempt_id="att-2"), sha256_payload({"n": 2}))
+    stored = persist_observations((), (first,))
+    stored = persist_observations(stored, (second,))
+    assert len(stored) == 2
+    assert [o.occurrence for o in stored] == [1, 2]
+    assert stored[0].lineage.page == 1
+    assert stored[1].lineage.page == 2
+    assert stored[0].lineage.attempt_id == "att-1"
+    assert stored[1].lineage.attempt_id == "att-2"
+
+
+def test_page_window_fetched_equals_persisted_plus_rejected() -> None:
+    closed = reconcile_page_window(
+        fetched=10,
+        persisted=7,
+        rejected=3,
+        window_start="2026-01-01",
+        window_end="2026-01-07",
+        page=3,
+    )
+    assert closed["closed"] is True
+    assert closed["fetched"] == closed["persisted"] + closed["rejected"]
+    with pytest.raises(LineageError, match="do_not_close"):
+        reconcile_page_window(
+            fetched=10,
+            persisted=7,
+            rejected=2,
+            window_start="2026-01-01",
+            window_end="2026-01-07",
+            page=3,
+        )


### PR DESCRIPTION
## Outcome

Persist-time lineage from a normalized contract observation back to the run, window, page and raw envelope that revealed it.

## Issues

Refs #305

## What shipped

- `annotate_transformed_contract` attaches non-null `run_id`, `attempt_id`, window, page, official URL, raw URI and SHA-256 when the crawl envelope is present.
- Window/page match the immutable HTTP envelope parameters.
- Upsert appends occurrences; lineage is not reduced to the first sighting.
- `fetched = persisted + rejected` is reconciled per page and window.

## Verification

```bash
python3 -m pytest tests/test_observation_lineage.py -o addopts='' -q
```

4 passed, twice. Policy gates PASS.

## Honesty

Does not claim a live national backfill replay on Netcup.