### PR TITLE
feat(dui): durable idempotent contact-discovery batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ output/bootstrap/
 output/readiness/
 output/runs/
 output/resilience/
+output/contact-discovery/
 
 # Agent memories (runtime)
 .claude/agent-memory/

--- a/db/migrations/093_contact_discovery_batch.sql
+++ b/db/migrations/093_contact_discovery_batch.sql
@@ -1,0 +1,166 @@
+-- 093_contact_discovery_batch.sql
+-- Additive durable job bus for CONFENGE_CONTACT_DISCOVERY.
+-- Does not reuse crawl_jobs (FK to sc_public_entities). Same lease/SKIP LOCKED vocabulary.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS contact_discovery_cohorts (
+    cohort_id                 TEXT PRIMARY KEY,
+    job_type                  TEXT NOT NULL DEFAULT 'CONFENGE_CONTACT_DISCOVERY',
+    service                   TEXT NOT NULL,
+    offer_context             TEXT,
+    discovery_policy_version  TEXT NOT NULL,
+    search_backend            TEXT NOT NULL,
+    budget_version            TEXT NOT NULL,
+    code_sha                  TEXT NOT NULL,
+    input_evidence_version    TEXT NOT NULL,
+    status                    TEXT NOT NULL DEFAULT 'OPEN' CHECK (status IN (
+        'OPEN', 'CLOSED', 'PUBLISHED', 'CANCELLED'
+    )),
+    denominator               INTEGER NOT NULL DEFAULT 0 CHECK (denominator >= 0),
+    snapshot_id               TEXT,
+    snapshot_pointer          TEXT,
+    snapshot_hash             TEXT,
+    published_at              TIMESTAMPTZ,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    metadata                  JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS contact_discovery_jobs (
+    id                          BIGSERIAL PRIMARY KEY,
+    job_type                    TEXT NOT NULL DEFAULT 'CONFENGE_CONTACT_DISCOVERY',
+    cohort_id                   TEXT NOT NULL REFERENCES contact_discovery_cohorts(cohort_id) ON DELETE CASCADE,
+    canonical_account_id        TEXT NOT NULL,
+    service                     TEXT NOT NULL,
+    offer_context               TEXT,
+    discovery_policy_version    TEXT NOT NULL,
+    search_backend              TEXT NOT NULL,
+    budget_version              TEXT NOT NULL,
+    code_sha                    TEXT NOT NULL,
+    input_evidence_version      TEXT NOT NULL,
+    idempotency_key             TEXT NOT NULL UNIQUE,
+    revision                    INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+    status                      TEXT NOT NULL DEFAULT 'PENDING' CHECK (status IN (
+        'PENDING', 'RUNNING', 'SUCCEEDED', 'BLOCKED', 'RETRYABLE', 'DLQ', 'CANCELLED'
+    )),
+    priority                    INTEGER NOT NULL DEFAULT 0,
+    domain_key                  TEXT NOT NULL,
+    backend_key                 TEXT NOT NULL,
+    cursor                      JSONB NOT NULL DEFAULT '{}'::jsonb,
+    lease_owner                 TEXT,
+    lease_expires_at            TIMESTAMPTZ,
+    heartbeat_at                TIMESTAMPTZ,
+    attempt_count               INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    max_attempts                INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts >= 1),
+    backend_concurrency_limit   INTEGER NOT NULL DEFAULT 2 CHECK (backend_concurrency_limit BETWEEN 1 AND 32),
+    domain_concurrency_limit    INTEGER NOT NULL DEFAULT 1 CHECK (domain_concurrency_limit BETWEEN 1 AND 32),
+    cancel_requested            BOOLEAN NOT NULL DEFAULT FALSE,
+    last_outcome                TEXT,
+    last_reason_code            TEXT,
+    last_error                  TEXT,
+    output_pointer              TEXT,
+    output_hash                 TEXT,
+    cost_metrics                JSONB NOT NULL DEFAULT '{}'::jsonb,
+    next_run_at                 TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (
+        (status = 'RUNNING' AND lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+        OR status <> 'RUNNING'
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contact_discovery_jobs_active_identity
+    ON contact_discovery_jobs (
+        canonical_account_id,
+        discovery_policy_version,
+        input_evidence_version,
+        search_backend,
+        budget_version,
+        service
+    )
+    WHERE status IN ('PENDING', 'RUNNING', 'RETRYABLE');
+
+CREATE INDEX IF NOT EXISTS idx_contact_discovery_jobs_admission
+    ON contact_discovery_jobs (priority DESC, next_run_at, id)
+    WHERE status IN ('PENDING', 'RETRYABLE');
+
+CREATE INDEX IF NOT EXISTS idx_contact_discovery_jobs_expired_lease
+    ON contact_discovery_jobs (lease_expires_at)
+    WHERE status = 'RUNNING';
+
+CREATE INDEX IF NOT EXISTS idx_contact_discovery_jobs_cohort_status
+    ON contact_discovery_jobs (cohort_id, status);
+
+CREATE TABLE IF NOT EXISTS contact_discovery_attempts (
+    id                  BIGSERIAL PRIMARY KEY,
+    job_id              BIGINT NOT NULL REFERENCES contact_discovery_jobs(id) ON DELETE CASCADE,
+    run_id              TEXT NOT NULL UNIQUE,
+    worker_id           TEXT NOT NULL,
+    status              TEXT NOT NULL CHECK (status IN (
+        'RUNNING', 'SUCCEEDED', 'BLOCKED', 'RETRYABLE', 'DLQ',
+        'INTERRUPTED', 'LEASE_EXPIRED', 'CANCELLED'
+    )),
+    started_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    heartbeat_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at         TIMESTAMPTZ,
+    lease_expires_at    TIMESTAMPTZ NOT NULL,
+    cursor              JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metrics             JSONB NOT NULL DEFAULT '{}'::jsonb,
+    reason_code         TEXT,
+    error_message       TEXT,
+    output_pointer      TEXT,
+    output_hash         TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (
+        (status = 'RUNNING' AND finished_at IS NULL)
+        OR (status <> 'RUNNING' AND finished_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_discovery_attempts_job
+    ON contact_discovery_attempts (job_id, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS contact_discovery_snapshots (
+    snapshot_id         TEXT PRIMARY KEY,
+    cohort_id           TEXT NOT NULL REFERENCES contact_discovery_cohorts(cohort_id) ON DELETE CASCADE,
+    approved            BOOLEAN NOT NULL DEFAULT FALSE,
+    pointer             TEXT NOT NULL,
+    content_hash        TEXT NOT NULL,
+    denominator         INTEGER NOT NULL,
+    status_counts       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    policy_version      TEXT NOT NULL,
+    code_sha            TEXT NOT NULL,
+    search_backend      TEXT NOT NULL,
+    budget_version      TEXT NOT NULL,
+    reject_reason       TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_discovery_snapshots_cohort
+    ON contact_discovery_snapshots (cohort_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS contact_discovery_kill_switch (
+    singleton     BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    enabled       BOOLEAN NOT NULL DEFAULT FALSE,
+    reason        TEXT NOT NULL DEFAULT '',
+    changed_by    TEXT NOT NULL DEFAULT '',
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO contact_discovery_kill_switch (singleton, enabled, reason, changed_by)
+VALUES (TRUE, FALSE, '', 'migration-093')
+ON CONFLICT (singleton) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS contact_discovery_backend_circuit (
+    backend_key             TEXT PRIMARY KEY,
+    state                   TEXT NOT NULL DEFAULT 'closed' CHECK (state IN ('closed', 'open', 'half_open')),
+    consecutive_failures    INTEGER NOT NULL DEFAULT 0 CHECK (consecutive_failures >= 0),
+    opened_at               TIMESTAMPTZ,
+    cooldown_until          TIMESTAMPTZ,
+    last_error_class        TEXT,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMIT;

--- a/deploy/systemd/extra-contact-discovery-worker@.service
+++ b/deploy/systemd/extra-contact-discovery-worker@.service
@@ -1,0 +1,47 @@
+[Unit]
+Description=Extra Consultoria leased contact-discovery worker %i
+After=network-online.target postgresql.service
+Wants=network-online.target
+Requires=postgresql.service
+OnFailure=extra-onfailure@%n.service
+StartLimitIntervalSec=900
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=extra-consultoria
+Group=extra-consultoria
+WorkingDirectory=/opt/extra-consultoria
+Environment=PYTHONPATH=/opt/extra-consultoria
+Environment=RESILIENCE_ENV=production
+EnvironmentFile=-/etc/extra-consultoria/crawler.env
+EnvironmentFile=-/etc/extra-cli/extra-collector.env
+ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.decision_unit_intelligence batch worker --loop --idle-sleep 5 --worker-id cd-worker-%i --out /var/lib/extra-consultoria/contact-discovery
+Restart=on-failure
+RestartSec=30
+Nice=15
+IOSchedulingClass=best-effort
+IOSchedulingPriority=6
+KillSignal=SIGTERM
+TimeoutStopSec=90
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryHigh=256M
+MemoryMax=384M
+CPUQuota=50%
+ReadWritePaths=/var/lib/extra-consultoria /var/log/extra-consultoria
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=extra-contact-discovery-worker-%i
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ops/contact-discovery-batch.md
+++ b/docs/ops/contact-discovery-batch.md
@@ -1,0 +1,34 @@
+# Contact discovery — durable batch
+
+Additive job bus around shipped `run_account`. Does not change
+`web_discovery.py` planner/crawler/heuristics.
+
+Job type: `CONFENGE_CONTACT_DISCOVERY`
+
+## Operator commands
+
+```bash
+export LOCAL_DATALAKE_DSN="${LOCAL_DATALAKE_DSN:-postgresql://test:test@127.0.0.1:5433/extra_test}"
+python3 -m scripts.ops.apply_migrations --dsn "$LOCAL_DATALAKE_DSN"
+
+python3 -m scripts.decision_unit_intelligence batch enqueue \
+  --cohort COHORT_ID --cnpjs 11222333000181,44555666000177 \
+  --search-backend off --service reajuste_14133
+
+python3 -m scripts.decision_unit_intelligence batch worker --loop --max-jobs 100
+python3 -m scripts.decision_unit_intelligence batch progress --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch inspect --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch failures --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch retry --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch resume --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch cancel --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch publish --cohort COHORT_ID
+python3 -m scripts.decision_unit_intelligence batch kill-switch --enable --reason pause --actor ops
+```
+
+Outputs live under `output/contact-discovery/` (gitignored).
+A snapshot is approved only when the denominator closes, every account is
+terminal or a nominal blocker, hashes reconcile, and there are no duplicates.
+
+429 / timeout / budget / source-block keep their reason codes. They never
+become “sem contato encontrado”.

--- a/scripts/decision_unit_intelligence/batch_outcomes.py
+++ b/scripts/decision_unit_intelligence/batch_outcomes.py
@@ -1,0 +1,282 @@
+"""Map shipped run_account results onto durable job states.
+
+Discovery remains a black box. This module only classifies outcomes so
+429/timeout/budget/source-block never become “sem contato encontrado”.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from scripts.decision_unit_intelligence.batch_queue import ClaimedDiscoveryJob
+from scripts.decision_unit_intelligence.models import AccountTerminal, ChannelType
+from scripts.decision_unit_intelligence.repository import account_hash, write_json
+
+FORBIDDEN_REASON_CODES = frozenset(
+    {
+        "SEM_CONTATO",
+        "NO_CONTACT",
+        "NO_CONTACT_FOUND",
+        "sem contato encontrado",
+        "SEM_CONTATO_ENCONTRADO",
+    }
+)
+
+RETRYABLE_TOKENS = (
+    "HTTPStatusError",
+    "HTTPError",
+    "RateLimit",
+    "Ratelimit",
+    "TooManyRequests",
+    "TimeoutException",
+    "ReadTimeout",
+    "ConnectTimeout",
+    "TimeoutError",
+    "ConnectError",
+    "RemoteProtocolError",
+)
+
+
+@dataclass
+class Outcome:
+    job_status: str
+    reason_code: str
+    discovery_terminal: str | None = None
+    error_message: str | None = None
+    metrics: dict[str, Any] = field(default_factory=dict)
+    domain_key: str | None = None
+    account_payload: dict[str, Any] | None = None
+    output_pointer: str | None = None
+    output_hash: str | None = None
+
+
+class RetryableDiscoveryError(Exception):
+    def __init__(self, reason_code: str, message: str):
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+class BlockedDiscoveryError(Exception):
+    def __init__(self, reason_code: str, message: str):
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.message = message
+
+
+def classify_exception(exc: BaseException) -> Outcome:
+    name = type(exc).__name__
+    text = f"{name}:{exc}"
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if status == 429 or "429" in text or "RateLimit" in name or "Ratelimit" in name:
+        return Outcome(job_status="RETRYABLE", reason_code="PROVIDER_429", error_message=text[:500])
+    if status is not None and int(status) >= 500:
+        return Outcome(job_status="RETRYABLE", reason_code="PROVIDER_5XX", error_message=text[:500])
+    if "timeout" in name.lower() or "timeout" in text.lower():
+        return Outcome(job_status="RETRYABLE", reason_code="PROVIDER_TIMEOUT", error_message=text[:500])
+    if "5" in str(status or "") and "HTTP" in name:
+        return Outcome(job_status="RETRYABLE", reason_code="PROVIDER_5XX", error_message=text[:500])
+    return Outcome(job_status="RETRYABLE", reason_code="PROVIDER_ERROR", error_message=text[:500])
+
+
+def _failure_blob(account: Any) -> str:
+    parts: list[str] = []
+    ledger = getattr(account, "ledger", None)
+    if ledger is not None:
+        parts.extend(str(item) for item in (ledger.blocked_sources or []))
+        for attempt in ledger.attempts or []:
+            extra = getattr(attempt, "extra", {}) or {}
+            parts.extend(str(item) for item in (extra.get("failures") or []))
+            parts.extend(str(item) for item in (extra.get("crawl_failures") or []))
+            if getattr(attempt, "reason", None):
+                parts.append(str(attempt.reason))
+            if getattr(attempt, "stop_reason", None):
+                parts.append(str(attempt.stop_reason))
+    return " ".join(parts)
+
+
+def _provider_failure_count(account: Any) -> int:
+    ledger = getattr(account, "ledger", None)
+    if ledger is None:
+        return 0
+    count = 0
+    for attempt in ledger.attempts or []:
+        extra = getattr(attempt, "extra", {}) or {}
+        count += len(extra.get("failures") or [])
+        count += len(extra.get("crawl_failures") or [])
+    return count
+
+
+def classify_account(account: Any) -> Outcome:
+    blob = _failure_blob(account)
+    terminal = getattr(account.terminal, "value", str(account.terminal))
+    metrics = extract_metrics(account)
+    domain = _domain_from_account(account)
+    payload = account.to_dict() if hasattr(account, "to_dict") else dict(account)
+
+    if any(token in blob for token in ("429", "RateLimit", "Ratelimit", "TooManyRequests")):
+        return Outcome(
+            job_status="RETRYABLE",
+            reason_code="PROVIDER_429",
+            discovery_terminal=terminal,
+            error_message=blob[:500] or None,
+            metrics=metrics,
+            domain_key=domain,
+            account_payload=payload,
+        )
+    if any(token in blob for token in ("TimeoutException", "ReadTimeout", "ConnectTimeout", "TimeoutError")):
+        return Outcome(
+            job_status="RETRYABLE",
+            reason_code="PROVIDER_TIMEOUT",
+            discovery_terminal=terminal,
+            error_message=blob[:500] or None,
+            metrics=metrics,
+            domain_key=domain,
+            account_payload=payload,
+        )
+    if "HTTPStatusError" in blob or re.search(r"\b5\d\d\b", blob):
+        return Outcome(
+            job_status="RETRYABLE",
+            reason_code="PROVIDER_5XX" if re.search(r"\b5\d\d\b", blob) else "PROVIDER_HTTP_ERROR",
+            discovery_terminal=terminal,
+            error_message=blob[:500] or None,
+            metrics=metrics,
+            domain_key=domain,
+            account_payload=payload,
+        )
+
+    if terminal == AccountTerminal.BLOCKED.value:
+        return Outcome(
+            job_status="BLOCKED",
+            reason_code="SOURCE_BLOCKED",
+            discovery_terminal=terminal,
+            error_message=blob[:500] or None,
+            metrics=metrics,
+            domain_key=domain,
+            account_payload=payload,
+        )
+
+    reason = "DISCOVERY_COMPLETED"
+    if terminal == AccountTerminal.ACTIONABLE_ROUTE.value:
+        reason = "ACTIONABLE_ROUTE"
+    elif terminal == AccountTerminal.EXHAUSTED.value:
+        reason = "BUDGET_EXHAUSTED"
+    elif terminal == AccountTerminal.DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED.value:
+        reason = "PERSON_WITHOUT_ROUTE"
+    elif terminal == AccountTerminal.NEEDS_ENRICHMENT.value:
+        reason = "NEEDS_ENRICHMENT"
+    return Outcome(
+        job_status="SUCCEEDED",
+        reason_code=reason,
+        discovery_terminal=terminal,
+        metrics=metrics,
+        domain_key=domain,
+        account_payload=payload,
+    )
+
+
+def extract_metrics(account: Any) -> dict[str, Any]:
+    ledger = getattr(account, "ledger", None)
+    routes = list(getattr(account, "routes", None) or [])
+    people = list(getattr(account, "candidates", None) or [])
+    extra = getattr(account, "extra", None) or {}
+    attempts = list(getattr(ledger, "attempts", None) or []) if ledger else []
+    cache_hits = 0
+    cache_misses = 0
+    pages = int(getattr(ledger, "documents_checked", 0) or 0) if ledger else 0
+    searches = len(getattr(ledger, "search_queries", None) or []) if ledger else 0
+    for attempt in attempts:
+        extra_a = getattr(attempt, "extra", {}) or {}
+        cache_hits += int(extra_a.get("cache_hits") or 0)
+        cache_misses += int(extra_a.get("cache_misses") or 0)
+    domain_resolution = extra.get("domain_resolution") or {}
+    observed = 0
+    inferred = 0
+    for route in routes:
+        channel_type = getattr(route, "channel_type", None)
+        value = getattr(channel_type, "value", channel_type)
+        if value == ChannelType.DIRECT_EMAIL.value:
+            observed += 1
+        elif value == ChannelType.INFERRED_DIRECT_EMAIL.value:
+            inferred += 1
+    reports = extra.get("email_verification") or []
+    email_validated = sum(
+        1
+        for report in reports
+        if isinstance(report, dict)
+        and (
+            report.get("final_classification") == "EMAIL_VALIDATED"
+            or report.get("mx") == "MX_PRESENT"
+            and report.get("final_classification") == "EMAIL_VALIDATED"
+        )
+    )
+    return {
+        "searches": searches,
+        "pages": pages,
+        "bytes_touched": int(getattr(ledger, "bytes_touched", 0) or 0) if ledger else 0,
+        "cache_hits": cache_hits,
+        "cache_misses": cache_misses,
+        "external_cost_brl": float(getattr(ledger, "cost_brl", 0) or 0) if ledger else 0.0,
+        "domains_resolved": 1 if domain_resolution.get("canonical_domain") else 0,
+        "named_people": len(people),
+        "observed_direct_email": observed,
+        "inferred_email": inferred,
+        "email_validated": email_validated,
+        "provider_failures": _provider_failure_count(account),
+        "retries": 0,
+        "discovery_terminal": getattr(account.terminal, "value", str(account.terminal)),
+        "duration_ms": int(getattr(ledger, "duration_ms", 0) or 0) if ledger else 0,
+    }
+
+
+def _domain_from_account(account: Any) -> str | None:
+    extra = getattr(account, "extra", None) or {}
+    domain = (extra.get("domain_resolution") or {}).get("canonical_domain")
+    if domain:
+        return f"domain:{domain}"
+    return None
+
+
+def persist_outcome(outcome: Outcome, *, job: ClaimedDiscoveryJob, output_root: Path) -> Outcome:
+    if outcome.reason_code in FORBIDDEN_REASON_CODES:
+        raise ValueError(f"forbidden reason code: {outcome.reason_code}")
+    payload = {
+        "schema_id": "confenge.contact_discovery.job_output.v1",
+        "job_type": "CONFENGE_CONTACT_DISCOVERY",
+        "job_id": job.id,
+        "cohort_id": job.cohort_id,
+        "canonical_account_id": job.canonical_account_id,
+        "revision": job.revision,
+        "attempt_id": job.attempt_id,
+        "run_id": job.run_id,
+        "job_status": outcome.job_status,
+        "reason_code": outcome.reason_code,
+        "discovery_terminal": outcome.discovery_terminal,
+        "policy_version": job.discovery_policy_version,
+        "search_backend": job.search_backend,
+        "budget_version": job.budget_version,
+        "code_sha": job.code_sha,
+        "input_evidence_version": job.input_evidence_version,
+        "metrics": outcome.metrics,
+        "account": outcome.account_payload,
+    }
+    directory = Path(output_root) / job.cohort_id
+    path = directory / f"{job.canonical_account_id}.json"
+    write_json(path, payload)
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    ).hexdigest()
+    if outcome.account_payload:
+        payload["account_hash"] = account_hash(outcome.account_payload)
+        write_json(path, payload)
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        ).hexdigest()
+    outcome.output_pointer = str(path)
+    outcome.output_hash = digest
+    return outcome

--- a/scripts/decision_unit_intelligence/batch_queue.py
+++ b/scripts/decision_unit_intelligence/batch_queue.py
@@ -1,0 +1,1052 @@
+"""Durable contact-discovery job bus. Additive; does not use crawl_jobs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from collections.abc import Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+JOB_TYPE = "CONFENGE_CONTACT_DISCOVERY"
+CLAIMABLE = ("PENDING", "RETRYABLE")
+TERMINAL = ("SUCCEEDED", "BLOCKED", "DLQ", "CANCELLED")
+ACTIVE = ("PENDING", "RUNNING", "RETRYABLE")
+NOMINAL_BLOCKERS = ("BLOCKED", "DLQ", "CANCELLED")
+SNAPSHOT_READY = ("SUCCEEDED",) + NOMINAL_BLOCKERS
+
+ADMISSION_LOCK = "extra:contact_discovery:admission:v1"
+
+
+def utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def as_record(row: Any, description: Any = None) -> dict[str, Any]:
+    if row is None:
+        raise RuntimeError("expected a database row")
+    if isinstance(row, Mapping):
+        return dict(row)
+    if description is not None and isinstance(row, (list, tuple)):
+        return {col.name: value for col, value in zip(description, row, strict=False)}
+    raise TypeError(f"cannot convert row of type {type(row)!r}")
+
+
+def fetch_one(cursor: Any) -> dict[str, Any] | None:
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    return as_record(row, cursor.description)
+
+
+def fetch_all(cursor: Any) -> list[dict[str, Any]]:
+    return [as_record(row, cursor.description) for row in (cursor.fetchall() or [])]
+
+
+def normalize_account_id(value: str | None) -> str:
+    digits = "".join(ch for ch in (value or "") if ch.isdigit())
+    return digits.zfill(14) if digits else ""
+
+
+def budget_version_from_knobs(knobs: dict[str, Any]) -> str:
+    payload = json.dumps(knobs, sort_keys=True, separators=(",", ":"), default=str)
+    return "budget." + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def idempotency_key(
+    *,
+    canonical_account_id: str,
+    service: str,
+    discovery_policy_version: str,
+    input_evidence_version: str,
+    search_backend: str,
+    budget_version: str,
+) -> str:
+    canonical = "|".join(
+        (
+            JOB_TYPE,
+            normalize_account_id(canonical_account_id),
+            service,
+            discovery_policy_version,
+            input_evidence_version,
+            search_backend,
+            budget_version,
+        )
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class ClaimedDiscoveryJob:
+    id: int
+    cohort_id: str
+    canonical_account_id: str
+    service: str
+    offer_context: str | None
+    discovery_policy_version: str
+    search_backend: str
+    budget_version: str
+    code_sha: str
+    input_evidence_version: str
+    idempotency_key: str
+    revision: int
+    domain_key: str
+    backend_key: str
+    cursor: dict[str, Any]
+    run_id: str
+    attempt_id: int
+    attempt_count: int
+    max_attempts: int
+    cancel_requested: bool
+
+
+@contextmanager
+def connect(dsn: str | None = None):
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    resolved = dsn or os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL")
+    if not resolved:
+        raise RuntimeError("LOCAL_DATALAKE_DSN or DATABASE_URL is required")
+    connection = psycopg2.connect(
+        resolved,
+        cursor_factory=RealDictCursor,
+        connect_timeout=10,
+    )
+    try:
+        with connection:
+            yield connection
+    finally:
+        connection.close()
+
+
+class ContactDiscoveryQueue:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def cursor(self):
+        from psycopg2.extras import RealDictCursor
+
+        return self.connection.cursor(cursor_factory=RealDictCursor)
+
+    def set_kill_switch(self, *, enabled: bool, reason: str, actor: str) -> dict[str, Any]:
+        if not reason or not actor:
+            raise ValueError("kill switch reason and actor are required")
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE contact_discovery_kill_switch
+                SET enabled = %s, reason = %s, changed_by = %s, updated_at = now()
+                WHERE singleton
+                RETURNING enabled, reason, changed_by, updated_at
+                """,
+                (enabled, reason, actor),
+            )
+            row = fetch_one(cursor)
+        return row if row else {"enabled": enabled, "reason": reason, "changed_by": actor}
+
+    def kill_switch(self) -> dict[str, Any]:
+        with self.cursor() as cursor:
+            cursor.execute(
+                "SELECT enabled, reason, changed_by, updated_at FROM contact_discovery_kill_switch WHERE singleton"
+            )
+            row = fetch_one(cursor)
+        return row if row else {"enabled": False, "reason": "", "changed_by": "", "updated_at": None}
+
+    def upsert_cohort(
+        self,
+        *,
+        cohort_id: str,
+        service: str,
+        offer_context: str | None,
+        discovery_policy_version: str,
+        search_backend: str,
+        budget_version: str,
+        code_sha: str,
+        input_evidence_version: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO contact_discovery_cohorts (
+                    cohort_id, service, offer_context, discovery_policy_version,
+                    search_backend, budget_version, code_sha, input_evidence_version,
+                    metadata
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                ON CONFLICT (cohort_id) DO UPDATE SET
+                    updated_at = now(),
+                    metadata = contact_discovery_cohorts.metadata || EXCLUDED.metadata
+                RETURNING *
+                """,
+                (
+                    cohort_id,
+                    service,
+                    offer_context,
+                    discovery_policy_version,
+                    search_backend,
+                    budget_version,
+                    code_sha,
+                    input_evidence_version,
+                    json.dumps(metadata or {}, sort_keys=True),
+                ),
+            )
+            row = fetch_one(cursor)
+            if row is None:
+                raise RuntimeError("cohort upsert returned no row")
+            return row
+
+    def enqueue(
+        self,
+        *,
+        cohort_id: str,
+        canonical_account_id: str,
+        service: str,
+        offer_context: str | None,
+        discovery_policy_version: str,
+        search_backend: str,
+        budget_version: str,
+        code_sha: str,
+        input_evidence_version: str,
+        priority: int = 0,
+        max_attempts: int = 5,
+        backend_concurrency_limit: int = 2,
+        domain_concurrency_limit: int = 1,
+        domain_key: str | None = None,
+        cursor: dict[str, Any] | None = None,
+    ) -> tuple[int, bool]:
+        account = normalize_account_id(canonical_account_id)
+        if not account:
+            raise ValueError("canonical_account_id / CNPJ is required")
+        key = idempotency_key(
+            canonical_account_id=account,
+            service=service,
+            discovery_policy_version=discovery_policy_version,
+            input_evidence_version=input_evidence_version,
+            search_backend=search_backend,
+            budget_version=budget_version,
+        )
+        resolved_domain = domain_key or f"account:{account}"
+        with self.cursor() as cursor_handle:
+            cursor_handle.execute(
+                """
+                INSERT INTO contact_discovery_jobs (
+                    cohort_id, canonical_account_id, service, offer_context,
+                    discovery_policy_version, search_backend, budget_version,
+                    code_sha, input_evidence_version, idempotency_key,
+                    domain_key, backend_key, cursor, priority, max_attempts,
+                    backend_concurrency_limit, domain_concurrency_limit
+                ) VALUES (
+                    %s, %s, %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s::jsonb, %s, %s,
+                    %s, %s
+                )
+                ON CONFLICT (idempotency_key) DO NOTHING
+                RETURNING id
+                """,
+                (
+                    cohort_id,
+                    account,
+                    service,
+                    offer_context,
+                    discovery_policy_version,
+                    search_backend,
+                    budget_version,
+                    code_sha,
+                    input_evidence_version,
+                    key,
+                    resolved_domain,
+                    search_backend,
+                    json.dumps(cursor or {}, sort_keys=True),
+                    priority,
+                    max_attempts,
+                    backend_concurrency_limit,
+                    domain_concurrency_limit,
+                ),
+            )
+            inserted = fetch_one(cursor_handle)
+            if inserted:
+                cursor_handle.execute(
+                    """
+                    UPDATE contact_discovery_cohorts
+                    SET denominator = (
+                            SELECT COUNT(*) FROM contact_discovery_jobs WHERE cohort_id = %s
+                        ),
+                        updated_at = now()
+                    WHERE cohort_id = %s
+                    """,
+                    (cohort_id, cohort_id),
+                )
+                return int(inserted["id"]), True
+            cursor_handle.execute(
+                "SELECT id FROM contact_discovery_jobs WHERE idempotency_key = %s",
+                (key,),
+            )
+            existing = fetch_one(cursor_handle)
+            if not existing:
+                raise RuntimeError("contact discovery idempotency lookup failed")
+            return int(existing["id"]), False
+
+    def reclaim_expired(self, *, now: datetime | None = None) -> int:
+        clock = now or utcnow()
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                WITH expired AS (
+                    UPDATE contact_discovery_jobs
+                    SET status = CASE
+                            WHEN cancel_requested THEN 'CANCELLED'
+                            WHEN attempt_count >= max_attempts THEN 'DLQ'
+                            ELSE 'RETRYABLE'
+                        END,
+                        next_run_at = CASE
+                            WHEN cancel_requested THEN now()
+                            WHEN attempt_count >= max_attempts THEN now() + interval '24 hours'
+                            ELSE now()
+                        END,
+                        last_outcome = 'lease_expired',
+                        last_reason_code = 'LEASE_EXPIRED',
+                        last_error = 'worker lease expired before terminal result',
+                        lease_owner = NULL,
+                        lease_expires_at = NULL,
+                        heartbeat_at = NULL,
+                        updated_at = now()
+                    WHERE status = 'RUNNING'
+                      AND lease_expires_at < %s
+                    RETURNING id, status, attempt_count, max_attempts, cursor
+                )
+                UPDATE contact_discovery_attempts a
+                SET status = 'LEASE_EXPIRED', finished_at = %s,
+                    reason_code = 'LEASE_EXPIRED',
+                    error_message = 'worker lease expired before terminal result'
+                FROM expired e
+                WHERE a.job_id = e.id AND a.status = 'RUNNING'
+                """,
+                (clock, clock),
+            )
+            return int(cursor.rowcount or 0)
+
+    def claim(
+        self,
+        *,
+        worker_id: str,
+        limit: int = 1,
+        lease_seconds: int = 300,
+        now: datetime | None = None,
+        backend_filter: str | None = None,
+    ) -> list[ClaimedDiscoveryJob]:
+        if limit < 1 or lease_seconds < 1:
+            raise ValueError("claim limit and lease_seconds must be positive")
+        clock = now or utcnow()
+        lease_expires = clock + timedelta(seconds=lease_seconds)
+        with self.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_advisory_xact_lock(hashtext(%s))",
+                (ADMISSION_LOCK,),
+            )
+            switch = self.kill_switch()
+            if switch.get("enabled"):
+                self.connection.commit()
+                return []
+            self.reclaim_expired(now=clock)
+            backend_clause = ""
+            params: list[Any] = [clock, clock, clock, clock]
+            if backend_filter:
+                backend_clause = "AND candidate.backend_key = %s"
+                params.append(backend_filter)
+            params.extend([limit, worker_id, lease_expires, clock, clock])
+            cursor.execute(  # noqa: S608 - backend_clause is a static SQL fragment
+                f"""
+                WITH open_circuits AS MATERIALIZED (
+                    SELECT backend_key
+                    FROM contact_discovery_backend_circuit
+                    WHERE state = 'open'
+                      AND cooldown_until IS NOT NULL
+                      AND cooldown_until > %s
+                ),
+                active_backends AS MATERIALIZED (
+                    SELECT backend_key, COUNT(*) AS active_count
+                    FROM contact_discovery_jobs
+                    WHERE status = 'RUNNING'
+                      AND lease_expires_at >= %s
+                    GROUP BY backend_key
+                ),
+                active_domains AS MATERIALIZED (
+                    SELECT domain_key, COUNT(*) AS active_count
+                    FROM contact_discovery_jobs
+                    WHERE status = 'RUNNING'
+                      AND lease_expires_at >= %s
+                    GROUP BY domain_key
+                ),
+                ranked AS MATERIALIZED (
+                    SELECT candidate.id,
+                           candidate.priority,
+                           candidate.next_run_at,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY candidate.backend_key
+                               ORDER BY candidate.priority DESC, candidate.next_run_at ASC, candidate.id ASC
+                           ) AS backend_slot,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY candidate.domain_key
+                               ORDER BY candidate.priority DESC, candidate.next_run_at ASC, candidate.id ASC
+                           ) AS domain_slot,
+                           GREATEST(
+                               candidate.backend_concurrency_limit
+                               - COALESCE(active_backend.active_count, 0),
+                               0
+                           ) AS backend_available,
+                           GREATEST(
+                               candidate.domain_concurrency_limit
+                               - COALESCE(active_domain.active_count, 0),
+                               0
+                           ) AS domain_available
+                    FROM contact_discovery_jobs candidate
+                    LEFT JOIN active_backends active_backend USING (backend_key)
+                    LEFT JOIN active_domains active_domain USING (domain_key)
+                    LEFT JOIN open_circuits circuit USING (backend_key)
+                    WHERE candidate.status IN ('PENDING', 'RETRYABLE')
+                      AND candidate.next_run_at <= %s
+                      AND candidate.cancel_requested = FALSE
+                      AND circuit.backend_key IS NULL
+                      {backend_clause}
+                ),
+                candidates AS MATERIALIZED (
+                    SELECT candidate.id
+                    FROM contact_discovery_jobs candidate
+                    JOIN ranked ON ranked.id = candidate.id
+                    WHERE ranked.backend_slot <= ranked.backend_available
+                      AND ranked.domain_slot <= ranked.domain_available
+                    ORDER BY ranked.priority DESC, ranked.next_run_at ASC, ranked.id ASC
+                    LIMIT %s
+                    FOR UPDATE OF candidate SKIP LOCKED
+                )
+                UPDATE contact_discovery_jobs job
+                SET status = 'RUNNING', lease_owner = %s,
+                    lease_expires_at = %s, heartbeat_at = %s,
+                    attempt_count = job.attempt_count + 1,
+                    updated_at = %s
+                FROM candidates
+                WHERE job.id = candidates.id
+                RETURNING job.*
+                """,  # noqa: S608
+                params,
+            )
+            rows = fetch_all(cursor)
+            claimed: list[ClaimedDiscoveryJob] = []
+            for row in rows:
+                run_id = f"cd-{uuid.uuid4().hex}"
+                cursor.execute(
+                    """
+                    INSERT INTO contact_discovery_attempts (
+                        job_id, run_id, worker_id, status, started_at,
+                        heartbeat_at, lease_expires_at, cursor, metrics
+                    ) VALUES (%s, %s, %s, 'RUNNING', %s, %s, %s, %s::jsonb, '{}'::jsonb)
+                    RETURNING id
+                    """,
+                    (
+                        row["id"],
+                        run_id,
+                        worker_id,
+                        clock,
+                        clock,
+                        lease_expires,
+                        json.dumps(row.get("cursor") or {}, sort_keys=True),
+                    ),
+                )
+                attempt = fetch_one(cursor)
+                if attempt is None:
+                    raise RuntimeError("attempt insert returned no row")
+                claimed.append(
+                    ClaimedDiscoveryJob(
+                        id=int(row["id"]),
+                        cohort_id=str(row["cohort_id"]),
+                        canonical_account_id=str(row["canonical_account_id"]),
+                        service=str(row["service"]),
+                        offer_context=row.get("offer_context"),
+                        discovery_policy_version=str(row["discovery_policy_version"]),
+                        search_backend=str(row["search_backend"]),
+                        budget_version=str(row["budget_version"]),
+                        code_sha=str(row["code_sha"]),
+                        input_evidence_version=str(row["input_evidence_version"]),
+                        idempotency_key=str(row["idempotency_key"]),
+                        revision=int(row["revision"]),
+                        domain_key=str(row["domain_key"]),
+                        backend_key=str(row["backend_key"]),
+                        cursor=dict(row.get("cursor") or {}),
+                        run_id=run_id,
+                        attempt_id=int(attempt["id"]),
+                        attempt_count=int(row["attempt_count"]),
+                        max_attempts=int(row["max_attempts"]),
+                        cancel_requested=bool(row.get("cancel_requested")),
+                    )
+                )
+            self.connection.commit()
+            return claimed
+
+    def heartbeat(
+        self,
+        job: ClaimedDiscoveryJob,
+        *,
+        worker_id: str,
+        cursor_state: dict[str, Any] | None = None,
+        metrics: dict[str, Any] | None = None,
+        lease_seconds: int = 300,
+    ) -> bool:
+        clock = utcnow()
+        lease_expires = clock + timedelta(seconds=lease_seconds)
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE contact_discovery_jobs
+                SET heartbeat_at = %s, lease_expires_at = %s,
+                    cursor = %s::jsonb, updated_at = %s
+                WHERE id = %s AND status = 'RUNNING' AND lease_owner = %s
+                RETURNING cancel_requested
+                """,
+                (
+                    clock,
+                    lease_expires,
+                    json.dumps(cursor_state if cursor_state is not None else job.cursor),
+                    clock,
+                    job.id,
+                    worker_id,
+                ),
+            )
+            row = fetch_one(cursor)
+            if not row:
+                return False
+            cursor.execute(
+                """
+                UPDATE contact_discovery_attempts
+                SET heartbeat_at = %s, lease_expires_at = %s,
+                    cursor = %s::jsonb,
+                    metrics = metrics || %s::jsonb
+                WHERE id = %s AND status = 'RUNNING'
+                """,
+                (
+                    clock,
+                    lease_expires,
+                    json.dumps(cursor_state if cursor_state is not None else job.cursor),
+                    json.dumps(metrics or {}),
+                    job.attempt_id,
+                ),
+            )
+            return True
+
+    def finish(
+        self,
+        job: ClaimedDiscoveryJob,
+        *,
+        worker_id: str,
+        outcome: str,
+        reason_code: str,
+        next_run_at: datetime | None = None,
+        cursor_state: dict[str, Any] | None = None,
+        metrics: dict[str, Any] | None = None,
+        error_message: str | None = None,
+        output_pointer: str | None = None,
+        output_hash: str | None = None,
+        domain_key: str | None = None,
+    ) -> bool:
+        if outcome not in {"SUCCEEDED", "BLOCKED", "RETRYABLE", "DLQ", "CANCELLED", "INTERRUPTED"}:
+            raise ValueError(f"invalid contact discovery outcome: {outcome}")
+        if reason_code in {"SEM_CONTATO", "NO_CONTACT", "NO_CONTACT_FOUND", "sem contato encontrado"}:
+            raise ValueError("forbidden reason code; timeout/budget/block must stay explicit")
+
+        job_status = outcome
+        if outcome == "INTERRUPTED":
+            job_status = "RETRYABLE"
+        if outcome == "RETRYABLE" and job.attempt_count >= job.max_attempts:
+            job_status = "DLQ"
+            outcome = "DLQ"
+        clock = utcnow()
+        delay = next_run_at or clock
+        cursor_payload = cursor_state if cursor_state is not None else job.cursor
+        metrics_payload = metrics or {}
+
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE contact_discovery_jobs
+                SET status = %s, next_run_at = %s,
+                    cursor = %s::jsonb, last_outcome = %s,
+                    last_reason_code = %s, last_error = %s,
+                    output_pointer = COALESCE(%s, output_pointer),
+                    output_hash = COALESCE(%s, output_hash),
+                    cost_metrics = cost_metrics || %s::jsonb,
+                    domain_key = COALESCE(%s, domain_key),
+                    lease_owner = NULL, lease_expires_at = NULL,
+                    heartbeat_at = NULL, updated_at = %s
+                WHERE id = %s AND status = 'RUNNING' AND lease_owner = %s
+                """,
+                (
+                    job_status,
+                    delay,
+                    json.dumps(cursor_payload, sort_keys=True),
+                    outcome,
+                    reason_code,
+                    error_message,
+                    output_pointer,
+                    output_hash,
+                    json.dumps(metrics_payload),
+                    domain_key,
+                    clock,
+                    job.id,
+                    worker_id,
+                ),
+            )
+            owned = cursor.rowcount == 1
+            if owned:
+                cursor.execute(
+                    """
+                    UPDATE contact_discovery_attempts
+                    SET status = %s, finished_at = %s, heartbeat_at = %s,
+                        cursor = %s::jsonb, metrics = metrics || %s::jsonb,
+                        reason_code = %s, error_message = %s,
+                        output_pointer = COALESCE(%s, output_pointer),
+                        output_hash = COALESCE(%s, output_hash)
+                    WHERE id = %s AND status = 'RUNNING'
+                    """,
+                    (
+                        outcome if outcome != "INTERRUPTED" else "INTERRUPTED",
+                        clock,
+                        clock,
+                        json.dumps(cursor_payload, sort_keys=True),
+                        json.dumps(metrics_payload),
+                        reason_code,
+                        error_message,
+                        output_pointer,
+                        output_hash,
+                        job.attempt_id,
+                    ),
+                )
+                if job_status == "RETRYABLE":
+                    self._record_backend_failure(cursor, job.backend_key, reason_code)
+                elif job_status == "SUCCEEDED":
+                    self._record_backend_success(cursor, job.backend_key)
+                return True
+
+            cursor.execute(
+                """
+                SELECT status, output_hash, last_reason_code
+                FROM contact_discovery_jobs
+                WHERE id = %s
+                """,
+                (job.id,),
+            )
+            existing = fetch_one(cursor)
+            if not existing:
+                return False
+            same_truth = (
+                existing["status"] in TERMINAL
+                and existing["output_hash"]
+                and output_hash
+                and existing["output_hash"] == output_hash
+            )
+            if same_truth:
+                cursor.execute(
+                    """
+                    UPDATE contact_discovery_attempts
+                    SET status = CASE WHEN status = 'RUNNING' THEN %s ELSE status END,
+                        finished_at = COALESCE(finished_at, %s),
+                        heartbeat_at = %s,
+                        reason_code = COALESCE(reason_code, %s),
+                        output_pointer = COALESCE(output_pointer, %s),
+                        output_hash = COALESCE(output_hash, %s)
+                    WHERE id = %s
+                    """,
+                    (existing["status"], clock, clock, reason_code, output_pointer, output_hash, job.attempt_id),
+                )
+                return True
+            return False
+
+    def _record_backend_failure(self, cursor: Any, backend_key: str, reason_code: str) -> None:
+        if reason_code not in {"PROVIDER_429", "PROVIDER_5XX", "PROVIDER_TIMEOUT"}:
+            return
+        cursor.execute(
+            """
+            INSERT INTO contact_discovery_backend_circuit (
+                backend_key, state, consecutive_failures, last_error_class, updated_at
+            ) VALUES (%s, 'closed', 1, %s, now())
+            ON CONFLICT (backend_key) DO UPDATE SET
+                consecutive_failures = contact_discovery_backend_circuit.consecutive_failures + 1,
+                last_error_class = EXCLUDED.last_error_class,
+                state = CASE
+                    WHEN contact_discovery_backend_circuit.consecutive_failures + 1 >= 3
+                    THEN 'open' ELSE contact_discovery_backend_circuit.state
+                END,
+                opened_at = CASE
+                    WHEN contact_discovery_backend_circuit.consecutive_failures + 1 >= 3
+                    THEN now() ELSE contact_discovery_backend_circuit.opened_at
+                END,
+                cooldown_until = CASE
+                    WHEN contact_discovery_backend_circuit.consecutive_failures + 1 >= 3
+                    THEN now() + interval '5 minutes'
+                    ELSE contact_discovery_backend_circuit.cooldown_until
+                END,
+                updated_at = now()
+            """,
+            (backend_key, reason_code),
+        )
+
+    def _record_backend_success(self, cursor: Any, backend_key: str) -> None:
+        cursor.execute(
+            """
+            INSERT INTO contact_discovery_backend_circuit (
+                backend_key, state, consecutive_failures, updated_at
+            ) VALUES (%s, 'closed', 0, now())
+            ON CONFLICT (backend_key) DO UPDATE SET
+                state = 'closed',
+                consecutive_failures = 0,
+                opened_at = NULL,
+                cooldown_until = NULL,
+                updated_at = now()
+            """,
+            (backend_key,),
+        )
+
+    def request_cancel(self, *, cohort_id: str | None = None, job_id: int | None = None) -> int:
+        clauses = ["status IN ('PENDING', 'RETRYABLE', 'RUNNING')"]
+        params: list[Any] = []
+        if cohort_id:
+            clauses.append("cohort_id = %s")
+            params.append(cohort_id)
+        if job_id is not None:
+            clauses.append("id = %s")
+            params.append(job_id)
+        if not cohort_id and job_id is None:
+            raise ValueError("cancel requires cohort_id or job_id")
+        where = " AND ".join(clauses)
+        with self.cursor() as cursor:
+            cursor.execute(  # noqa: S608 - WHERE is composed of fixed clauses
+                f"""
+                UPDATE contact_discovery_jobs
+                SET cancel_requested = TRUE,
+                    status = CASE WHEN status IN ('PENDING', 'RETRYABLE') THEN 'CANCELLED' ELSE status END,
+                    last_outcome = CASE
+                        WHEN status IN ('PENDING', 'RETRYABLE') THEN 'cancelled' ELSE last_outcome
+                    END,
+                    last_reason_code = CASE
+                        WHEN status IN ('PENDING', 'RETRYABLE') THEN 'CANCELLED' ELSE last_reason_code
+                    END,
+                    lease_owner = CASE
+                        WHEN status IN ('PENDING', 'RETRYABLE') THEN NULL ELSE lease_owner
+                    END,
+                    updated_at = now()
+                WHERE {where}
+                """,  # noqa: S608
+                params,
+            )
+            return int(cursor.rowcount or 0)
+
+    def retry(
+        self,
+        *,
+        cohort_id: str | None = None,
+        job_id: int | None = None,
+        reason_codes: list[str] | None = None,
+    ) -> int:
+        clauses = ["status IN ('RETRYABLE', 'BLOCKED', 'DLQ')"]
+        params: list[Any] = []
+        if cohort_id:
+            clauses.append("cohort_id = %s")
+            params.append(cohort_id)
+        if job_id is not None:
+            clauses.append("id = %s")
+            params.append(job_id)
+        if reason_codes:
+            clauses.append("last_reason_code = ANY(%s)")
+            params.append(reason_codes)
+        if not cohort_id and job_id is None:
+            raise ValueError("retry requires cohort_id or job_id")
+        where = " AND ".join(clauses)
+        with self.cursor() as cursor:
+            cursor.execute(  # noqa: S608 - WHERE is composed of fixed clauses
+                f"""
+                UPDATE contact_discovery_jobs
+                SET status = 'PENDING',
+                    next_run_at = now(),
+                    cancel_requested = FALSE,
+                    last_outcome = 'requeued',
+                    updated_at = now()
+                WHERE {where}
+                """,  # noqa: S608
+                params,
+            )
+            return int(cursor.rowcount or 0)
+
+    def resume(self, *, cohort_id: str) -> dict[str, Any]:
+        reclaimed = self.reclaim_expired()
+        retried = self.retry(cohort_id=cohort_id)
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE contact_discovery_jobs
+                SET next_run_at = now(), updated_at = now()
+                WHERE cohort_id = %s AND status IN ('PENDING', 'RETRYABLE')
+                """,
+                (cohort_id,),
+            )
+            pending = int(cursor.rowcount or 0)
+        return {"reclaimed": reclaimed, "retried": retried, "pending": pending}
+
+    def inspect(self, *, cohort_id: str | None = None, job_id: int | None = None) -> list[dict[str, Any]]:
+        clauses = ["TRUE"]
+        params: list[Any] = []
+        if cohort_id:
+            clauses.append("cohort_id = %s")
+            params.append(cohort_id)
+        if job_id is not None:
+            clauses.append("id = %s")
+            params.append(job_id)
+        where = " AND ".join(clauses)
+        with self.cursor() as cursor:
+            cursor.execute(  # noqa: S608 - WHERE is composed of fixed clauses
+                f"""
+                SELECT id, cohort_id, canonical_account_id, status, revision,
+                       last_reason_code, last_outcome, last_error, attempt_count,
+                       max_attempts, output_pointer, output_hash, lease_owner,
+                       lease_expires_at, heartbeat_at, next_run_at,
+                       discovery_policy_version, search_backend, budget_version,
+                       code_sha, input_evidence_version, idempotency_key,
+                       cost_metrics, domain_key, backend_key, cancel_requested
+                FROM contact_discovery_jobs
+                WHERE {where}
+                ORDER BY id
+                """,  # noqa: S608
+                params,
+            )
+            return fetch_all(cursor)
+
+    def failures(self, *, cohort_id: str) -> list[dict[str, Any]]:
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT id, canonical_account_id, status, last_reason_code,
+                       last_error, attempt_count, output_pointer, output_hash
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s
+                  AND status IN ('BLOCKED', 'RETRYABLE', 'DLQ')
+                ORDER BY id
+                """,
+                (cohort_id,),
+            )
+            return fetch_all(cursor)
+
+    def progress(self, *, cohort_id: str) -> dict[str, Any]:
+        with self.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM contact_discovery_cohorts WHERE cohort_id = %s",
+                (cohort_id,),
+            )
+            cohort = fetch_one(cursor)
+            if not cohort:
+                raise ValueError(f"unknown cohort: {cohort_id}")
+            cursor.execute(
+                """
+                SELECT status, COUNT(*) AS n
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s
+                GROUP BY status
+                """,
+                (cohort_id,),
+            )
+            counts = {str(row["status"]): int(row["n"]) for row in fetch_all(cursor)}
+            cursor.execute(
+                """
+                SELECT last_reason_code, COUNT(*) AS n
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s AND last_reason_code IS NOT NULL
+                GROUP BY last_reason_code
+                """,
+                (cohort_id,),
+            )
+            reasons = {str(row["last_reason_code"]): int(row["n"]) for row in fetch_all(cursor)}
+            cursor.execute(
+                """
+                SELECT
+                    COUNT(*) FILTER (WHERE status = 'SUCCEEDED') AS succeeded,
+                    COALESCE(SUM((cost_metrics->>'duration_ms')::numeric), 0) AS duration_ms,
+                    COALESCE(SUM((cost_metrics->>'searches')::numeric), 0) AS searches,
+                    COALESCE(SUM((cost_metrics->>'pages')::numeric), 0) AS pages,
+                    COALESCE(SUM((cost_metrics->>'bytes_touched')::numeric), 0) AS bytes_touched,
+                    COALESCE(SUM((cost_metrics->>'cache_hits')::numeric), 0) AS cache_hits,
+                    COALESCE(SUM((cost_metrics->>'cache_misses')::numeric), 0) AS cache_misses,
+                    COALESCE(SUM((cost_metrics->>'external_cost_brl')::numeric), 0) AS external_cost_brl,
+                    COALESCE(SUM((cost_metrics->>'domains_resolved')::numeric), 0) AS domains_resolved,
+                    COALESCE(SUM((cost_metrics->>'named_people')::numeric), 0) AS named_people,
+                    COALESCE(SUM((cost_metrics->>'observed_direct_email')::numeric), 0) AS observed_direct_email,
+                    COALESCE(SUM((cost_metrics->>'inferred_email')::numeric), 0) AS inferred_email,
+                    COALESCE(SUM((cost_metrics->>'email_validated')::numeric), 0) AS email_validated,
+                    COALESCE(SUM((cost_metrics->>'retries')::numeric), 0) AS retries,
+                    COALESCE(SUM((cost_metrics->>'provider_failures')::numeric), 0) AS provider_failures
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s
+                """,
+                (cohort_id,),
+            )
+            totals = fetch_one(cursor) or {}
+            cursor.execute(
+                """
+                SELECT
+                    percentile_cont(0.5) WITHIN GROUP (
+                        ORDER BY (cost_metrics->>'duration_ms')::numeric
+                    ) AS p50_ms,
+                    percentile_cont(0.95) WITHIN GROUP (
+                        ORDER BY (cost_metrics->>'duration_ms')::numeric
+                    ) AS p95_ms
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s
+                  AND cost_metrics ? 'duration_ms'
+                """,
+                (cohort_id,),
+            )
+            latency = fetch_one(cursor) or {}
+            cursor.execute(
+                """
+                SELECT MIN(created_at) AS first_at, MAX(updated_at) AS last_at
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s
+                """,
+                (cohort_id,),
+            )
+            window = fetch_one(cursor) or {}
+        denominator = int(cohort["denominator"] or sum(counts.values()))
+        succeeded = int(counts.get("SUCCEEDED") or 0)
+        first_at = window.get("first_at")
+        last_at = window.get("last_at")
+        hours = 0.0
+        if first_at and last_at:
+            hours = max((last_at - first_at).total_seconds() / 3600.0, 1e-9)
+        cache_hits = float(totals.get("cache_hits") or 0)
+        cache_misses = float(totals.get("cache_misses") or 0)
+        return {
+            "cohort_id": cohort_id,
+            "job_type": JOB_TYPE,
+            "status": cohort["status"],
+            "denominator": denominator,
+            "counts": {
+                "pending": int(counts.get("PENDING") or 0),
+                "running": int(counts.get("RUNNING") or 0),
+                "succeeded": succeeded,
+                "blocked": int(counts.get("BLOCKED") or 0),
+                "retryable": int(counts.get("RETRYABLE") or 0),
+                "dlq": int(counts.get("DLQ") or 0),
+                "cancelled": int(counts.get("CANCELLED") or 0),
+            },
+            "reason_codes": reasons,
+            "throughput_accounts_per_hour": round(succeeded / hours, 4) if succeeded else 0.0,
+            "p50_ms": float(latency["p50_ms"]) if latency.get("p50_ms") is not None else None,
+            "p95_ms": float(latency["p95_ms"]) if latency.get("p95_ms") is not None else None,
+            "searches": float(totals.get("searches") or 0),
+            "pages": float(totals.get("pages") or 0),
+            "bytes_touched": float(totals.get("bytes_touched") or 0),
+            "cache_hits": cache_hits,
+            "cache_hit_rate": round(cache_hits / (cache_hits + cache_misses), 4)
+            if cache_hits + cache_misses
+            else 0.0,
+            "external_cost_brl": float(totals.get("external_cost_brl") or 0),
+            "domains_resolved": float(totals.get("domains_resolved") or 0),
+            "named_people": float(totals.get("named_people") or 0),
+            "observed_direct_email": float(totals.get("observed_direct_email") or 0),
+            "inferred_email": float(totals.get("inferred_email") or 0),
+            "email_validated": float(totals.get("email_validated") or 0),
+            "retries": float(totals.get("retries") or 0),
+            "provider_failures": float(totals.get("provider_failures") or 0),
+            "policy_version": cohort["discovery_policy_version"],
+            "search_backend": cohort["search_backend"],
+            "budget_version": cohort["budget_version"],
+            "code_sha": cohort["code_sha"],
+            "input_evidence_version": cohort["input_evidence_version"],
+            "snapshot_id": cohort.get("snapshot_id"),
+            "snapshot_hash": cohort.get("snapshot_hash"),
+            "closable": self._closable(denominator, counts),
+        }
+
+    def _closable(self, denominator: int, counts: dict[str, int]) -> bool:
+        total = sum(counts.values())
+        if denominator <= 0 or total != denominator:
+            return False
+        open_count = int(counts.get("PENDING") or 0) + int(counts.get("RUNNING") or 0) + int(
+            counts.get("RETRYABLE") or 0
+        )
+        return open_count == 0
+
+    def duplicate_identities(self, *, cohort_id: str) -> list[dict[str, Any]]:
+        with self.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT canonical_account_id, discovery_policy_version,
+                       input_evidence_version, search_backend, budget_version,
+                       service, COUNT(*) AS n
+                FROM contact_discovery_jobs
+                WHERE cohort_id = %s
+                GROUP BY 1, 2, 3, 4, 5, 6
+                HAVING COUNT(*) > 1
+                """,
+                (cohort_id,),
+            )
+            return fetch_all(cursor)
+
+    def mark_cohort_published(
+        self,
+        *,
+        cohort_id: str,
+        snapshot_id: str,
+        pointer: str,
+        content_hash: str,
+        approved: bool,
+        status_counts: dict[str, Any],
+        reject_reason: str | None,
+    ) -> None:
+        with self.cursor() as cursor:
+            cursor.execute(
+                "SELECT * FROM contact_discovery_cohorts WHERE cohort_id = %s",
+                (cohort_id,),
+            )
+            cohort = fetch_one(cursor)
+            if not cohort:
+                raise ValueError(f"unknown cohort: {cohort_id}")
+            cursor.execute(
+                """
+                INSERT INTO contact_discovery_snapshots (
+                    snapshot_id, cohort_id, approved, pointer, content_hash,
+                    denominator, status_counts, policy_version, code_sha,
+                    search_backend, budget_version, reject_reason
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)
+                """,
+                (
+                    snapshot_id,
+                    cohort_id,
+                    approved,
+                    pointer,
+                    content_hash,
+                    int(cohort["denominator"] or 0),
+                    json.dumps(status_counts, sort_keys=True),
+                    cohort["discovery_policy_version"],
+                    cohort["code_sha"],
+                    cohort["search_backend"],
+                    cohort["budget_version"],
+                    reject_reason,
+                ),
+            )
+            if approved:
+                cursor.execute(
+                    """
+                    UPDATE contact_discovery_cohorts
+                    SET status = 'PUBLISHED',
+                        snapshot_id = %s,
+                        snapshot_pointer = %s,
+                        snapshot_hash = %s,
+                        published_at = now(),
+                        updated_at = now()
+                    WHERE cohort_id = %s
+                    """,
+                    (snapshot_id, pointer, content_hash, cohort_id),
+                )

--- a/scripts/decision_unit_intelligence/batch_snapshot.py
+++ b/scripts/decision_unit_intelligence/batch_snapshot.py
@@ -1,0 +1,152 @@
+"""Approved snapshot gate for a contact-discovery cohort."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.decision_unit_intelligence.batch_queue import ContactDiscoveryQueue
+from scripts.decision_unit_intelligence.repository import write_json
+
+PUBLISHABLE = {"SUCCEEDED", "BLOCKED", "DLQ", "CANCELLED"}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def reconcile_outputs(jobs: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    for job in jobs:
+        if job["status"] not in PUBLISHABLE:
+            continue
+        if job["status"] in {"BLOCKED", "DLQ", "CANCELLED"}:
+            continue
+        pointer = job.get("output_pointer")
+        digest = job.get("output_hash")
+        if not pointer or not digest:
+            errors.append(f"job {job['id']} missing output pointer/hash")
+            continue
+        path = Path(str(pointer))
+        if not path.is_file():
+            errors.append(f"job {job['id']} output missing on disk: {pointer}")
+            continue
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        recomputed = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        ).hexdigest()
+        if recomputed != digest:
+            errors.append(f"job {job['id']} output hash mismatch")
+    return errors
+
+
+def evaluate_publish(queue: ContactDiscoveryQueue, *, cohort_id: str) -> dict[str, Any]:
+    progress = queue.progress(cohort_id=cohort_id)
+    jobs = queue.inspect(cohort_id=cohort_id)
+    duplicates = queue.duplicate_identities(cohort_id=cohort_id)
+    reasons: list[str] = []
+    if not progress["closable"]:
+        reasons.append("denominator has non-terminal jobs")
+    if duplicates:
+        reasons.append("duplicate jobs for same account×policy×input")
+    missing_meta = [
+        job["id"]
+        for job in jobs
+        if not (
+            job.get("discovery_policy_version")
+            and job.get("code_sha")
+            and job.get("search_backend")
+            and job.get("budget_version")
+        )
+    ]
+    if missing_meta:
+        reasons.append(f"jobs missing policy/sha/backend/budget: {missing_meta[:8]}")
+    reasons.extend(reconcile_outputs(jobs))
+    return {
+        "cohort_id": cohort_id,
+        "approved": not reasons,
+        "reject_reasons": reasons,
+        "progress": progress,
+        "job_count": len(jobs),
+        "duplicates": duplicates,
+    }
+
+
+def publish_snapshot(
+    queue: ContactDiscoveryQueue,
+    *,
+    cohort_id: str,
+    output_root: Path,
+    allow_partial: bool = False,
+) -> dict[str, Any]:
+    evaluation = evaluate_publish(queue, cohort_id=cohort_id)
+    approved = bool(evaluation["approved"])
+    if not approved and not allow_partial:
+        snapshot_id = f"reject-{uuid.uuid4().hex[:12]}"
+        pointer = str(Path(output_root) / cohort_id / f"{snapshot_id}.json")
+        payload = {
+            "schema_id": "confenge.contact_discovery.snapshot.v1",
+            "snapshot_id": snapshot_id,
+            "approved": False,
+            "created_at": _now_iso(),
+            **evaluation,
+        }
+        write_json(Path(pointer), payload)
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        ).hexdigest()
+        queue.mark_cohort_published(
+            cohort_id=cohort_id,
+            snapshot_id=snapshot_id,
+            pointer=pointer,
+            content_hash=digest,
+            approved=False,
+            status_counts=evaluation["progress"]["counts"],
+            reject_reason="; ".join(evaluation["reject_reasons"]),
+        )
+        return {**payload, "pointer": pointer, "content_hash": digest}
+
+    snapshot_id = f"snap-{uuid.uuid4().hex[:12]}"
+    jobs = queue.inspect(cohort_id=cohort_id)
+    payload = {
+        "schema_id": "confenge.contact_discovery.snapshot.v1",
+        "snapshot_id": snapshot_id,
+        "approved": approved,
+        "created_at": _now_iso(),
+        "progress": evaluation["progress"],
+        "jobs": [
+            {
+                "id": job["id"],
+                "canonical_account_id": job["canonical_account_id"],
+                "status": job["status"],
+                "reason_code": job["last_reason_code"],
+                "output_pointer": job["output_pointer"],
+                "output_hash": job["output_hash"],
+                "policy_version": job["discovery_policy_version"],
+                "code_sha": job["code_sha"],
+                "search_backend": job["search_backend"],
+                "budget_version": job["budget_version"],
+            }
+            for job in jobs
+        ],
+        "reject_reasons": evaluation["reject_reasons"],
+    }
+    pointer = str(Path(output_root) / cohort_id / f"{snapshot_id}.json")
+    write_json(Path(pointer), payload)
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    ).hexdigest()
+    queue.mark_cohort_published(
+        cohort_id=cohort_id,
+        snapshot_id=snapshot_id,
+        pointer=pointer,
+        content_hash=digest,
+        approved=approved,
+        status_counts=evaluation["progress"]["counts"],
+        reject_reason=None if approved else "; ".join(evaluation["reject_reasons"]),
+    )
+    return {**payload, "pointer": pointer, "content_hash": digest}

--- a/scripts/decision_unit_intelligence/batch_worker.py
+++ b/scripts/decision_unit_intelligence/batch_worker.py
@@ -1,0 +1,286 @@
+"""Leased contact-discovery worker. Calls run_account as a black box."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import socket
+import threading
+import time
+from collections.abc import Callable
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+from scripts.crawl.worker import AdmissionLimits, admission_blockers
+from scripts.decision_unit_intelligence import POLICY_VERSION
+from scripts.decision_unit_intelligence.batch_outcomes import (
+    BlockedDiscoveryError,
+    Outcome,
+    RetryableDiscoveryError,
+    classify_account,
+    classify_exception,
+    persist_outcome,
+)
+from scripts.decision_unit_intelligence.batch_queue import (
+    ClaimedDiscoveryJob,
+    ContactDiscoveryQueue,
+    connect,
+    utcnow,
+)
+from scripts.decision_unit_intelligence.runner import run_account
+from scripts.decision_unit_intelligence.web_discovery import SearchBudget
+
+logger = logging.getLogger(__name__)
+
+AdmissionProbe = Callable[[], list[str]]
+DiscoveryFn = Callable[[ClaimedDiscoveryJob], Any]
+
+
+class Heartbeat:
+    def __init__(
+        self,
+        *,
+        dsn: str,
+        job: ClaimedDiscoveryJob,
+        worker_id: str,
+        interval_seconds: int,
+        lease_seconds: int,
+    ):
+        self.dsn = dsn
+        self.job = job
+        self.worker_id = worker_id
+        self.interval_seconds = interval_seconds
+        self.lease_seconds = lease_seconds
+        self.stop_event = threading.Event()
+        self.thread = threading.Thread(
+            target=self._run, name=f"cd-heartbeat-{job.id}", daemon=True
+        )
+
+    def start(self) -> None:
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        self.thread.join(timeout=max(1, self.interval_seconds + 1))
+
+    def _run(self) -> None:
+        while not self.stop_event.wait(self.interval_seconds):
+            try:
+                with connect(self.dsn) as connection:
+                    owned = ContactDiscoveryQueue(connection).heartbeat(
+                        self.job,
+                        worker_id=self.worker_id,
+                        lease_seconds=self.lease_seconds,
+                        metrics={"heartbeat_count": 1},
+                    )
+                    if not owned:
+                        return
+            except Exception as exc:  # noqa: BLE001 - lease expiry remains authority
+                logger.warning("contact discovery heartbeat failed job=%s: %s", self.job.id, exc)
+                continue
+
+
+def default_discovery(job: ClaimedDiscoveryJob) -> Any:
+    knobs = (job.cursor or {}).get("budget") or {}
+    budget = SearchBudget(
+        max_queries=int(knobs.get("max_queries") or 4),
+        max_results_per_query=int(knobs.get("max_results_per_query") or 5),
+        max_pages=int(knobs.get("max_pages") or 4),
+        max_bytes=int(knobs.get("max_bytes") or 1_500_000),
+        timeout_seconds=float(knobs.get("timeout_seconds") or 12.0),
+        min_query_interval_seconds=float(knobs.get("min_query_interval_seconds") or 1.0),
+        cache_ttl_days=int(knobs.get("cache_ttl_days") or 7),
+    )
+    cache_dir = Path(knobs.get("cache_dir") or ".cache/confenge-prospect")
+    return run_account(
+        job.canonical_account_id,
+        service=job.service,
+        infer_email=bool(knobs.get("infer_email", True)),
+        search_backend=job.search_backend,
+        searxng_url=knobs.get("searxng_url") or os.getenv("CONFENGE_SEARXNG_URL"),
+        search_budget=budget,
+        cache_dir=cache_dir,
+        verify_email_dns=bool(knobs.get("verify_email_dns", False)),
+    )
+
+
+def execute_claimed(
+    job: ClaimedDiscoveryJob,
+    *,
+    discovery: DiscoveryFn,
+    output_root: Path,
+) -> Outcome:
+    if job.cancel_requested:
+        return Outcome(job_status="CANCELLED", reason_code="CANCELLED")
+    try:
+        account = discovery(job)
+    except RetryableDiscoveryError as exc:
+        return Outcome(job_status="RETRYABLE", reason_code=exc.reason_code, error_message=exc.message)
+    except BlockedDiscoveryError as exc:
+        return Outcome(job_status="BLOCKED", reason_code=exc.reason_code, error_message=exc.message)
+    except Exception as exc:  # noqa: BLE001 - classify, never invent "no contact"
+        return classify_exception(exc)
+    outcome = classify_account(account)
+    return persist_outcome(outcome, job=job, output_root=output_root)
+
+
+class ContactDiscoveryWorker:
+    def __init__(
+        self,
+        *,
+        dsn: str,
+        worker_id: str | None = None,
+        lease_seconds: int = 300,
+        heartbeat_seconds: int = 30,
+        limits: AdmissionLimits | None = None,
+        discovery: DiscoveryFn | None = None,
+        admission_probe: AdmissionProbe | None = None,
+        output_root: Path | None = None,
+        claim_limit: int = 1,
+        backend_filter: str | None = None,
+    ):
+        self.dsn = dsn
+        self.worker_id = worker_id or f"cd-{socket.gethostname()}-{os.getpid()}"
+        self.lease_seconds = lease_seconds
+        self.heartbeat_seconds = heartbeat_seconds
+        self.limits = limits or AdmissionLimits()
+        self.discovery = discovery or default_discovery
+        if admission_probe is not None:
+            self.admission_probe = admission_probe
+        elif os.getenv("CONTACT_DISCOVERY_ADMISSION", "on").lower() in {"off", "0", "false"}:
+            self.admission_probe = lambda: []
+        else:
+            self.admission_probe = lambda: admission_blockers(self.limits)
+        self.output_root = Path(output_root or "output/contact-discovery")
+        self.claim_limit = claim_limit
+        self.backend_filter = backend_filter
+        self.shutdown_requested = threading.Event()
+
+    def request_shutdown(self, *_args: Any) -> None:
+        self.shutdown_requested.set()
+
+    def install_signal_handlers(self) -> None:
+        signal.signal(signal.SIGTERM, self.request_shutdown)
+        signal.signal(signal.SIGINT, self.request_shutdown)
+
+    def run_once(self) -> dict[str, Any]:
+        blockers = self.admission_probe()
+        if blockers:
+            return {
+                "status": "backpressure",
+                "worker_id": self.worker_id,
+                "blockers": blockers,
+                "reason_code": "ADMISSION_PRESSURE",
+            }
+        with connect(self.dsn) as connection:
+            queue = ContactDiscoveryQueue(connection)
+            switch = queue.kill_switch()
+            if switch.get("enabled"):
+                return {
+                    "status": "blocked",
+                    "worker_id": self.worker_id,
+                    "reason_code": "KILL_SWITCH",
+                    "reason": switch.get("reason"),
+                }
+            claimed = queue.claim(
+                worker_id=self.worker_id,
+                limit=self.claim_limit,
+                lease_seconds=self.lease_seconds,
+                backend_filter=self.backend_filter,
+            )
+        if not claimed:
+            return {"status": "idle", "worker_id": self.worker_id}
+        return self._run_job(claimed[0])
+
+    def _run_job(self, job: ClaimedDiscoveryJob) -> dict[str, Any]:
+        heartbeat = Heartbeat(
+            dsn=self.dsn,
+            job=job,
+            worker_id=self.worker_id,
+            interval_seconds=self.heartbeat_seconds,
+            lease_seconds=self.lease_seconds,
+        )
+        started = time.monotonic()
+        heartbeat.start()
+        outcome = Outcome(job_status="RETRYABLE", reason_code="INTERRUPTED")
+        try:
+            if self.shutdown_requested.is_set():
+                outcome = Outcome(job_status="RETRYABLE", reason_code="INTERRUPTED")
+            else:
+                outcome = execute_claimed(job, discovery=self.discovery, output_root=self.output_root)
+                if self.shutdown_requested.is_set() and outcome.job_status not in {
+                    "SUCCEEDED",
+                    "BLOCKED",
+                    "CANCELLED",
+                }:
+                    outcome.job_status = "RETRYABLE"
+                    outcome.reason_code = "INTERRUPTED"
+        except Exception as exc:  # noqa: BLE001 - attempt must close
+            classified = classify_exception(exc)
+            outcome = classified
+            if self.shutdown_requested.is_set():
+                outcome.job_status = "RETRYABLE"
+                outcome.reason_code = "INTERRUPTED"
+        finally:
+            heartbeat.stop()
+
+        duration_ms = round((time.monotonic() - started) * 1000, 3)
+        metrics = {
+            **dict(outcome.metrics or {}),
+            "duration_ms": duration_ms,
+            "run_id": job.run_id,
+            "retries": max(0, job.attempt_count - 1),
+            "policy_version": job.discovery_policy_version or POLICY_VERSION,
+        }
+        delay = utcnow()
+        if outcome.job_status == "RETRYABLE":
+            delay = utcnow() + timedelta(minutes=min(60, 2 ** max(0, job.attempt_count - 1)))
+        elif outcome.job_status == "BLOCKED":
+            delay = utcnow() + timedelta(hours=6)
+        with connect(self.dsn) as connection:
+            owned = ContactDiscoveryQueue(connection).finish(
+                job,
+                worker_id=self.worker_id,
+                outcome=outcome.job_status,
+                reason_code=outcome.reason_code,
+                next_run_at=delay,
+                cursor_state=job.cursor,
+                metrics=metrics,
+                error_message=outcome.error_message,
+                output_pointer=outcome.output_pointer,
+                output_hash=outcome.output_hash,
+                domain_key=outcome.domain_key,
+            )
+        if not owned:
+            raise RuntimeError(f"contact discovery lease lost before finish: {job.id}")
+        return {
+            "status": outcome.job_status,
+            "reason_code": outcome.reason_code,
+            "worker_id": self.worker_id,
+            "job_id": job.id,
+            "attempt_id": job.attempt_id,
+            "run_id": job.run_id,
+            "output_pointer": outcome.output_pointer,
+            "output_hash": outcome.output_hash,
+            "metrics": metrics,
+        }
+
+    def run_loop(self, *, idle_sleep: float = 2.0, max_jobs: int | None = None) -> dict[str, Any]:
+        self.install_signal_handlers()
+        processed = 0
+        last: dict[str, Any] = {"status": "idle", "worker_id": self.worker_id}
+        while not self.shutdown_requested.is_set():
+            last = self.run_once()
+            if last.get("status") not in {"idle", "backpressure", "blocked"}:
+                processed += 1
+                if max_jobs is not None and processed >= max_jobs:
+                    break
+                continue
+            if max_jobs == 0:
+                break
+            time.sleep(idle_sleep)
+            if max_jobs is not None and processed >= max_jobs:
+                break
+        return {"processed": processed, "last": last, "worker_id": self.worker_id}

--- a/scripts/decision_unit_intelligence/cli.py
+++ b/scripts/decision_unit_intelligence/cli.py
@@ -1,4 +1,4 @@
-"""CLI: plan / run / report / replay / shadow."""
+"""CLI: plan / run / report / replay / shadow / batch."""
 
 from __future__ import annotations
 
@@ -9,6 +9,13 @@ import sys
 from pathlib import Path
 
 from scripts.decision_unit_intelligence import POLICY_VERSION, PROVIDER_VERSION, SCHEMA_VERSION
+from scripts.decision_unit_intelligence.batch_queue import (
+    ContactDiscoveryQueue,
+    budget_version_from_knobs,
+    connect,
+)
+from scripts.decision_unit_intelligence.batch_snapshot import publish_snapshot
+from scripts.decision_unit_intelligence.batch_worker import ContactDiscoveryWorker
 from scripts.decision_unit_intelligence.benchmark import funnel, replay_report
 from scripts.decision_unit_intelligence.cohort import TRACK_A_CNPJS, build_manifest
 from scripts.decision_unit_intelligence.operator_pack import build_card, write_operator_pack
@@ -181,6 +188,188 @@ def cmd_replay(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_code_sha(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    env = os.getenv("EXTRA_CODE_SHA") or os.getenv("GITHUB_SHA")
+    if env:
+        return env
+    head = Path(".git/HEAD")
+    if not head.is_file():
+        return "unknown"
+    text = head.read_text(encoding="utf-8").strip()
+    if text.startswith("ref:"):
+        ref = Path(".git") / text.split(" ", 1)[1].strip()
+        if ref.is_file():
+            return ref.read_text(encoding="utf-8").strip()
+    return text or "unknown"
+
+
+def _budget_knobs(args: argparse.Namespace) -> dict[str, object]:
+    return {
+        "max_queries": args.search_max_queries,
+        "max_results_per_query": args.search_results_per_query,
+        "max_pages": args.crawl_max_pages,
+        "max_bytes": args.crawl_max_bytes,
+        "timeout_seconds": args.web_timeout_seconds,
+        "min_query_interval_seconds": args.search_min_interval_seconds,
+        "cache_ttl_days": args.search_cache_ttl_days,
+        "cache_dir": args.search_cache_dir,
+        "infer_email": not args.no_infer_email,
+        "verify_email_dns": args.verify_email_dns,
+        "searxng_url": args.searxng_url or os.getenv("CONFENGE_SEARXNG_URL"),
+    }
+
+
+def _print(payload: object) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2, default=str))
+
+
+def cmd_batch_enqueue(args: argparse.Namespace) -> int:
+    cnpjs = _load_cnpjs(args)
+    knobs = _budget_knobs(args)
+    version = budget_version_from_knobs(knobs)
+    code_sha = _resolve_code_sha(args.code_sha)
+    inserted = 0
+    reused = 0
+    ids: list[int] = []
+    with connect(args.dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        queue.upsert_cohort(
+            cohort_id=args.cohort,
+            service=args.service,
+            offer_context=args.offer_context,
+            discovery_policy_version=POLICY_VERSION,
+            search_backend=args.search_backend,
+            budget_version=version,
+            code_sha=code_sha,
+            input_evidence_version=args.input_evidence_version,
+            metadata={"n": len(cnpjs), "output_root": args.out},
+        )
+        for cnpj in cnpjs:
+            job_id, created = queue.enqueue(
+                cohort_id=args.cohort,
+                canonical_account_id=cnpj,
+                service=args.service,
+                offer_context=args.offer_context,
+                discovery_policy_version=POLICY_VERSION,
+                search_backend=args.search_backend,
+                budget_version=version,
+                code_sha=code_sha,
+                input_evidence_version=args.input_evidence_version,
+                max_attempts=args.max_attempts,
+                backend_concurrency_limit=args.backend_concurrency,
+                domain_concurrency_limit=args.domain_concurrency,
+                cursor={"budget": knobs},
+            )
+            ids.append(job_id)
+            if created:
+                inserted += 1
+            else:
+                reused += 1
+        progress = queue.progress(cohort_id=args.cohort)
+    _print(
+        {
+            "cohort": args.cohort,
+            "enqueued": inserted,
+            "reused": reused,
+            "job_ids": ids,
+            "policy_version": POLICY_VERSION,
+            "budget_version": version,
+            "code_sha": code_sha,
+            "search_backend": args.search_backend,
+            "progress": progress,
+        }
+    )
+    return 0
+
+
+def cmd_batch_inspect(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        jobs = ContactDiscoveryQueue(connection).inspect(cohort_id=args.cohort, job_id=args.job_id)
+    _print({"cohort": args.cohort, "n": len(jobs), "jobs": jobs})
+    return 0
+
+
+def cmd_batch_progress(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        _print(ContactDiscoveryQueue(connection).progress(cohort_id=args.cohort))
+    return 0
+
+
+def cmd_batch_failures(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        rows = ContactDiscoveryQueue(connection).failures(cohort_id=args.cohort)
+    _print({"cohort": args.cohort, "n": len(rows), "failures": rows})
+    return 0
+
+
+def cmd_batch_retry(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        n = ContactDiscoveryQueue(connection).retry(
+            cohort_id=args.cohort,
+            job_id=args.job_id,
+            reason_codes=args.reason_code,
+        )
+    _print({"retried": n, "cohort": args.cohort, "job_id": args.job_id})
+    return 0
+
+
+def cmd_batch_cancel(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        n = ContactDiscoveryQueue(connection).request_cancel(cohort_id=args.cohort, job_id=args.job_id)
+    _print({"cancelled": n, "cohort": args.cohort, "job_id": args.job_id})
+    return 0
+
+
+def cmd_batch_resume(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        _print(ContactDiscoveryQueue(connection).resume(cohort_id=args.cohort))
+    return 0
+
+
+def cmd_batch_publish(args: argparse.Namespace) -> int:
+    with connect(args.dsn) as connection:
+        result = publish_snapshot(
+            ContactDiscoveryQueue(connection),
+            cohort_id=args.cohort,
+            output_root=Path(args.out),
+            allow_partial=args.allow_partial,
+        )
+    _print(result)
+    return 0 if result.get("approved") else 2
+
+
+def cmd_batch_worker(args: argparse.Namespace) -> int:
+    dsn = args.dsn or os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL")
+    worker = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id=args.worker_id,
+        lease_seconds=args.lease_seconds,
+        output_root=Path(args.out),
+        claim_limit=args.claim_limit,
+        backend_filter=args.backend,
+    )
+    if args.loop:
+        _print(worker.run_loop(idle_sleep=args.idle_sleep, max_jobs=args.max_jobs))
+    else:
+        _print(worker.run_once())
+    return 0
+
+
+def cmd_batch_kill_switch(args: argparse.Namespace) -> int:
+    if args.enable == args.disable:
+        raise SystemExit("kill-switch requires exactly one of --enable or --disable")
+    with connect(args.dsn) as connection:
+        result = ContactDiscoveryQueue(connection).set_kill_switch(
+            enabled=bool(args.enable),
+            reason=args.reason or ("enabled" if args.enable else "disabled"),
+            actor=args.actor,
+        )
+    _print(result)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="decision-unit-intelligence")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -221,6 +410,88 @@ def build_parser() -> argparse.ArgumentParser:
     replay.add_argument("--run-a", required=True)
     replay.add_argument("--run-b", required=True)
     replay.set_defaults(func=cmd_replay)
+
+    batch = sub.add_parser("batch", help="Durable contact-discovery cohort operations")
+    batch_sub = batch.add_subparsers(dest="batch_cmd", required=True)
+
+    enqueue = batch_sub.add_parser("enqueue")
+    enqueue.add_argument("--cohort", required=True)
+    enqueue.add_argument("--out", default="output/contact-discovery")
+    enqueue.add_argument("--manifest")
+    enqueue.add_argument("--cnpjs")
+    enqueue.add_argument("--limit", type=int)
+    enqueue.add_argument("--service", default="reajuste_14133")
+    enqueue.add_argument("--offer-context")
+    enqueue.add_argument("--input-evidence-version", default="input.v1")
+    enqueue.add_argument("--code-sha")
+    enqueue.add_argument("--dsn")
+    enqueue.add_argument("--max-attempts", type=int, default=5)
+    enqueue.add_argument("--backend-concurrency", type=int, default=2)
+    enqueue.add_argument("--domain-concurrency", type=int, default=1)
+    enqueue.add_argument("--no-infer-email", action="store_true")
+    _add_web_discovery_args(enqueue)
+    enqueue.set_defaults(func=cmd_batch_enqueue)
+
+    inspect = batch_sub.add_parser("inspect")
+    inspect.add_argument("--cohort", required=True)
+    inspect.add_argument("--job-id", type=int)
+    inspect.add_argument("--dsn")
+    inspect.set_defaults(func=cmd_batch_inspect)
+
+    progress = batch_sub.add_parser("progress")
+    progress.add_argument("--cohort", required=True)
+    progress.add_argument("--dsn")
+    progress.set_defaults(func=cmd_batch_progress)
+
+    failures = batch_sub.add_parser("failures")
+    failures.add_argument("--cohort", required=True)
+    failures.add_argument("--dsn")
+    failures.set_defaults(func=cmd_batch_failures)
+
+    retry = batch_sub.add_parser("retry")
+    retry.add_argument("--cohort")
+    retry.add_argument("--job-id", type=int)
+    retry.add_argument("--reason-code", action="append")
+    retry.add_argument("--dsn")
+    retry.set_defaults(func=cmd_batch_retry)
+
+    cancel = batch_sub.add_parser("cancel")
+    cancel.add_argument("--cohort")
+    cancel.add_argument("--job-id", type=int)
+    cancel.add_argument("--dsn")
+    cancel.set_defaults(func=cmd_batch_cancel)
+
+    resume = batch_sub.add_parser("resume")
+    resume.add_argument("--cohort", required=True)
+    resume.add_argument("--dsn")
+    resume.set_defaults(func=cmd_batch_resume)
+
+    publish = batch_sub.add_parser("publish")
+    publish.add_argument("--cohort", required=True)
+    publish.add_argument("--out", default="output/contact-discovery")
+    publish.add_argument("--allow-partial", action="store_true")
+    publish.add_argument("--dsn")
+    publish.set_defaults(func=cmd_batch_publish)
+
+    worker = batch_sub.add_parser("worker")
+    worker.add_argument("--dsn")
+    worker.add_argument("--worker-id")
+    worker.add_argument("--loop", action="store_true")
+    worker.add_argument("--idle-sleep", type=float, default=2.0)
+    worker.add_argument("--max-jobs", type=int)
+    worker.add_argument("--lease-seconds", type=int, default=300)
+    worker.add_argument("--claim-limit", type=int, default=1)
+    worker.add_argument("--backend")
+    worker.add_argument("--out", default="output/contact-discovery")
+    worker.set_defaults(func=cmd_batch_worker)
+
+    kill = batch_sub.add_parser("kill-switch")
+    kill.add_argument("--enable", action="store_true")
+    kill.add_argument("--disable", action="store_true")
+    kill.add_argument("--reason", default="")
+    kill.add_argument("--actor", default="operator")
+    kill.add_argument("--dsn")
+    kill.set_defaults(func=cmd_batch_kill_switch)
     return p
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,11 @@ def _mock_psycopg2_connect(request):
         yield
         return
 
+    # Durable contact-discovery batch proves SKIP LOCKED / lease / resume on real PG.
+    if "test_contact_discovery_batch.py" in path_parts:
+        yield
+        return
+
     # Real database access is opt-in. Several legacy integration tests mutate
     # shared local tables, so a marker alone must never disable isolation.
     if request.node.get_closest_marker("integration") is not None and require_real:

--- a/tests/test_contact_discovery_batch.py
+++ b/tests/test_contact_discovery_batch.py
@@ -1,0 +1,545 @@
+"""Adversarial tests for the shipped contact-discovery batch path."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.real_db
+
+from scripts.crawl.worker import AdmissionLimits, admission_blockers
+from scripts.decision_unit_intelligence.batch_outcomes import (
+    classify_account,
+    classify_exception,
+    persist_outcome,
+)
+from scripts.decision_unit_intelligence.batch_queue import (
+    ContactDiscoveryQueue,
+    connect,
+    idempotency_key,
+)
+from scripts.decision_unit_intelligence.batch_snapshot import publish_snapshot
+from scripts.decision_unit_intelligence.batch_worker import (
+    ContactDiscoveryWorker,
+    execute_claimed,
+)
+from scripts.decision_unit_intelligence.cli import main
+from scripts.decision_unit_intelligence.models import AccountTerminal, SearchLedger
+
+MIGRATION = Path(__file__).resolve().parents[1] / "db" / "migrations" / "093_contact_discovery_batch.sql"
+DSN = (
+    os.getenv("LOCAL_DATALAKE_DSN")
+    or os.getenv("TEST_DSN")
+    or "postgresql://test:test@127.0.0.1:5433/extra_test"
+)
+
+
+def _skip_without_pg() -> None:
+    try:
+        import psycopg2
+
+        conn = psycopg2.connect(DSN, connect_timeout=3)
+        conn.close()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"test postgres unavailable: {exc}")
+
+
+@pytest.fixture
+def dsn() -> str:
+    _skip_without_pg()
+    import psycopg2
+
+    sql = MIGRATION.read_text(encoding="utf-8")
+    connection = psycopg2.connect(DSN)
+    connection.autocommit = True
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(sql)
+            cursor.execute(
+                """
+                TRUNCATE contact_discovery_snapshots,
+                         contact_discovery_attempts,
+                         contact_discovery_jobs,
+                         contact_discovery_cohorts,
+                         contact_discovery_backend_circuit
+                RESTART IDENTITY CASCADE
+                """
+            )
+            cursor.execute(
+                """
+                UPDATE contact_discovery_kill_switch
+                SET enabled = FALSE, reason = '', changed_by = 'test'
+                """
+            )
+    finally:
+        connection.close()
+    return DSN
+
+
+def _account(cnpj: str, terminal: AccountTerminal = AccountTerminal.ACTIONABLE_ROUTE) -> SimpleNamespace:
+    ledger = SearchLedger(duration_ms=12, bytes_touched=100, search_queries=["q1"])
+    return SimpleNamespace(
+        cnpj=cnpj,
+        terminal=terminal,
+        ledger=ledger,
+        routes=[],
+        candidates=[],
+        extra={"domain_resolution": {"canonical_domain": "exemplo.com.br"}},
+        to_dict=lambda: {
+            "cnpj": cnpj,
+            "terminal": terminal.value,
+            "candidates": [],
+            "routes": [],
+            "recommendation": None,
+            "policy_version": "dui.policy.v1",
+        },
+    )
+
+
+def _seed(queue: ContactDiscoveryQueue, *, cohort: str, accounts: list[str], policy: str = "dui.policy.v1", backend: str = "off", budget: str = "budget.test", service: str = "reajuste_14133") -> list[int]:
+    queue.upsert_cohort(
+        cohort_id=cohort,
+        service=service,
+        offer_context="canary",
+        discovery_policy_version=policy,
+        search_backend=backend,
+        budget_version=budget,
+        code_sha="sha-test",
+        input_evidence_version="input.v1",
+    )
+    ids = []
+    for account in accounts:
+        job_id, _created = queue.enqueue(
+            cohort_id=cohort,
+            canonical_account_id=account,
+            service=service,
+            offer_context="canary",
+            discovery_policy_version=policy,
+            search_backend=backend,
+            budget_version=budget,
+            code_sha="sha-test",
+            input_evidence_version="input.v1",
+        )
+        ids.append(job_id)
+    return ids
+
+
+def test_duplicate_enqueue_does_not_create_second_truth(dsn: str) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        first = _seed(queue, cohort="c-dup", accounts=["11222333000181"])
+        second_id, created = queue.enqueue(
+            cohort_id="c-dup",
+            canonical_account_id="11.222.333/0001-81",
+            service="reajuste_14133",
+            offer_context="canary",
+            discovery_policy_version="dui.policy.v1",
+            search_backend="off",
+            budget_version="budget.test",
+            code_sha="sha-test",
+            input_evidence_version="input.v1",
+        )
+        assert created is False
+        assert second_id == first[0]
+        jobs = queue.inspect(cohort_id="c-dup")
+        assert len(jobs) == 1
+        assert jobs[0]["idempotency_key"] == idempotency_key(
+            canonical_account_id="11222333000181",
+            service="reajuste_14133",
+            discovery_policy_version="dui.policy.v1",
+            input_evidence_version="input.v1",
+            search_backend="off",
+            budget_version="budget.test",
+        )
+
+
+def test_policy_change_creates_new_revision_identity(dsn: str) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-policy-a", accounts=["11222333000181"], policy="dui.policy.v1")
+        queue.upsert_cohort(
+            cohort_id="c-policy-b",
+            service="reajuste_14133",
+            offer_context="canary",
+            discovery_policy_version="dui.policy.v2",
+            search_backend="off",
+            budget_version="budget.test",
+            code_sha="sha-test",
+            input_evidence_version="input.v1",
+        )
+        new_id, created = queue.enqueue(
+            cohort_id="c-policy-b",
+            canonical_account_id="11222333000181",
+            service="reajuste_14133",
+            offer_context="canary",
+            discovery_policy_version="dui.policy.v2",
+            search_backend="off",
+            budget_version="budget.test",
+            code_sha="sha-test",
+            input_evidence_version="input.v1",
+        )
+        assert created is True
+        assert new_id != 0
+        assert len(queue.inspect(cohort_id="c-policy-a")) == 1
+        assert len(queue.inspect(cohort_id="c-policy-b")) == 1
+
+
+def test_two_workers_claim_same_job_exactly_once(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        _seed(ContactDiscoveryQueue(connection), cohort="c-race", accounts=["11222333000181"])
+    results: list[dict] = []
+
+    def _run(worker_id: str) -> None:
+        worker = ContactDiscoveryWorker(
+            dsn=dsn,
+            worker_id=worker_id,
+            output_root=tmp_path,
+            admission_probe=lambda: [],
+            discovery=lambda job: _account(job.canonical_account_id),
+        )
+        results.append(worker.run_once())
+
+    threads = [
+        threading.Thread(target=_run, args=("w-a",)),
+        threading.Thread(target=_run, args=("w-b",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    owners = [row for row in results if row.get("status") == "SUCCEEDED"]
+    idles = [row for row in results if row.get("status") == "idle"]
+    assert len(owners) == 1
+    assert len(idles) == 1
+    with connect(dsn) as connection:
+        jobs = ContactDiscoveryQueue(connection).inspect(cohort_id="c-race")
+        assert len(jobs) == 1
+        assert jobs[0]["status"] == "SUCCEEDED"
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) AS n FROM contact_discovery_attempts WHERE job_id = %s AND status = 'SUCCEEDED'",
+                (jobs[0]["id"],),
+            )
+            assert int(cursor.fetchone()["n"]) == 1
+
+
+def test_crash_before_commit_resumes_same_job(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-crash-before", accounts=["11222333000181"])
+        claimed = queue.claim(worker_id="doomed", lease_seconds=1)
+        assert len(claimed) == 1
+        outcome = execute_claimed(
+            claimed[0],
+            discovery=lambda job: _account(job.canonical_account_id),
+            output_root=tmp_path,
+        )
+        assert outcome.output_pointer and Path(outcome.output_pointer).is_file()
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE contact_discovery_jobs SET lease_expires_at = now() - interval '10 seconds' WHERE id = %s",
+                (claimed[0].id,),
+            )
+        reclaimed = queue.reclaim_expired()
+        assert reclaimed == 1
+        jobs = queue.inspect(job_id=claimed[0].id)
+        assert jobs[0]["status"] == "RETRYABLE"
+        assert jobs[0]["last_reason_code"] == "LEASE_EXPIRED"
+    worker = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="survivor",
+        output_root=tmp_path,
+        admission_probe=lambda: [],
+        discovery=lambda job: _account(job.canonical_account_id),
+    )
+    result = worker.run_once()
+    assert result["status"] == "SUCCEEDED"
+    with connect(dsn) as connection:
+        jobs = ContactDiscoveryQueue(connection).inspect(cohort_id="c-crash-before")
+        assert jobs[0]["status"] == "SUCCEEDED"
+        assert jobs[0]["output_hash"]
+
+
+def test_output_written_commit_fails_then_promotes_once(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-commit-fail", accounts=["11222333000181"])
+        claimed = queue.claim(worker_id="owner", lease_seconds=60)
+        outcome = persist_outcome(
+            classify_account(_account(claimed[0].canonical_account_id)),
+            job=claimed[0],
+            output_root=tmp_path,
+        )
+        stolen = queue.finish(
+            claimed[0],
+            worker_id="not-the-owner",
+            outcome="SUCCEEDED",
+            reason_code="ACTIONABLE_ROUTE",
+            output_pointer=outcome.output_pointer,
+            output_hash=outcome.output_hash,
+        )
+        assert stolen is False
+        jobs = queue.inspect(job_id=claimed[0].id)
+        assert jobs[0]["status"] == "RUNNING"
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE contact_discovery_jobs SET lease_expires_at = now() - interval '1 second' WHERE id = %s",
+                (claimed[0].id,),
+            )
+        queue.reclaim_expired()
+        claimed2 = queue.claim(worker_id="owner-2", lease_seconds=60)
+        assert len(claimed2) == 1
+        promoted = queue.finish(
+            claimed2[0],
+            worker_id="owner-2",
+            outcome="SUCCEEDED",
+            reason_code="ACTIONABLE_ROUTE",
+            output_pointer=outcome.output_pointer,
+            output_hash=outcome.output_hash,
+        )
+        assert promoted is True
+        jobs = queue.inspect(job_id=claimed2[0].id)
+        assert jobs[0]["status"] == "SUCCEEDED"
+
+
+def test_terminal_commit_ack_lost_is_idempotent(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-ack", accounts=["11222333000181"])
+        claimed = queue.claim(worker_id="owner", lease_seconds=60)
+        outcome = persist_outcome(
+            classify_account(_account(claimed[0].canonical_account_id)),
+            job=claimed[0],
+            output_root=tmp_path,
+        )
+        first = queue.finish(
+            claimed[0],
+            worker_id="owner",
+            outcome="SUCCEEDED",
+            reason_code="ACTIONABLE_ROUTE",
+            output_pointer=outcome.output_pointer,
+            output_hash=outcome.output_hash,
+        )
+        second = queue.finish(
+            claimed[0],
+            worker_id="owner",
+            outcome="SUCCEEDED",
+            reason_code="ACTIONABLE_ROUTE",
+            output_pointer=outcome.output_pointer,
+            output_hash=outcome.output_hash,
+        )
+        assert first is True
+        assert second is True
+        jobs = queue.inspect(cohort_id="c-ack")
+        assert jobs[0]["status"] == "SUCCEEDED"
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT COUNT(*) AS n FROM contact_discovery_jobs WHERE cohort_id = 'c-ack'")
+            assert int(cursor.fetchone()["n"]) == 1
+
+
+def test_reboot_recovery_via_resume(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-reboot", accounts=["11222333000181", "44555666000177"])
+        claimed = queue.claim(worker_id="dead-host", lease_seconds=1)
+        assert claimed
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE contact_discovery_jobs SET lease_expires_at = now() - interval '30 seconds' WHERE status = 'RUNNING'"
+            )
+        report = queue.resume(cohort_id="c-reboot")
+        assert report["reclaimed"] >= 1
+        assert report["pending"] >= 1
+    worker = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="rebooted",
+        output_root=tmp_path,
+        admission_probe=lambda: [],
+        discovery=lambda job: _account(job.canonical_account_id),
+    )
+    first = worker.run_once()
+    second = worker.run_once()
+    assert {first["status"], second["status"]} == {"SUCCEEDED"}
+    with connect(dsn) as connection:
+        progress = ContactDiscoveryQueue(connection).progress(cohort_id="c-reboot")
+        assert progress["denominator"] == 2
+        assert progress["counts"]["succeeded"] == 2
+        assert progress["closable"] is True
+
+
+def test_429_and_timeout_never_become_no_contact(dsn: str, tmp_path: Path) -> None:
+    class Http429Error(Exception):
+        def __init__(self) -> None:
+            self.response = SimpleNamespace(status_code=429)
+            super().__init__("429 Too Many Requests")
+
+    class ProviderTimeoutError(TimeoutError):
+        pass
+
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-429", accounts=["11222333000181"])
+        _seed(queue, cohort="c-timeout", accounts=["44555666000177"])
+
+    def boom_429(_job):
+        raise Http429Error()
+
+    def boom_timeout(_job):
+        raise ProviderTimeoutError("provider timeout")
+
+    r429 = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="w-429",
+        output_root=tmp_path,
+        admission_probe=lambda: [],
+        discovery=boom_429,
+    ).run_once()
+    rto = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="w-to",
+        output_root=tmp_path,
+        admission_probe=lambda: [],
+        discovery=boom_timeout,
+    ).run_once()
+    assert r429["status"] == "RETRYABLE"
+    assert r429["reason_code"] == "PROVIDER_429"
+    assert rto["status"] == "RETRYABLE"
+    assert rto["reason_code"] == "PROVIDER_TIMEOUT"
+    assert r429["reason_code"] not in {"SEM_CONTATO", "NO_CONTACT", "NO_CONTACT_FOUND"}
+    assert rto["reason_code"] not in {"SEM_CONTATO", "NO_CONTACT", "NO_CONTACT_FOUND"}
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        assert queue.inspect(cohort_id="c-429")[0]["status"] == "RETRYABLE"
+        assert queue.inspect(cohort_id="c-timeout")[0]["status"] == "RETRYABLE"
+        assert queue.inspect(cohort_id="c-429")[0]["last_reason_code"] == "PROVIDER_429"
+
+
+def test_kill_switch_blocks_admission_without_false_success(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-kill", accounts=["11222333000181"])
+        queue.set_kill_switch(enabled=True, reason="operator pause", actor="test")
+    result = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="w-kill",
+        output_root=tmp_path,
+        admission_probe=lambda: [],
+        discovery=lambda job: _account(job.canonical_account_id),
+    ).run_once()
+    assert result["status"] == "blocked"
+    assert result["reason_code"] == "KILL_SWITCH"
+    with connect(dsn) as connection:
+        jobs = ContactDiscoveryQueue(connection).inspect(cohort_id="c-kill")
+        assert jobs[0]["status"] == "PENDING"
+
+
+def test_cpu_disk_pressure_pauses_admission(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        _seed(ContactDiscoveryQueue(connection), cohort="c-pressure", accounts=["11222333000181"])
+    blockers = admission_blockers(
+        AdmissionLimits(max_load_per_cpu=0.9, min_free_disk_ratio=0.1),
+        load_average=8.0,
+        cpu_count=4,
+        memory_ratio=0.5,
+        disk_ratio=0.05,
+    )
+    assert "cpu_pressure" in blockers
+    assert "disk_pressure" in blockers
+    result = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="w-pressure",
+        output_root=tmp_path,
+        admission_probe=lambda: blockers,
+        discovery=lambda job: _account(job.canonical_account_id),
+    ).run_once()
+    assert result["status"] == "backpressure"
+    assert result["reason_code"] == "ADMISSION_PRESSURE"
+    with connect(dsn) as connection:
+        jobs = ContactDiscoveryQueue(connection).inspect(cohort_id="c-pressure")
+        assert jobs[0]["status"] == "PENDING"
+
+
+def test_partial_blocked_batch_refuses_approved_snapshot(dsn: str, tmp_path: Path) -> None:
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(queue, cohort="c-partial", accounts=["11222333000181", "44555666000177", "99888777000166"])
+
+    def adapter(job):
+        if job.canonical_account_id.endswith("166"):
+            return _account(job.canonical_account_id, AccountTerminal.BLOCKED)
+        return _account(job.canonical_account_id)
+
+    worker = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="w-partial",
+        output_root=tmp_path,
+        admission_probe=lambda: [],
+        discovery=adapter,
+    )
+    worker.run_once()
+    worker.run_once()
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        progress = queue.progress(cohort_id="c-partial")
+        assert progress["counts"]["pending"] == 1
+        assert progress["closable"] is False
+        refused = publish_snapshot(queue, cohort_id="c-partial", output_root=tmp_path)
+        assert refused["approved"] is False
+        assert any("non-terminal" in reason for reason in refused["reject_reasons"])
+    worker.run_once()
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        closed = queue.progress(cohort_id="c-partial")
+        assert closed["counts"]["blocked"] == 1
+        assert closed["counts"]["succeeded"] == 2
+        assert closed["closable"] is True
+        published = publish_snapshot(queue, cohort_id="c-partial", output_root=tmp_path)
+        assert published["approved"] is True
+
+
+def test_classify_never_emits_sem_contato() -> None:
+    account = _account("11222333000181", AccountTerminal.EXHAUSTED)
+    outcome = classify_account(account)
+    assert outcome.job_status == "SUCCEEDED"
+    assert outcome.reason_code == "BUDGET_EXHAUSTED"
+    assert outcome.reason_code not in {"SEM_CONTATO", "NO_CONTACT"}
+    classified = classify_exception(TimeoutError("slow"))
+    assert classified.job_status == "RETRYABLE"
+    assert classified.reason_code == "PROVIDER_TIMEOUT"
+
+
+def test_cli_enqueue_worker_progress_publish_is_idempotent(dsn: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOCAL_DATALAKE_DSN", dsn)
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    out = tmp_path / "cli-out"
+    common = [
+        "--cohort",
+        "c-cli",
+        "--cnpjs",
+        "11222333000181,44555666000177",
+        "--search-backend",
+        "off",
+        "--dsn",
+        dsn,
+    ]
+    assert main(["batch", "enqueue", *common, "--out", str(out)]) == 0
+    monkeypatch.setenv("CONTACT_DISCOVERY_ADMISSION", "off")
+    assert main(["batch", "worker", "--dsn", dsn, "--worker-id", "cli-w1", "--out", str(out)]) == 0
+    assert main(["batch", "worker", "--dsn", dsn, "--worker-id", "cli-w2", "--out", str(out)]) == 0
+    assert main(["batch", "inspect", "--cohort", "c-cli", "--dsn", dsn]) == 0
+    assert main(["batch", "progress", "--cohort", "c-cli", "--dsn", dsn]) == 0
+    rc = main(["batch", "publish", "--cohort", "c-cli", "--out", str(out), "--dsn", dsn])
+    assert rc == 0
+    first = main(["batch", "enqueue", *common, "--out", str(out)])
+    assert first == 0
+    with connect(dsn) as connection:
+        progress = ContactDiscoveryQueue(connection).progress(cohort_id="c-cli")
+        assert progress["denominator"] == 2
+        assert progress["counts"]["succeeded"] == 2
+        jobs = ContactDiscoveryQueue(connection).inspect(cohort_id="c-cli")
+        assert len(jobs) == 2
+        assert {job["status"] for job in jobs} == {"SUCCEEDED"}


### PR DESCRIPTION
## Summary

Adds an **additive** durable batch path around the already-merged `#392` `run_account` adapter. It does **not** change query planner, crawler, person↔email association, heuristics, pattern inference, or email verification.

A cohort of CNPJs can now be enqueued as `CONFENGE_CONTACT_DISCOVERY` jobs, leased by workers (`FOR UPDATE SKIP LOCKED`), resumed after crash/reboot, retried on 429/timeout, and published only when the denominator closes.

## What shipped

- Migration `093_contact_discovery_batch.sql` — own tables (not `crawl_jobs` / `sc_public_entities`)
- Queue: idempotency key `account × policy × input × backend × budget × service`
- Worker: backend/domain limits, admission backpressure, SIGTERM, lease expiry, kill switch
- CLI under existing DUI authority: `batch enqueue|inspect|progress|failures|retry|cancel|resume|publish|worker|kill-switch`
- Snapshot gate: no approved snapshot while PENDING/RUNNING/RETRYABLE remain
- Reason codes stay explicit (`PROVIDER_429`, `PROVIDER_TIMEOUT`, `SOURCE_BLOCKED`, `BUDGET_EXHAUSTED`). Never “sem contato encontrado”.

## Evidence

- 13 adversarial tests on real PostgreSQL (`tests/test_contact_discovery_batch.py`)
- CLI twice: second enqueue reused 2/2, worker idle, same snapshot
- Canary 30 Track A (`search-backend=off`): 30/30 terminal, snapshot approved
- Canary 100: 100/100 terminal (66 ACTIONABLE_ROUTE / 33 NEEDS_ENRICHMENT / 1 PERSON_WITHOUT_ROUTE)
- Live DDGS n=2: 2/2 SUCCEEDED, ~29s p50, 2 domains resolved
- Netcup reachable but this SHA is **not** deployed → `LOCAL_READY` / `LIVE_UNPROVEN`

## Operator

See `docs/ops/contact-discovery-batch.md`.

## Test plan

- [x] `pytest tests/test_contact_discovery_batch.py --no-cov`
- [x] apply migration 093
- [x] CLI enqueue → worker → publish → re-enqueue is idempotent
- [ ] After merge: install `extra-contact-discovery-worker@.service` on Netcup with exact SHA and reboot-test reclaim