### PR TITLE
feat(dui): add bounded public contact discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ docs/ops/campaigns/**/evidence/**/package-final-fixture/*.xlsx
 # Spec Kit / Grok runtime (keep skills + constitution + workflows definitions)
 .specify/workflows/**/runs/
 .specify/.cache/
+.cache/confenge-prospect/
+work/confenge-prospect-live-*/
 .grok/tmp/
 .grok/cache/
 specs/**/checklists/.runtime/

--- a/DOD.md
+++ b/DOD.md
@@ -471,6 +471,17 @@ Um item pode ser marcado como concluído apenas quando pelo menos uma das evidê
 - [ ] O `confenge.outreach.v1` publica uma decisão target-fit completa para todo CNPJ endereçável do universo reconciliado, inclusive OUT, insuficiente, stale, DNC, downgrades e tombstones; omissão nunca preserva autorização anterior.
 - [ ] O primeiro ciclo de uso real registra decisões de Tiago, contatos realizados e resultados observados, inclusive quando não houver conversão.
 
+#### Contact resolution público e defensável
+
+- [ ] Para cada conta A1/A2 priorizada, a busca web contextual é executada dentro de budget explícito ou registra `POLICY_SKIP`/`SOURCE_BLOCKED`; ausência de execução não conta como cobertura.
+- [ ] Resolução de domínio retorna domínio canônico, confiança, alternativas, evidências e reason codes; ambiguidade, holding, terceiro, marketplace, rede social ou domínio abandonado não são promovidos silenciosamente.
+- [ ] Pessoa, cargo, domínio, derivação de email, verificação técnica, suitability e freshness permanecem dimensões independentes com provenance por campo.
+- [ ] Busca/crawl respeita fontes públicas profissionais, robots, limites de tempo/bytes/páginas, cache, retries e proteção SSRF; não usa scraping autenticado, evasão, breach data ou data broker pago.
+- [ ] `INFERRED` nunca vira `OBSERVED`; MX/SMTP não provam identidade; telefone geral nunca vira telefone pessoal sem evidência explícita.
+- [ ] A projeção consumer-agnostic chega ao Warmbly sem segunda verdade e sem autorizar envio. Outcomes retornam apenas como sinais idempotentes, não como CRM replicado.
+- [ ] Golden set cobre email nominal publicado, caixa genérica, padrão inferido, catch-all, domínio ambíguo/grupo, sem site, stale e conflito, com regressões epistemológicas fail-closed.
+- [ ] O primeiro canário de 10-30 contas reais publica métricas de busca, domínio, pessoa, rota, verificação, falhas e reason codes. Fixture prova lógica, não operação live.
+
 #### Gate imediato `CONFENGE_COMMERCIAL_READY`
 
 - [ ] O perfil comercial e o catálogo de sinais estão versionados.

--- a/docs/architecture/adr-decision-unit-intelligence.md
+++ b/docs/architecture/adr-decision-unit-intelligence.md
@@ -1,6 +1,6 @@
 # ADR: Decision-Unit Intelligence + Reachability
 
-**Status:** Accepted for implementation  
+**Status:** Accepted and incrementally implemented
 **Date:** 2026-08-14  
 **Branch:** `feat/decision-unit-intelligence`
 
@@ -22,3 +22,10 @@ It does **not** treat “named email explicitly published” as success.
 - `#370` remains the email-safe Warmbly canary. This epic does not close it.
 - Work stays off PR `#371`.
 - There is no `AUTO_SEND`.
+- Public web search is a first-class bounded provider, not an untracked fallback.
+- Search, crawl, domain resolution, and verification remain replaceable adapters.
+- SearXNG is allowed only across an HTTP service boundary; its AGPL code is not embedded.
+- The local canary may use the MIT-licensed DDGS adapter. Static HTML crawling reuses existing dependencies.
+- extra-cli remains the identity/reachability truth plane; Warmbly remains the activation/outcome plane.
+
+Operational contract: [`../commercial-intelligence/contact-resolution.md`](../commercial-intelligence/contact-resolution.md).

--- a/docs/commercial-intelligence/contact-resolution.md
+++ b/docs/commercial-intelligence/contact-resolution.md
@@ -1,0 +1,143 @@
+# CONFENGE contact resolution
+
+## Ownership and boundary
+
+`CONFENGE Prospect` is not a product, repository, CRM, or lead database. It is a distributed capability:
+
+```text
+extra-cli facts + public web
+  -> account/trigger/offer
+  -> decision unit/person/route/evidence/confidence
+  -> versioned consumer projection
+  -> Warmbly CONFENGE cockpit
+  -> human review and channel policy
+  -> action/reply/outcome
+  -> bounded commercial feedback
+```
+
+- **extra-cli owns intelligence:** canonical account identity, domain resolution, people, observed roles, contact candidates, derivation, verification, provenance, freshness, suitability, and consumer-agnostic projections.
+- **Warmbly owns activation:** operator review, approval/rejection, messages, campaigns, mailbox effects, replies, outcomes, suppression, and the commercial action ledger.
+- Warmbly may materialize the exact projection needed for audit and execution. It does not repeat search or become the identity/reachability source of truth.
+- Contact intelligence never grants permission to send. `EMAIL_VALIDATED` remains restricted to the existing email-safe policy. Inference does not become observation.
+
+## Epistemic and route model
+
+The model keeps these dimensions separate:
+
+- person identity confidence;
+- observed or inferred role and role confidence;
+- corporate-domain confidence;
+- email derivation;
+- technical verification;
+- route suitability;
+- evidence freshness and conflicts;
+- suppression and policy status.
+
+Operational classes already map to R0-R5. A company switchboard plus a named person is R3 `ROUTES_TO_NAMED_PERSON`, never a personal phone. A pattern-generated email remains `INFERRED`, even when technically plausible. SMTP or MX evidence does not prove mailbox ownership or identity.
+
+## Public web discovery
+
+Public search is a first-class bounded provider when explicitly enabled. The cascade uses cached datalake/campaign facts to obtain the legal name and known site, then runs targeted search before a positive early stop. Search remains disabled by default in generic/test commands so no caller silently creates network traffic.
+
+The query planner records the full contextual plan and executes only the configured budget. It covers:
+
+- company name plus decision roles appropriate to the offer;
+- company name plus directorate, partners, contact, email, and telephone;
+- CNPJ plus email or telephone;
+- known-domain queries for directorate, engineering, contact, published email patterns, and PDFs.
+
+Each account records executed queries, result count, pages, bytes, failures, duration, backend, domain alternatives, reason codes, and stop reason. Search and crawl failures remain visible as `SOURCE_BLOCKED`, `BUDGET_EXHAUSTED`, or `POLICY_SKIP`; they are not converted to “no route”.
+
+### Domain resolution
+
+Input is CNPJ, legal name, service context, optional known site, and public search hits. The resolver:
+
+1. excludes government, social, directory/aggregator, and common third-party hosts;
+2. scores exact CNPJ evidence, legal-name tokens, official-site language, observed known site, and corporate TLD;
+3. returns one canonical domain only above a minimum explainable score;
+4. returns `UNKNOWN` or ambiguous alternatives when top candidates conflict.
+
+Output is persisted under `extra.domain_resolution` and in the search attempt:
+
+```json
+{
+  "canonical_domain": "example.com.br",
+  "confidence": "HIGH",
+  "alternatives": [],
+  "reason_codes": ["CNPJ_EXACT_ON_RESULT", "LEGAL_NAME_TOKEN_MATCH"]
+}
+```
+
+### Crawl and extraction safety
+
+- public HTTP(S) only; private, loopback, link-local, multicast, and reserved targets fail closed;
+- robots policy is checked before fetch;
+- redirects are revalidated;
+- HTML/plain text only in the first slice;
+- per-account query, result, page, byte, timeout, retry, and inter-query limits;
+- local TTL cache prevents blind rediscovery;
+- exact public page text may produce observed person/role/contact evidence;
+- email-to-person association requires the observed person's first and last name in the address local part in this first slice;
+- generic mailboxes never become named contacts;
+- observed company telephone remains company-owned unless explicit evidence proves otherwise.
+
+## Replaceable adapters and licenses
+
+Evaluation date: 2026-08-14. Recheck license and maintenance before upgrades.
+
+| Project | Repository | License | Decision and reuse |
+|---|---|---|---|
+| DDGS | <https://github.com/deedy5/ddgs> | MIT | Selected for the small local canary through a lazy adapter. It is replaceable and rate-limited; engine behavior is not treated as a stable contract. |
+| SearXNG | <https://github.com/searxng/searxng> | AGPL-3.0 | Selected only as an optional HTTP service boundary. No SearXNG code is copied or linked into extra-cli. A modified/network deployment requires explicit license compliance review. |
+| Crawl4AI | <https://github.com/unclecode/crawl4ai> | Apache-2.0 | Evaluated and deferred. It is active and capable, but browser/runtime weight is unnecessary for the first static-HTML slice. The crawler interface allows later adoption. |
+| theHarvester | <https://github.com/laramies/theHarvester> | GPL metadata / repository license ambiguity | Not adopted. Its broad OSINT surface and licensing posture add more risk and complexity than this targeted professional-public-data use case needs. |
+| dnspython | <https://github.com/rthalley/dnspython> | ISC | Selected for passive DNS/MX resolution. It never performs mailbox ownership or SMTP identity proof. |
+
+The first slice reuses existing `httpx`, Beautiful Soup, and lxml dependencies. No paid data provider, authenticated LinkedIn scraping, breach data, evasion, or copied third-party code is introduced.
+
+## Verification boundary
+
+`--verify-email-dns` runs syntax, domain, DNS and MX checks with a TTL cache. Reports explicitly preserve `MX_PRESENT_NOT_MAILBOX_PROOF`, `UNKNOWN_NOT_PROBED` for catch-all, and `SKIPPED_POLICY` for SMTP. Direct candidates remain `UNVERIFIED_DIRECT_CANDIDATE`; generic and role mailboxes remain generic. No passive result proves a person owns a mailbox.
+
+SMTP and catch-all probing are intentionally not implemented in the default adapter. A future implementation requires an explicit policy, controlled egress, reputation safeguards, rate limits, retry/timeouts, a kill switch, and evidence that the probe is technically reliable and lawful for the exact use case.
+
+## Projection contract
+
+The current account projection remains `confenge.decision_unit_account.v1`. Additive fields include persisted field evidence and `extra.domain_resolution`. `confenge.decision_unit_queue.v1` remains the multichannel operator projection. `confenge.outreach.v1` remains the narrower observed-email-safe projection consumed by Warmbly.
+
+Warmbly must display the route's person, role, company, relevance, channel, derivation, verification, confidence dimensions, source links, freshness, warnings, and policy status. It must not reinterpret an inferred route as observed or sendable.
+
+## Feedback boundary
+
+Warmbly owns delivered, bounce, replied, positive reply, wrong person, left company, generic mailbox, referral, meeting, no interest, and suppression events. extra-cli may consume the smallest idempotent signal needed to update a route, pattern, role prior, or golden case. It does not copy campaign or CRM state.
+
+## Metrics
+
+Every run manifest records public-web accounts attempted, domains resolved, searches, pages, bytes, and external cost. The account ledger also preserves duration, cache/search attempts, failures, and stop reasons. Decision-unit and route coverage remain in the existing funnel; Warmbly remains authoritative for approved, sent, delivered, bounced, replies, positive replies, meetings, and opportunities.
+
+The North Star is not email coverage. It is `qualified account -> defensible decision-maker route -> observed commercial outcome`.
+
+## Local runbook
+
+Install dependencies, then choose one explicit backend:
+
+```bash
+# Small zero-cost canary through the MIT adapter
+python3 -m scripts.decision_unit_intelligence run \
+  --out /tmp/confenge-prospect-10 \
+  --limit 10 \
+  --search-backend ddgs \
+  --search-max-queries 2 \
+  --search-results-per-query 4 \
+  --crawl-max-pages 2 \
+  --verify-email-dns
+
+# Self-hosted metasearch boundary
+CONFENGE_SEARXNG_URL=https://search.internal.example \
+python3 -m scripts.decision_unit_intelligence run \
+  --out /tmp/confenge-prospect-10 \
+  --limit 10 \
+  --search-backend searxng
+```
+
+Raw search/crawl cache stays under `.cache/confenge-prospect/` and is not committed. Operator output and projections remain review-only. No command enables auto-send.

