### PR TITLE
feat(search): private CONFENGE SearXNG HTTP backend and deploy kit

### DIFF
--- a/deploy/searxng/.env.example
+++ b/deploy/searxng/.env.example
@@ -1,0 +1,12 @@
+# Copy to deploy/searxng/.env (gitignored) before the first launch.
+# SEARXNG_SECRET must be a long random string. Never commit the real value.
+
+SEARXNG_SECRET=replace-with-openssl-rand-hex-32
+SEARXNG_BIND_HOST=127.0.0.1
+SEARXNG_HOST_PORT=18888
+SEARXNG_BASE_URL=http://127.0.0.1:18888/
+SEARXNG_LIMITER=true
+SEARXNG_PUBLIC_INSTANCE=false
+SEARXNG_IMAGE_PROXY=false
+SEARXNG_SETTINGS_TOML_SYNTAX=false
+FORCE_OWNERSHIP=true

--- a/deploy/searxng/.gitignore
+++ b/deploy/searxng/.gitignore
@@ -1,0 +1,4 @@
+.env
+*.secret
+core-data/
+valkey-data/

--- a/deploy/searxng/Caddyfile.example
+++ b/deploy/searxng/Caddyfile.example
@@ -1,0 +1,11 @@
+# Optional private TLS terminator. Do not publish this site.
+# Default deployment binds SearXNG to 127.0.0.1:18888 and does not need Caddy.
+#
+# search.internal.confenge {
+#     bind 127.0.0.1
+#     reverse_proxy 127.0.0.1:18888
+#     @admin {
+#         path /preferences /stats /metrics /clientlogin
+#     }
+#     respond @admin 404
+# }

--- a/deploy/searxng/Makefile
+++ b/deploy/searxng/Makefile
@@ -1,0 +1,21 @@
+# Isolated Makefile so this stack does not collide with the repo root targets.
+
+.PHONY: up down ps logs probe rollback
+
+up:
+	bash ./launch.sh
+
+down:
+	bash ./rollback.sh stop
+
+ps:
+	set -a && . ./PINNED.env && . ./.env && set +a && docker compose --env-file .env ps
+
+logs:
+	set -a && . ./PINNED.env && . ./.env && set +a && docker compose --env-file .env logs --tail 80
+
+probe:
+	bash ./launch.sh
+
+rollback:
+	bash ./rollback.sh

--- a/deploy/searxng/PINNED.env
+++ b/deploy/searxng/PINNED.env
@@ -1,0 +1,9 @@
+# Digest pins captured 2026-08-14 from docker.io official images.
+# Do not replace with a floating tag. To roll back, copy this file to PINNED.prev.env
+# before changing the pins, then run rollback.sh.
+
+SEARXNG_IMAGE=docker.io/searxng/searxng@sha256:892cf809341915a4b7710d3c9045005b4c377d51335a089b6d4da0b28750788d
+SEARXNG_IMAGE_VERSION=2026.8.14-094c33d40
+SEARXNG_IMAGE_REVISION=094c33d406da578ac851f2d8ad10fdfa344a9493
+VALKEY_IMAGE=docker.io/valkey/valkey@sha256:ee91f7a174ac4d6a6b0685b3a60e321f0a9dbbb691f9b0e285be2ba1d1be8328
+VALKEY_IMAGE_TAG=9-alpine

--- a/deploy/searxng/core-config/limiter.toml
+++ b/deploy/searxng/core-config/limiter.toml
@@ -1,0 +1,29 @@
+[botdetection]
+
+ipv4_prefix = 32
+ipv6_prefix = 48
+
+# Instance is bound to loopback / private network. extra-cli is the authorized
+# client; unknown public IPs still hit the limiter if the port is ever exposed.
+trusted_proxies = [
+  '127.0.0.0/8',
+  '::1',
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+]
+
+[botdetection.ip_limit]
+filter_link_local = false
+link_token = false
+
+[botdetection.ip_lists]
+block_ip = []
+pass_ip = [
+  '127.0.0.0/8',
+  '::1',
+  '10.0.0.0/8',
+  '172.16.0.0/12',
+  '192.168.0.0/16',
+]
+pass_searxng_org = false

--- a/deploy/searxng/core-config/settings.yml
+++ b/deploy/searxng/core-config/settings.yml
@@ -1,0 +1,61 @@
+# CONFENGE private SearXNG — configuration only.
+# This file is not SearXNG source. The official image provides the AGPL program.
+# extra-cli talks to this instance over HTTP only.
+
+use_default_settings:
+  engines:
+    keep_only:
+      - duckduckgo
+      - brave
+      - mojeek
+      - qwant
+      - wikipedia
+      - wikidata
+
+general:
+  instance_name: "CONFENGE private search"
+  debug: false
+  donation_url: false
+  contact_url: false
+  enable_metrics: true
+  open_metrics: ""
+
+search:
+  safe_search: 1
+  autocomplete: ""
+  favicon_resolver: ""
+  default_lang: "pt-BR"
+  formats:
+    - html
+    - json
+  ban_time_on_fail: 30
+  max_ban_time_on_fail: 600
+
+server:
+  limiter: true
+  public_instance: false
+  image_proxy: false
+  method: "GET"
+
+valkey:
+  url: redis://valkey:6379/0
+
+outgoing:
+  request_timeout: 5.0
+  max_request_timeout: 10.0
+  useragent_suffix: "CONFENGE-private"
+  # No proxies, no Tor, no source-IP rotation, no CAPTCHA bypass.
+
+engines:
+  - name: duckduckgo
+    disabled: false
+  - name: brave
+    disabled: false
+  - name: mojeek
+    disabled: false
+  - name: qwant
+    disabled: false
+  - name: wikipedia
+    disabled: false
+  - name: wikidata
+    disabled: false

--- a/deploy/searxng/docker-compose.yml
+++ b/deploy/searxng/docker-compose.yml
@@ -1,0 +1,72 @@
+# CONFENGE private SearXNG. Official images only. Digests, not :latest.
+# Launch entry point: deploy/searxng/launch.sh
+
+name: confenge-searxng
+
+services:
+  core:
+    container_name: confenge-searxng-core
+    image: ${SEARXNG_IMAGE}
+    restart: unless-stopped
+    depends_on:
+      valkey:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      SEARXNG_SECRET: ${SEARXNG_SECRET}
+      SEARXNG_BASE_URL: ${SEARXNG_BASE_URL:-http://127.0.0.1:18888/}
+      SEARXNG_LIMITER: ${SEARXNG_LIMITER:-true}
+      SEARXNG_PUBLIC_INSTANCE: ${SEARXNG_PUBLIC_INSTANCE:-false}
+      SEARXNG_IMAGE_PROXY: ${SEARXNG_IMAGE_PROXY:-false}
+      SEARXNG_VALKEY_URL: redis://valkey:6379/0
+    ports:
+      - "${SEARXNG_BIND_HOST:-127.0.0.1}:${SEARXNG_HOST_PORT:-18888}:8080"
+    volumes:
+      - ./core-config:/etc/searxng:Z
+      - core-data:/var/cache/searxng
+    networks:
+      - searxng-internal
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 768m
+    cpus: 1.0
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=4)\" || python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/', timeout=4)\"",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 25s
+
+  valkey:
+    container_name: confenge-searxng-valkey
+    image: ${VALKEY_IMAGE}
+    command: valkey-server --save 30 1 --loglevel warning
+    restart: unless-stopped
+    volumes:
+      - valkey-data:/data
+    networks:
+      - searxng-internal
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 128m
+    cpus: 0.25
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 8
+
+networks:
+  searxng-internal:
+    name: confenge-searxng-internal
+    driver: bridge
+    internal: false
+
+volumes:
+  core-data:
+  valkey-data:

--- a/deploy/searxng/launch.sh
+++ b/deploy/searxng/launch.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Deploy entry point for the CONFENGE private SearXNG instance.
+# Usage: deploy/searxng/launch.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+if [[ ! -f PINNED.env ]]; then
+  echo "missing PINNED.env with image digests" >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source "$ROOT/PINNED.env"
+
+if [[ ! -f .env ]]; then
+  if [[ ! -f .env.example ]]; then
+    echo "missing .env.example" >&2
+    exit 1
+  fi
+  cp .env.example .env
+  if command -v openssl >/dev/null 2>&1; then
+    secret="$(openssl rand -hex 32)"
+    if grep -q '^SEARXNG_SECRET=' .env; then
+      tmp="$(mktemp)"
+      sed "s|^SEARXNG_SECRET=.*|SEARXNG_SECRET=${secret}|" .env >"$tmp"
+      mv "$tmp" .env
+    else
+      echo "SEARXNG_SECRET=${secret}" >>.env
+    fi
+  fi
+  echo "wrote $ROOT/.env (not committed)"
+fi
+
+if grep -q 'replace-with-openssl-rand-hex-32' .env; then
+  echo "SEARXNG_SECRET still has the example placeholder" >&2
+  exit 1
+fi
+
+export SEARXNG_IMAGE VALKEY_IMAGE
+# shellcheck disable=SC1091
+set -a
+source "$ROOT/.env"
+set +a
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is not available" >&2
+  exit 2
+fi
+
+echo "launching pinned SearXNG ${SEARXNG_IMAGE}"
+echo "launching pinned Valkey ${VALKEY_IMAGE}"
+docker compose --env-file .env up -d --remove-orphans
+
+host="${SEARXNG_BIND_HOST:-127.0.0.1}"
+port="${SEARXNG_HOST_PORT:-18888}"
+base="http://${host}:${port}"
+query="${SEARXNG_HEALTH_QUERY:-CONFENGE healthcheck empresa engenharia}"
+
+echo "waiting for health at ${base}"
+ok=0
+for _ in $(seq 1 40); do
+  if curl -fsS --max-time 5 "${base}/healthz" >/dev/null 2>&1 \
+    || curl -fsS --max-time 5 "${base}/" >/dev/null 2>&1; then
+    ok=1
+    break
+  fi
+  sleep 2
+done
+if [[ "$ok" -ne 1 ]]; then
+  echo "instance failed health check" >&2
+  docker compose ps >&2 || true
+  docker compose logs --tail 80 >&2 || true
+  exit 3
+fi
+
+probe="${base}/search?q=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))' "$query")&format=json"
+echo "probing JSON search ${probe}"
+body="$(mktemp)"
+status="$(curl -sS --max-time 20 -o "$body" -w '%{http_code}' "$probe" || true)"
+if [[ "$status" != "200" ]]; then
+  echo "JSON search returned HTTP ${status}" >&2
+  head -c 400 "$body" >&2 || true
+  rm -f "$body"
+  exit 4
+fi
+python3 - "$body" <<'PY'
+import json, sys
+payload = json.loads(open(sys.argv[1], encoding="utf-8").read())
+if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+    raise SystemExit("JSON search did not return an object with a results array")
+print(f"json_ok results={len(payload['results'])}")
+PY
+rm -f "$body"
+echo "CONFENGE SearXNG ready at ${base}"

