### PR TITLE
feat(contracts): national publishing-org denominator (#302)

### DIFF
--- a/scripts/national_contract_truth/national_universe.py
+++ b/scripts/national_contract_truth/national_universe.py
@@ -1,0 +1,150 @@
+"""#302 — versioned national denominator of publishing orgs/units.
+
+Separated from Extra's commercial 1.093-entity universe. "Nacional completo"
+is emitted only when every partition of the denominator closes with evidence.
+Replaying the same raws/hashes reproduces the catalog and reconciliation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+SCHEMA_VERSION = "national-universe/1.0"
+EXTRA_COMMERCIAL_DENOMINATOR = 1093
+
+PartitionStatus = Literal["FOUND", "ZERO_CONFIRMED", "BLOCKED", "FAILED"]
+
+
+class NationalUniverseError(ValueError):
+    """National completeness cannot be claimed."""
+
+
+def sha256_payload(obj: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class PublishingOrg:
+    org_id: str
+    source: str
+    competence: str
+    name: str
+    unit_count: int = 1
+
+
+@dataclass(frozen=True)
+class NationalUniverse:
+    national_universe_id: str
+    source: str
+    competence: str
+    cutoff: str
+    orgs: tuple[PublishingOrg, ...]
+    method: str
+
+    @property
+    def org_count(self) -> int:
+        return len(self.orgs)
+
+    @property
+    def unit_count(self) -> int:
+        return sum(o.unit_count for o in self.orgs)
+
+    @property
+    def catalog_hash(self) -> str:
+        return sha256_payload(
+            {
+                "national_universe_id": self.national_universe_id,
+                "source": self.source,
+                "competence": self.competence,
+                "cutoff": self.cutoff,
+                "orgs": [asdict(o) for o in self.orgs],
+                "method": self.method,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class PartitionResult:
+    partition_id: str
+    status: PartitionStatus
+    expected: bool = True
+    evidence: str | None = None
+
+
+def build_universe(
+    *,
+    source: str,
+    competence: str,
+    cutoff: str,
+    orgs: tuple[PublishingOrg, ...],
+    method: str,
+) -> NationalUniverse:
+    if not source or not competence or not cutoff:
+        raise NationalUniverseError("source, competence and cutoff are required")
+    if not orgs:
+        raise NationalUniverseError("denominator has zero publishing orgs")
+    if any(o.unit_count < 1 for o in orgs):
+        raise NationalUniverseError("unit_count must be >= 1")
+    uid = sha256_payload(
+        {"source": source, "competence": competence, "cutoff": cutoff, "method": method}
+    )[:16]
+    return NationalUniverse(
+        national_universe_id=f"nu-{source}-{competence}-{uid}",
+        source=source,
+        competence=competence,
+        cutoff=cutoff,
+        orgs=orgs,
+        method=method,
+    )
+
+
+def reconcile_partitions(
+    universe: NationalUniverse,
+    results: tuple[PartitionResult, ...],
+) -> dict[str, Any]:
+    expected_ids = {o.org_id for o in universe.orgs}
+    seen = {r.partition_id for r in results}
+    blockers: list[str] = []
+    if expected_ids != seen:
+        blockers.append(f"partition_set_mismatch:expected={sorted(expected_ids)} got={sorted(seen)}")
+    by_status = {status: 0 for status in ("FOUND", "ZERO_CONFIRMED", "BLOCKED", "FAILED")}
+    for result in results:
+        if result.status not in by_status:
+            blockers.append(f"illegal_status:{result.status}")
+            continue
+        if result.status in {"FOUND", "ZERO_CONFIRMED"} and not result.evidence:
+            blockers.append(f"missing_evidence:{result.partition_id}")
+        by_status[result.status] += 1
+    closed = (
+        not blockers
+        and by_status["BLOCKED"] == 0
+        and by_status["FAILED"] == 0
+        and by_status["FOUND"] + by_status["ZERO_CONFIRMED"] == universe.org_count
+    )
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "national_universe_id": universe.national_universe_id,
+        "source": universe.source,
+        "competence": universe.competence,
+        "cutoff": universe.cutoff,
+        "catalog_hash": universe.catalog_hash,
+        "org_count": universe.org_count,
+        "unit_count": universe.unit_count,
+        "method": universe.method,
+        "expected_partitions": universe.org_count,
+        "consulted_partitions": len(results),
+        "by_status": by_status,
+        "nacional_completo": closed,
+        "extra_1093_used_as_denominator": False,
+        "extra_commercial_denominator": EXTRA_COMMERCIAL_DENOMINATOR,
+        "blockers": blockers,
+    }
+    payload["reconciliation_hash"] = sha256_payload(payload)
+    if blockers:
+        raise NationalUniverseError(";".join(blockers))
+    return payload

--- a/tests/test_national_universe.py
+++ b/tests/test_national_universe.py
@@ -1,0 +1,97 @@
+"""Tests for #302 national publishing-org denominator."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.national_contract_truth.national_universe import (
+    EXTRA_COMMERCIAL_DENOMINATOR,
+    NationalUniverseError,
+    PartitionResult,
+    PublishingOrg,
+    build_universe,
+    reconcile_partitions,
+)
+
+
+def _orgs() -> tuple[PublishingOrg, ...]:
+    return (
+        PublishingOrg("org-a", "pncp", "2026", "Orgao A"),
+        PublishingOrg("org-b", "pncp", "2026", "Orgao B", unit_count=3),
+    )
+
+
+def test_universe_has_id_source_cutoff_hash_and_counts() -> None:
+    universe = build_universe(
+        source="pncp",
+        competence="contratos-2026",
+        cutoff="2026-08-01",
+        orgs=_orgs(),
+        method="pncp-orgaos-publicantes-v1",
+    )
+    assert universe.national_universe_id.startswith("nu-pncp-")
+    assert universe.source == "pncp"
+    assert universe.cutoff == "2026-08-01"
+    assert universe.org_count == 2
+    assert universe.unit_count == 4
+    assert len(universe.catalog_hash) == 64
+    again = build_universe(
+        source="pncp",
+        competence="contratos-2026",
+        cutoff="2026-08-01",
+        orgs=_orgs(),
+        method="pncp-orgaos-publicantes-v1",
+    )
+    assert again.catalog_hash == universe.catalog_hash
+    assert again.national_universe_id == universe.national_universe_id
+
+
+def test_nacional_completo_only_when_every_partition_closes() -> None:
+    universe = build_universe(
+        source="pncp",
+        competence="contratos-2026",
+        cutoff="2026-08-01",
+        orgs=_orgs(),
+        method="pncp-orgaos-publicantes-v1",
+    )
+    report = reconcile_partitions(
+        universe,
+        (
+            PartitionResult("org-a", "FOUND", evidence="raw:a"),
+            PartitionResult("org-b", "ZERO_CONFIRMED", evidence="raw:b-empty"),
+        ),
+    )
+    assert report["nacional_completo"] is True
+    assert report["extra_1093_used_as_denominator"] is False
+    assert report["extra_commercial_denominator"] == EXTRA_COMMERCIAL_DENOMINATOR == 1093
+    replay = reconcile_partitions(
+        universe,
+        (
+            PartitionResult("org-a", "FOUND", evidence="raw:a"),
+            PartitionResult("org-b", "ZERO_CONFIRMED", evidence="raw:b-empty"),
+        ),
+    )
+    assert replay["reconciliation_hash"] == report["reconciliation_hash"]
+
+
+def test_blocked_partition_and_1093_substitution_fail_closed() -> None:
+    universe = build_universe(
+        source="pncp",
+        competence="contratos-2026",
+        cutoff="2026-08-01",
+        orgs=_orgs(),
+        method="pncp-orgaos-publicantes-v1",
+    )
+    report = reconcile_partitions(
+        universe,
+        (
+            PartitionResult("org-a", "FOUND", evidence="raw:a"),
+            PartitionResult("org-b", "BLOCKED", evidence="429"),
+        ),
+    )
+    assert report["nacional_completo"] is False
+    with pytest.raises(NationalUniverseError, match="partition_set_mismatch"):
+        reconcile_partitions(
+            universe,
+            (PartitionResult("org-a", "FOUND", evidence="raw:a"),),
+        )


### PR DESCRIPTION
## Outcome

Versioned national denominator of publishing orgs/units, separate from Extra's 1.093 commercial universe.

## Issues

Refs #302

## What shipped

- Each competence has `national_universe_id`, official source, cutoff, hash and org/unit counts.
- Each run reports expected/consulted partitions as `FOUND`, `ZERO_CONFIRMED`, `BLOCKED` or `FAILED`.
- `nacional_completo` is true only when every partition closes with evidence.
- The 1.093 Extra universe is never used as a substitute denominator.
- Replaying the same catalog + results reproduces hashes.

## Verification

```bash
python3 -m pytest tests/test_national_universe.py -o addopts='' -q
```

3 passed, twice. Policy gates PASS.

## Honesty

Does not claim national completeness on a live 3.7M-row corpus. Closing this PR is not DOD acceptance or `VPS_OPERATIONAL`.