--- a/docs/ops/decision-unit-intelligence-runbook.md
+++ b/docs/ops/decision-unit-intelligence-runbook.md
@@ -18,6 +18,27 @@ python3 -m scripts.decision_unit_intelligence replay \
 Fontes Tier 0: artefatos da campanha `reajuste_14133-2026-08-05-56dc6c48` e planilha CRM enriquecida.
 DSN (`LOCAL_DATALAKE_DSN`) é opcional.
 
+## Web discovery canary
+
+Busca web é explícita, limitada e reutilizável. O backend `off` registra `POLICY_SKIP`; não conta como cobertura.
+
+```bash
+python3 -m scripts.decision_unit_intelligence run \
+  --out /tmp/dui-web-10 \
+  --limit 10 \
+  --search-backend ddgs \
+  --search-max-queries 2 \
+  --search-results-per-query 4 \
+  --crawl-max-pages 2 \
+  --verify-email-dns
+```
+
+Para SearXNG, use `--search-backend searxng` e `--searxng-url` ou `CONFENGE_SEARXNG_URL`. Não use instância pública de terceiros para batch. Cache local: `.cache/confenge-prospect/`.
+
+O manifesto registra contas tentadas, domínios resolvidos, buscas, páginas, bytes e custo externo. Falha de fonte, orçamento esgotado e ausência de evidência são estados diferentes.
+
+`--verify-email-dns` verifica apenas sintaxe/DNS/MX. Catch-all permanece `UNKNOWN_NOT_PROBED` e SMTP permanece `SKIPPED_POLICY`; MX não prova caixa nem identidade.
+
 ## Shadow
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,10 @@ pydantic>=2.0.0
 lxml>=5.0.0
 beautifulsoup4>=4.12.0
 
+# Public web search canary adapter (MIT); production may use SearXNG over HTTP.
+ddgs>=9.14.4,<10
+dnspython>=2.7.0,<3
+
 # Fuzzy string matching (optional, fallback to difflib)
 rapidfuzz>=3.0.0
 

--- a/scripts/decision_unit_intelligence/cli.py
+++ b/scripts/decision_unit_intelligence/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from scripts.decision_unit_intelligence.operator_pack import build_card, write_o
 from scripts.decision_unit_intelligence.projection import project_warmbly_outreach
 from scripts.decision_unit_intelligence.repository import JsonRunRepository, account_hash, write_json
 from scripts.decision_unit_intelligence.runner import run_account
+from scripts.decision_unit_intelligence.web_discovery import SearchBudget
 
 
 def _load_cnpjs(args: argparse.Namespace) -> list[str]:
@@ -36,7 +38,9 @@ def cmd_plan(args: argparse.Namespace) -> int:
     out = Path(args.out)
     manifest = build_manifest(_load_cnpjs(args))
     write_json(out, manifest)
-    print(json.dumps({"wrote": str(out), "n": manifest["n"], "seed": manifest["selection"]["seed"]}, ensure_ascii=False))
+    print(
+        json.dumps({"wrote": str(out), "n": manifest["n"], "seed": manifest["selection"]["seed"]}, ensure_ascii=False)
+    )
     return 0
 
 
@@ -44,13 +48,33 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
     cnpjs = _load_cnpjs(args)
     repo = JsonRunRepository(Path(args.out))
     accounts = []
+    search_budget = SearchBudget(
+        max_queries=args.search_max_queries,
+        max_results_per_query=args.search_results_per_query,
+        max_pages=args.crawl_max_pages,
+        max_bytes=args.crawl_max_bytes,
+        timeout_seconds=args.web_timeout_seconds,
+        min_query_interval_seconds=args.search_min_interval_seconds,
+        cache_ttl_days=args.search_cache_ttl_days,
+    )
     for cnpj in cnpjs:
-        acc = run_account(cnpj, service=args.service, infer_email=not args.no_infer_email)
+        acc = run_account(
+            cnpj,
+            service=args.service,
+            infer_email=not args.no_infer_email,
+            search_backend=args.search_backend,
+            searxng_url=args.searxng_url or os.getenv("CONFENGE_SEARXNG_URL"),
+            search_budget=search_budget,
+            cache_dir=Path(args.search_cache_dir),
+            verify_email_dns=args.verify_email_dns,
+        )
         payload = acc.to_dict()
         payload["replay_hash"] = account_hash(payload)
         repo.save_account(payload)
         accounts.append(acc)
-        print(f"{label}\t{acc.cnpj}\t{acc.terminal.value}\t{acc.extra.get('account_reachability_class')}\t{acc.legal_name}")
+        print(
+            f"{label}\t{acc.cnpj}\t{acc.terminal.value}\t{acc.extra.get('account_reachability_class')}\t{acc.legal_name}"
+        )
     fun = funnel(accounts)
     repo.save_funnel(fun)
     cards = [build_card(a) for a in accounts]
@@ -59,6 +83,35 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
     warmbly = [project_warmbly_outreach(a) for a in accounts]
     email_safe = sum(w["email_safe_count"] for w in warmbly)
     write_json(Path(args.out) / "warmbly_outreach.json", {"accounts": warmbly, "email_safe_total": email_safe})
+    web_attempts = [
+        attempt for account in accounts for attempt in account.ledger.attempts if attempt.provider_id == "public_search"
+    ]
+    web_metrics = {
+        "accounts_attempted": sum(attempt.status != "skipped" for attempt in web_attempts),
+        "domains_resolved": sum(
+            bool((attempt.extra.get("domain_resolution") or {}).get("canonical_domain")) for attempt in web_attempts
+        ),
+        "searches": sum(len(attempt.queries) for attempt in web_attempts if attempt.status != "skipped"),
+        "pages": sum(attempt.documents_checked for attempt in web_attempts),
+        "bytes_touched": sum(attempt.bytes_touched for attempt in web_attempts),
+        "external_cost_brl": sum(attempt.cost_brl for attempt in web_attempts),
+    }
+    cache_hits = sum(int(attempt.extra.get("cache_hits") or 0) for attempt in web_attempts)
+    cache_misses = sum(int(attempt.extra.get("cache_misses") or 0) for attempt in web_attempts)
+    attempted_accounts = int(web_metrics["accounts_attempted"])
+    web_metrics["cache_hits"] = cache_hits
+    web_metrics["cache_misses"] = cache_misses
+    web_metrics["cache_hit_rate"] = round(cache_hits / (cache_hits + cache_misses), 4) if cache_hits + cache_misses else 0.0
+    web_metrics["duration_ms"] = sum(attempt.duration_ms for attempt in web_attempts)
+    web_metrics["searches_per_account"] = (
+        round(int(web_metrics["searches"]) / attempted_accounts, 4) if attempted_accounts else 0.0
+    )
+    web_metrics["pages_per_account"] = (
+        round(int(web_metrics["pages"]) / attempted_accounts, 4) if attempted_accounts else 0.0
+    )
+    web_metrics["time_per_account_ms"] = (
+        round(int(web_metrics["duration_ms"]) / attempted_accounts, 2) if attempted_accounts else 0.0
+    )
     manifest = {
         "schema_id": "confenge.dui.run.v1",
         "schema_version": SCHEMA_VERSION,
@@ -69,6 +122,31 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
         "funnel": fun,
         "operator_pack": pack_paths,
         "email_safe_warmbly": email_safe,
+        "web_discovery": {
+            "backend": args.search_backend,
+            "budget": {
+                "max_queries_per_account": search_budget.max_queries,
+                "max_results_per_query": search_budget.max_results_per_query,
+                "max_pages_per_account": search_budget.max_pages,
+                "max_bytes_per_account": search_budget.max_bytes,
+            },
+            "metrics": web_metrics,
+        },
+        "email_verification": {
+            "enabled": args.verify_email_dns,
+            "emails_checked": sum(len(account.extra.get("email_verification") or []) for account in accounts),
+            "mx_present": sum(
+                report.get("mx") == "MX_PRESENT"
+                for account in accounts
+                for report in (account.extra.get("email_verification") or [])
+            ),
+            "smtp_skipped_policy": sum(
+                report.get("smtp") == "SKIPPED_POLICY"
+                for account in accounts
+                for report in (account.extra.get("email_verification") or [])
+            ),
+            "identity_proven": 0,
+        },
         "selection": build_manifest(cnpjs)["selection"],
         "auto_send": False,
     }
@@ -88,7 +166,11 @@ def cmd_shadow(args: argparse.Namespace) -> int:
 def cmd_report(args: argparse.Namespace) -> int:
     repo = JsonRunRepository(Path(args.run))
     accounts = repo.load_accounts()
-    print(json.dumps({"n": len(accounts), "path": args.run, "sample": accounts[0]["cnpj"] if accounts else None}, indent=2))
+    print(
+        json.dumps(
+            {"n": len(accounts), "path": args.run, "sample": accounts[0]["cnpj"] if accounts else None}, indent=2
+        )
+    )
     return 0
 
 
@@ -117,6 +199,7 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--limit", type=int, default=30)
     run.add_argument("--service", default="reajuste_14133")
     run.add_argument("--no-infer-email", action="store_true")
+    _add_web_discovery_args(run)
     run.set_defaults(func=cmd_run)
 
     shadow = sub.add_parser("shadow")
@@ -127,6 +210,7 @@ def build_parser() -> argparse.ArgumentParser:
     shadow.add_argument("--limit", type=int, default=100)
     shadow.add_argument("--service", default="reajuste_14133")
     shadow.add_argument("--no-infer-email", action="store_true")
+    _add_web_discovery_args(shadow)
     shadow.set_defaults(func=cmd_shadow)
 
     report = sub.add_parser("report")
@@ -138,6 +222,20 @@ def build_parser() -> argparse.ArgumentParser:
     replay.add_argument("--run-b", required=True)
     replay.set_defaults(func=cmd_replay)
     return p