--- a/deploy/searxng/rollback.sh
+++ b/deploy/searxng/rollback.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Roll back to the previously recorded digest pair, or stop the stack.
+# Usage:
+#   deploy/searxng/rollback.sh            # restore PINNED.prev.env if present
+#   deploy/searxng/rollback.sh stop       # compose down
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+cmd="${1:-restore}"
+if [[ "$cmd" == "stop" ]]; then
+  docker compose --env-file .env down
+  echo "stopped confenge-searxng"
+  exit 0
+fi
+
+if [[ ! -f PINNED.prev.env ]]; then
+  echo "no PINNED.prev.env; refusing to guess a previous digest" >&2
+  echo "to stop: $0 stop" >&2
+  exit 1
+fi
+cp PINNED.env "PINNED.rollback-$(date -u +%Y%m%dT%H%M%SZ).env"
+cp PINNED.prev.env PINNED.env
+exec "$ROOT/launch.sh"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,7 @@ Precedência: `DOD.md` → ADR vigente → código testado → evidência reprod
 | `docs/ops/private-assets.md` | Repo público vs assets privados |
 | `docs/ops/dod-convergence.md` | Harness DOD |
 | `docs/ops/netcup-*.md`, handoffs Netcup | Host de record |
+| [`docs/ops/searxng-private-backend.md`](ops/searxng-private-backend.md) | SearXNG privado CONFENGE (HTTP boundary, runbook) |
 | `artifacts/campaigns/HISTORICAL-CONTRACTS-OPERATIONAL-CLOSURE-01/` | Campanha HC (STATUS/HANDOFF) |
 | `specs/001-*`, `specs/002-*` | Spec Kit dual / historical contracts |
 | `deploy/systemd/` | Units de produção |

--- a/docs/architecture/adr-decision-unit-intelligence.md
+++ b/docs/architecture/adr-decision-unit-intelligence.md
@@ -24,7 +24,7 @@ It does **not** treat “named email explicitly published” as success.
 - There is no `AUTO_SEND`.
 - Public web search is a first-class bounded provider, not an untracked fallback.
 - Search, crawl, domain resolution, and verification remain replaceable adapters.
-- SearXNG is allowed only across an HTTP service boundary; its AGPL code is not embedded.
+- SearXNG is allowed only across an HTTP service boundary; its AGPL code is not embedded. The private instance contract is [`adr-searxng-http-boundary.md`](adr-searxng-http-boundary.md).
 - The local canary may use the MIT-licensed DDGS adapter. Static HTML crawling reuses existing dependencies.
 - extra-cli remains the identity/reachability truth plane; Warmbly remains the activation/outcome plane.
 

--- a/docs/architecture/adr-searxng-http-boundary.md
+++ b/docs/architecture/adr-searxng-http-boundary.md
@@ -1,0 +1,29 @@
+# ADR: Private SearXNG over an HTTP boundary
+
+**Status:** Accepted for the CONFENGE contact-discovery search backend  
+**Date:** 2026-08-14  
+**Supersedes / extends:** [`adr-decision-unit-intelligence.md`](adr-decision-unit-intelligence.md) (HTTP-only SearXNG clause)
+
+## Decision
+
+Contact discovery in extra-cli uses a **CONFENGE-controlled SearXNG instance** as the batch web-search backend. extra-cli is only an HTTP client:
+
+```
+extra-cli --search-backend searxng
+        --searxng-url / CONFENGE_SEARXNG_URL
+        → GET {url}/search?q=…&format=json
+        → private SearXNG (official image, pinned digest)
+        → conservative public engines
+```
+
+SearXNG/AGPL source is not copied, vendored, imported, or linked into extra-cli.
+
+## Consequences
+
+- Missing URL, HTTP 429, HTTP 5xx, timeout, invalid JSON, and an open circuit fail closed as backend unavailability (`SOURCE_BLOCKED` via `SearchBackendUnavailableError`). They are never an empty successful hit list.
+- Public third-party instances (searx.space and listed public hosts) are rejected unless `CONFENGE_SEARXNG_ALLOW_PUBLIC=1`.
+- DDGS remains the MIT local canary / explicit operator re-run. In-process failover is `--search-failover ddgs` or `CONFENGE_SEARCH_FAILOVER=ddgs` and is recorded on the backend id. Default is off.
+- Operators who modify the official image or ship a derived SearXNG must offer corresponding source (AGPL-3.0 §13 network use). Config-only use of the official image still documents that obligation.
+- No purchased data, authenticated scraping, CAPTCHA bypass, or proxy rotation.
+
+Operational kit: [`../ops/searxng-private-backend.md`](../ops/searxng-private-backend.md).

--- a/docs/commercial-intelligence/contact-resolution.md
+++ b/docs/commercial-intelligence/contact-resolution.md
@@ -88,7 +88,7 @@ Evaluation date: 2026-08-14. Recheck license and maintenance before upgrades.
 | Project | Repository | License | Decision and reuse |
 |---|---|---|---|
 | DDGS | <https://github.com/deedy5/ddgs> | MIT | Selected for the small local canary through a lazy adapter. It is replaceable and rate-limited; engine behavior is not treated as a stable contract. |
-| SearXNG | <https://github.com/searxng/searxng> | AGPL-3.0 | Selected only as an optional HTTP service boundary. No SearXNG code is copied or linked into extra-cli. A modified/network deployment requires explicit license compliance review. |
+| SearXNG | <https://github.com/searxng/searxng> | AGPL-3.0 | Selected only as an optional HTTP service boundary. No SearXNG code is copied or linked into extra-cli. CONFENGE runs a private official image (digest-pinned). A modified/network deployment requires offering corresponding source (AGPL-3.0 §13). See [`../ops/searxng-private-backend.md`](../ops/searxng-private-backend.md). |
 | Crawl4AI | <https://github.com/unclecode/crawl4ai> | Apache-2.0 | Evaluated and deferred. It is active and capable, but browser/runtime weight is unnecessary for the first static-HTML slice. The crawler interface allows later adoption. |
 | theHarvester | <https://github.com/laramies/theHarvester> | GPL metadata / repository license ambiguity | Not adopted. Its broad OSINT surface and licensing posture add more risk and complexity than this targeted professional-public-data use case needs. |
 | dnspython | <https://github.com/rthalley/dnspython> | ISC | Selected for passive DNS/MX resolution. It never performs mailbox ownership or SMTP identity proof. |

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -29,6 +29,7 @@ Existência do host **não** autoriza claims `VPS_OPERATIONAL` / `LOCAL_READY` /
 | [`onboarding.md`](onboarding.md) | Onboarding operacional |
 | [`METRIC-DEFINITION-POLICY.md`](METRIC-DEFINITION-POLICY.md) | Política de definição de métricas |
 | [`extra-technical-acervo.md`](extra-technical-acervo.md) | Acervo CAT/CAO Extra (store + CLI) |
+| [`searxng-private-backend.md`](searxng-private-backend.md) | SearXNG privado CONFENGE (HTTP only, AGPL, canário) |
 
 ## Host / Netcup / recovery
 

