### PR TITLE
feat(storage): national contracts workload contract (#315)

### DIFF
--- a/scripts/national_contract_truth/storage_workload.py
+++ b/scripts/national_contract_truth/storage_workload.py
@@ -102,18 +102,36 @@ def seal_workload(
     incomplete = [
         e.query_id
         for e in evidence
-        if not e.explain_analyze or e.p50_ms is None or e.p95_ms is None or e.p99_ms is None
+        if (
+            not e.explain_analyze
+            or e.p50_ms is None
+            or e.p95_ms is None
+            or e.p99_ms is None
+            or e.wal_bytes is None
+        )
     ]
     if incomplete:
         blockers.append(f"incomplete_metrics:{incomplete}")
     pk = evaluate_pk_headroom(candidate.pk_type, current_rows)
     if pk["blocker"]:
         blockers.append(str(pk["blocker"]))
-    if disk_wal_budget is None:
+    if not disk_wal_budget or any(int(v) <= 0 for v in disk_wal_budget.values()):
         blockers.append("disk_wal_budget_unrecorded")
     if not rollback_rehearsed:
         blockers.append("rollback_not_rehearsed")
 
+    evidence_payload = [
+        {
+            "query_id": item.query_id,
+            "explain_analyze": item.explain_analyze,
+            "p50_ms": item.p50_ms,
+            "p95_ms": item.p95_ms,
+            "p99_ms": item.p99_ms,
+            "wal_bytes": item.wal_bytes,
+            "buffers": item.buffers,
+        }
+        for item in evidence
+    ]
     seal: Seal = "PROVEN" if not blockers else "UNPROVEN"
     payload = {
         "schema_version": SCHEMA_VERSION,
@@ -127,6 +145,9 @@ def seal_workload(
         },
         "corpus_facts": corpus_facts,
         "incremental_churn": incremental_churn,
+        "evidence": evidence_payload,
+        "disk_wal_budget": dict(disk_wal_budget or {}),
+        "rollback_rehearsed": rollback_rehearsed,
         "pk": pk,
         "seal": seal,
         "blockers": blockers,

--- a/scripts/national_contract_truth/storage_workload.py
+++ b/scripts/national_contract_truth/storage_workload.py
@@ -1,0 +1,138 @@
+"""#315 — versioned physical-design workload contract for national contracts.
+
+A design is PROVEN only when a representative corpus (>= 3.7M facts) ran
+the versioned SQL workload and recorded EXPLAIN/latency/WAL evidence.
+Otherwise the seal stays UNPROVEN. This module never invents a 3.7M run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+SCHEMA_VERSION = "storage-workload/1.0"
+WORKLOAD_VERSION = "national-contracts-sql-v1"
+MIN_REPRESENTATIVE_FACTS = 3_700_000
+SERIAL_MAX = 2_147_483_647
+
+Seal = Literal["PROVEN", "UNPROVEN"]
+
+WORKLOAD_QUERIES: tuple[dict[str, str], ...] = (
+    {"id": "upsert_conflict", "sql": "INSERT INTO national_contracts AS t (...) ON CONFLICT (source, source_contract_id) DO UPDATE ..."},
+    {"id": "temporal_range", "sql": "SELECT * FROM national_contracts WHERE source_event_date BETWEEN %s AND %s"},
+    {"id": "by_buyer", "sql": "SELECT * FROM national_contracts WHERE orgao_cnpj = %s"},
+    {"id": "by_supplier", "sql": "SELECT * FROM national_contracts WHERE supplier_identifier = %s"},
+    {"id": "by_id", "sql": "SELECT * FROM national_contracts WHERE canonical_contract_id = %s"},
+    {"id": "versions", "sql": "SELECT * FROM national_contract_versions WHERE canonical_contract_id = %s"},
+    {"id": "aggregates", "sql": "SELECT orgao_cnpj, count(*), sum(valor_total) FROM national_contracts GROUP BY 1"},
+)
+
+
+class StorageWorkloadError(ValueError):
+    """Physical-design proof cannot be sealed."""
+
+
+def sha256_payload(obj: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+@dataclass(frozen=True)
+class WorkloadEvidence:
+    query_id: str
+    explain_analyze: str | None
+    p50_ms: float | None
+    p95_ms: float | None
+    p99_ms: float | None
+    wal_bytes: int | None
+    buffers: dict[str, int] | None = None
+
+
+@dataclass(frozen=True)
+class DesignCandidate:
+    name: str
+    partitioning: str
+    pk_type: str
+    notes: str
+
+
+def evaluate_pk_headroom(pk_type: str, current_rows: int) -> dict[str, Any]:
+    if pk_type.upper() == "SERIAL":
+        remaining = SERIAL_MAX - current_rows
+        return {
+            "pk_type": pk_type,
+            "supports_national_growth": False,
+            "remaining": remaining,
+            "blocker": "SERIAL_EXHAUSTION_RISK",
+        }
+    if pk_type.upper() in {"BIGSERIAL", "BIGINT", "UUID"}:
+        return {
+            "pk_type": pk_type,
+            "supports_national_growth": True,
+            "remaining": None,
+            "blocker": None,
+        }
+    raise StorageWorkloadError(f"unknown_pk_type:{pk_type}")
+
+
+def seal_workload(
+    *,
+    corpus_facts: int,
+    incremental_churn: int,
+    evidence: tuple[WorkloadEvidence, ...],
+    candidate: DesignCandidate,
+    current_rows: int,
+    disk_wal_budget: dict[str, int] | None = None,
+    rollback_rehearsed: bool = False,
+) -> dict[str, Any]:
+    """Return the versioned contract. UNPROVEN unless the corpus actually ran."""
+    required_ids = {q["id"] for q in WORKLOAD_QUERIES}
+    seen = {e.query_id for e in evidence}
+    blockers: list[str] = []
+    if corpus_facts < MIN_REPRESENTATIVE_FACTS:
+        blockers.append(f"corpus_below_representative:{corpus_facts}<{MIN_REPRESENTATIVE_FACTS}")
+    if incremental_churn < 0:
+        blockers.append("negative_churn")
+    missing = required_ids - seen
+    if missing:
+        blockers.append(f"missing_workload:{sorted(missing)}")
+    incomplete = [
+        e.query_id
+        for e in evidence
+        if not e.explain_analyze or e.p50_ms is None or e.p95_ms is None or e.p99_ms is None
+    ]
+    if incomplete:
+        blockers.append(f"incomplete_metrics:{incomplete}")
+    pk = evaluate_pk_headroom(candidate.pk_type, current_rows)
+    if pk["blocker"]:
+        blockers.append(str(pk["blocker"]))
+    if disk_wal_budget is None:
+        blockers.append("disk_wal_budget_unrecorded")
+    if not rollback_rehearsed:
+        blockers.append("rollback_not_rehearsed")
+
+    seal: Seal = "PROVEN" if not blockers else "UNPROVEN"
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "workload_version": WORKLOAD_VERSION,
+        "workload": list(WORKLOAD_QUERIES),
+        "candidate": {
+            "name": candidate.name,
+            "partitioning": candidate.partitioning,
+            "pk_type": candidate.pk_type,
+            "notes": candidate.notes,
+        },
+        "corpus_facts": corpus_facts,
+        "incremental_churn": incremental_churn,
+        "pk": pk,
+        "seal": seal,
+        "blockers": blockers,
+        "claim_nacional_physical_design_proven": seal == "PROVEN",
+    }
+    payload["contract_hash"] = sha256_payload(
+        {k: v for k, v in payload.items() if k != "contract_hash"}
+    )
+    return payload

--- a/tests/test_storage_workload.py
+++ b/tests/test_storage_workload.py
@@ -81,3 +81,93 @@ def test_full_evidence_seals_proven() -> None:
         rollback_rehearsed=True,
     )
     assert replay["contract_hash"] == report["contract_hash"]
+    assert report["rollback_rehearsed"] is True
+    assert report["disk_wal_budget"] == {"disk_gb": 200, "wal_gb": 20}
+    assert {row["query_id"] for row in report["evidence"]} == {q["id"] for q in WORKLOAD_QUERIES}
+
+
+def test_wal_required_and_evidence_binds_contract_hash() -> None:
+    candidate = DesignCandidate(
+        name="range_partition_month",
+        partitioning="range(source_event_date)",
+        pk_type="BIGSERIAL",
+        notes="decision pending cost comparison",
+    )
+    missing_wal = tuple(
+        WorkloadEvidence(
+            query_id=q["id"],
+            explain_analyze="Index Scan",
+            p50_ms=5.0,
+            p95_ms=12.0,
+            p99_ms=20.0,
+            wal_bytes=None,
+        )
+        for q in WORKLOAD_QUERIES
+    )
+    unproven = seal_workload(
+        corpus_facts=MIN_REPRESENTATIVE_FACTS,
+        incremental_churn=10_000,
+        evidence=missing_wal,
+        candidate=candidate,
+        current_rows=MIN_REPRESENTATIVE_FACTS,
+        disk_wal_budget={"disk_gb": 200, "wal_gb": 20},
+        rollback_rehearsed=True,
+    )
+    assert unproven["seal"] == "UNPROVEN"
+    assert any(b.startswith("incomplete_metrics") for b in unproven["blockers"])
+
+    empty_budget = seal_workload(
+        corpus_facts=MIN_REPRESENTATIVE_FACTS,
+        incremental_churn=10_000,
+        evidence=tuple(
+            WorkloadEvidence(
+                query_id=q["id"],
+                explain_analyze="Index Scan",
+                p50_ms=5.0,
+                p95_ms=12.0,
+                p99_ms=20.0,
+                wal_bytes=100,
+            )
+            for q in WORKLOAD_QUERIES
+        ),
+        candidate=candidate,
+        current_rows=MIN_REPRESENTATIVE_FACTS,
+        disk_wal_budget={},
+        rollback_rehearsed=True,
+    )
+    assert empty_budget["seal"] == "UNPROVEN"
+    assert "disk_wal_budget_unrecorded" in empty_budget["blockers"]
+
+    def _full(explain: str, p50: float) -> tuple[WorkloadEvidence, ...]:
+        return tuple(
+            WorkloadEvidence(
+                query_id=q["id"],
+                explain_analyze=explain,
+                p50_ms=p50,
+                p95_ms=12.0,
+                p99_ms=20.0,
+                wal_bytes=100,
+            )
+            for q in WORKLOAD_QUERIES
+        )
+
+    index_scan = seal_workload(
+        corpus_facts=MIN_REPRESENTATIVE_FACTS,
+        incremental_churn=10_000,
+        evidence=_full("Index Scan", 5.0),
+        candidate=candidate,
+        current_rows=MIN_REPRESENTATIVE_FACTS,
+        disk_wal_budget={"disk_gb": 200, "wal_gb": 20},
+        rollback_rehearsed=True,
+    )
+    seq_scan = seal_workload(
+        corpus_facts=MIN_REPRESENTATIVE_FACTS,
+        incremental_churn=10_000,
+        evidence=_full("Seq Scan", 30_000.0),
+        candidate=candidate,
+        current_rows=MIN_REPRESENTATIVE_FACTS,
+        disk_wal_budget={"disk_gb": 200, "wal_gb": 20},
+        rollback_rehearsed=True,
+    )
+    assert index_scan["seal"] == seq_scan["seal"] == "PROVEN"
+    assert index_scan["contract_hash"] != seq_scan["contract_hash"]

--- a/tests/test_storage_workload.py
+++ b/tests/test_storage_workload.py
@@ -1,0 +1,83 @@
+"""Tests for #315 national contracts storage-workload contract."""
+
+from __future__ import annotations
+
+from scripts.national_contract_truth.storage_workload import (
+    MIN_REPRESENTATIVE_FACTS,
+    WORKLOAD_QUERIES,
+    DesignCandidate,
+    WorkloadEvidence,
+    evaluate_pk_headroom,
+    seal_workload,
+)
+
+
+def test_serial_does_not_support_national_growth() -> None:
+    serial = evaluate_pk_headroom("SERIAL", current_rows=4_000_000)
+    assert serial["supports_national_growth"] is False
+    assert serial["blocker"] == "SERIAL_EXHAUSTION_RISK"
+    big = evaluate_pk_headroom("BIGSERIAL", current_rows=4_000_000)
+    assert big["supports_national_growth"] is True
+
+
+def test_unrun_corpus_stays_unproven() -> None:
+    candidate = DesignCandidate(
+        name="unpartitioned_brin",
+        partitioning="none",
+        pk_type="BIGSERIAL",
+        notes="candidate only; not selected",
+    )
+    report = seal_workload(
+        corpus_facts=1_000,
+        incremental_churn=50,
+        evidence=(),
+        candidate=candidate,
+        current_rows=1_000,
+    )
+    assert report["seal"] == "UNPROVEN"
+    assert report["claim_nacional_physical_design_proven"] is False
+    assert report["corpus_facts"] < MIN_REPRESENTATIVE_FACTS
+    assert any(b.startswith("corpus_below_representative") for b in report["blockers"])
+    assert {q["id"] for q in report["workload"]} == {q["id"] for q in WORKLOAD_QUERIES}
+
+
+def test_full_evidence_seals_proven() -> None:
+    candidate = DesignCandidate(
+        name="range_partition_month",
+        partitioning="range(source_event_date)",
+        pk_type="BIGSERIAL",
+        notes="decision pending cost comparison",
+    )
+    evidence = tuple(
+        WorkloadEvidence(
+            query_id=q["id"],
+            explain_analyze="Index Scan",
+            p50_ms=5.0,
+            p95_ms=12.0,
+            p99_ms=20.0,
+            wal_bytes=100,
+            buffers={"hits": 10},
+        )
+        for q in WORKLOAD_QUERIES
+    )
+    report = seal_workload(
+        corpus_facts=MIN_REPRESENTATIVE_FACTS,
+        incremental_churn=10_000,
+        evidence=evidence,
+        candidate=candidate,
+        current_rows=MIN_REPRESENTATIVE_FACTS,
+        disk_wal_budget={"disk_gb": 200, "wal_gb": 20},
+        rollback_rehearsed=True,
+    )
+    assert report["seal"] == "PROVEN"
+    assert report["claim_nacional_physical_design_proven"] is True
+    replay = seal_workload(
+        corpus_facts=MIN_REPRESENTATIVE_FACTS,
+        incremental_churn=10_000,
+        evidence=evidence,
+        candidate=candidate,
+        current_rows=MIN_REPRESENTATIVE_FACTS,
+        disk_wal_budget={"disk_gb": 200, "wal_gb": 20},
+        rollback_rehearsed=True,
+    )
+    assert replay["contract_hash"] == report["contract_hash"]


### PR DESCRIPTION
## Outcome

Versioned physical-design workload contract. Seal stays `UNPROVEN` unless a representative >=3.7M corpus actually ran.

## Issues

Refs #315

Does **not** auto-close: the 3.7M-row benchmark was not executed in this environment.

## What shipped

- Versioned SQL workload: upsert, temporal range, buyer, supplier, id, versions, aggregates.
- `PROVEN` requires corpus size, EXPLAIN/latency, WAL/disk budget and rollback rehearsal.
- `SERIAL` is rejected for national growth; `BIGSERIAL`/`BIGINT`/`UUID` are accepted pk types.
- Replaying the same evidence reproduces `contract_hash`.

## Verification

```bash
python3 -m pytest tests/test_storage_workload.py -o addopts='' -q
```

3 passed, twice. Policy gates PASS.

## Honesty

No 3.7M load, no EXPLAIN on production, no architectural selection claimed as proven.