+
+
+def _add_web_discovery_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--search-backend", choices=("off", "searxng", "ddgs"), default="off")
+    parser.add_argument("--searxng-url")
+    parser.add_argument("--search-max-queries", type=int, default=4)
+    parser.add_argument("--search-results-per-query", type=int, default=5)
+    parser.add_argument("--crawl-max-pages", type=int, default=4)
+    parser.add_argument("--crawl-max-bytes", type=int, default=1_500_000)
+    parser.add_argument("--web-timeout-seconds", type=float, default=12.0)
+    parser.add_argument("--search-min-interval-seconds", type=float, default=1.0)
+    parser.add_argument("--search-cache-ttl-days", type=int, default=7)
+    parser.add_argument("--search-cache-dir", default=".cache/confenge-prospect")
+    parser.add_argument("--verify-email-dns", action="store_true")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/decision_unit_intelligence/email_verification.py
+++ b/scripts/decision_unit_intelligence/email_verification.py
@@ -1,0 +1,197 @@
+"""Passive, auditable email-domain verification.
+
+DNS/MX plausibility is deliberately separate from mailbox and identity proof.
+SMTP and catch-all probes stay disabled unless a future explicit policy provides
+an approved verifier adapter, rate limits, and network-reputation safeguards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Protocol
+
+import dns.exception
+import dns.resolver
+
+from scripts.decision_unit_intelligence.models import ReachabilityRoute, normalize_email, now_iso
+from scripts.decision_unit_intelligence.reachability import (
+    classify_observed_email_channel,
+    is_generic_mailbox,
+    is_role_mailbox,
+)
+from scripts.decision_unit_intelligence.web_discovery import JsonDiscoveryCache
+
+
+class DnsLookupError(RuntimeError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class DnsResolver(Protocol):
+    def query(self, domain: str, record_type: str) -> list[str]: ...
+
+
+class DnspythonResolver:
+    def __init__(self, *, timeout_seconds: float = 5.0) -> None:
+        self._resolver = dns.resolver.Resolver()
+        self._resolver.timeout = timeout_seconds
+        self._resolver.lifetime = timeout_seconds
+
+    def query(self, domain: str, record_type: str) -> list[str]:
+        try:
+            answer = self._resolver.resolve(domain, record_type, raise_on_no_answer=False)
+        except dns.resolver.NXDOMAIN as exc:
+            raise DnsLookupError("NXDOMAIN") from exc
+        except dns.resolver.NoNameservers as exc:
+            raise DnsLookupError("NO_NAMESERVERS") from exc
+        except dns.exception.Timeout as exc:
+            raise DnsLookupError("DNS_TIMEOUT") from exc
+        except dns.exception.DNSException as exc:
+            raise DnsLookupError(type(exc).__name__.upper()) from exc
+        return sorted(str(record).strip() for record in (answer or []))
+
+
+@dataclass(frozen=True)
+class EmailVerificationReport:
+    email: str
+    syntax: str
+    domain: str
+    dns: str
+    mx: str
+    mx_hosts: tuple[str, ...]
+    catch_all: str
+    smtp: str
+    final_classification: str
+    checked_at: str
+    reason_codes: tuple[str, ...]
+    cache_hit: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class PassiveEmailVerifier:
+    def __init__(
+        self,
+        resolver: DnsResolver,
+        *,
+        cache: JsonDiscoveryCache | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.cache = cache
+
+    def verify(self, raw_email: str) -> EmailVerificationReport:
+        email = normalize_email(raw_email)
+        if not email:
+            return EmailVerificationReport(
+                email=raw_email,
+                syntax="INVALID",
+                domain="UNKNOWN",
+                dns="NOT_CHECKED",
+                mx="NOT_CHECKED",
+                mx_hosts=(),
+                catch_all="UNKNOWN_NOT_PROBED",
+                smtp="SKIPPED_POLICY",
+                final_classification="UNVERIFIED",
+                checked_at=now_iso(),
+                reason_codes=("INVALID_SYNTAX", "SMTP_DISABLED_BY_POLICY"),
+            )
+        domain = email.split("@", 1)[1]
+        cached = self.cache.get("email-dns", domain) if self.cache else None
+        if cached is not None:
+            return EmailVerificationReport(
+                email=email,
+                syntax="VALID",
+                domain=domain,
+                dns=str(cached["dns"]),
+                mx=str(cached["mx"]),
+                mx_hosts=tuple(cached.get("mx_hosts") or []),
+                catch_all="UNKNOWN_NOT_PROBED",
+                smtp="SKIPPED_POLICY",
+                final_classification=_final_classification(email),
+                checked_at=str(cached["checked_at"]),
+                reason_codes=tuple(cached.get("reason_codes") or []) + ("CACHE_HIT",),
+                cache_hit=True,
+            )
+
+        dns_status = "UNKNOWN"
+        mx_status = "UNKNOWN"
+        mx_hosts: tuple[str, ...] = ()
+        reasons = ["SYNTAX_VALID", "SMTP_DISABLED_BY_POLICY", "CATCH_ALL_NOT_PROBED"]
+        try:
+            mx_records = self.resolver.query(domain, "MX")
+            mx_hosts = tuple(mx_records)
+            if any(record.split() and record.split()[-1] == "." for record in mx_records):
+                dns_status = "RESOLVED"
+                mx_status = "NULL_MX"
+                reasons.append("NULL_MX_DECLINES_EMAIL")
+            elif mx_records:
+                dns_status = "RESOLVED"
+                mx_status = "MX_PRESENT"
+                reasons.append("MX_PRESENT_NOT_MAILBOX_PROOF")
+            else:
+                dns_status, mx_status, fallback_reason = self._implicit_mx(domain)
+                reasons.append(fallback_reason)
+        except DnsLookupError as exc:
+            dns_status = exc.reason
+            mx_status = "MISSING"
+            reasons.append(exc.reason)
+
+        checked_at = now_iso()
+        cache_value = {
+            "dns": dns_status,
+            "mx": mx_status,
+            "mx_hosts": list(mx_hosts),
+            "checked_at": checked_at,
+            "reason_codes": reasons,
+        }
+        if self.cache:
+            self.cache.set("email-dns", domain, cache_value)
+        return EmailVerificationReport(
+            email=email,
+            syntax="VALID",
+            domain=domain,
+            dns=dns_status,
+            mx=mx_status,
+            mx_hosts=mx_hosts,
+            catch_all="UNKNOWN_NOT_PROBED",
+            smtp="SKIPPED_POLICY",
+            final_classification=_final_classification(email),
+            checked_at=checked_at,
+            reason_codes=tuple(reasons),
+        )
+
+    def _implicit_mx(self, domain: str) -> tuple[str, str, str]:
+        for record_type in ("A", "AAAA"):
+            try:
+                if self.resolver.query(domain, record_type):
+                    return "RESOLVED", "IMPLICIT_MX_A", "IMPLICIT_MX_NOT_MAILBOX_PROOF"
+            except DnsLookupError:
+                continue
+        return "MISSING", "MISSING", "NO_MX_OR_ADDRESS_RECORD"
+
+
+def _final_classification(email: str) -> str:
+    if is_role_mailbox(email):
+        return "GENERIC_ROLE_MAILBOX"
+    if is_generic_mailbox(email):
+        return "GENERIC_MAILBOX"
+    if classify_observed_email_channel(email).value == "DIRECT_EMAIL":
+        return "UNVERIFIED_DIRECT_CANDIDATE"
+    return "UNVERIFIED"
+
+
+def verify_email_routes(
+    routes: list[ReachabilityRoute],
+    verifier: PassiveEmailVerifier,
+) -> list[EmailVerificationReport]:
+    reports: dict[str, EmailVerificationReport] = {}
+    for route in routes:
+        email = normalize_email(route.channel_value)
+        if not email:
+            continue
+        report = reports.setdefault(email, verifier.verify(email))
+        route.extra["email_verification"] = report.to_dict()
+        route.extra["identity_proven_by_verification"] = False
+    return list(reports.values())

--- a/scripts/decision_unit_intelligence/operator_pack.py
+++ b/scripts/decision_unit_intelligence/operator_pack.py
@@ -28,6 +28,8 @@ def build_card(account: AccountInvestigation) -> dict[str, Any]:
         )
         if route and route.channel_type.value in {"COMPANY_SWITCHBOARD", "DIRECT_PHONE"}:
             do_not_claim.append("Não alegar que o telefone pertence à pessoa.")
+    email_verification = route.extra.get("email_verification") if route else None
+    verification_status = _operator_verification_status(email_verification)
     return {
         "empresa": account.legal_name,
         "cnpj": account.cnpj,
@@ -52,6 +54,15 @@ def build_card(account: AccountInvestigation) -> dict[str, Any]:
         "channel_source_url": route.source_url if route else None,
         "channel_epistemic_class": route.epistemic_class.value if route else None,
         "channel_ownership": route.ownership.value if route else None,
+        "route_freshness": route.freshness.value if route else None,
+        "route_suppression": route.suppression.value if route else None,
+        "route_confidence": route.route_confidence.value if route else None,
+        "email_verification": email_verification,
+        "email_verification_reports": account.extra.get("email_verification", []),
+        "verification_status": verification_status,
+        # Passive DNS/MX never makes a route send-ready or proves a mailbox/person.
+        "email_send_ready": False,
+        "domain_resolution": account.extra.get("domain_resolution"),
         "action_mode": rec.action_mode.value if rec else None,
         "channel": route.channel_value if route else None,
         "exact_next_action": action or (rec.next_action if rec else None),
@@ -62,15 +73,32 @@ def build_card(account: AccountInvestigation) -> dict[str, Any]:
                 "channel_type": a.channel_type.value,
                 "channel": a.channel_value,
                 "action": a.action_mode.value,
+                "epistemic_class": a.epistemic_class.value,
+                "verification": a.extra.get("email_verification"),
             }
             for a in alts
         ],
         "confidence_dimensions": rec.dimensions if rec else {},
-        "evidence_links": [r.source_url for r in account.routes if r.source_url],
+        "evidence_links": list(
+            dict.fromkeys(
+                [r.source_url for r in account.routes if r.source_url]
+                + [e.source_url for e in account.evidence if e.source_url]
+            )
+        ),
+        "field_evidence": [e.to_dict() for e in account.evidence],
         "warnings": account.warnings + (rec.warnings if rec else []),
         "do_not_claim": do_not_claim,
         "terminal": account.terminal.value,
     }
+
+
+def _operator_verification_status(report: object) -> str:
+    if not isinstance(report, dict):
+        return "NOT_FOUND"
+    classification = str(report.get("final_classification") or "").upper()
+    if classification in {"GENERIC_MAILBOX", "GENERIC_ROLE_MAILBOX"}:
+        return "INSTITUTIONAL_GENERIC"
+    return "CANDIDATE_UNVERIFIED"
 
 
 def render_markdown(cards: list[dict[str, Any]]) -> str:
@@ -93,6 +121,9 @@ def render_markdown(cards: list[dict[str, Any]]) -> str:
                 f"- Relação canal↔pessoa: `{card.get('route_relation') or '—'}`",
                 f"- Reason codes da rota: {card.get('route_reason_codes')}",
                 f"- Provenance do canal: `{card.get('channel_source_type')}` / `{card.get('channel_epistemic_class')}` / `{card.get('channel_ownership')}`",
+                f"- Domínio: {card.get('domain_resolution')}",
+                f"- Verificação de e-mail: {card.get('email_verification')}",
+                f"- Verificações de rotas alternativas: {card.get('email_verification_reports')}",
                 f"- Action mode: `{card.get('action_mode')}`",
                 f"- Canal: `{card.get('channel')}`",
                 f"- **AÇÃO:** {card.get('exact_next_action')}",

--- a/scripts/decision_unit_intelligence/orchestrator.py
+++ b/scripts/decision_unit_intelligence/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import Any
 
 from scripts.decision_unit_intelligence.corroboration import (
     detect_channel_conflicts,
@@ -35,6 +36,7 @@ from scripts.decision_unit_intelligence.models import (
     DecisionUnitCandidate,
     EpistemicClass,
     FieldAspect,
+    FieldEvidence,
     PersonObservation,
     PersonRelation,
     ReachabilityClass,
@@ -322,7 +324,7 @@ def recommend(
     routes: list[ReachabilityRoute],
 ) -> Recommendation:
     usable_people = [c for c in candidates if person_is_suitable(c)]
-    usable_people.sort(key=lambda c: (c.person_name or ""))
+    usable_people.sort(key=lambda c: c.person_name or "")
     usable_people.sort(key=_candidate_sort_key, reverse=True)
     actionable = [r for r in routes if is_actionable_route(r)]
     actionable.sort(key=route_rank, reverse=True)
@@ -343,9 +345,7 @@ def recommend(
     # Prefer a route that reaches the primary person; do not pick a worse person
     # just because they have a prettier email.
     person_routes = [
-        r
-        for r in actionable
-        if primary_person and r.decision_unit_candidate_id == primary_person.candidate_id
+        r for r in actionable if primary_person and r.decision_unit_candidate_id == primary_person.candidate_id
     ]
     role_or_corp = [
         r
@@ -394,8 +394,10 @@ def recommend(
 
     secondary = [c.candidate_id for c in usable_people[1:4]]
     alternatives = [r.route_id for r in actionable if primary_route is None or r.route_id != primary_route.route_id][:5]
-    action = primary_route.action_mode if primary_route else (
-        ActionMode.NEEDS_ENRICHMENT if primary_person else ActionMode.NO_ACTIONABLE_ROUTE
+    action = (
+        primary_route.action_mode
+        if primary_route
+        else (ActionMode.NEEDS_ENRICHMENT if primary_person else ActionMode.NO_ACTIONABLE_ROUTE)
     )
     return Recommendation(
         primary_target_id=primary_person.candidate_id if primary_person else None,
@@ -451,6 +453,8 @@ def investigate_account(
     mx_valid: bool = False,
     catch_all: bool = False,
     public_email_hits: list[str] | None = None,
+    evidence: list[FieldEvidence] | None = None,
+    discovery_extra: dict[str, Any] | None = None,
     blocked: bool = False,
 ) -> AccountInvestigation:
     entity_id = normalize_cnpj(cnpj)
@@ -464,12 +468,17 @@ def investigate_account(
     # Normalize observed emails to a channel type before routing.
     normalized_channels: list[ChannelObservation] = []
     for ch in channels:
-        if ch.channel_value and "@" in ch.channel_value and ch.channel_type in {
-            ChannelType.DIRECT_EMAIL,
-            ChannelType.GENERIC_CORPORATE_EMAIL,
-            ChannelType.ROLE_MAILBOX,
-            ChannelType.OTHER_PUBLIC_BUSINESS_ROUTE,
-        }:
+        if (
+            ch.channel_value
+            and "@" in ch.channel_value
+            and ch.channel_type
+            in {
+                ChannelType.DIRECT_EMAIL,
+                ChannelType.GENERIC_CORPORATE_EMAIL,
+                ChannelType.ROLE_MAILBOX,
+                ChannelType.OTHER_PUBLIC_BUSINESS_ROUTE,
+            }
+        ):
             ch.channel_type = classify_observed_email_channel(ch.channel_value)
         normalized_channels.append(ch)
     routes = build_routes(normalized_channels, candidates, company_entity_id=entity_id)
@@ -510,10 +519,11 @@ def investigate_account(
         recommendation=rec,
         ledger=ledger,
         terminal=terminal,
+        evidence=evidence or [],
         conflicts=conflicts,
         reason_codes=reasons,
         warnings=list(dict.fromkeys(rec.warnings)),
         policy_version=POLICY_VERSION,
         built_at=now_iso(),
-        extra={"account_reachability_class": klass.value},
+        extra={"account_reachability_class": klass.value, **(discovery_extra or {})},
     )

--- a/scripts/decision_unit_intelligence/providers/base.py
+++ b/scripts/decision_unit_intelligence/providers/base.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 from scripts.decision_unit_intelligence.models import (
     ChannelObservation,
     CostObservation,
+    FieldEvidence,
     PersonObservation,
     SearchAttempt,
 )
@@ -25,6 +26,7 @@ class InvestigationContext:
 class ProviderResult:
     people: list[PersonObservation] = field(default_factory=list)
     channels: list[ChannelObservation] = field(default_factory=list)
+    evidence: list[FieldEvidence] = field(default_factory=list)
     attempts: list[SearchAttempt] = field(default_factory=list)
     cursor: dict[str, Any] = field(default_factory=dict)
     terminal: str = "ok"

--- a/scripts/decision_unit_intelligence/providers/historical_campaign.py
+++ b/scripts/decision_unit_intelligence/providers/historical_campaign.py
@@ -175,6 +175,7 @@ class HistoricalCampaignProvider:
             return ProviderResult(attempts=[attempt], terminal="miss")
         people: list[PersonObservation] = []
         channels: list[ChannelObservation] = []
+        evidence = []
         for blob_key in ("qsa", "qsa2"):
             for name, role in parse_qsa_blob(row.get(blob_key)):
                 ev = make_evidence(
@@ -187,6 +188,7 @@ class HistoricalCampaignProvider:
                     evidence_snippet=f"{name} ({role})" if role else name,
                     extraction_method="qsa_cadastre",
                 )
+                evidence.append(ev)
                 people.append(
                     PersonObservation(
                         observation_id=stable_id("qsa", cnpj, name),
@@ -215,6 +217,7 @@ class HistoricalCampaignProvider:
                 evidence_snippet=str(tel),
                 extraction_method="rfb_phone",
             )
+            evidence.append(ev)
             channels.append(
                 ChannelObservation(
                     observation_id=stable_id("tel", cnpj, str(tel)),
@@ -242,6 +245,7 @@ class HistoricalCampaignProvider:
                 evidence_snippet=email,
                 extraction_method="public_or_manual_override",
             )
+            evidence.append(ev)
             channels.append(
                 ChannelObservation(
                     observation_id=stable_id("email", cnpj, email),
@@ -301,10 +305,14 @@ class HistoricalCampaignProvider:
         return ProviderResult(
             people=people,
             channels=channels,
+            evidence=evidence,
             attempts=[attempt],
             terminal="ok",
             why_now=why,
             company_site=str(site) if site else None,
             legal_name=row.get("legal_name") or row.get("razao_social") or row.get("Empresa"),
-            extra={"service_hint": service, "row": {k: row.get(k) for k in ("orgao", "valor", "melhor_contrato", "municipio", "uf")}},
+            extra={
+                "service_hint": service,
+                "row": {k: row.get(k) for k in ("orgao", "valor", "melhor_contrato", "municipio", "uf")},
+            },
         )

--- a/scripts/decision_unit_intelligence/providers/public_search.py
+++ b/scripts/decision_unit_intelligence/providers/public_search.py
@@ -1,29 +1,177 @@
-"""Tier 4 public search. Fail-fast when yield is structurally weak."""
+"""First-class, bounded public search and official-site evidence discovery."""
 
 from __future__ import annotations
 
-from scripts.decision_unit_intelligence.models import SearchAttempt, normalize_cnpj, stable_id
+from time import perf_counter
+
+from scripts.decision_unit_intelligence.evidence import make_evidence
+from scripts.decision_unit_intelligence.models import EpistemicClass, SearchAttempt, normalize_cnpj, now_iso, stable_id
 from scripts.decision_unit_intelligence.providers.base import InvestigationContext, ProviderResult
+from scripts.decision_unit_intelligence.web_discovery import (
+    SearchBackend,
+    SearchBudget,
+    WebCrawler,
+    build_query_plan,
+    dedupe_search_hits,
+    extract_public_evidence,
+    rank_crawl_urls,
+    resolve_corporate_domain,
+)
 
 
 class PublicSearchProvider:
     provider_id = "public_search"
-    tier = 4
+    tier = 1
+    first_class = True
+
+    def __init__(
+        self,
+        *,
+        backend: SearchBackend | None = None,
+        crawler: WebCrawler | None = None,
+        budget: SearchBudget | None = None,
+    ) -> None:
+        self.backend = backend
+        self.crawler = crawler
+        self.budget = budget or SearchBudget()
+        self.enabled = backend is not None
 
     def collect(self, context: InvestigationContext) -> ProviderResult:
         cnpj = normalize_cnpj(context.cnpj)
-        return ProviderResult(
-            attempts=[
-                SearchAttempt(
-                    attempt_id=stable_id("att", self.provider_id, cnpj),
-                    company_entity_id=cnpj,
-                    tier=4,
-                    provider_id=self.provider_id,
-                    source="public_search",
-                    status="skipped",
-                    reason="yield_fail_fast_aggregators_not_primary",
-                    extra={"policy": "do_not_burn_budget_on_weak_aggregators"},
-                )
-            ],
-            terminal="skipped",
+        known_site = str(context.extra.get("company_site") or "") or None
+        plan = build_query_plan(context, known_domain=_domain(known_site))
+        queries = plan[: self.budget.max_queries]
+        attempt = SearchAttempt(
+            attempt_id=stable_id("att", self.provider_id, cnpj, "|".join(queries)),
+            company_entity_id=cnpj,
+            tier=self.tier,
+            provider_id=self.provider_id,
+            source="public_web",
+            status="skipped",
+            queries=queries,
+            extra={
+                "planned_query_count": len(plan),
+                "budget": {
+                    "max_queries": self.budget.max_queries,
+                    "max_results_per_query": self.budget.max_results_per_query,
+                    "max_pages": self.budget.max_pages,
+                    "max_bytes": self.budget.max_bytes,
+                },
+            },
         )
+        if self.backend is None:
+            attempt.reason = "search_backend_not_configured"
+            attempt.stop_reason = "POLICY_SKIP"
+            return ProviderResult(attempts=[attempt], terminal="skipped")
+        if not context.legal_name:
+            attempt.reason = "legal_name_required_for_targeted_search"
+            attempt.stop_reason = "POLICY_SKIP"
+            return ProviderResult(attempts=[attempt], terminal="skipped")
+
+        started = perf_counter()
+        search_cache_before = (
+            int(getattr(self.backend, "cache_hits", 0)),
+            int(getattr(self.backend, "cache_misses", 0)),
+        )
+        crawl_cache_before = (
+            int(getattr(self.crawler, "cache_hits", 0)),
+            int(getattr(self.crawler, "cache_misses", 0)),
+        )
+        hits = []
+        failures: list[str] = []
+        for query in queries:
+            try:
+                hits.extend(self.backend.search(query, limit=self.budget.max_results_per_query))
+            except Exception as exc:  # provider failures are preserved, not promoted to evidence
+                failures.append(f"{type(exc).__name__}:{query}")
+        hits = dedupe_search_hits(hits)
+        resolution = resolve_corporate_domain(context, hits, known_site=known_site)
+        attempt.extra["search_backend"] = self.backend.backend_id
+        attempt.extra["result_count"] = len(hits)
+        attempt.extra["failures"] = failures
+        attempt.extra["domain_resolution"] = resolution.to_dict()
+
+        evidence = []
+        if resolution.canonical_domain:
+            domain_evidence = make_evidence(
+                field="canonical_domain",
+                value=resolution.canonical_domain,
+                epistemic_class=EpistemicClass.CORROBORATED,
+                source_type="public_search",
+                source_url=resolution.alternatives[0].evidence_urls[0],
+                evidence_snippet="; ".join(resolution.reason_codes),
+                observed_at=now_iso(),
+                extraction_method="explainable_domain_resolution",
+                extra={"confidence": resolution.confidence},
+            )
+            evidence.append(domain_evidence)
+
+        people = []
+        channels = []
+        crawled_urls: list[str] = []
+        bytes_touched = 0
+        crawl_failures: list[str] = []
+        if self.crawler and resolution.canonical_domain:
+            urls = rank_crawl_urls(hits, resolution.canonical_domain, limit=self.budget.max_pages)
+            remaining_bytes = self.budget.max_bytes
+            for url in urls:
+                if remaining_bytes <= 0:
+                    break
+                try:
+                    document = self.crawler.fetch(url, max_bytes=remaining_bytes)
+                except Exception as exc:
+                    crawl_failures.append(f"{type(exc).__name__}:{url}")
+                    continue
+                crawled_urls.append(document.url)
+                bytes_touched += document.bytes_touched
+                remaining_bytes -= document.bytes_touched
+                extracted = extract_public_evidence(context, document)
+                people.extend(extracted.people)
+                channels.extend(extracted.channels)
+                evidence.extend(extracted.evidence)
+
+        attempt.documents_checked = len(crawled_urls)
+        attempt.bytes_touched = bytes_touched
+        attempt.duration_ms = int((perf_counter() - started) * 1000)
+        attempt.extra["crawled_urls"] = crawled_urls
+        attempt.extra["crawl_failures"] = crawl_failures
+        attempt.extra["cache_hits"] = (
+            int(getattr(self.backend, "cache_hits", 0))
+            - search_cache_before[0]
+            + int(getattr(self.crawler, "cache_hits", 0))
+            - crawl_cache_before[0]
+        )
+        attempt.extra["cache_misses"] = (
+            int(getattr(self.backend, "cache_misses", 0))
+            - search_cache_before[1]
+            + int(getattr(self.crawler, "cache_misses", 0))
+            - crawl_cache_before[1]
+        )
+        attempt.status = "hit" if resolution.canonical_domain or people or channels else "miss"
+        attempt.reason = None if attempt.status == "hit" else "no_defensible_web_evidence"
+        if failures and not hits:
+            attempt.status = "blocked"
+            attempt.blocked = True
+            attempt.reason = "all_search_queries_failed"
+            attempt.stop_reason = "SOURCE_BLOCKED"
+        elif len(queries) >= self.budget.max_queries and not (people or channels):
+            attempt.stop_reason = "BUDGET_EXHAUSTED"
+        return ProviderResult(
+            people=people,
+            channels=channels,
+            evidence=evidence,
+            attempts=[attempt],
+            terminal=attempt.status,
+            company_site=(f"https://{resolution.canonical_domain}" if resolution.canonical_domain else known_site),
+            extra={"domain_resolution": resolution.to_dict()},
+        )
+
+
+def _domain(site: str | None) -> str | None:
+    if not site:
+        return None
+    from urllib.parse import urlsplit
+
+    candidate = site if "://" in site else f"https://{site}"
+    host = (urlsplit(candidate).hostname or "").lower()
+    return host[4:] if host.startswith("www.") else host or None

--- a/scripts/decision_unit_intelligence/repository.py
+++ b/scripts/decision_unit_intelligence/repository.py
@@ -11,7 +11,8 @@ from scripts.decision_unit_intelligence.models import dumps_stable
 
 def write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    # Machine JSON stays ASCII-safe so Windows readers using the locale default do not corrupt evidence.
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
 def read_json(path: Path) -> Any:

--- a/scripts/decision_unit_intelligence/runner.py
+++ b/scripts/decision_unit_intelligence/runner.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from time import perf_counter
 from typing import Any
 
+from scripts.decision_unit_intelligence.email_verification import (
+    DnspythonResolver,
+    PassiveEmailVerifier,
+    verify_email_routes,
+)
 from scripts.decision_unit_intelligence.models import SearchLedger, normalize_cnpj
 from scripts.decision_unit_intelligence.orchestrator import investigate_account
 from scripts.decision_unit_intelligence.providers.administrative_process import AdministrativeProcessProvider
@@ -15,21 +21,65 @@ from scripts.decision_unit_intelligence.providers.external_enrichment import Ext
 from scripts.decision_unit_intelligence.providers.historical_campaign import HistoricalCampaignProvider
 from scripts.decision_unit_intelligence.providers.official_documents import OfficialDocumentsProvider
 from scripts.decision_unit_intelligence.providers.public_search import PublicSearchProvider
+from scripts.decision_unit_intelligence.web_discovery import (
+    CachedPublicCrawler,
+    CachedRateLimitedSearchBackend,
+    DdgsSearchBackend,
+    HttpxPublicCrawler,
+    JsonDiscoveryCache,
+    SearchBudget,
+    SearxngSearchBackend,
+)
 
 _SHARED_HISTORICAL: HistoricalCampaignProvider | None = None
 
 
-def default_providers(*, external_enabled: bool = False) -> list[Any]:
+def default_providers(
+    *,
+    external_enabled: bool = False,
+    search_backend: str = "off",
+    searxng_url: str | None = None,
+    search_budget: SearchBudget | None = None,
+    cache_dir: Path | None = None,
+) -> list[Any]:
     global _SHARED_HISTORICAL
     if _SHARED_HISTORICAL is None:
         _SHARED_HISTORICAL = HistoricalCampaignProvider()
+    budget = search_budget or SearchBudget()
+    backend = None
+    if search_backend != "off":
+        if search_backend == "searxng":
+            if not searxng_url:
+                raise ValueError("searxng search backend requires --searxng-url")
+            raw_backend = SearxngSearchBackend(searxng_url, timeout_seconds=budget.timeout_seconds)
+        elif search_backend == "ddgs":
+            raw_backend = DdgsSearchBackend(timeout_seconds=budget.timeout_seconds)
+        else:
+            raise ValueError(f"unsupported search backend: {search_backend}")
+        cache = JsonDiscoveryCache(cache_dir or Path(".cache/confenge-prospect"), ttl_days=budget.cache_ttl_days)
+        backend = CachedRateLimitedSearchBackend(
+            raw_backend,
+            cache=cache,
+            min_interval_seconds=budget.min_query_interval_seconds,
+        )
     return [
         _SHARED_HISTORICAL,
         ExistingDatalakeProvider(),
+        PublicSearchProvider(
+            backend=backend,
+            crawler=(
+                CachedPublicCrawler(
+                    HttpxPublicCrawler(timeout_seconds=budget.timeout_seconds),
+                    cache=cache,
+                )
+                if backend
+                else None
+            ),
+            budget=budget,
+        ),
         AdministrativeProcessProvider(),
         OfficialDocumentsProvider(),
         CompanyWebsiteProvider(),
-        PublicSearchProvider(),
         ExternalEnrichmentProvider(enabled=external_enabled),
     ]
 
@@ -40,12 +90,24 @@ def run_account(
     service: str = "reajuste_14133",
     providers: list[Any] | None = None,
     infer_email: bool = True,
+    search_backend: str = "off",
+    searxng_url: str | None = None,
+    search_budget: SearchBudget | None = None,
+    cache_dir: Path | None = None,
+    verify_email_dns: bool = False,
 ) -> Any:
     started = perf_counter()
     ctx = InvestigationContext(cnpj=normalize_cnpj(cnpj), service=service)
-    providers = providers or default_providers()
+    providers = providers or default_providers(
+        search_backend=search_backend,
+        searxng_url=searxng_url,
+        search_budget=search_budget,
+        cache_dir=cache_dir,
+    )
     people = []
     channels = []
+    evidence = []
+    discovery_extra: dict[str, Any] = {}
     ledger = SearchLedger()
     legal_name = None
     why_now = None
@@ -60,6 +122,7 @@ def run_account(
             continue
         people.extend(result.people)
         channels.extend(result.channels)
+        evidence.extend(result.evidence)
         ledger.attempts.extend(result.attempts)
         ledger.provider_attempts += len(result.attempts)
         ledger.documents_checked += sum(a.documents_checked for a in result.attempts)
@@ -71,17 +134,27 @@ def run_account(
                 blocked = True
         if result.legal_name:
             legal_name = result.legal_name
+            ctx.legal_name = result.legal_name
         if result.why_now:
             why_now = result.why_now
         if result.company_site:
             site = result.company_site
+            ctx.extra["company_site"] = result.company_site
+        if result.extra.get("domain_resolution"):
+            discovery_extra["domain_resolution"] = result.extra["domain_resolution"]
+        ledger.cost_brl += result.cost.cost_brl
+        ledger.bytes_touched += result.cost.bytes_touched + sum(a.bytes_touched for a in result.attempts)
         ledger.tiers_completed.append(provider.tier)
         ledger.known_evidence_checked += len(result.people) + len(result.channels)
-        # Positive stop: we already have a named person and a channel.
-        if people and channels:
+        required = {
+            p.provider_id for p in providers if getattr(p, "first_class", False) and getattr(p, "enabled", False)
+        }
+        attempted = {attempt.provider_id for attempt in ledger.attempts}
+        # Positive stop only after every enabled first-class provider ran.
+        if people and channels and required.issubset(attempted):
             break
     ledger.duration_ms = int((perf_counter() - started) * 1000)
-    return investigate_account(
+    account = investigate_account(
         cnpj=cnpj,
         legal_name=legal_name,
         service=ctx.service,
@@ -91,5 +164,20 @@ def run_account(
         ledger=ledger,
         company_site=site,
         infer_email=infer_email,
+        evidence=evidence,
+        discovery_extra=discovery_extra,
         blocked=blocked,
     )
+    if verify_email_dns:
+        verification_cache = JsonDiscoveryCache(cache_dir or Path(".cache/confenge-prospect"), ttl_days=7)
+        reports = verify_email_routes(
+            account.routes,
+            PassiveEmailVerifier(
+                DnspythonResolver(),
+                cache=verification_cache,
+            ),
+        )
+        account.extra["email_verification"] = [report.to_dict() for report in reports]
+    else:
+        account.extra["email_verification"] = []
+    return account

--- a/scripts/decision_unit_intelligence/web_discovery.py
+++ b/scripts/decision_unit_intelligence/web_discovery.py
@@ -1,0 +1,682 @@
+"""Bounded public-web discovery primitives for CONFENGE accounts.
+
+Search, crawl, extraction, and domain resolution are replaceable adapters. The
+module never turns a search hit, an email pattern, or a reachable mailbox into
+proof of a person's identity or permission to contact them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+import socket
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from time import monotonic, sleep
+from typing import Any, Protocol
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.robotparser import RobotFileParser
+
+import httpx
+from bs4 import BeautifulSoup
+
+from scripts.decision_unit_intelligence.decision_policy import normalize_observed_role
+from scripts.decision_unit_intelligence.evidence import make_evidence
+from scripts.decision_unit_intelligence.models import (
+    ChannelObservation,
+    ChannelType,
+    EpistemicClass,
+    FieldEvidence,
+    OwnershipStatus,
+    PersonObservation,
+    PersonRelation,
+    fold_text,
+    normalize_cnpj,
+    normalize_email,
+    normalize_name,
+    normalize_phone,
+    now_iso,
+    stable_id,
+)
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext
+from scripts.decision_unit_intelligence.reachability import classify_observed_email_channel
+
+USER_AGENT = "CONFENGE-Public-Discovery/1.0 (+https://github.com/tjsasakifln/extra-cli)"
+
+_ROLE_PATTERN = (
+    r"diretor(?:a)?(?:\s+(?:de\s+)?(?:engenharia|comercial|opera(?:ç|c)[oõ]es))?"
+    r"|gerente(?:\s+(?:de\s+)?(?:engenharia|comercial|contratos|licita(?:ç|c)[oõ]es|suprimentos))?"
+    r"|s[oó]ci[oa](?:[-\s]+administrador(?:a)?)?|propriet[aá]ri[oa]|presidente"
+    r"|respons[aá]vel\s+t[eé]cnico|representante\s+legal|preposto|signat[aá]rio"
+)
+_NAME_WORD = r"[A-ZÁÉÍÓÚÂÊÔÃÕÇ][A-Za-zÀ-ÖØ-öø-ÿ'’-]+"
+_NAME_PATTERN = rf"{_NAME_WORD}(?:\s+(?:(?:d[aeo]s?|e)\s+)?{_NAME_WORD}){{1,4}}"
+_ROLE_THEN_NAME = re.compile(rf"(?P<role>{_ROLE_PATTERN})\s*[:|,\-–]\s*(?P<name>{_NAME_PATTERN})", re.I)
+_NAME_THEN_ROLE = re.compile(rf"(?P<name>{_NAME_PATTERN})\s*[:|,\-–]\s*(?P<role>{_ROLE_PATTERN})", re.I)
+_EMAIL_RE = re.compile(r"(?<![\w.+-])([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})(?![\w-])", re.I)
+_PHONE_RE = re.compile(r"(?<!\d)(?:\+?55\s*)?(?:\(?\d{2}\)?[\s.-]*)?\d{4,5}[\s.-]*\d{4}(?!\d)")
+
+_EXCLUDED_HOST_SUFFIXES = (
+    "bing.com",
+    "checkpj.app",
+    "duckduckgo.com",
+    "facebook.com",
+    "glassdoor.com.br",
+    "google.com",
+    "guiapj.com.br",
+    "instagram.com",
+    "jusbrasil.com.br",
+    "linkedin.com",
+    "maps.google.com",
+    "youtube.com",
+)
+_THIRD_PARTY_HOST_MARKERS = (
+    "cnpj",
+    "econodata",
+    "empresadois",
+    "escavador",
+    "guiamais",
+    "solutudo",
+)
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    url: str
+    title: str = ""
+    snippet: str = ""
+    engine: str | None = None
+
+
+@dataclass(frozen=True)
+class CrawlDocument:
+    url: str
+    text: str
+    content_type: str
+    retrieved_at: str
+    links: tuple[str, ...] = ()
+    bytes_touched: int = 0
+
+
+@dataclass(frozen=True)
+class SearchBudget:
+    max_queries: int = 4
+    max_results_per_query: int = 5
+    max_pages: int = 4
+    max_bytes: int = 1_500_000
+    timeout_seconds: float = 12.0
+    min_query_interval_seconds: float = 1.0
+    cache_ttl_days: int = 7
+
+    def __post_init__(self) -> None:
+        for value in (self.max_queries, self.max_results_per_query, self.max_pages, self.max_bytes):
+            if value <= 0:
+                raise ValueError("web discovery budgets must be positive")
+
+
+@dataclass(frozen=True)
+class DomainCandidate:
+    domain: str
+    score: int
+    reason_codes: tuple[str, ...]
+    evidence_urls: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DomainResolution:
+    canonical_domain: str | None
+    confidence: str
+    alternatives: tuple[DomainCandidate, ...]
+    reason_codes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "canonical_domain": self.canonical_domain,
+            "confidence": self.confidence,
+            "alternatives": [asdict(candidate) for candidate in self.alternatives],
+            "reason_codes": list(self.reason_codes),
+        }
+
+
+@dataclass
+class ExtractedWebEvidence:
+    people: list[PersonObservation] = field(default_factory=list)
+    channels: list[ChannelObservation] = field(default_factory=list)
+    evidence: list[FieldEvidence] = field(default_factory=list)
+
+
+class SearchBackend(Protocol):
+    backend_id: str
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]: ...
+
+
+class WebCrawler(Protocol):
+    def fetch(self, url: str, *, max_bytes: int) -> CrawlDocument: ...
+
+
+class JsonDiscoveryCache:
+    """Small replaceable disk cache. Raw pages remain local runtime assets."""
+
+    def __init__(self, root: Path, *, ttl_days: int = 7) -> None:
+        self.root = root
+        self.ttl = timedelta(days=ttl_days)
+
+    def _path(self, namespace: str, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self.root / namespace / f"{digest}.json"
+
+    def get(self, namespace: str, key: str) -> Any | None:
+        path = self._path(namespace, key)
+        if not path.exists():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            stored_at = datetime.fromisoformat(payload["stored_at"].replace("Z", "+00:00"))
+            if datetime.now(UTC) - stored_at > self.ttl:
+                return None
+            return payload.get("value")
+        except (OSError, ValueError, KeyError, TypeError):
+            return None
+
+    def set(self, namespace: str, key: str, value: Any) -> None:
+        path = self._path(namespace, key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"stored_at": now_iso(), "value": value}
+        path.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+
+
+class SearxngSearchBackend:
+    """HTTP adapter only; no SearXNG code is linked into extra-cli."""
+
+    backend_id = "searxng"
+
+    def __init__(self, base_url: str, *, timeout_seconds: float = 12.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        response = httpx.get(
+            f"{self.base_url}/search",
+            params={"q": query, "format": "json", "language": "pt-BR", "safesearch": 1},
+            headers={"User-Agent": USER_AGENT},
+            timeout=self.timeout_seconds,
+            follow_redirects=False,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return [
+            SearchHit(
+                url=str(row.get("url") or ""),
+                title=str(row.get("title") or ""),
+                snippet=str(row.get("content") or ""),
+                engine=str(row.get("engine") or "") or None,
+            )
+            for row in (payload.get("results") or [])[:limit]
+            if row.get("url")
+        ]
+
+
+class DdgsSearchBackend:
+    """Optional MIT-licensed local canary adapter; import stays lazy."""
+
+    backend_id = "ddgs"
+
+    def __init__(self, *, timeout_seconds: float = 12.0) -> None:
+        try:
+            from ddgs import DDGS
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise RuntimeError("ddgs backend requires the optional 'ddgs' package") from exc
+        self._ddgs = DDGS(timeout=timeout_seconds)
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        rows = self._ddgs.text(query, region="br-pt", safesearch="moderate", max_results=limit)
+        return [
+            SearchHit(
+                url=str(row.get("href") or row.get("url") or ""),
+                title=str(row.get("title") or ""),
+                snippet=str(row.get("body") or row.get("snippet") or ""),
+                engine=str(row.get("source") or "") or None,
+            )
+            for row in rows
+            if row.get("href") or row.get("url")
+        ]
+
+
+class CachedRateLimitedSearchBackend:
+    def __init__(
+        self,
+        backend: SearchBackend,
+        *,
+        cache: JsonDiscoveryCache,
+        min_interval_seconds: float,
+    ) -> None:
+        self.backend = backend
+        self.backend_id = backend.backend_id
+        self.cache = cache
+        self.min_interval_seconds = min_interval_seconds
+        self._last_query_at = 0.0
+        self.cache_hits = 0
+        self.cache_misses = 0
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        key = f"{self.backend_id}|{limit}|{query}"
+        cached = self.cache.get("search", key)
+        if cached is not None:
+            self.cache_hits += 1
+            return [SearchHit(**row) for row in cached]
+        self.cache_misses += 1
+        wait = self.min_interval_seconds - (monotonic() - self._last_query_at)
+        if wait > 0:
+            sleep(wait)
+        hits = self.backend.search(query, limit=limit)
+        self._last_query_at = monotonic()
+        self.cache.set("search", key, [asdict(hit) for hit in hits])
+        return hits
+
+
+class CachedPublicCrawler:
+    def __init__(self, crawler: WebCrawler, *, cache: JsonDiscoveryCache) -> None:
+        self.crawler = crawler
+        self.cache = cache
+        self.cache_hits = 0
+        self.cache_misses = 0
+
+    def fetch(self, url: str, *, max_bytes: int) -> CrawlDocument:
+        key = f"{max_bytes}|{url}"
+        cached = self.cache.get("crawl", key)
+        if cached is not None:
+            self.cache_hits += 1
+            return CrawlDocument(
+                url=cached["url"],
+                text=cached["text"],
+                content_type=cached["content_type"],
+                retrieved_at=cached["retrieved_at"],
+                links=tuple(cached.get("links") or []),
+                bytes_touched=int(cached.get("bytes_touched") or 0),
+            )
+        self.cache_misses += 1
+        document = self.crawler.fetch(url, max_bytes=max_bytes)
+        self.cache.set("crawl", key, asdict(document))
+        return document
+
+
+def _public_http_url(url: str) -> bool:
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return False
+    try:
+        addresses = {row[4][0] for row in socket.getaddrinfo(parsed.hostname, parsed.port or 443)}
+    except OSError:
+        return False
+    for raw in addresses:
+        ip = ipaddress.ip_address(raw)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved:
+            return False
+    return True
+
+
+class HttpxPublicCrawler:
+    def __init__(self, *, timeout_seconds: float = 12.0, retries: int = 1) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.retries = retries
+        self._robots: dict[str, RobotFileParser] = {}
+
+    def _robots_allowed(self, url: str) -> bool:
+        parsed = urlsplit(url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        robot = self._robots.get(origin)
+        if robot is None:
+            robot = RobotFileParser(urljoin(origin, "/robots.txt"))
+            try:
+                robot.read()
+            except OSError:
+                return False
+            self._robots[origin] = robot
+        return robot.can_fetch(USER_AGENT, url)
+
+    def fetch(self, url: str, *, max_bytes: int) -> CrawlDocument:
+        if not _public_http_url(url):
+            raise ValueError("crawler only accepts public HTTP(S) URLs")
+        if not self._robots_allowed(url):
+            raise PermissionError("robots policy does not allow this crawl")
+        last_error: Exception | None = None
+        for _attempt in range(self.retries + 1):
+            try:
+                with httpx.stream(
+                    "GET",
+                    url,
+                    headers={"User-Agent": USER_AGENT, "Accept": "text/html,text/plain;q=0.8"},
+                    timeout=self.timeout_seconds,
+                    follow_redirects=True,
+                ) as response:
+                    response.raise_for_status()
+                    if not _public_http_url(str(response.url)):
+                        raise ValueError("redirected outside public HTTP(S)")
+                    content_type = response.headers.get("content-type", "").split(";", 1)[0].lower()
+                    if content_type not in {"text/html", "text/plain"}:
+                        raise ValueError(f"unsupported crawl content type: {content_type}")
+                    chunks: list[bytes] = []
+                    size = 0
+                    for chunk in response.iter_bytes():
+                        size += len(chunk)
+                        if size > max_bytes:
+                            raise ValueError("crawl byte budget exceeded")
+                        chunks.append(chunk)
+                    raw = b"".join(chunks)
+                    text, links = _html_to_text_and_links(raw, str(response.url), content_type)
+                    return CrawlDocument(
+                        url=str(response.url),
+                        text=text,
+                        content_type=content_type,
+                        retrieved_at=now_iso(),
+                        links=tuple(links),
+                        bytes_touched=len(raw),
+                    )
+            except (httpx.HTTPError, OSError, ValueError, PermissionError) as exc:
+                last_error = exc
+        if last_error is None:  # pragma: no cover - loop always runs at least once
+            raise RuntimeError("crawler failed without an exception")
+        raise last_error
+
+
+def _html_to_text_and_links(raw: bytes, url: str, content_type: str) -> tuple[str, list[str]]:
+    if content_type == "text/plain":
+        return raw.decode("utf-8", errors="replace"), []
+    soup = BeautifulSoup(raw, "lxml")
+    for node in soup(["script", "style", "noscript", "svg"]):
+        node.decompose()
+    text = re.sub(r"\s+", " ", soup.get_text(" ", strip=True))
+    links: list[str] = []
+    host = urlsplit(url).hostname
+    for anchor in soup.find_all("a", href=True):
+        target = urljoin(url, str(anchor["href"]))
+        parsed = urlsplit(target)
+        if parsed.scheme in {"http", "https"} and parsed.hostname == host:
+            links.append(urlunsplit((parsed.scheme, parsed.netloc, parsed.path, parsed.query, "")))
+    return text, list(dict.fromkeys(links))
+
+
+def build_query_plan(context: InvestigationContext, *, known_domain: str | None = None) -> list[str]:
+    company = (context.legal_name or "").strip()
+    cnpj = normalize_cnpj(context.cnpj)
+    role_terms = {
+        "reajuste_14133": ["diretor de engenharia", "contratos", "financeiro"],
+        "acompanhamento_contratual": ["contratos", "diretor de engenharia", "jurídico contratual"],
+        "licitacoes_propostas": ["licitações", "comercial", "suprimentos"],
+        "orcamento_bdi": ["orçamento", "engenharia", "diretor de engenharia"],
+    }.get(context.service, ["diretor", "engenharia", "comercial"])
+    queries: list[str] = []
+    if company:
+        queries.extend(f'"{company}" {term}' for term in role_terms)
+        queries.extend(
+            [
+                f'"{company}" diretoria',
+                f'"{company}" sócio',
+                f'"{company}" contato',
+                f'"{company}" email',
+                f'"{company}" telefone',
+            ]
+        )
+    if cnpj:
+        queries.extend([f'"{cnpj}" email', f'"{cnpj}" telefone'])
+    if known_domain:
+        queries.extend(
+            [
+                f"site:{known_domain} diretor",
+                f"site:{known_domain} engenharia",
+                f"site:{known_domain} contato",
+                f"site:{known_domain} filetype:pdf",
+                f'"{company}" "@{known_domain}"' if company else f'"@{known_domain}"',
+            ]
+        )
+    return list(dict.fromkeys(query for query in queries if query.strip()))
+
+
+def _host(url: str) -> str | None:
+    try:
+        host = (urlsplit(url).hostname or "").lower().strip(".")
+    except ValueError:
+        return None
+    return host[4:] if host.startswith("www.") else host or None
+
+
+def _candidate_allowed(host: str) -> bool:
+    if host.endswith(".gov.br") or host == "gov.br":
+        return False
+    if any(host == suffix or host.endswith(f".{suffix}") for suffix in _EXCLUDED_HOST_SUFFIXES):
+        return False
+    return not any(marker in host for marker in _THIRD_PARTY_HOST_MARKERS)
+
+
+def resolve_corporate_domain(
+    context: InvestigationContext,
+    hits: list[SearchHit],
+    *,
+    known_site: str | None = None,
+) -> DomainResolution:
+    cnpj = normalize_cnpj(context.cnpj)
+    name_tokens = [
+        token
+        for token in re.findall(r"[a-z0-9]+", (context.legal_name or "").lower())
+        if len(token) >= 4 and token not in {"ltda", "eireli", "engenharia", "construtora", "servicos"}
+    ]
+    grouped: dict[str, dict[str, Any]] = {}
+    if known_site:
+        known_host = _host(known_site)
+        if known_host and _candidate_allowed(known_host):
+            grouped[known_host] = {"score": 7, "reasons": {"KNOWN_SITE_OBSERVED"}, "urls": {known_site}}
+    for hit in hits:
+        host = _host(hit.url)
+        if not host or not _candidate_allowed(host):
+            continue
+        row = grouped.setdefault(host, {"score": 0, "reasons": set(), "urls": set()})
+        haystack = f"{hit.title} {hit.snippet}".lower()
+        row["urls"].add(hit.url)
+        if cnpj and cnpj in re.sub(r"\D", "", haystack):
+            row["score"] += 4
+            row["reasons"].add("CNPJ_EXACT_ON_RESULT")
+        result_overlap = sum(1 for token in name_tokens if token in haystack)
+        if result_overlap:
+            row["score"] += min(3, result_overlap)
+            row["reasons"].add("LEGAL_NAME_TOKEN_MATCH")
+        host_overlap = sum(1 for token in name_tokens if token in host)
+        if host_overlap:
+            row["score"] += min(6, host_overlap * 3)
+            row["reasons"].add("DOMAIN_NAME_TOKEN_MATCH")
+        if host.endswith(".com.br"):
+            row["score"] += 1
+            row["reasons"].add("BRAZIL_CORPORATE_TLD")
+        if any(word in haystack for word in ("site oficial", "institucional", "quem somos")):
+            row["score"] += 2
+            row["reasons"].add("OFFICIAL_SITE_LANGUAGE")
+    candidates = sorted(
+        (
+            DomainCandidate(
+                domain=host,
+                score=int(row["score"]),
+                reason_codes=tuple(sorted(row["reasons"])),
+                evidence_urls=tuple(sorted(row["urls"])),
+            )
+            for host, row in grouped.items()
+        ),
+        key=lambda candidate: (-candidate.score, candidate.domain),
+    )
+    candidates = [
+        candidate
+        for candidate in candidates
+        if "KNOWN_SITE_OBSERVED" in candidate.reason_codes or "DOMAIN_NAME_TOKEN_MATCH" in candidate.reason_codes
+    ]
+    if not candidates or candidates[0].score < 4:
+        return DomainResolution(None, "UNKNOWN", tuple(candidates[:5]), ("NO_DEFENSIBLE_DOMAIN",))
+    top = candidates[0]
+    ambiguous = len(candidates) > 1 and candidates[1].score >= top.score - 1
+    if ambiguous:
+        return DomainResolution(None, "LOW", tuple(candidates[:5]), ("AMBIGUOUS_TOP_DOMAINS",))
+    confidence = "HIGH" if top.score >= 8 else "MEDIUM"
+    return DomainResolution(top.domain, confidence, tuple(candidates[:5]), top.reason_codes)
+
+
+def rank_crawl_urls(hits: list[SearchHit], canonical_domain: str, *, limit: int) -> list[str]:
+    scored: list[tuple[int, str]] = []
+    for hit in hits:
+        if _host(hit.url) != canonical_domain:
+            continue
+        path = urlsplit(hit.url).path.lower()
+        score = 0
+        if any(token in path for token in ("contato", "equipe", "diret", "quem-somos", "institucional")):
+            score += 5
+        if path in {"", "/"}:
+            score += 3
+        if path.endswith(".pdf"):
+            score -= 5
+        scored.append((-score, hit.url))
+    ranked = list(dict.fromkeys(url for _score, url in sorted(scored)))
+    homepage = f"https://{canonical_domain}/"
+    if homepage not in ranked:
+        if len(ranked) >= limit:
+            ranked = ranked[: max(0, limit - 1)]
+        ranked.append(homepage)
+    return ranked[:limit]
+
+
+def _context_snippet(text: str, start: int, end: int, *, radius: int = 140) -> str:
+    return text[max(0, start - radius) : min(len(text), end + radius)].strip()
+
+
+def _match_person_to_email(email: str, people: list[PersonObservation]) -> str | None:
+    local = re.sub(r"[^a-z0-9]", "", email.split("@", 1)[0].lower())
+    matches: list[str] = []
+    for person in people:
+        name = normalize_name(person.person_name)
+        if not name:
+            continue
+        tokens = [re.sub(r"[^a-z0-9]", "", token) for token in fold_text(name).split()]
+        tokens = [token for token in tokens if token and token not in {"da", "de", "do", "dos", "das"}]
+        if len(tokens) >= 2 and tokens[0] in local and tokens[-1] in local:
+            matches.append(name)
+    return matches[0] if len(set(matches)) == 1 else None
+
+
+def extract_public_evidence(
+    context: InvestigationContext,
+    document: CrawlDocument,
+) -> ExtractedWebEvidence:
+    cnpj = normalize_cnpj(context.cnpj)
+    extracted = ExtractedWebEvidence()
+    seen_people: set[tuple[str, str]] = set()
+    for pattern in (_ROLE_THEN_NAME, _NAME_THEN_ROLE):
+        for match in pattern.finditer(document.text):
+            name = normalize_name(match.group("name"))
+            role = match.group("role").strip()
+            if not name or (name, role.lower()) in seen_people:
+                continue
+            seen_people.add((name, role.lower()))
+            snippet = _context_snippet(document.text, match.start(), match.end())
+            evidence = make_evidence(
+                field="person_role",
+                value=f"{name}|{role}",
+                epistemic_class=EpistemicClass.OBSERVED,
+                source_type="company_website",
+                source_url=document.url,
+                evidence_snippet=snippet,
+                observed_at=document.retrieved_at,
+                extraction_method="public_page_exact_text",
+            )
+            extracted.evidence.append(evidence)
+            extracted.people.append(
+                PersonObservation(
+                    observation_id=stable_id("web-person", cnpj, name, role, document.url),
+                    company_entity_id=cnpj,
+                    person_name=name,
+                    observed_role=role,
+                    normalized_role_class=normalize_observed_role(role),
+                    relation=PersonRelation.COMPANY_MEMBER,
+                    source_type="company_website",
+                    source_url=document.url,
+                    snippet=snippet,
+                    observed_at=document.retrieved_at,
+                    epistemic_class=EpistemicClass.OBSERVED,
+                    evidence_id=evidence.evidence_id,
+                )
+            )
+    for email_match in _EMAIL_RE.finditer(document.text):
+        email = normalize_email(email_match.group(1))
+        if not email:
+            continue
+        person_name = _match_person_to_email(email, extracted.people)
+        channel_type = classify_observed_email_channel(email)
+        snippet = _context_snippet(document.text, email_match.start(), email_match.end())
+        evidence = make_evidence(
+            field="email",
+            value=email,
+            epistemic_class=EpistemicClass.OBSERVED,
+            source_type="company_website",
+            source_url=document.url,
+            evidence_snippet=snippet,
+            observed_at=document.retrieved_at,
+            extraction_method="public_page_exact_text",
+        )
+        extracted.evidence.append(evidence)
+        extracted.channels.append(
+            ChannelObservation(
+                observation_id=stable_id("web-email", cnpj, email, document.url),
+                company_entity_id=cnpj,
+                channel_type=channel_type,
+                channel_value=email,
+                person_name=person_name,
+                source_type="company_website",
+                source_url=document.url,
+                snippet=snippet,
+                observed_at=document.retrieved_at,
+                epistemic_class=EpistemicClass.OBSERVED,
+                ownership=OwnershipStatus.COMPANY_OWNED,
+                evidence_id=evidence.evidence_id,
+                extra={"identity_explicitly_associated": bool(person_name)},
+            )
+        )
+    for phone_match in _PHONE_RE.finditer(document.text):
+        phone = normalize_phone(phone_match.group(0))
+        if not phone or phone in cnpj:
+            continue
+        snippet = _context_snippet(document.text, phone_match.start(), phone_match.end())
+        evidence = make_evidence(
+            field="company_phone",
+            value=phone,
+            epistemic_class=EpistemicClass.OBSERVED,
+            source_type="company_website",
+            source_url=document.url,
+            evidence_snippet=snippet,
+            observed_at=document.retrieved_at,
+            extraction_method="public_page_exact_text",
+        )
+        extracted.evidence.append(evidence)
+        extracted.channels.append(
+            ChannelObservation(
+                observation_id=stable_id("web-phone", cnpj, phone, document.url),
+                company_entity_id=cnpj,
+                channel_type=ChannelType.COMPANY_SWITCHBOARD,
+                channel_value=phone,
+                source_type="company_website",
+                source_url=document.url,
+                snippet=snippet,
+                observed_at=document.retrieved_at,
+                epistemic_class=EpistemicClass.OBSERVED,
+                ownership=OwnershipStatus.COMPANY_OWNED,
+                evidence_id=evidence.evidence_id,
+                extra={"person_owns_phone": False},
+            )
+        )
+    return extracted
+
+
+def dedupe_search_hits(hits: list[SearchHit]) -> list[SearchHit]:
+    unique: dict[str, SearchHit] = {}
+    for hit in hits:
+        parsed = urlsplit(hit.url)
+        normalized = urlunsplit((parsed.scheme.lower(), parsed.netloc.lower(), parsed.path, parsed.query, ""))
+        unique.setdefault(normalized, hit)
+    return list(unique.values())

--- a/tests/test_decision_unit_email_verification.py
+++ b/tests/test_decision_unit_email_verification.py
@@ -1,0 +1,123 @@
+"""Email verification must never collapse technical plausibility into identity."""
+
+from pathlib import Path
+
+from scripts.decision_unit_intelligence.email_verification import (
+    DnsLookupError,
+    PassiveEmailVerifier,
+    verify_email_routes,
+)
+from scripts.decision_unit_intelligence.models import (
+    ChannelObservation,
+    ChannelType,
+    EpistemicClass,
+    PersonObservation,
+    PersonRelation,
+)
+from scripts.decision_unit_intelligence.operator_pack import build_card
+from scripts.decision_unit_intelligence.orchestrator import investigate_account
+from scripts.decision_unit_intelligence.web_discovery import JsonDiscoveryCache
+
+
+class FakeDns:
+    def __init__(self, records: dict[tuple[str, str], list[str]] | None = None) -> None:
+        self.records = records or {}
+        self.calls: list[tuple[str, str]] = []
+
+    def query(self, domain: str, record_type: str) -> list[str]:
+        self.calls.append((domain, record_type))
+        key = (domain, record_type)
+        if key not in self.records:
+            raise DnsLookupError("NXDOMAIN")
+        return self.records[key]
+
+
+def test_mx_present_is_not_mailbox_or_identity_proof():
+    verifier = PassiveEmailVerifier(FakeDns({("empresa.com.br", "MX"): ["10 mx.empresa.com.br."]}))
+    report = verifier.verify("joao.silva@empresa.com.br")
+    assert report.syntax == "VALID"
+    assert report.mx == "MX_PRESENT"
+    assert report.smtp == "SKIPPED_POLICY"
+    assert report.catch_all == "UNKNOWN_NOT_PROBED"
+    assert report.final_classification == "UNVERIFIED_DIRECT_CANDIDATE"
+    assert "MX_PRESENT_NOT_MAILBOX_PROOF" in report.reason_codes
+
+
+def test_null_mx_and_generic_role_mailbox_remain_unsuitable_for_named_identity():
+    verifier = PassiveEmailVerifier(FakeDns({("empresa.example", "MX"): ["0 ."]}))
+    report = verifier.verify("licitacoes@empresa.example")
+    assert report.mx == "NULL_MX"
+    assert report.final_classification == "GENERIC_ROLE_MAILBOX"
+    assert "NULL_MX_DECLINES_EMAIL" in report.reason_codes
+
+
+def test_domain_cache_avoids_repeating_dns_and_keeps_each_email_classification(tmp_path: Path):
+    dns = FakeDns({("empresa.com.br", "MX"): ["10 mx.empresa.com.br."]})
+    verifier = PassiveEmailVerifier(dns, cache=JsonDiscoveryCache(tmp_path, ttl_days=7))
+    first = verifier.verify("joao.silva@empresa.com.br")
+    second = verifier.verify("contato@empresa.com.br")
+    assert first.cache_hit is False
+    assert second.cache_hit is True
+    assert len(dns.calls) == 1
+    assert second.final_classification == "GENERIC_MAILBOX"
+    assert "CACHE_HIT" in second.reason_codes
+
+
+def test_invalid_syntax_never_touches_dns():
+    dns = FakeDns()
+    report = PassiveEmailVerifier(dns).verify("not-an-email")
+    assert report.syntax == "INVALID"
+    assert report.dns == "NOT_CHECKED"
+    assert not dns.calls
+
+
+def test_operator_projection_exposes_verification_without_promoting_identity():
+    account = investigate_account(
+        cnpj="12345678000190",
+        legal_name="EMPRESA LTDA",
+        service="reajuste_14133",
+        why_now="contrato ativo",
+        people=[
+            PersonObservation(
+                observation_id="person-1",
+                company_entity_id="12345678000190",
+                person_name="JOAO SILVA",
+                observed_role="Diretor de Engenharia",
+                relation=PersonRelation.COMPANY_MEMBER,
+                source_type="company_website",
+                source_url="https://empresa.com.br/diretoria",
+                epistemic_class=EpistemicClass.OBSERVED,
+            )
+        ],
+        channels=[
+            ChannelObservation(
+                observation_id="email-1",
+                company_entity_id="12345678000190",
+                channel_type=ChannelType.DIRECT_EMAIL,
+                channel_value="joao.silva@empresa.com.br",
+                person_name="JOAO SILVA",
+                source_type="company_website",
+                source_url="https://empresa.com.br/diretoria",
+                epistemic_class=EpistemicClass.OBSERVED,
+            )
+        ],
+        infer_email=False,
+        discovery_extra={
+            "domain_resolution": {
+                "canonical_domain": "empresa.com.br",
+                "confidence": "HIGH",
+                "alternatives": [],
+                "reason_codes": ["KNOWN_SITE_OBSERVED"],
+            }
+        },
+    )
+    reports = verify_email_routes(
+        account.routes,
+        PassiveEmailVerifier(FakeDns({("empresa.com.br", "MX"): ["10 mx.empresa.com.br."]})),
+    )
+    account.extra["email_verification"] = [report.to_dict() for report in reports]
+    card = build_card(account)
+    assert card["domain_resolution"]["canonical_domain"] == "empresa.com.br"
+    assert card["email_verification"]["mx"] == "MX_PRESENT"
+    assert card["email_verification"]["final_classification"] == "UNVERIFIED_DIRECT_CANDIDATE"
+    assert card["email_verification"].get("identity_proven") is None

--- a/tests/test_decision_unit_intelligence_cli.py
+++ b/tests/test_decision_unit_intelligence_cli.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 from scripts.decision_unit_intelligence.cli import main
 from scripts.decision_unit_intelligence.cohort import TRACK_A_CNPJS
+from scripts.decision_unit_intelligence.operator_pack import build_card
 from scripts.decision_unit_intelligence.providers.historical_campaign import load_campaign_index
+from scripts.decision_unit_intelligence.runner import run_account
 
 
 def test_cli_plan_and_run_track_a(tmp_path: Path):
@@ -53,6 +55,27 @@ def test_cli_plan_and_run_track_a(tmp_path: Path):
             if card["primary_route"] == "COMPANY_SWITCHBOARD":
                 assert "pedir por" in (card["exact_next_action"] or "").lower()
                 assert "Não alegar que o telefone pertence à pessoa." in (card.get("do_not_claim") or [])
+
+
+def test_operator_card_keeps_passive_email_verification_fail_closed() -> None:
+    account = run_account(TRACK_A_CNPJS[0])
+    email_route = next(route for route in account.routes if "@" in (route.channel_value or ""))
+    account.recommendation.primary_route_id = email_route.route_id
+    email_route.extra["email_verification"] = {
+        "dns": "RESOLVED",
+        "mx": "MX_PRESENT",
+        "catch_all": "UNKNOWN_NOT_PROBED",
+        "smtp": "SKIPPED_POLICY",
+        "final_classification": "UNVERIFIED_DIRECT_CANDIDATE",
+    }
+    account.extra["email_verification"] = [email_route.extra["email_verification"]]
+
+    card = build_card(account)
+
+    assert card["verification_status"] == "CANDIDATE_UNVERIFIED"
+    assert card["email_send_ready"] is False
+    assert card["email_verification"]["mx"] == "MX_PRESENT"
+    assert card["email_verification_reports"][0]["smtp"] == "SKIPPED_POLICY"
 
 
 def test_cli_replay_is_deterministic(tmp_path: Path):

--- a/tests/test_decision_unit_web_discovery.py
+++ b/tests/test_decision_unit_web_discovery.py
@@ -1,0 +1,223 @@
+"""Adversarial contract tests for bounded public web discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.decision_unit_intelligence.models import (
+    ChannelObservation,
+    ChannelType,
+    EpistemicClass,
+    OwnershipStatus,
+    PersonObservation,
+    PersonRelation,
+    SearchAttempt,
+    stable_id,
+)
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext, ProviderResult
+from scripts.decision_unit_intelligence.providers.public_search import PublicSearchProvider
+from scripts.decision_unit_intelligence.runner import run_account
+from scripts.decision_unit_intelligence.web_discovery import (
+    CachedRateLimitedSearchBackend,
+    CrawlDocument,
+    JsonDiscoveryCache,
+    SearchBudget,
+    SearchHit,
+    build_query_plan,
+    extract_public_evidence,
+    resolve_corporate_domain,
+)
+
+
+class FakeSearch:
+    backend_id = "fake"
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        self.queries.append(query)
+        return [
+            SearchHit(
+                url="https://empresaexemplo.com.br/institucional/diretoria",
+                title="Empresa Exemplo - site oficial",
+                snippet="Empresa Exemplo Engenharia. Diretoria e contato institucional.",
+                engine="fixture",
+            )
+        ][:limit]
+
+
+class FakeCrawler:
+    def fetch(self, url: str, *, max_bytes: int) -> CrawlDocument:
+        text = (
+            "Diretor de Engenharia: João da Silva. "
+            "Contato profissional publicado: joao.silva@empresaexemplo.com.br. "
+            "Telefone geral (48) 3333-4444."
+        )
+        assert len(text.encode()) < max_bytes
+        return CrawlDocument(
+            url=url,
+            text=text,
+            content_type="text/html",
+            retrieved_at="2026-08-14T12:00:00Z",
+            bytes_touched=len(text.encode()),
+        )
+
+
+class PreloadedProvider:
+    provider_id = "preloaded"
+    tier = 0
+
+    def collect(self, context: InvestigationContext) -> ProviderResult:
+        cnpj = context.cnpj
+        return ProviderResult(
+            legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA",
+            people=[
+                PersonObservation(
+                    observation_id="qsa-1",
+                    company_entity_id=cnpj,
+                    person_name="CARLOS SOCIO",
+                    observed_role="Sócio-Administrador",
+                    relation=PersonRelation.COMPANY_MEMBER,
+                    source_type="qsa_rfb",
+                    source_url="https://public.example/qsa",
+                    epistemic_class=EpistemicClass.OBSERVED,
+                    evidence_id="evidence-qsa",
+                )
+            ],
+            channels=[
+                ChannelObservation(
+                    observation_id="phone-1",
+                    company_entity_id=cnpj,
+                    channel_type=ChannelType.COMPANY_SWITCHBOARD,
+                    channel_value="4833330000",
+                    source_type="rfb_cadastre",
+                    source_url="https://public.example/cnpj",
+                    epistemic_class=EpistemicClass.OBSERVED,
+                    ownership=OwnershipStatus.COMPANY_OWNED,
+                    extra={"person_owns_phone": False},
+                )
+            ],
+            attempts=[
+                SearchAttempt(
+                    attempt_id=stable_id("preloaded", cnpj),
+                    company_entity_id=cnpj,
+                    tier=0,
+                    provider_id=self.provider_id,
+                    source="fixture",
+                    status="hit",
+                )
+            ],
+        )
+
+
+def _context() -> InvestigationContext:
+    return InvestigationContext(
+        cnpj="12345678000190",
+        legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA",
+        service="reajuste_14133",
+    )
+
+
+def test_query_plan_is_contextual_and_contains_required_public_search_shapes():
+    queries = build_query_plan(_context(), known_domain="empresaexemplo.com.br")
+    assert '"EMPRESA EXEMPLO ENGENHARIA LTDA" diretor de engenharia' in queries
+    assert '"12345678000190" email' in queries
+    assert "site:empresaexemplo.com.br contato" in queries
+    assert "site:empresaexemplo.com.br filetype:pdf" in queries
+
+
+def test_domain_resolution_rejects_aggregator_and_preserves_alternatives():
+    resolution = resolve_corporate_domain(
+        _context(),
+        [
+            SearchHit("https://cnpj.biz/123", "Empresa Exemplo", "CNPJ 12.345.678/0001-90"),
+            SearchHit(
+                "https://chapeco.org/associados/empresa-exemplo",
+                "Empresa Exemplo",
+                "Empresa Exemplo Engenharia, CNPJ 12.345.678/0001-90",
+            ),
+            SearchHit(
+                "https://glassdoor.com.br/empresa/empresa-exemplo",
+                "Empresa Exemplo",
+                "Empresa Exemplo Engenharia, CNPJ 12.345.678/0001-90",
+            ),
+            SearchHit(
+                "https://empresaexemplo.com.br/quem-somos",
+                "Empresa Exemplo - site oficial",
+                "Empresa Exemplo Engenharia, CNPJ 12.345.678/0001-90",
+            ),
+        ],
+    )
+    assert resolution.canonical_domain == "empresaexemplo.com.br"
+    assert resolution.confidence == "HIGH"
+    assert all("cnpj.biz" not in candidate.domain for candidate in resolution.alternatives)
+    assert all("chapeco.org" not in candidate.domain for candidate in resolution.alternatives)
+    assert all("glassdoor.com.br" not in candidate.domain for candidate in resolution.alternatives)
+
+
+def test_exact_public_page_keeps_identity_role_and_route_dimensions_separate():
+    document = FakeCrawler().fetch("https://empresaexemplo.com.br/diretoria", max_bytes=10_000)
+    extracted = extract_public_evidence(_context(), document)
+    person = next(person for person in extracted.people if person.person_name == "João da Silva")
+    email = next(
+        channel for channel in extracted.channels if channel.channel_value == "joao.silva@empresaexemplo.com.br"
+    )
+    phone = next(channel for channel in extracted.channels if channel.channel_type == ChannelType.COMPANY_SWITCHBOARD)
+    assert person.epistemic_class == EpistemicClass.OBSERVED
+    assert person.observed_role == "Diretor de Engenharia"
+    assert email.epistemic_class == EpistemicClass.OBSERVED
+    assert email.person_name == "João da Silva"
+    assert email.extra["identity_explicitly_associated"] is True
+    assert phone.extra["person_owns_phone"] is False
+    assert all(item.source_url == document.url for item in extracted.evidence)
+
+
+def test_enabled_web_search_runs_before_positive_early_stop_and_persists_evidence():
+    search = FakeSearch()
+    public_search = PublicSearchProvider(
+        backend=search,
+        crawler=FakeCrawler(),
+        budget=SearchBudget(
+            max_queries=2,
+            max_results_per_query=2,
+            max_pages=1,
+            max_bytes=20_000,
+            min_query_interval_seconds=0,
+        ),
+    )
+    account = run_account(
+        "12345678000190",
+        providers=[PreloadedProvider(), public_search],
+        infer_email=False,
+    )
+    attempts = {attempt.provider_id: attempt for attempt in account.ledger.attempts}
+    assert search.queries
+    assert attempts["public_search"].documents_checked == 1
+    assert account.extra["domain_resolution"]["canonical_domain"] == "empresaexemplo.com.br"
+    assert any(item.field == "canonical_domain" for item in account.evidence)
+    assert any(person.person_name == "João da Silva" for person in account.candidates)
+    assert any(route.channel_value == "joao.silva@empresaexemplo.com.br" for route in account.routes)
+
+
+def test_search_backend_off_is_explicit_policy_skip_not_false_coverage():
+    provider = PublicSearchProvider()
+    result = provider.collect(_context())
+    assert result.terminal == "skipped"
+    assert result.attempts[0].reason == "search_backend_not_configured"
+    assert result.attempts[0].stop_reason == "POLICY_SKIP"
+
+
+def test_search_cache_reuses_public_discovery_without_a_second_provider_call(tmp_path: Path):
+    raw = FakeSearch()
+    cached = CachedRateLimitedSearchBackend(
+        raw,
+        cache=JsonDiscoveryCache(tmp_path, ttl_days=7),
+        min_interval_seconds=0,
+    )
+    first = cached.search('"EMPRESA EXEMPLO" diretor', limit=2)
+    second = cached.search('"EMPRESA EXEMPLO" diretor', limit=2)
+    assert first == second
+    assert len(raw.queries) == 1
+    assert cached.cache_misses == 1
+    assert cached.cache_hits == 1


### PR DESCRIPTION
## O que mudou

Evolui a PR #392 (não substitui o DUI) para um motor de **email discovery** com evidência contextual:

- associação pessoa↔e-mail por card DOM, `mailto:`, rótulo “e-mail de Nome”, janela única e página da pessoa — local-part first+last é só sinal
- classes distintas: OBSERVED associated/unresolved, INFERRED_PATTERN, GENERIC/ROLE, DOMAIN_ONLY, TECHNICALLY_PLAUSIBLE, EMAIL_VALIDATED (só com a política email-safe vigente), BLOCKED/UNKNOWN
- query planner de e-mail (`"NOME" "empresa"`, `site:dominio equipe|contato`, …) + people conhecidas do QSA
- crawl bounded de slugs/anchors same-domain (equipe, diretoria, contato, …)
- padrões versionados só a partir de OBSERVED do mesmo domínio; candidato gerado permanece INFERRED mesmo com MX
- recusa caixa de marca (`setep@setep.com.br`), escritório/capital (`vitoria@`, `brasilia@`), ética (`conduta@`) e terceiro (`.adv.br`)
- Warmbly/`confenge.outreach.v1` recebe campos aditivos; `auto_send` continua false; CANDIDATE_UNVERIFIED nunca vira VALIDATED

## Canário real Track A

- 10 + 30 contas reais via CLI (`--search-backend ddgs`), custo R$ 0
- 21/30 domínios HIGH/MEDIUM; 57 pessoas nomeadas; 87 páginas; 8.3 MB
- superfície pública desta coorte é quase só caixa genérica/role/marca
- **0 identidades defensáveis / 0 EMAIL_VALIDATED honestos** após recusar os falsos positivos (advogado, `conduta@`, `setep@`, `vitoria@`)
- 0 auto-send; MX continua não provando identidade

## Segurança epistemológica

MX não prova mailbox nem identidade. Inferência não vira observação. Caixa genérica nunca vira pessoa. Nenhuma descoberta autoriza envio.

## Validação

- 51 testes focais (fixtures adversariais + regressão DUI)
- ruff no recorte passou
- generated-artifacts-policy passou
- pr-reviewability --draft passou
- mypy global preexistente fora deste recorte

HEAD: `591cf53a`