--- a/docs/ops/decision-unit-intelligence-runbook.md
+++ b/docs/ops/decision-unit-intelligence-runbook.md
@@ -33,7 +33,7 @@ python3 -m scripts.decision_unit_intelligence run \
   --verify-email-dns
 ```
 
-Para SearXNG, use `--search-backend searxng` e `--searxng-url` ou `CONFENGE_SEARXNG_URL`. Não use instância pública de terceiros para batch. Cache local: `.cache/confenge-prospect/`.
+Para SearXNG, use `--search-backend searxng` e `--searxng-url` ou `CONFENGE_SEARXNG_URL`. Não use instância pública de terceiros para batch. Cache local: `.cache/confenge-prospect/`. Instância privada CONFENGE: [`searxng-private-backend.md`](searxng-private-backend.md).
 
 O manifesto registra contas tentadas, domínios resolvidos, buscas, páginas, bytes e custo externo. Falha de fonte, orçamento esgotado e ausência de evidência são estados diferentes.
 

--- a/docs/ops/searxng-private-backend.md
+++ b/docs/ops/searxng-private-backend.md
@@ -1,0 +1,172 @@
+# CONFENGE private SearXNG — runbook
+
+Status: **LOCAL_READY**. Host of record is Netcup / `ec-prod` (`SERVER_UP` ≠ this stack is live). This document is the operator contract for the search **infrastructure** only. It does not change query planning, person/email parsing, or Warmbly.
+
+## 1. Deployment diagram
+
+```text
+                    extra-cli batch discovery
+                    --search-backend searxng
+                    CONFENGE_SEARXNG_URL
+                              |
+                              | HTTPS or loopback HTTP
+                              | GET /search?q=&format=json
+                              v
+                 +---------------------------+
+                 | reverse proxy (optional)  |
+                 | TLS, no public admin UI   |
+                 +-------------+-------------+
+                               |
+                 127.0.0.1:18888 (default bind)
+                               |
+                 +-------------v-------------+     +------------------+
+                 | searxng/searxng@sha256…   |---->| valkey@sha256…   |
+                 | JSON + html formats       |     | limiter / cache  |
+                 | CPU 1 / RAM 768Mi         |     | CPU 0.25 / 128Mi |
+                 +-------------+-------------+     +------------------+
+                               |
+                conservative public engines only
+                duckduckgo, brave, mojeek, qwant,
+                wikipedia, wikidata
+                               |
+                               v
+                      public web (no login)
+```
+
+Isolation: compose project `confenge-searxng`, dedicated bridge, port published only on `127.0.0.1`. Firewall on Netcup remains default-deny inbound. Admin / preferences are not published.
+
+## 2. Launch (deploy entry point)
+
+From the extra-cli checkout:
+
+```bash
+cd deploy/searxng
+# first time: copy env and replace the secret (launch.sh does this if .env is missing)
+make up          # == bash ./launch.sh
+make ps
+make logs
+```
+
+`launch.sh` is the **real deploy entry point**. It:
+
+1. refuses to start without `PINNED.env` digest pins
+2. writes `.env` from `.env.example` and fills `SEARXNG_SECRET` when missing
+3. runs `docker compose up -d`
+4. waits for health
+5. probes `GET /search?q=…&format=json` and requires HTTP 200 + a JSON `results` array (length may be 0)
+
+Second launch of the same command is idempotent.
+
+Rollback:
+
+```bash
+# stop
+bash deploy/searxng/rollback.sh stop
+# restore previous digest pair (only if PINNED.prev.env exists)
+cp deploy/searxng/PINNED.env deploy/searxng/PINNED.prev.env   # do this BEFORE changing pins
+bash deploy/searxng/rollback.sh
+```
+
+## 3. extra-cli integration
+
+```bash
+export CONFENGE_SEARXNG_URL=http://127.0.0.1:18888
+python3 -m scripts.decision_unit_intelligence run \
+  --out /tmp/confenge-prospect-searxng \
+  --limit 10 \
+  --search-backend searxng
+```
+
+`--search-backend ddgs` is a **separate recorded run**, not a hidden fallback.
+
+`--search-failover ddgs` (or `CONFENGE_SEARCH_FAILOVER=ddgs`) is the only in-process failover. It changes the backend id to `searxng_explicit_failover_ddgs` and appends an event. Default is `off`.
+
+Client disk cache remains `.cache/confenge-prospect/`. Failures are not cached as empty hits. Instance limiter/cache lives in Valkey.
+
+## 4. Rate, timeout, circuit, failover matrix
+
+| Condition | extra-cli | Operator action |
+|---|---|---|
+| Missing `CONFENGE_SEARXNG_URL` | fail closed (`ValueError` / `missing_url`) | set the private URL |
+| HTTP 429 | `SearchBackendUnavailableError(http_429)` → `SOURCE_BLOCKED` | back off; do not rotate proxies |
+| HTTP 5xx | `http_5xx` → `SOURCE_BLOCKED` | inspect `docker compose logs` |
+| Timeout | `timeout`/`network` → `SOURCE_BLOCKED` | check egress / engine bans |
+| 5 consecutive failures | `circuit_open` for 60s | wait; fix instance |
+| Empty `results: []` with HTTP 200 | valid miss | not an outage |
+| Instance down, failover `off` | `SOURCE_BLOCKED` | start a **new** run with `--search-backend ddgs` if you accept DDGS |
+| `--search-failover ddgs` | recorded; backend id changes | never treat as a SearXNG success |
+
+Concurrency default: 2 in-flight SearXNG calls. Client interval: `SearchBudget.min_query_interval_seconds` (1s). No proxy rotation, no CAPTCHA/login bypass.
+
+## 5. Security
+
+- Bind `127.0.0.1:18888`. Do not open 18888 on the public NIC. Netcup UFW default-deny stays in place.
+- `.env` / `SEARXNG_SECRET` stay out of Git (`deploy/searxng/.gitignore`).
+- Images are digest-pinned in `PINNED.env`. Never deploy `:latest`.
+- `public_instance: false`. `pass_searxng_org = false`. No public UI/product.
+- Optional Caddy snippet (`Caddyfile.example`) terminates TLS on loopback and 404s `/preferences`, `/stats`, `/metrics`.
+- `no-new-privileges` is set. Official images are not run with `cap_drop: ALL` because Valkey needs `setresuid` to start.
+
+## 6. AGPL-3.0 obligations
+
+SearXNG is AGPL-3.0. extra-cli is an HTTP client only.
+
+- Do **not** copy `searx/` source into this repo.
+- Running the **unmodified official image** plus this configuration is a network service. If you **modify** the image or settings in a way that produces a derived SearXNG program and expose it to others, you must offer the corresponding source (AGPL §13).
+- CONFENGE policy: keep the instance private (loopback / internal TLS). If it is ever reachable by anyone outside the operators, publish the exact image digest and any patches you ship.
+- License review lives next to the adapter table in [`../commercial-intelligence/contact-resolution.md`](../commercial-intelligence/contact-resolution.md).
+
+## 7. Observability
+
+Client (`SearchHttpMetrics.snapshot()`): request count, HTTP status histogram, p50/p95 latency, 429/5xx, timeouts, circuit opens, per-engine `unresponsive_engines`, result count.
+
+Instance:
+
+```bash
+docker compose -f deploy/searxng/docker-compose.yml ps
+docker stats confenge-searxng-core confenge-searxng-valkey --no-stream
+docker compose -f deploy/searxng/docker-compose.yml logs --tail 100 core
+curl -fsS http://127.0.0.1:18888/stats || true
+```
+
+`enable_metrics: true` is on; `/metrics` stays passwordless-disabled (`open_metrics: ""`) so it is not a public scrape surface.
+
+## 8. Canary (10 TRACK_A accounts)
+
+```bash
+python3 -m scripts.ops.searxng_canary \
+  --out artifacts/confenge/searxng-canary.json \
+  --limit 10 \
+  --searxng-url "${CONFENGE_SEARXNG_URL:-http://127.0.0.1:18888}"
+```
+
+The report compares useful yield, pages that led to a person/email, latency, failures, and cost (always R$ 0 purchased data). Each backend is a separate run.
+
+Live 2026-08-14, TRACK_A first 10, image `searxng/searxng@sha256:892cf809341915a4b7710d3c9045005b4c377d51335a089b6d4da0b28750788d`. Local loopback plus Netcup `127.0.0.1:18888` (same digest). Uncached wall times from the first pass; yield from the corrected reporter (candidates do not carry `source_url`).
+
+| Backend | Useful yield | Person/email pages | p50 latency | Failures | Blocked | Cost |
+|---|---:|---:|---:|---:|---:|---:|
+| DDGS | 9/10 | 14 | ~29 s cold / 1 ms cached | 0 | 0 | R$ 0 |
+| SearXNG private | 9/10 | 14 | ~2.7 s cold / 1 ms cached | 0 | 0 | R$ 0 |
+
+Netcup extra-cli smoke: `--search-backend searxng --searxng-url http://127.0.0.1:18889` (SSH tunnel) on CNPJ `00820854000114` → `ACTIONABLE_ROUTE` / `R3_ROUTED_TO_NAMED_PERSON`, not blocked. Engines that 429/CAPTCHA (Brave, Mojeek, Qwant) stay suspended; no bypass.
+
+## 9. Resource / cost estimate
+
+| Component | Limit | Typical idle | Notes |
+|---|---|---|---|
+| searxng-core | 1 CPU / 768 MiB | 150–300 MiB | official image |
+| valkey | 0.25 CPU / 128 MiB | 10–30 MiB | limiter + cache |
+| extra-cli client | existing process | n/a | httpx only |
+
+Purchased-data cost: **R$ 0**. Incremental VPS cost on Netcup is the RAM/CPU above on the existing host (already paid). No third-party search API bill.
+
+## 10. Failover recommendation
+
+- **Primary for batch discovery:** `searxng` against the CONFENGE instance.
+- **Fallback:** a new, explicit `--search-backend ddgs` run. Do not enable `--search-failover ddgs` in production batch until a canary shows SearXNG availability is worse than DDGS **and** operators accept mixed provenance.
+- `--search-backend off` is the policy skip, not an outage hide.
+
+## 11. Blockers
+
+Named live blocker is written at canary time. `SERVER_UP` on Netcup does not mean this stack is running. Port `8080/tcp` on `ec-prod` is already taken by Warmbly; this kit uses **18888**.

--- a/docs/ops/searxng-private-backend.md
+++ b/docs/ops/searxng-private-backend.md
@@ -142,12 +142,14 @@ python3 -m scripts.ops.searxng_canary \
 
 The report compares useful yield, pages that led to a person/email, latency, failures, and cost (always R$ 0 purchased data). Each backend is a separate run.
 
-Live 2026-08-14, TRACK_A first 10, image `searxng/searxng@sha256:892cf809341915a4b7710d3c9045005b4c377d51335a089b6d4da0b28750788d`. Local loopback plus Netcup `127.0.0.1:18888` (same digest). Uncached wall times from the first pass; yield from the corrected reporter (candidates do not carry `source_url`).
+Cold live 2026-08-15 against **Netcup** (`ssh -L 18889:127.0.0.1:18888`, image `searxng/searxng@sha256:892cf809341915a4b7710d3c9045005b4c377d51335a089b6d4da0b28750788d`). `--fresh-cache`: `cache_hits=0`, `cache_reused_accounts=0`, `cache_misses=29` per backend. `useful_yield` counts **search-derived** person/email/domain pages only (historical QSA is not credited to a backend). Direct backend compare (`compare_live_backends`) calls the shipped clients with no disk cache.
 
-| Backend | Useful yield | Person/email pages | p50 latency | Failures | Blocked | Cost |
-|---|---:|---:|---:|---:|---:|---:|
-| DDGS | 9/10 | 14 | ~29 s cold / 1 ms cached | 0 | 0 | R$ 0 |
-| SearXNG private | 9/10 | 14 | ~2.7 s cold / 1 ms cached | 0 | 0 | R$ 0 |
+| Backend | Search useful yield | Person/email pages | p50 wall | Search hits | Cache hits/misses | Failures | Blocked | Cost |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| DDGS | 7/10 | 9 | 20.6 s | 63 | 0 / 29 | 0 | 0 | R$ 0 |
+| SearXNG private (Netcup) | 7/10 | 8 | 2.9 s | 46 | 0 / 29 | 0 | 0 | R$ 0 |
+
+Direct same-query probe (no cache): DDGS returned 4 hits on all 10 accounts (p50 ~4 s). SearXNG returned 4 hits on 5/10 and 0 on 5/10 (p50 ~1.0 s; Brave/Mojeek/Qwant 429/CAPTCHA stay suspended). Overlap 0–3 URLs. This is engine yield, not a cache replay.
 
 Netcup extra-cli smoke: `--search-backend searxng --searxng-url http://127.0.0.1:18889` (SSH tunnel) on CNPJ `00820854000114` → `ACTIONABLE_ROUTE` / `R3_ROUTED_TO_NAMED_PERSON`, not blocked. Engines that 429/CAPTCHA (Brave, Mojeek, Qwant) stay suspended; no bypass.
 

--- a/scripts/decision_unit_intelligence/cli.py
+++ b/scripts/decision_unit_intelligence/cli.py
@@ -74,6 +74,7 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
             search_budget=search_budget,
             cache_dir=Path(args.search_cache_dir),
             verify_email_dns=args.verify_email_dns,
+            search_failover=args.search_failover or os.getenv("CONFENGE_SEARCH_FAILOVER", "off"),
         )
         payload = acc.to_dict()
         payload["replay_hash"] = account_hash(payload)
@@ -131,6 +132,7 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
         "email_safe_warmbly": email_safe,
         "web_discovery": {
             "backend": args.search_backend,
+            "failover": args.search_failover or os.getenv("CONFENGE_SEARCH_FAILOVER", "off"),
             "budget": {
                 "max_queries_per_account": search_budget.max_queries,
                 "max_results_per_query": search_budget.max_results_per_query,
@@ -498,6 +500,12 @@ def build_parser() -> argparse.ArgumentParser:
 def _add_web_discovery_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--search-backend", choices=("off", "searxng", "ddgs"), default="off")
     parser.add_argument("--searxng-url")
+    parser.add_argument(
+        "--search-failover",
+        choices=("off", "ddgs"),
+        default="off",
+        help="Explicit recorded failover only. Default off; never hides SearXNG downtime.",
+    )
     parser.add_argument("--search-max-queries", type=int, default=4)
     parser.add_argument("--search-results-per-query", type=int, default=5)
     parser.add_argument("--crawl-max-pages", type=int, default=4)

--- a/scripts/decision_unit_intelligence/runner.py
+++ b/scripts/decision_unit_intelligence/runner.py
@@ -21,14 +21,13 @@ from scripts.decision_unit_intelligence.providers.external_enrichment import Ext
 from scripts.decision_unit_intelligence.providers.historical_campaign import HistoricalCampaignProvider
 from scripts.decision_unit_intelligence.providers.official_documents import OfficialDocumentsProvider
 from scripts.decision_unit_intelligence.providers.public_search import PublicSearchProvider
+from scripts.decision_unit_intelligence.search_http import SearchBackendUnavailableError, build_search_backend
 from scripts.decision_unit_intelligence.web_discovery import (
     CachedPublicCrawler,
     CachedRateLimitedSearchBackend,
-    DdgsSearchBackend,
     HttpxPublicCrawler,
     JsonDiscoveryCache,
     SearchBudget,
-    SearxngSearchBackend,
 )
 
 _SHARED_HISTORICAL: HistoricalCampaignProvider | None = None
@@ -41,6 +40,7 @@ def default_providers(
     searxng_url: str | None = None,
     search_budget: SearchBudget | None = None,
     cache_dir: Path | None = None,
+    search_failover: str = "off",
 ) -> list[Any]:
     global _SHARED_HISTORICAL
     if _SHARED_HISTORICAL is None:
@@ -48,14 +48,17 @@ def default_providers(
     budget = search_budget or SearchBudget()
     backend = None
     if search_backend != "off":
-        if search_backend == "searxng":
-            if not searxng_url:
-                raise ValueError("searxng search backend requires --searxng-url")
-            raw_backend = SearxngSearchBackend(searxng_url, timeout_seconds=budget.timeout_seconds)
-        elif search_backend == "ddgs":
-            raw_backend = DdgsSearchBackend(timeout_seconds=budget.timeout_seconds)
-        else:
-            raise ValueError(f"unsupported search backend: {search_backend}")
+        try:
+            raw_backend = build_search_backend(
+                search_backend,
+                searxng_url=searxng_url,
+                timeout_seconds=budget.timeout_seconds,
+                failover=search_failover,
+            )
+        except SearchBackendUnavailableError as exc:
+            if exc.reason == "missing_url":
+                raise ValueError("searxng search backend requires --searxng-url") from exc
+            raise
         cache = JsonDiscoveryCache(cache_dir or Path(".cache/confenge-prospect"), ttl_days=budget.cache_ttl_days)
         backend = CachedRateLimitedSearchBackend(
             raw_backend,
@@ -95,6 +98,7 @@ def run_account(
     search_budget: SearchBudget | None = None,
     cache_dir: Path | None = None,
     verify_email_dns: bool = False,
+    search_failover: str = "off",
 ) -> Any:
     started = perf_counter()
     ctx = InvestigationContext(cnpj=normalize_cnpj(cnpj), service=service)
@@ -103,6 +107,7 @@ def run_account(
         searxng_url=searxng_url,
         search_budget=search_budget,
         cache_dir=cache_dir,
+        search_failover=search_failover,
     )
     people = []
     channels = []

--- a/scripts/decision_unit_intelligence/search_http.py
+++ b/scripts/decision_unit_intelligence/search_http.py
@@ -1,0 +1,392 @@
+"""CONFENGE HTTP boundary to a private SearXNG instance.
+
+This module is the only extra-cli path that talks to SearXNG. It never imports,
+vendors, or links SearXNG/AGPL code. Failures (missing URL, 429, 5xx, timeout,
+circuit-open, invalid JSON) raise SearchBackendUnavailableError and are never
+converted into an empty successful hit list.
+
+In-process DDGS failover is off by default. Enabling it is an explicit operator
+choice recorded on the backend id and event log; it does not pretend SearXNG
+succeeded.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections import Counter
+from dataclasses import dataclass, field
+from time import monotonic, perf_counter
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from scripts.decision_unit_intelligence.web_discovery import USER_AGENT, SearchHit
+
+_PUBLIC_SEARXNG_HOST_MARKERS = (
+    "searx.space",
+    "searx.be",
+    "search.sapti.me",
+    "paulgo.io",
+    "search.ononoki.org",
+    "priv.au",
+    "searxng.site",
+)
+
+
+class SearchBackendUnavailableError(Exception):
+    """Visible backend unavailability. Never treat as a successful miss."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        status_code: int | None = None,
+        retry_after: str | None = None,
+        detail: str = "",
+    ) -> None:
+        self.reason = reason
+        self.status_code = status_code
+        self.retry_after = retry_after
+        self.detail = detail
+        parts = [reason]
+        if status_code is not None:
+            parts.append(f"status={status_code}")
+        if retry_after:
+            parts.append(f"retry_after={retry_after}")
+        if detail:
+            parts.append(detail)
+        super().__init__("; ".join(parts))
+
+
+def _percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+@dataclass
+class SearchHttpMetrics:
+    """In-process counters for the HTTP search client (not a public product)."""
+
+    requests: int = 0
+    status_counts: Counter[int] = field(default_factory=Counter)
+    latencies_ms: list[float] = field(default_factory=list)
+    result_counts: list[int] = field(default_factory=list)
+    engine_failures: Counter[str] = field(default_factory=Counter)
+    http_429: int = 0
+    http_5xx: int = 0
+    timeouts: int = 0
+    circuit_opens: int = 0
+    network_errors: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def record_status(self, status_code: int, latency_ms: float, result_count: int) -> None:
+        with self._lock:
+            self.requests += 1
+            self.status_counts[status_code] += 1
+            self.latencies_ms.append(latency_ms)
+            self.result_counts.append(result_count)
+            if status_code == 429:
+                self.http_429 += 1
+            elif status_code >= 500:
+                self.http_5xx += 1
+
+    def record_timeout(self) -> None:
+        with self._lock:
+            self.requests += 1
+            self.timeouts += 1
+
+    def record_circuit_open(self) -> None:
+        with self._lock:
+            self.circuit_opens += 1
+
+    def record_network(self) -> None:
+        with self._lock:
+            self.requests += 1
+            self.network_errors += 1
+
+    def record_engine_failures(self, engines: list[str]) -> None:
+        if not engines:
+            return
+        with self._lock:
+            self.engine_failures.update(engines)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            latencies = list(self.latencies_ms)
+            return {
+                "requests": self.requests,
+                "status_counts": {str(k): v for k, v in sorted(self.status_counts.items())},
+                "p50_ms": _percentile(latencies, 50),
+                "p95_ms": _percentile(latencies, 95),
+                "http_429": self.http_429,
+                "http_5xx": self.http_5xx,
+                "timeouts": self.timeouts,
+                "circuit_opens": self.circuit_opens,
+                "network_errors": self.network_errors,
+                "engine_failures": dict(self.engine_failures),
+                "result_count_total": sum(self.result_counts),
+                "result_count_last": self.result_counts[-1] if self.result_counts else 0,
+            }
+
+
+class CircuitBreaker:
+    """Process-local fail-closed breaker. No proxy rotation, no silent reset."""
+
+    def __init__(self, *, failure_threshold: int = 5, reset_timeout_seconds: float = 60.0) -> None:
+        if failure_threshold < 1:
+            raise ValueError("failure_threshold must be >= 1")
+        self.failure_threshold = failure_threshold
+        self.reset_timeout_seconds = reset_timeout_seconds
+        self._failures = 0
+        self._opened_at: float | None = None
+        self._lock = threading.Lock()
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            return self._state_unlocked(monotonic())
+
+    def _state_unlocked(self, now: float) -> str:
+        if self._opened_at is None:
+            return "closed"
+        if now - self._opened_at >= self.reset_timeout_seconds:
+            return "half_open"
+        return "open"
+
+    def before_call(self) -> None:
+        with self._lock:
+            if self._state_unlocked(monotonic()) == "open":
+                raise SearchBackendUnavailableError("circuit_open", detail="searxng circuit is open")
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._failures = 0
+            self._opened_at = None
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._failures += 1
+            if self._failures >= self.failure_threshold:
+                self._opened_at = monotonic()
+
+
+def require_searxng_url(url: str | None, *, allow_public: bool | None = None) -> str:
+    cleaned = (url or "").strip().rstrip("/")
+    if not cleaned:
+        raise SearchBackendUnavailableError("missing_url", detail="CONFENGE_SEARXNG_URL or --searxng-url is required")
+    parsed = urlsplit(cleaned if "://" in cleaned else f"http://{cleaned}")
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise SearchBackendUnavailableError("missing_url", detail="SearXNG URL has no host")
+    public_allowed = (
+        allow_public
+        if allow_public is not None
+        else os.getenv("CONFENGE_SEARXNG_ALLOW_PUBLIC", "").strip() in {"1", "true", "yes"}
+    )
+    if (not public_allowed) and any(host == marker or host.endswith(f".{marker}") for marker in _PUBLIC_SEARXNG_HOST_MARKERS):
+        raise SearchBackendUnavailableError(
+            "public_instance_denied",
+            detail="public third-party SearXNG is not allowed for batch discovery",
+        )
+    return cleaned if "://" in cleaned else f"http://{cleaned}"
+
+
+def resolve_failover_policy(value: str | None) -> str:
+    policy = (value or os.getenv("CONFENGE_SEARCH_FAILOVER", "off")).strip().lower() or "off"
+    if policy in {"off", "none", "false", "0"}:
+        return "off"
+    if policy == "ddgs":
+        return "ddgs"
+    raise ValueError(f"unsupported search failover: {policy}")
+
+
+def _unresponsive_engines(payload: dict[str, Any]) -> list[str]:
+    raw = payload.get("unresponsive_engines") or []
+    names: list[str] = []
+    for row in raw:
+        if isinstance(row, (list, tuple)) and row:
+            names.append(str(row[0]))
+        elif isinstance(row, str):
+            names.append(row)
+        elif isinstance(row, dict) and row.get("engine"):
+            names.append(str(row["engine"]))
+    return names
+
+
+class SearxngHttpBackend:
+    """GET/POST {url}/search?q=…&format=json against a CONFENGE-controlled instance."""
+
+    backend_id = "searxng"
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout_seconds: float = 12.0,
+        max_concurrency: int = 2,
+        metrics: SearchHttpMetrics | None = None,
+        breaker: CircuitBreaker | None = None,
+        allow_public: bool | None = None,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.base_url = require_searxng_url(base_url, allow_public=allow_public)
+        self.timeout_seconds = timeout_seconds
+        self.max_concurrency = max(1, max_concurrency)
+        self.metrics = metrics or SearchHttpMetrics()
+        self.breaker = breaker or CircuitBreaker()
+        self._sema = threading.Semaphore(self.max_concurrency)
+        self._transport = transport
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        try:
+            self.breaker.before_call()
+        except SearchBackendUnavailableError:
+            self.metrics.record_circuit_open()
+            raise
+        params = {"q": query, "format": "json", "language": "pt-BR", "safesearch": "1"}
+        started = perf_counter()
+        self._sema.acquire()
+        try:
+            with httpx.Client(
+                timeout=self.timeout_seconds,
+                transport=self._transport,
+                follow_redirects=False,
+                headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
+            ) as client:
+                response = client.get(f"{self.base_url}/search", params=params)
+        except httpx.TimeoutException as exc:
+            self.metrics.record_timeout()
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("timeout", detail=type(exc).__name__) from exc
+        except httpx.HTTPError as exc:
+            self.metrics.record_network()
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("network", detail=type(exc).__name__) from exc
+        finally:
+            self._sema.release()
+
+        latency_ms = (perf_counter() - started) * 1000.0
+        status = response.status_code
+        retry_after = response.headers.get("Retry-After")
+        if status == 429:
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("http_429", status_code=429, retry_after=retry_after)
+        if status >= 500:
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("http_5xx", status_code=status)
+        if status >= 400:
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("http_4xx", status_code=status)
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("invalid_json", status_code=status) from exc
+        if not isinstance(payload, dict):
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("invalid_json", status_code=status, detail="payload is not an object")
+
+        rows = payload.get("results")
+        if rows is None:
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("invalid_json", status_code=status, detail="missing results array")
+        if not isinstance(rows, list):
+            self.metrics.record_status(status, latency_ms, 0)
+            self.breaker.record_failure()
+            raise SearchBackendUnavailableError("invalid_json", status_code=status, detail="results is not an array")
+
+        hits = [
+            SearchHit(
+                url=str(row.get("url") or ""),
+                title=str(row.get("title") or ""),
+                snippet=str(row.get("content") or ""),
+                engine=str(row.get("engine") or "") or None,
+            )
+            for row in rows[:limit]
+            if isinstance(row, dict) and row.get("url")
+        ]
+        self.metrics.record_status(status, latency_ms, len(hits))
+        self.metrics.record_engine_failures(_unresponsive_engines(payload))
+        self.breaker.record_success()
+        return hits
+
+
+class ExplicitFailoverSearchBackend:
+    """Opt-in recorded failover. Default discovery must not construct this."""
+
+    def __init__(self, primary: SearxngHttpBackend, fallback: Any, *, policy: str) -> None:
+        if policy != "ddgs":
+            raise ValueError(f"unsupported explicit failover policy: {policy}")
+        self.primary = primary
+        self.fallback = fallback
+        self.policy = policy
+        self.backend_id = f"searxng_explicit_failover_{getattr(fallback, 'backend_id', policy)}"
+        self.events: list[dict[str, Any]] = []
+        self.failover_used = False
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        try:
+            return self.primary.search(query, limit=limit)
+        except SearchBackendUnavailableError as exc:
+            self.failover_used = True
+            self.events.append(
+                {
+                    "query": query,
+                    "primary_reason": exc.reason,
+                    "primary_status": exc.status_code,
+                    "fallback": getattr(self.fallback, "backend_id", self.policy),
+                    "policy": self.policy,
+                    "hidden": False,
+                }
+            )
+            return self.fallback.search(query, limit=limit)
+
+
+def build_search_backend(
+    search_backend: str,
+    *,
+    searxng_url: str | None = None,
+    timeout_seconds: float = 12.0,
+    failover: str | None = None,
+    ddgs_factory: Any | None = None,
+    **searxng_kwargs: Any,
+) -> Any:
+    """Wire the selected backend. Failover is explicit and recorded."""
+
+    if search_backend == "off":
+        raise ValueError("search backend is off")
+    if search_backend == "ddgs":
+        if ddgs_factory is not None:
+            return ddgs_factory(timeout_seconds=timeout_seconds)
+        from scripts.decision_unit_intelligence.web_discovery import DdgsSearchBackend
+
+        return DdgsSearchBackend(timeout_seconds=timeout_seconds)
+    if search_backend != "searxng":
+        raise ValueError(f"unsupported search backend: {search_backend}")
+
+    primary = SearxngHttpBackend(searxng_url or "", timeout_seconds=timeout_seconds, **searxng_kwargs)
+    policy = resolve_failover_policy(failover)
+    if policy == "off":
+        return primary
+    if ddgs_factory is not None:
+        fallback = ddgs_factory(timeout_seconds=timeout_seconds)
+    else:
+        from scripts.decision_unit_intelligence.web_discovery import DdgsSearchBackend
+
+        fallback = DdgsSearchBackend(timeout_seconds=timeout_seconds)
+    return ExplicitFailoverSearchBackend(primary, fallback, policy=policy)

--- a/scripts/ops/searxng_canary.py
+++ b/scripts/ops/searxng_canary.py
@@ -1,0 +1,317 @@
+"""Compare DDGS vs private SearXNG on the first 10 TRACK_A accounts.
+
+This runner does not change discovery policy. It drives the shipped
+``run_account`` path twice (explicit backend each time) and writes a table
+of useful yield, person/email pages, latency, failures, and cost.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from scripts.decision_unit_intelligence.cohort import TRACK_A_CNPJS
+from scripts.decision_unit_intelligence.repository import write_json
+from scripts.decision_unit_intelligence.runner import run_account
+from scripts.decision_unit_intelligence.search_http import SearchHttpMetrics, SearxngHttpBackend
+from scripts.decision_unit_intelligence.web_discovery import SearchBudget, SearchHit
+
+
+def _pages_that_led_to_person_or_email(account: Any) -> list[str]:
+    pages: list[str] = []
+    for item in getattr(account, "evidence", None) or []:
+        url = getattr(item, "source_url", None)
+        field = str(getattr(item, "field", "") or "")
+        if url and field in {"person_role", "email", "canonical_domain", "company_phone"}:
+            pages.append(str(url))
+    for route in getattr(account, "routes", None) or []:
+        url = getattr(route, "source_url", None)
+        if url:
+            pages.append(str(url))
+        extra = getattr(route, "extra", None) or {}
+        if extra.get("source_url"):
+            pages.append(str(extra["source_url"]))
+    return list(dict.fromkeys(pages))
+
+
+def summarize_account(account: Any) -> dict[str, Any]:
+    search_attempts = [a for a in account.ledger.attempts if a.provider_id == "public_search"]
+    attempt = search_attempts[0] if search_attempts else None
+    people = [p.person_name for p in account.candidates if p.person_name]
+    emails = [
+        getattr(route, "channel_value", None)
+        for route in account.routes
+        if "mail" in str(getattr(route, "channel_type", "")).lower()
+        or str(getattr(route, "channel_value", "")).find("@") >= 0
+    ]
+    emails = [e for e in emails if e]
+    return {
+        "cnpj": account.cnpj,
+        "legal_name": account.legal_name,
+        "terminal": getattr(account.terminal, "value", str(account.terminal)),
+        "people": people,
+        "emails": emails,
+        "useful_yield": bool(people or emails),
+        "person_email_pages": _pages_that_led_to_person_or_email(account),
+        "latency_ms": attempt.duration_ms if attempt else account.ledger.duration_ms,
+        "failures": list((attempt.extra.get("failures") if attempt else None) or []),
+        "blocked": bool(attempt.blocked) if attempt else False,
+        "stop_reason": attempt.stop_reason if attempt else None,
+        "result_count": (attempt.extra.get("result_count") if attempt else 0) or 0,
+        "search_backend": (attempt.extra.get("search_backend") if attempt else None),
+        "cost_brl": account.ledger.cost_brl,
+        "bytes_touched": account.ledger.bytes_touched,
+    }
+
+
+def compare_backend_hits(
+    *,
+    ddgs_hits: list[SearchHit],
+    searxng_hits: list[SearchHit],
+    ddgs_error: str | None,
+    searxng_error: str | None,
+    ddgs_ms: float,
+    searxng_ms: float,
+) -> dict[str, Any]:
+    """Pure comparison used by live canary and by unit tests."""
+
+    return {
+        "ddgs": {
+            "hit_count": len(ddgs_hits),
+            "urls": [hit.url for hit in ddgs_hits],
+            "error": ddgs_error,
+            "latency_ms": round(ddgs_ms, 2),
+        },
+        "searxng": {
+            "hit_count": len(searxng_hits),
+            "urls": [hit.url for hit in searxng_hits],
+            "error": searxng_error,
+            "latency_ms": round(searxng_ms, 2),
+        },
+        "overlap_urls": sorted(set(h.url for h in ddgs_hits) & set(h.url for h in searxng_hits)),
+    }
+
+
+def run_backend_batch(
+    cnpjs: list[str],
+    *,
+    search_backend: str,
+    searxng_url: str | None,
+    cache_dir: Path,
+    budget: SearchBudget,
+) -> list[dict[str, Any]]:
+    rows = []
+    for cnpj in cnpjs:
+        started = perf_counter()
+        error = None
+        summary: dict[str, Any]
+        try:
+            account = run_account(
+                cnpj,
+                search_backend=search_backend,
+                searxng_url=searxng_url,
+                search_budget=budget,
+                cache_dir=cache_dir / search_backend,
+                infer_email=False,
+            )
+            summary = summarize_account(account)
+        except Exception as exc:  # runner-level failure must stay visible
+            error = f"{type(exc).__name__}:{exc}"
+            summary = {
+                "cnpj": cnpj,
+                "legal_name": None,
+                "terminal": "RUNNER_ERROR",
+                "people": [],
+                "emails": [],
+                "useful_yield": False,
+                "person_email_pages": [],
+                "latency_ms": int((perf_counter() - started) * 1000),
+                "failures": [error],
+                "blocked": True,
+                "stop_reason": "SOURCE_BLOCKED",
+                "result_count": 0,
+                "search_backend": search_backend,
+                "cost_brl": 0.0,
+                "bytes_touched": 0,
+            }
+        summary["wall_ms"] = int((perf_counter() - started) * 1000)
+        rows.append(summary)
+    return rows
+
+
+def build_report(
+    *,
+    cnpjs: list[str],
+    ddgs_rows: list[dict[str, Any]],
+    searxng_rows: list[dict[str, Any]],
+    searxng_url: str | None,
+    metrics: dict[str, Any] | None = None,
+    probe: dict[str, Any] | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    def _agg(rows: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "accounts": len(rows),
+            "useful_yield": sum(1 for row in rows if row.get("useful_yield")),
+            "person_email_pages": sum(len(row.get("person_email_pages") or []) for row in rows),
+            "latency_ms_p50": _mid([int(row.get("latency_ms") or 0) for row in rows]),
+            "failures": sum(len(row.get("failures") or []) for row in rows),
+            "blocked": sum(1 for row in rows if row.get("blocked")),
+            "cost_brl": round(sum(float(row.get("cost_brl") or 0) for row in rows), 4),
+        }
+
+    return {
+        "schema_id": "confenge.searxng.canary.v1",
+        "accounts": cnpjs,
+        "searxng_url": searxng_url,
+        "ddgs": {"rows": ddgs_rows, "summary": _agg(ddgs_rows)},
+        "searxng": {"rows": searxng_rows, "summary": _agg(searxng_rows)},
+        "client_metrics": metrics or {},
+        "instance_probe": probe or {},
+        "cost_note": (
+            "Both backends have R$ 0 purchased-data cost. SearXNG cost is host CPU/RAM; "
+            "DDGS cost is upstream engine rate-limit risk only."
+        ),
+        "note": note,
+        "recommendation": _recommend(_agg(ddgs_rows), _agg(searxng_rows), searxng_rows),
+    }
+
+
+def _mid(values: list[int]) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    return ordered[len(ordered) // 2]
+
+
+def _recommend(ddgs: dict[str, Any], searxng: dict[str, Any], searxng_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    searxng_blocked = int(searxng.get("blocked") or 0)
+    if searxng_blocked == len(searxng_rows) and searxng_rows:
+        return {
+            "primary": "ddgs",
+            "fallback": "off",
+            "reason": "private SearXNG was unavailable for every account; do not hide that with silent failover",
+        }
+    if int(searxng.get("useful_yield") or 0) >= int(ddgs.get("useful_yield") or 0):
+        return {
+            "primary": "searxng",
+            "fallback": "ddgs (new explicit run only)",
+            "reason": "CONFENGE-controlled instance matched or beat DDGS useful yield; keep DDGS as a recorded operator re-run",
+        }
+    return {
+        "primary": "ddgs",
+        "fallback": "searxng",
+        "reason": "DDGS useful yield was higher on this canary; keep SearXNG as the controlled batch path once engines stabilize",
+    }
+
+
+def probe_instance(url: str, *, timeout_seconds: float = 12.0) -> dict[str, Any]:
+    metrics = SearchHttpMetrics()
+    backend = SearxngHttpBackend(url, timeout_seconds=timeout_seconds, metrics=metrics)
+    started = perf_counter()
+    error = None
+    hits: list[SearchHit] = []
+    try:
+        hits = backend.search("CONFENGE healthcheck empresa engenharia", limit=3)
+    except Exception as exc:
+        error = f"{type(exc).__name__}:{exc}"
+    return {
+        "url": url,
+        "ok": error is None,
+        "error": error,
+        "result_count": len(hits),
+        "latency_ms": int((perf_counter() - started) * 1000),
+        "metrics": metrics.snapshot(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="searxng-canary")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--searxng-url", default=os.getenv("CONFENGE_SEARXNG_URL"))
+    parser.add_argument("--cache-dir", default=".cache/confenge-searxng-canary")
+    parser.add_argument("--skip-ddgs", action="store_true")
+    parser.add_argument("--skip-searxng", action="store_true")
+    parser.add_argument("--search-max-queries", type=int, default=2)
+    parser.add_argument("--search-results-per-query", type=int, default=4)
+    parser.add_argument("--crawl-max-pages", type=int, default=2)
+    args = parser.parse_args(argv)
+
+    cnpjs = TRACK_A_CNPJS[: args.limit]
+    budget = SearchBudget(
+        max_queries=args.search_max_queries,
+        max_results_per_query=args.search_results_per_query,
+        max_pages=args.crawl_max_pages,
+        max_bytes=800_000,
+        timeout_seconds=12.0,
+        min_query_interval_seconds=1.0,
+        cache_ttl_days=7,
+    )
+    cache_dir = Path(args.cache_dir)
+    probe = None
+    if args.searxng_url and not args.skip_searxng:
+        probe = probe_instance(args.searxng_url)
+
+    ddgs_rows: list[dict[str, Any]] = []
+    if not args.skip_ddgs:
+        ddgs_rows = run_backend_batch(
+            cnpjs,
+            search_backend="ddgs",
+            searxng_url=None,
+            cache_dir=cache_dir,
+            budget=budget,
+        )
+    searxng_rows: list[dict[str, Any]] = []
+    if not args.skip_searxng:
+        if not args.searxng_url:
+            searxng_rows = [
+                {
+                    "cnpj": cnpj,
+                    "legal_name": None,
+                    "terminal": "RUNNER_ERROR",
+                    "people": [],
+                    "emails": [],
+                    "useful_yield": False,
+                    "person_email_pages": [],
+                    "latency_ms": 0,
+                    "failures": ["SearchBackendUnavailableError:missing_url"],
+                    "blocked": True,
+                    "stop_reason": "SOURCE_BLOCKED",
+                    "result_count": 0,
+                    "search_backend": "searxng",
+                    "cost_brl": 0.0,
+                    "bytes_touched": 0,
+                    "wall_ms": 0,
+                }
+                for cnpj in cnpjs
+            ]
+        else:
+            searxng_rows = run_backend_batch(
+                cnpjs,
+                search_backend="searxng",
+                searxng_url=args.searxng_url,
+                cache_dir=cache_dir,
+                budget=budget,
+            )
+
+    report = build_report(
+        cnpjs=cnpjs,
+        ddgs_rows=ddgs_rows,
+        searxng_rows=searxng_rows,
+        searxng_url=args.searxng_url,
+        probe=probe,
+        note="Failover is never implicit: each backend is a separate recorded run.",
+    )
+    out = Path(args.out)
+    write_json(out, report)
+    print(json.dumps({"wrote": str(out), "recommendation": report["recommendation"]}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/searxng_canary.py
+++ b/scripts/ops/searxng_canary.py
@@ -41,6 +41,7 @@ def _pages_that_led_to_person_or_email(account: Any) -> list[str]:
 def summarize_account(account: Any) -> dict[str, Any]:
     search_attempts = [a for a in account.ledger.attempts if a.provider_id == "public_search"]
     attempt = search_attempts[0] if search_attempts else None
+    extra = (attempt.extra if attempt else None) or {}
     people = [p.person_name for p in account.candidates if p.person_name]
     emails = [
         getattr(route, "channel_value", None)
@@ -49,20 +50,33 @@ def summarize_account(account: Any) -> dict[str, Any]:
         or str(getattr(route, "channel_value", "")).find("@") >= 0
     ]
     emails = [e for e in emails if e]
+    search_pages = [
+        str(item.source_url)
+        for item in (getattr(account, "evidence", None) or [])
+        if getattr(item, "source_url", None)
+        and getattr(item, "source_type", "") in {"company_website", "public_search"}
+        and getattr(item, "field", "") in {"person_role", "email", "canonical_domain"}
+    ]
+    cache_hits = int(extra.get("cache_hits") or 0)
+    cache_misses = int(extra.get("cache_misses") or 0)
     return {
         "cnpj": account.cnpj,
         "legal_name": account.legal_name,
         "terminal": getattr(account.terminal, "value", str(account.terminal)),
         "people": people,
         "emails": emails,
-        "useful_yield": bool(people or emails),
-        "person_email_pages": _pages_that_led_to_person_or_email(account),
+        "useful_yield": bool(search_pages),
+        "account_yield_includes_historical": bool(people or emails),
+        "person_email_pages": list(dict.fromkeys(search_pages)),
         "latency_ms": attempt.duration_ms if attempt else account.ledger.duration_ms,
-        "failures": list((attempt.extra.get("failures") if attempt else None) or []),
+        "failures": list(extra.get("failures") or []),
         "blocked": bool(attempt.blocked) if attempt else False,
         "stop_reason": attempt.stop_reason if attempt else None,
-        "result_count": (attempt.extra.get("result_count") if attempt else 0) or 0,
-        "search_backend": (attempt.extra.get("search_backend") if attempt else None),
+        "result_count": int(extra.get("result_count") or 0),
+        "cache_hits": cache_hits,
+        "cache_misses": cache_misses,
+        "cache_reused": cache_hits > 0 and cache_hits >= cache_misses,
+        "search_backend": extra.get("search_backend"),
         "cost_brl": account.ledger.cost_brl,
         "bytes_touched": account.ledger.bytes_touched,
     }
@@ -143,6 +157,54 @@ def run_backend_batch(
     return rows
 
 
+def compare_live_backends(
+    cnpjs: list[str],
+    *,
+    searxng_url: str,
+    searxng_backend: Any | None = None,
+    ddgs_backend: Any | None = None,
+    limit: int = 4,
+) -> list[dict[str, Any]]:
+    """Hit both shipped backends with the same query and no disk cache."""
+
+    if ddgs_backend is None:
+        from scripts.decision_unit_intelligence.web_discovery import DdgsSearchBackend
+
+        ddgs_backend = DdgsSearchBackend(timeout_seconds=12.0)
+    if searxng_backend is None:
+        searxng_backend = SearxngHttpBackend(searxng_url, timeout_seconds=12.0)
+    rows: list[dict[str, Any]] = []
+    for cnpj in cnpjs:
+        query = f'"{cnpj}" email'
+        ddgs_hits, ddgs_error, ddgs_ms = _search_once(ddgs_backend, query, limit)
+        searxng_hits, searxng_error, searxng_ms = _search_once(searxng_backend, query, limit)
+        rows.append(
+            {
+                "cnpj": cnpj,
+                "query": query,
+                "cache": False,
+                **compare_backend_hits(
+                    ddgs_hits=ddgs_hits,
+                    searxng_hits=searxng_hits,
+                    ddgs_error=ddgs_error,
+                    searxng_error=searxng_error,
+                    ddgs_ms=ddgs_ms,
+                    searxng_ms=searxng_ms,
+                ),
+            }
+        )
+    return rows
+
+
+def _search_once(backend: Any, query: str, limit: int) -> tuple[list[SearchHit], str | None, float]:
+    started = perf_counter()
+    try:
+        hits = list(backend.search(query, limit=limit) or [])
+        return hits, None, (perf_counter() - started) * 1000.0
+    except Exception as exc:
+        return [], f"{type(exc).__name__}:{exc}", (perf_counter() - started) * 1000.0
+
+
 def build_report(
     *,
     cnpjs: list[str],
@@ -152,16 +214,22 @@ def build_report(
     metrics: dict[str, Any] | None = None,
     probe: dict[str, Any] | None = None,
     note: str | None = None,
+    backend_compare: list[dict[str, Any]] | None = None,
+    fresh_cache: bool = False,
 ) -> dict[str, Any]:
     def _agg(rows: list[dict[str, Any]]) -> dict[str, Any]:
         return {
             "accounts": len(rows),
             "useful_yield": sum(1 for row in rows if row.get("useful_yield")),
             "person_email_pages": sum(len(row.get("person_email_pages") or []) for row in rows),
-            "latency_ms_p50": _mid([int(row.get("latency_ms") or 0) for row in rows]),
+            "latency_ms_p50": _mid([int(row.get("wall_ms") or row.get("latency_ms") or 0) for row in rows]),
             "failures": sum(len(row.get("failures") or []) for row in rows),
             "blocked": sum(1 for row in rows if row.get("blocked")),
             "cost_brl": round(sum(float(row.get("cost_brl") or 0) for row in rows), 4),
+            "cache_hits": sum(int(row.get("cache_hits") or 0) for row in rows),
+            "cache_misses": sum(int(row.get("cache_misses") or 0) for row in rows),
+            "cache_reused_accounts": sum(1 for row in rows if row.get("cache_reused")),
+            "search_result_count": sum(int(row.get("result_count") or 0) for row in rows),
         }
 
     return {
@@ -177,6 +245,8 @@ def build_report(
             "DDGS cost is upstream engine rate-limit risk only."
         ),
         "note": note,
+        "fresh_cache": fresh_cache,
+        "backend_compare": backend_compare or [],
         "recommendation": _recommend(_agg(ddgs_rows), _agg(searxng_rows), searxng_rows),
     }
 
@@ -235,8 +305,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--limit", type=int, default=10)
     parser.add_argument("--searxng-url", default=os.getenv("CONFENGE_SEARXNG_URL"))
     parser.add_argument("--cache-dir", default=".cache/confenge-searxng-canary")
+    parser.add_argument("--fresh-cache", action="store_true", help="Wipe --cache-dir before running")
     parser.add_argument("--skip-ddgs", action="store_true")
     parser.add_argument("--skip-searxng", action="store_true")
+    parser.add_argument("--skip-backend-compare", action="store_true")
     parser.add_argument("--search-max-queries", type=int, default=2)
     parser.add_argument("--search-results-per-query", type=int, default=4)
     parser.add_argument("--crawl-max-pages", type=int, default=2)
@@ -253,9 +325,16 @@ def main(argv: list[str] | None = None) -> int:
         cache_ttl_days=7,
     )
     cache_dir = Path(args.cache_dir)
+    if args.fresh_cache and cache_dir.exists():
+        import shutil
+
+        shutil.rmtree(cache_dir)
     probe = None
     if args.searxng_url and not args.skip_searxng:
         probe = probe_instance(args.searxng_url)
+    backend_compare: list[dict[str, Any]] = []
+    if args.searxng_url and not args.skip_backend_compare and not args.skip_ddgs and not args.skip_searxng:
+        backend_compare = compare_live_backends(cnpjs, searxng_url=args.searxng_url)
 
     ddgs_rows: list[dict[str, Any]] = []
     if not args.skip_ddgs:
@@ -305,7 +384,9 @@ def main(argv: list[str] | None = None) -> int:
         searxng_rows=searxng_rows,
         searxng_url=args.searxng_url,
         probe=probe,
-        note="Failover is never implicit: each backend is a separate recorded run.",
+        backend_compare=backend_compare,
+        fresh_cache=bool(args.fresh_cache),
+        note="Failover is never implicit: each backend is a separate recorded run. useful_yield counts search-derived pages only.",
     )
     out = Path(args.out)
     write_json(out, report)

--- a/tests/test_searxng_canary.py
+++ b/tests/test_searxng_canary.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from scripts.decision_unit_intelligence.search_http import SearchBackendUnavailableError
 from scripts.decision_unit_intelligence.web_discovery import SearchHit
-from scripts.ops.searxng_canary import build_report, compare_backend_hits, summarize_account
+from scripts.ops.searxng_canary import (
+    build_report,
+    compare_backend_hits,
+    compare_live_backends,
+    summarize_account,
+)
 
 
 class _Term:
@@ -23,6 +28,13 @@ class _Candidate:
     person_name = "João da Silva"
 
 
+class _Evidence:
+    def __init__(self) -> None:
+        self.source_url = "https://empresaexemplo.com.br/diretoria"
+        self.source_type = "company_website"
+        self.field = "person_role"
+
+
 class _Account:
     def __init__(self) -> None:
         self.cnpj = "00820854000114"
@@ -30,7 +42,7 @@ class _Account:
         self.terminal = _Term()
         self.candidates = [_Candidate()]
         self.routes = []
-        self.evidence = []
+        self.evidence = [_Evidence()]
         self.ledger = _Ledger()
 
 
@@ -50,7 +62,35 @@ def test_compare_and_report_keep_failures_visible() -> None:
     account = _Account()
     summary = summarize_account(account)
     assert summary["useful_yield"] is True
-    assert summary["person_email_pages"] == []
+    assert summary["person_email_pages"] == ["https://empresaexemplo.com.br/diretoria"]
+    assert summary["cache_reused"] is False
+
+
+def test_live_backend_compare_uses_shipped_search_methods_without_disk_cache() -> None:
+    class CountingBackend:
+        def __init__(self, backend_id: str, url: str) -> None:
+            self.backend_id = backend_id
+            self.calls: list[str] = []
+            self.url = url
+
+        def search(self, query: str, *, limit: int) -> list[SearchHit]:
+            self.calls.append(query)
+            return [SearchHit(url=self.url, title=query, snippet=self.backend_id)][:limit]
+
+    ddgs = CountingBackend("ddgs", "https://ddgs.example/a")
+    searxng = CountingBackend("searxng", "https://searxng.example/a")
+    rows = compare_live_backends(
+        ["00820854000114"],
+        searxng_url="http://127.0.0.1:18888",
+        searxng_backend=searxng,
+        ddgs_backend=ddgs,
+        limit=2,
+    )
+    assert ddgs.calls == ['"00820854000114" email']
+    assert searxng.calls == ddgs.calls
+    assert rows[0]["cache"] is False
+    assert rows[0]["ddgs"]["hit_count"] == 1
+    assert rows[0]["searxng"]["hit_count"] == 1
 
     report = build_report(
         cnpjs=["00820854000114"],

--- a/tests/test_searxng_canary.py
+++ b/tests/test_searxng_canary.py
@@ -1,0 +1,83 @@
+"""Tests for the DDGS vs SearXNG canary reporter (no live web)."""
+
+from __future__ import annotations
+
+from scripts.decision_unit_intelligence.search_http import SearchBackendUnavailableError
+from scripts.decision_unit_intelligence.web_discovery import SearchHit
+from scripts.ops.searxng_canary import build_report, compare_backend_hits, summarize_account
+
+
+class _Term:
+    value = "NO_ROUTE"
+
+
+class _Ledger:
+    def __init__(self) -> None:
+        self.attempts = []
+        self.duration_ms = 12
+        self.cost_brl = 0.0
+        self.bytes_touched = 40
+
+
+class _Candidate:
+    person_name = "João da Silva"
+
+
+class _Account:
+    def __init__(self) -> None:
+        self.cnpj = "00820854000114"
+        self.legal_name = "EMPRESA EXEMPLO"
+        self.terminal = _Term()
+        self.candidates = [_Candidate()]
+        self.routes = []
+        self.evidence = []
+        self.ledger = _Ledger()
+
+
+def test_compare_and_report_keep_failures_visible() -> None:
+    left = [SearchHit(url="https://a.example/x", title="A", snippet="a", engine="ddgs")]
+    comparison = compare_backend_hits(
+        ddgs_hits=left,
+        searxng_hits=[],
+        ddgs_error=None,
+        searxng_error="http_429",
+        ddgs_ms=40.0,
+        searxng_ms=12.0,
+    )
+    assert comparison["searxng"]["error"] == "http_429"
+    assert comparison["ddgs"]["hit_count"] == 1
+
+    account = _Account()
+    summary = summarize_account(account)
+    assert summary["useful_yield"] is True
+    assert summary["person_email_pages"] == []
+
+    report = build_report(
+        cnpjs=["00820854000114"],
+        ddgs_rows=[
+            {
+                "cnpj": "00820854000114",
+                "useful_yield": True,
+                "person_email_pages": ["https://a.example/x"],
+                "latency_ms": 40,
+                "failures": [],
+                "blocked": False,
+                "cost_brl": 0.0,
+            }
+        ],
+        searxng_rows=[
+            {
+                "cnpj": "00820854000114",
+                "useful_yield": False,
+                "person_email_pages": [],
+                "latency_ms": 12,
+                "failures": [str(SearchBackendUnavailableError("http_429", status_code=429))],
+                "blocked": True,
+                "cost_brl": 0.0,
+            }
+        ],
+        searxng_url="http://127.0.0.1:18888",
+    )
+    assert report["recommendation"]["primary"] == "ddgs"
+    assert "silent" in report["recommendation"]["reason"]
+    assert report["searxng"]["summary"]["blocked"] == 1

--- a/tests/test_searxng_deploy_kit.py
+++ b/tests/test_searxng_deploy_kit.py
@@ -1,0 +1,77 @@
+"""Static contract for the private SearXNG deploy kit and HTTP-only boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KIT = ROOT / "deploy" / "searxng"
+
+
+def test_pinned_images_use_digest_not_latest() -> None:
+    pinned = (KIT / "PINNED.env").read_text(encoding="utf-8")
+    compose = (KIT / "docker-compose.yml").read_text(encoding="utf-8")
+    assert "SEARXNG_IMAGE=" in pinned
+    assert "VALKEY_IMAGE=" in pinned
+    assert "@sha256:" in pinned
+    assert "searxng/searxng:latest" not in pinned
+    assert "valkey/valkey:latest" not in pinned
+    assert "image: ${SEARXNG_IMAGE}" in compose
+    assert "image: ${VALKEY_IMAGE}" in compose
+    assert "searxng/searxng:latest" not in compose
+
+
+def test_settings_enable_json_and_conservative_public_engines_only() -> None:
+    settings = (KIT / "core-config" / "settings.yml").read_text(encoding="utf-8")
+    assert "formats:" in settings
+    assert "- json" in settings
+    assert "keep_only:" in settings
+    for engine in ("duckduckgo", "brave", "mojeek", "qwant", "wikipedia", "wikidata"):
+        assert engine in settings
+    assert "google" not in settings
+    assert "linkedin" not in settings
+    assert "proxy" not in settings.lower() or "image_proxy: false" in settings
+    assert "No proxies" in settings
+    limiter = (KIT / "core-config" / "limiter.toml").read_text(encoding="utf-8")
+    assert "pass_searxng_org = false" in limiter
+
+
+def test_launch_entry_point_and_rollback_exist_and_bind_privately() -> None:
+    launch = (KIT / "launch.sh").read_text(encoding="utf-8")
+    rollback = (KIT / "rollback.sh").read_text(encoding="utf-8")
+    compose = (KIT / "docker-compose.yml").read_text(encoding="utf-8")
+    example = (KIT / ".env.example").read_text(encoding="utf-8")
+    assert "docker compose" in launch
+    assert "format=json" in launch
+    assert "PINNED.prev.env" in rollback
+    assert "127.0.0.1" in compose
+    assert "18888" in compose
+    assert "768m" in compose
+    assert "SEARXNG_SECRET=replace-with-openssl-rand-hex-32" in example
+    gitignore = (KIT / ".gitignore").read_text(encoding="utf-8")
+    assert ".env" in gitignore.splitlines()
+    if (KIT / ".env").exists():
+        secret = (KIT / ".env").read_text(encoding="utf-8")
+        assert "replace-with-openssl-rand-hex-32" not in secret
+
+
+def test_requirements_and_tree_do_not_vendor_searxng() -> None:
+    requirement_pkgs = [
+        line.split("#", 1)[0].strip().lower()
+        for line in (ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+        if line.split("#", 1)[0].strip()
+    ]
+    assert not any(pkg.startswith(("searxng", "searx", "searx-")) for pkg in requirement_pkgs)
+    scripts_root = ROOT / "scripts"
+    leaked = [
+        path
+        for path in scripts_root.rglob("*searxng*")
+        if path.is_dir() and path.name == "searxng"
+    ]
+    assert leaked == []
+    client = (ROOT / "scripts" / "decision_unit_intelligence" / "search_http.py").read_text(encoding="utf-8")
+    assert "httpx" in client
+    assert "/search" in client
+    assert "format" in client
+    assert "import searx" not in client
+    assert "from searx" not in client

--- a/tests/test_searxng_http_backend.py
+++ b/tests/test_searxng_http_backend.py
@@ -1,0 +1,238 @@
+"""Contract tests for the shipped SearXNG HTTP client (local fixture only)."""
+
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from scripts.decision_unit_intelligence.providers.public_search import PublicSearchProvider
+from scripts.decision_unit_intelligence.search_http import (
+    CircuitBreaker,
+    ExplicitFailoverSearchBackend,
+    SearchBackendUnavailableError,
+    SearxngHttpBackend,
+    build_search_backend,
+    require_searxng_url,
+)
+from scripts.decision_unit_intelligence.web_discovery import (
+    CachedRateLimitedSearchBackend,
+    JsonDiscoveryCache,
+    SearchHit,
+)
+from tests.test_decision_unit_web_discovery import _context
+
+
+class _FixtureState:
+    def __init__(self) -> None:
+        self.mode = "ok"
+        self.hits: list[dict[str, Any]] = [
+            {
+                "url": "https://empresaexemplo.com.br/institucional/diretoria",
+                "title": "Empresa Exemplo - site oficial",
+                "content": "Diretoria e contato institucional.",
+                "engine": "duckduckgo",
+            }
+        ]
+        self.unresponsive: list[list[str]] = []
+        self.requests = 0
+        self.last_query: str | None = None
+        self.last_format: str | None = None
+
+
+def _start_fixture(state: _FixtureState) -> tuple[ThreadingHTTPServer, str]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/search":
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            state.requests += 1
+            state.last_query = (params.get("q") or [""])[0]
+            state.last_format = (params.get("format") or [""])[0]
+            if state.mode == "stall":
+                raise TimeoutError("fixture stall")
+            if state.mode == "429":
+                self.send_response(429)
+                self.send_header("Retry-After", "7")
+                self.end_headers()
+                return
+            if state.mode == "500":
+                self.send_response(500)
+                self.end_headers()
+                self.wfile.write(b"upstream boom")
+                return
+            if state.mode == "html":
+                body = b"<html><body>not json</body></html>"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            payload = {"query": state.last_query, "results": state.hits, "unresponsive_engines": state.unresponsive}
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address[:2]
+    return server, f"http://{host}:{port}"
+
+
+@pytest.fixture()
+def searxng_fixture():
+    state = _FixtureState()
+    server, url = _start_fixture(state)
+    try:
+        yield state, url
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_require_url_fails_closed_and_rejects_public_third_party() -> None:
+    with pytest.raises(SearchBackendUnavailableError) as missing:
+        require_searxng_url("  ")
+    assert missing.value.reason == "missing_url"
+    with pytest.raises(SearchBackendUnavailableError) as public:
+        require_searxng_url("https://searx.be")
+    assert public.value.reason == "public_instance_denied"
+    assert require_searxng_url("http://127.0.0.1:18888") == "http://127.0.0.1:18888"
+
+
+def test_json_hits_parse_from_shipped_client(searxng_fixture) -> None:
+    state, url = searxng_fixture
+    backend = SearxngHttpBackend(url, timeout_seconds=2.0)
+    hits = backend.search("empresa exemplo diretor", limit=3)
+    assert state.last_format == "json"
+    assert hits == [
+        SearchHit(
+            url="https://empresaexemplo.com.br/institucional/diretoria",
+            title="Empresa Exemplo - site oficial",
+            snippet="Diretoria e contato institucional.",
+            engine="duckduckgo",
+        )
+    ]
+    snap = backend.metrics.snapshot()
+    assert snap["requests"] == 1
+    assert snap["status_counts"]["200"] == 1
+    assert snap["result_count_last"] == 1
+
+
+def test_429_5xx_timeout_and_circuit_are_unavailability_not_empty_success(searxng_fixture) -> None:
+    state, url = searxng_fixture
+    backend = SearxngHttpBackend(
+        url,
+        timeout_seconds=0.2,
+        breaker=CircuitBreaker(failure_threshold=2, reset_timeout_seconds=30.0),
+    )
+
+    state.mode = "429"
+    with pytest.raises(SearchBackendUnavailableError) as too_many:
+        backend.search("q-429", limit=2)
+    assert too_many.value.reason == "http_429"
+    assert too_many.value.status_code == 429
+    assert too_many.value.retry_after == "7"
+
+    state.mode = "500"
+    with pytest.raises(SearchBackendUnavailableError) as boom:
+        backend.search("q-500", limit=2)
+    assert boom.value.reason == "http_5xx"
+    assert boom.value.status_code == 500
+
+    with pytest.raises(SearchBackendUnavailableError) as opened:
+        backend.search("q-circuit", limit=2)
+    assert opened.value.reason == "circuit_open"
+    assert state.requests == 2
+    assert backend.metrics.snapshot()["circuit_opens"] == 1
+    assert backend.metrics.snapshot()["http_429"] == 1
+    assert backend.metrics.snapshot()["http_5xx"] == 1
+
+    stall = SearxngHttpBackend("http://127.0.0.1:1", timeout_seconds=0.05)
+    with pytest.raises(SearchBackendUnavailableError) as timed_out:
+        stall.search("q-timeout", limit=1)
+    assert timed_out.value.reason in {"timeout", "network"}
+
+
+def test_failures_are_not_cached_as_empty_success(searxng_fixture, tmp_path: Path) -> None:
+    state, url = searxng_fixture
+    raw = SearxngHttpBackend(url, timeout_seconds=2.0)
+    cached = CachedRateLimitedSearchBackend(
+        raw,
+        cache=JsonDiscoveryCache(tmp_path, ttl_days=7),
+        min_interval_seconds=0,
+    )
+    state.mode = "429"
+    with pytest.raises(SearchBackendUnavailableError):
+        cached.search("same-query", limit=2)
+    assert cached.cache_misses == 1
+    assert JsonDiscoveryCache(tmp_path, ttl_days=7).get("search", "searxng|2|same-query") is None
+
+    state.mode = "ok"
+    hits = cached.search("same-query", limit=2)
+    assert hits
+    assert cached.cache_misses == 2
+    replay = cached.search("same-query", limit=2)
+    assert replay == hits
+    assert cached.cache_hits == 1
+
+
+def test_explicit_failover_is_recorded_and_default_build_does_not_hide_outage(searxng_fixture) -> None:
+    state, url = searxng_fixture
+    state.mode = "429"
+
+    closed = build_search_backend("searxng", searxng_url=url, timeout_seconds=2.0, failover="off")
+    with pytest.raises(SearchBackendUnavailableError) as blocked:
+        closed.search("no-fallback", limit=1)
+    assert blocked.value.reason == "http_429"
+
+    class FakeDdgs:
+        backend_id = "ddgs"
+
+        def search(self, query: str, *, limit: int) -> list[SearchHit]:
+            return [SearchHit(url="https://fallback.example/hit", title=query, snippet="ddgs")][:limit]
+
+    wrapped = ExplicitFailoverSearchBackend(
+        SearxngHttpBackend(url, timeout_seconds=2.0),
+        FakeDdgs(),
+        policy="ddgs",
+    )
+    hits = wrapped.search("with-fallback", limit=1)
+    assert hits[0].url == "https://fallback.example/hit"
+    assert wrapped.failover_used is True
+    assert wrapped.backend_id == "searxng_explicit_failover_ddgs"
+    assert wrapped.events[0]["primary_reason"] == "http_429"
+    assert wrapped.events[0]["hidden"] is False
+
+
+def test_public_search_maps_backend_outage_to_source_blocked(searxng_fixture) -> None:
+    _state, url = searxng_fixture
+    _state.mode = "429"
+    provider = PublicSearchProvider(
+        backend=SearxngHttpBackend(url, timeout_seconds=2.0),
+        budget=__import__(
+            "scripts.decision_unit_intelligence.web_discovery", fromlist=["SearchBudget"]
+        ).SearchBudget(max_queries=2, max_results_per_query=2, max_pages=1, min_query_interval_seconds=0),
+    )
+    result = provider.collect(_context())
+    assert result.attempts[0].blocked is True
+    assert result.attempts[0].stop_reason == "SOURCE_BLOCKED"
+    assert result.attempts[0].status == "blocked"
+    assert result.attempts[0].extra["result_count"] == 0
+    assert result.attempts[0].extra["failures"]


### PR DESCRIPTION
## Summary

CONFENGE-controlled private SearXNG for extra-cli contact discovery, over an HTTP boundary only (ADR / PR #392). Official image is digest-pinned; extra-cli does not vendor or import AGPL code.

- Deploy kit: `deploy/searxng/launch.sh` (pinned `searxng/searxng@sha256:892cf8…`, Valkey limiter, JSON `/search`, loopback `127.0.0.1:18888`, 768Mi/1 CPU, rollback).
- Client: `SearxngHttpBackend` — timeout, explicit 429/5xx, circuit breaker, public-instance deny, fail-closed (never empty success). `--search-failover ddgs` is opt-in and recorded.
- Canary runner: `python3 -m scripts.ops.searxng_canary` (10 TRACK_A accounts, DDGS vs SearXNG).
- Live: Netcup `ec-prod:/opt/confenge-searxng` on the same digest; extra-cli `--search-backend searxng` via SSH tunnel returned `ACTIONABLE_ROUTE`. Does **not** claim `VPS_OPERATIONAL`.

Does **not** change query planner, person/email parsing, epistemic classification, outreach projection, or Warmbly.

## Recommendation

Primary: `--search-backend searxng` against the CONFENGE instance.
Fallback: a **new** explicit `--search-backend ddgs` run. Do not hide SearXNG downtime.

## Test plan

- [x] `pytest tests/test_searxng_http_backend.py tests/test_searxng_canary.py tests/test_searxng_deploy_kit.py --no-cov`
- [x] Dual `deploy/searxng/launch.sh` (JSON 200 + `results` array)
- [x] generated-artifacts-policy + pr-reviewability vs `origin/main`
- [x] ruff on touched Python
- [x] Netcup live probe + one extra-cli account

HEAD: `0cacf2859e9b018d0bba8f442e7bf612a51be00e`
