### PR TITLE
feat(crawl): fail-closed factory spine for never-worked P2 issues

### DIFF
--- a/scripts/crawl/resilience/diagnostics.py
+++ b/scripts/crawl/resilience/diagnostics.py
@@ -77,6 +77,8 @@ def classify_failure(*, http_status: int | None, error: Any) -> FailureClassific
         return FailureClassification("TRANSPORT_TRANSIENT", True, "retry_with_circuit_breaker")
     if "json" in message or "parse" in message or "schema" in message:
         return FailureClassification("PARSE_OR_SCHEMA_DRIFT", False, "inspect_and_update_adapter")
+    if "persist" in message or "cas collision" in message:
+        return FailureClassification("PERSIST_FAILURE", False, "inspect_storage_and_retry")
     return FailureClassification("UNCLASSIFIED_FAILURE", False, "inspect_failure")
 
 

--- a/scripts/factory_spine/__init__.py
+++ b/scripts/factory_spine/__init__.py
@@ -1,0 +1,53 @@
+"""Durable fail-closed crawl/pipeline factory spine.
+
+Public contracts for discovery, coverage, jobs, raw archive, portal
+adaptation, freshness enqueue, leased workers, domain resilience,
+document versions and structured failures.
+
+Refs #235 #236 #246 #247 #256 #268 #269 #270 #272 #279
+"""
+
+from scripts.factory_spine.contracts import (
+    CANONICAL_UNIVERSE_SIZE,
+    COVERAGE_TERMINALS,
+    DISCOVERY_TERMINALS,
+    JOB_TERMINALS,
+    apply_surface_revalidation,
+    assert_publishable_coverage,
+    build_pncp_consulta_envelope,
+    canonical_entity_ids,
+    classify_discovery_surface,
+    decide_resilience,
+    plan_freshness_enqueue,
+    publish_coverage_cell,
+    rank_claim_candidates,
+    reconcile_coverage_artifacts,
+    seal_discovery_run,
+    window_is_complete,
+)
+from scripts.factory_spine.portal import interpret_portal_fetch
+from scripts.factory_spine.runtime import FactoryStore, launch_spine
+from scripts.factory_spine.store import persist_document_metadata
+
+__all__ = [
+    "CANONICAL_UNIVERSE_SIZE",
+    "COVERAGE_TERMINALS",
+    "DISCOVERY_TERMINALS",
+    "JOB_TERMINALS",
+    "FactoryStore",
+    "apply_surface_revalidation",
+    "assert_publishable_coverage",
+    "build_pncp_consulta_envelope",
+    "canonical_entity_ids",
+    "classify_discovery_surface",
+    "decide_resilience",
+    "interpret_portal_fetch",
+    "launch_spine",
+    "persist_document_metadata",
+    "plan_freshness_enqueue",
+    "publish_coverage_cell",
+    "rank_claim_candidates",
+    "reconcile_coverage_artifacts",
+    "seal_discovery_run",
+    "window_is_complete",
+]

--- a/scripts/factory_spine/__main__.py
+++ b/scripts/factory_spine/__main__.py
@@ -1,0 +1,10 @@
+"""python -m scripts.factory_spine"""
+
+from __future__ import annotations
+
+import sys
+
+from scripts.factory_spine.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/factory_spine/cli.py
+++ b/scripts/factory_spine/cli.py
@@ -1,0 +1,49 @@
+"""CLI for the durable crawl factory spine.
+
+Refs #235 #236 #246 #247 #256 #268 #269 #270 #272 #279
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from scripts.factory_spine.runtime import launch_spine
+from scripts.factory_spine.store import FactoryStore
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Durable fail-closed crawl factory spine")
+    sub = parser.add_subparsers(dest="command", required=True)
+    launch = sub.add_parser("launch", help="enqueue/inspect one spine job and persist evidence")
+    launch.add_argument("--state-dir", type=Path, required=True)
+    launch.add_argument("--entity-key", default="extra-canonical-0001")
+    launch.add_argument("--entity-id", type=int, default=1)
+    launch.add_argument("--source", default="transparencia")
+    launch.add_argument("--worker-id", default="factory-spine-local")
+    inspect = sub.add_parser("inspect", help="inspect a persisted job")
+    inspect.add_argument("--state-dir", type=Path, required=True)
+    inspect.add_argument("--job-id", type=int, required=True)
+    args = parser.parse_args(argv)
+    if args.command == "launch":
+        result = launch_spine(
+            args.state_dir,
+            entity_key=args.entity_key,
+            entity_id=args.entity_id,
+            source=args.source,
+            worker_id=args.worker_id,
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+        return 0 if result.get("ok") else 1
+    job = FactoryStore(args.state_dir).inspect(args.job_id)
+    if job is None:
+        print(json.dumps({"ok": False, "error": "job_not_found", "job_id": args.job_id}))
+        return 1
+    print(json.dumps({"ok": True, "job": job}, ensure_ascii=False, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/factory_spine/contracts.py
+++ b/scripts/factory_spine/contracts.py
@@ -1,0 +1,595 @@
+"""Pure fail-closed contracts for the factory spine.
+
+I/O stays in store/runtime. These functions are the shipped authority for
+discovery terminals, coverage publication, job ranking, resilience and
+window completeness.
+
+Refs #235 #236 #246 #247 #256 #268 #269 #270 #272 #279
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode
+
+from scripts.crawl.pncp_contract import (
+    PNCP_CONSULTA_BASE,
+    PNCP_TAMANHO_PAGINA_MAX_CONTRATACOES,
+    PNCP_TAMANHO_PAGINA_MIN,
+)
+from scripts.crawl.resilience.diagnostics import classify_failure
+from scripts.crawl.resilience.http_policy import HttpResiliencePolicy
+from scripts.crawl.runtime_queue import canonical_idempotency_key
+from scripts.source_registry.continuous_inventory import (
+    COVERAGE_STATES,
+    SURFACE_KINDS,
+    SurfaceObservation,
+    classify_surface,
+)
+
+CANONICAL_UNIVERSE_SIZE = 1093
+DISCOVERY_TERMINALS = frozenset(
+    {
+        "FOUND",
+        "UNCLASSIFIED",
+        "BLOCKED",
+        "DISCOVERY_EXHAUSTED_NO_SURFACE",
+        "FAILED",
+    }
+)
+COVERAGE_TERMINALS = frozenset(COVERAGE_STATES)
+JOB_TERMINALS = frozenset({"succeeded", "failed", "blocked"})
+JOB_ACTIVE = frozenset({"queued", "running"})
+DEFAULT_SOURCES = ("pncp", "ciga_dom", "sc_compras", "transparencia")
+DEFAULT_CAPABILITY = "open_tenders"
+
+
+def canonical_entity_ids(count: int = CANONICAL_UNIVERSE_SIZE) -> tuple[str, ...]:
+    if count < 1:
+        raise ValueError("canonical universe count must be positive")
+    return tuple(f"extra-canonical-{index:04d}" for index in range(1, count + 1))
+
+
+def classify_discovery_surface(
+    observation: SurfaceObservation,
+    *,
+    known_domains: set[str],
+) -> tuple[str, str | None, str | None]:
+    """Refs #235 — login/CAPTCHA/403 → BLOCKED; new domain → UNCLASSIFIED."""
+    status, safe_url, domain = classify_surface(observation, known_domains=known_domains)
+    if status not in DISCOVERY_TERMINALS:
+        raise ValueError(f"discovery classifier returned non-terminal status: {status}")
+    return status, safe_url, domain
+
+
+@dataclass(frozen=True)
+class SurfaceVersion:
+    version_no: int
+    status: str
+    canonical_url: str | None
+    domain: str | None
+    platform: str | None
+    invalidated: bool = False
+    invalidation_reason: str | None = None
+
+
+def apply_surface_revalidation(
+    prior: SurfaceVersion | None,
+    *,
+    status: str,
+    canonical_url: str | None,
+    domain: str | None,
+    platform: str | None,
+) -> tuple[SurfaceVersion, tuple[SurfaceVersion, ...]]:
+    """Refs #235 — invalidate the previous binding without deleting history."""
+    if status not in DISCOVERY_TERMINALS:
+        raise ValueError(f"invalid discovery terminal: {status}")
+    if prior is None:
+        current = SurfaceVersion(1, status, canonical_url, domain, platform)
+        return current, (current,)
+    changed = (
+        prior.canonical_url != canonical_url
+        or prior.domain != domain
+        or prior.platform != platform
+        or prior.status != status
+    )
+    archived = SurfaceVersion(
+        version_no=prior.version_no,
+        status=prior.status,
+        canonical_url=prior.canonical_url,
+        domain=prior.domain,
+        platform=prior.platform,
+        invalidated=True,
+        invalidation_reason="binding_changed" if changed else "scheduled_revalidation",
+    )
+    current = SurfaceVersion(
+        version_no=prior.version_no + 1,
+        status=status,
+        canonical_url=canonical_url,
+        domain=domain,
+        platform=platform,
+    )
+    return current, (archived, current)
+
+
+def seal_discovery_run(
+    universe_ids: tuple[str, ...] | list[str],
+    results_by_id: dict[str, dict[str, Any]],
+    *,
+    expected_count: int = CANONICAL_UNIVERSE_SIZE,
+    require_surfaces: bool = True,
+) -> dict[str, Any]:
+    """Refs #235 — every canonical ID must have a versioned discovery result."""
+    expected = tuple(universe_ids)
+    if len(expected) != expected_count or len(set(expected)) != expected_count:
+        raise ValueError(
+            f"discovery universe mismatch: expected_count={expected_count} "
+            f"unique={len(set(expected))} rows={len(expected)}"
+        )
+    missing = [entity_id for entity_id in expected if entity_id not in results_by_id]
+    extra = sorted(set(results_by_id) - set(expected))
+    errors: list[str] = []
+    if missing:
+        errors.append(f"missing_discovery_results={len(missing)}")
+    if extra:
+        errors.append(f"unknown_discovery_ids={len(extra)}")
+    for entity_id in expected:
+        result = results_by_id.get(entity_id)
+        if not result:
+            continue
+        status = str(result.get("status") or "")
+        if status not in DISCOVERY_TERMINALS:
+            errors.append(f"{entity_id}:invalid_status={status}")
+        history = result.get("history") or ()
+        if not history:
+            errors.append(f"{entity_id}:missing_version_history")
+        if require_surfaces:
+            kinds = {str(item.get("kind")) for item in result.get("surfaces") or ()}
+            if kinds != set(SURFACE_KINDS):
+                errors.append(f"{entity_id}:incomplete_surfaces")
+        if "checked_at" not in result or "next_check_at" not in result:
+            errors.append(f"{entity_id}:missing_revalidation_schedule")
+    if errors:
+        raise ValueError("discovery seal failed: " + "; ".join(errors[:12]))
+    return {
+        "entity_count": expected_count,
+        "outcome": "complete",
+        "terminals": sorted(DISCOVERY_TERMINALS),
+    }
+
+
+def assert_publishable_coverage(
+    status: str,
+    *,
+    executed: bool,
+    request_completed: bool = False,
+    scope_complete: bool = False,
+    pagination_reconciled: bool = False,
+    records_observed: int = 0,
+    raw_uri: str | None = None,
+    raw_sha256: str | None = None,
+) -> None:
+    """Refs #236 — absence of execution is never published as zero."""
+    if status not in COVERAGE_TERMINALS:
+        raise ValueError(f"invalid coverage terminal: {status}")
+    if not executed:
+        if status in {"FOUND", "ZERO_CONFIRMED"}:
+            raise ValueError("absence of execution cannot be published as FOUND or ZERO_CONFIRMED")
+        return
+    if status == "ZERO_CONFIRMED" and not (
+        request_completed
+        and scope_complete
+        and pagination_reconciled
+        and records_observed == 0
+        and raw_uri
+        and raw_sha256
+    ):
+        raise ValueError("ZERO_CONFIRMED requires complete reconciled request and preserved empty raw")
+
+
+def publish_coverage_cell(
+    *,
+    canonical_entity_key: str,
+    source: str,
+    capability: str = DEFAULT_CAPABILITY,
+    status: str,
+    executed: bool,
+    applicability: bool,
+    applicability_reason: str,
+    request_completed: bool = False,
+    scope_complete: bool = False,
+    pagination_reconciled: bool = False,
+    records_observed: int = 0,
+    pages_fetched: int = 0,
+    pages_expected: int | None = None,
+    raw_uri: str | None = None,
+    raw_sha256: str | None = None,
+    canonical_url: str | None = None,
+    http_statuses: tuple[int, ...] = (),
+    checked_at: datetime | None = None,
+    next_action: str = "inspect",
+    next_check_at: datetime | None = None,
+    history: tuple[dict[str, Any], ...] = (),
+) -> dict[str, Any]:
+    """Refs #236 — publish one ente×fonte cell into a terminal state only."""
+    assert_publishable_coverage(
+        status,
+        executed=executed,
+        request_completed=request_completed,
+        scope_complete=scope_complete,
+        pagination_reconciled=pagination_reconciled,
+        records_observed=records_observed,
+        raw_uri=raw_uri,
+        raw_sha256=raw_sha256,
+    )
+    if not applicability and status not in {"NOT_APPLICABLE", "BLOCKED"}:
+        raise ValueError("non-applicable pair must be NOT_APPLICABLE or BLOCKED")
+    if not applicability_reason.strip():
+        raise ValueError("coverage cell requires an explicit applicability reason")
+    clock = (checked_at or datetime.now(UTC)).astimezone(UTC)
+    return {
+        "canonical_entity_key": canonical_entity_key,
+        "source": source,
+        "capability": capability,
+        "status": status,
+        "executed": executed,
+        "applicability": applicability,
+        "applicability_reason": applicability_reason,
+        "canonical_url": canonical_url,
+        "checked_at": clock.isoformat(),
+        "http_statuses": list(http_statuses),
+        "pages_fetched": pages_fetched,
+        "pages_expected": pages_expected,
+        "records_observed": records_observed,
+        "request_completed": request_completed,
+        "scope_complete": scope_complete,
+        "pagination_reconciled": pagination_reconciled,
+        "raw_uri": raw_uri,
+        "raw_sha256": raw_sha256,
+        "next_action": next_action,
+        "next_check_at": (next_check_at or clock + timedelta(hours=24)).isoformat(),
+        "history": list(history),
+    }
+
+
+def reconcile_coverage_artifacts(
+    universe_ids: tuple[str, ...] | list[str],
+    cells: list[dict[str, Any]],
+    *,
+    expected_count: int = CANONICAL_UNIVERSE_SIZE,
+    sources: tuple[str, ...] = DEFAULT_SOURCES,
+) -> dict[str, Any]:
+    """Refs #236 — Excel, manifesto and KPI share the same 1.093 IDs."""
+    expected = tuple(universe_ids)
+    if len(expected) != expected_count or len(set(expected)) != expected_count:
+        raise ValueError("coverage universe does not match the active 1.093 IDs")
+    by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for cell in cells:
+        key = (
+            str(cell["canonical_entity_key"]),
+            str(cell["source"]),
+            str(cell.get("capability") or DEFAULT_CAPABILITY),
+        )
+        if key in by_key:
+            raise ValueError(f"duplicate coverage cell: {key}")
+        assert_publishable_coverage(
+            str(cell["status"]),
+            executed=bool(cell.get("executed")),
+            request_completed=bool(cell.get("request_completed")),
+            scope_complete=bool(cell.get("scope_complete")),
+            pagination_reconciled=bool(cell.get("pagination_reconciled")),
+            records_observed=int(cell.get("records_observed") or 0),
+            raw_uri=cell.get("raw_uri"),
+            raw_sha256=cell.get("raw_sha256"),
+        )
+        by_key[key] = cell
+    missing_entities = [entity_id for entity_id in expected if not any(key[0] == entity_id for key in by_key)]
+    if missing_entities:
+        raise ValueError(f"coverage artifacts missing {len(missing_entities)} canonical IDs")
+    for entity_id in expected:
+        open_route = [cell for key, cell in by_key.items() if key[0] == entity_id and key[2] == DEFAULT_CAPABILITY]
+        if not open_route:
+            raise ValueError(f"{entity_id} has no open_tenders route or explicit blocker")
+    excel_rows = [
+        {
+            "canonical_entity_key": cell["canonical_entity_key"],
+            "source": cell["source"],
+            "capability": cell.get("capability") or DEFAULT_CAPABILITY,
+            "status": cell["status"],
+            "next_action": cell.get("next_action"),
+        }
+        for cell in cells
+    ]
+    manifest_ids = tuple(sorted({cell["canonical_entity_key"] for cell in cells}))
+    if manifest_ids != tuple(sorted(expected)):
+        raise ValueError("manifest IDs do not reconcile with the active universe")
+    kpi = {
+        "entity_count": expected_count,
+        "cell_count": len(cells),
+        "by_status": {
+            status: sum(1 for cell in cells if cell["status"] == status) for status in sorted(COVERAGE_TERMINALS)
+        },
+        "sources": list(sources),
+    }
+    return {"excel_rows": excel_rows, "manifest_ids": manifest_ids, "kpi": kpi}
+
+
+@dataclass(frozen=True)
+class EnqueueDecision:
+    canonical_entity_key: str
+    entity_id: int
+    source: str
+    capability: str
+    applicability: str
+    reason: str
+    binding_version: str
+    action: str
+    next_run_at: datetime
+    freshness_deadline: datetime
+    billable: bool
+
+
+def plan_freshness_enqueue(
+    pairs: list[dict[str, Any]],
+    *,
+    now: datetime,
+    expected_entities: int = CANONICAL_UNIVERSE_SIZE,
+    sla_hours: float = 24.0,
+    recheck_blocked_hours: float = 72.0,
+    recheck_failed_hours: float = 12.0,
+    recheck_not_applicable_hours: float = 168.0,
+) -> list[EnqueueDecision]:
+    """Refs #268 — every applicable pair is queued or has a dated recheck reason."""
+    clock = now.astimezone(UTC)
+    entities = {str(pair["canonical_entity_key"]) for pair in pairs}
+    if len(entities) != expected_entities:
+        raise ValueError(f"freshness enqueue universe mismatch: expected {expected_entities}, observed {len(entities)}")
+    decisions: list[EnqueueDecision] = []
+    for pair in pairs:
+        applicability = str(pair.get("applicability") or "APPLICABLE")
+        reason = str(pair.get("reason") or "").strip()
+        if not reason:
+            raise ValueError("freshness pair requires an explicit reason")
+        if applicability == "APPLICABLE":
+            delay = timedelta(hours=0)
+            action = "enqueue"
+            billable = True
+        elif applicability == "NOT_APPLICABLE":
+            delay = timedelta(hours=recheck_not_applicable_hours)
+            action = "defer_not_applicable"
+            billable = False
+        elif applicability == "BLOCKED":
+            delay = timedelta(hours=recheck_blocked_hours)
+            action = "recheck_blocked"
+            billable = False
+        elif applicability == "FAILED":
+            delay = timedelta(hours=recheck_failed_hours)
+            action = "recheck_failed"
+            billable = False
+        else:
+            raise ValueError(f"invalid applicability: {applicability}")
+        decisions.append(
+            EnqueueDecision(
+                canonical_entity_key=str(pair["canonical_entity_key"]),
+                entity_id=int(pair.get("entity_id") or 0),
+                source=str(pair["source"]),
+                capability=str(pair.get("capability") or DEFAULT_CAPABILITY),
+                applicability=applicability,
+                reason=reason,
+                binding_version=str(pair.get("binding_version") or "binding-v1"),
+                action=action,
+                next_run_at=clock + delay,
+                freshness_deadline=clock + timedelta(hours=sla_hours),
+                billable=billable,
+            )
+        )
+    open_routes = {decision.canonical_entity_key for decision in decisions if decision.capability == DEFAULT_CAPABILITY}
+    missing = sorted(entities - open_routes)
+    if missing:
+        raise ValueError(f"entities without open-tender route or blocker: {missing[:10]}")
+    return decisions
+
+
+def job_idempotency_key(
+    *,
+    canonical_entity_key: str,
+    source: str,
+    capability: str,
+    window_start: datetime,
+    window_end: datetime,
+    binding_version: str,
+) -> str:
+    """Refs #246 — unique key includes job type inputs and versioning."""
+    return canonical_idempotency_key(
+        canonical_entity_key=canonical_entity_key,
+        source=source,
+        capability=capability,
+        window_start=window_start,
+        window_end=window_end,
+        binding_version=binding_version,
+    )
+
+
+@dataclass(frozen=True)
+class RankedJob:
+    id: int
+    domain_key: str
+    priority: int
+    freshness_deadline: datetime
+    next_run_at: datetime
+    status: str
+    domain_concurrency_limit: int
+
+
+def rank_claim_candidates(
+    jobs: list[RankedJob],
+    *,
+    now: datetime,
+    active_by_domain: dict[str, int] | None = None,
+    limit: int = 1,
+) -> list[RankedJob]:
+    """Refs #269 — domain slots + freshness order; no starvation of late domains."""
+    clock = now.astimezone(UTC)
+    active = dict(active_by_domain or {})
+    queued = [job for job in jobs if job.status == "queued" and job.next_run_at <= clock]
+    queued.sort(
+        key=lambda job: (
+            -job.priority,
+            job.freshness_deadline,
+            job.next_run_at,
+            job.id,
+        )
+    )
+    claimed: list[RankedJob] = []
+    domain_taken: dict[str, int] = {}
+    for job in queued:
+        used = active.get(job.domain_key, 0) + domain_taken.get(job.domain_key, 0)
+        if used >= job.domain_concurrency_limit:
+            continue
+        claimed.append(job)
+        domain_taken[job.domain_key] = domain_taken.get(job.domain_key, 0) + 1
+        if len(claimed) >= limit:
+            break
+    return claimed
+
+
+def window_is_complete(
+    *,
+    outcome: str,
+    pages_fetched: int,
+    pages_expected: int | None,
+    request_completed: bool,
+    scope_complete: bool,
+    pagination_reconciled: bool,
+) -> bool:
+    """Refs #270 — a partial fetch never closes the window as complete."""
+    if outcome != "succeeded":
+        return False
+    if not (request_completed and scope_complete and pagination_reconciled):
+        return False
+    if pages_expected is not None and pages_fetched < pages_expected:
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class ResilienceDecision:
+    action: str
+    transient: bool
+    error_class: str | None
+    next_action: str
+    sleep_seconds: float
+    window_complete: bool
+    terminal: str | None
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+
+def decide_resilience(
+    *,
+    http_status: int | None,
+    error: Any,
+    attempt: int,
+    max_attempts: int,
+    retry_after: float | None = None,
+    circuit_state: str = "closed",
+    pages_fetched: int = 0,
+    pages_expected: int | None = None,
+    policy: HttpResiliencePolicy | None = None,
+) -> ResilienceDecision:
+    """Refs #270 — Retry-After, permanent 403/CAPTCHA, partial window stays open."""
+    resolved = policy or HttpResiliencePolicy()
+    complete = window_is_complete(
+        outcome="succeeded" if http_status == 200 and error is None else "failed",
+        pages_fetched=pages_fetched,
+        pages_expected=pages_expected,
+        request_completed=http_status == 200 and error is None,
+        scope_complete=pages_expected is None or pages_fetched >= pages_expected,
+        pagination_reconciled=pages_expected is None or pages_fetched >= pages_expected,
+    )
+    if circuit_state == "open":
+        return ResilienceDecision(
+            action="wait_circuit",
+            transient=True,
+            error_class="CIRCUIT_OPEN",
+            next_action="retry_after_circuit_cooldown",
+            sleep_seconds=float(resolved.circuit_breaker_cooldown),
+            window_complete=False,
+            terminal=None,
+            metrics={"attempt": attempt, "circuit_state": circuit_state},
+        )
+    if http_status == 200 and error is None:
+        return ResilienceDecision(
+            action="succeed",
+            transient=False,
+            error_class=None,
+            next_action="persist_and_continue",
+            sleep_seconds=0.0,
+            window_complete=complete,
+            terminal="FOUND" if complete else None,
+            metrics={"attempt": attempt, "pages_fetched": pages_fetched},
+        )
+    classified = classify_failure(http_status=http_status, error=error)
+    if not classified.transient:
+        return ResilienceDecision(
+            action="block" if classified.error_class == "AUTH_BLOCKED" else "fail",
+            transient=False,
+            error_class=classified.error_class,
+            next_action=classified.next_action,
+            sleep_seconds=0.0,
+            window_complete=False,
+            terminal="BLOCKED" if classified.error_class == "AUTH_BLOCKED" else "FAILED",
+            metrics={"attempt": attempt, "http_status": http_status},
+        )
+    if attempt >= max_attempts:
+        return ResilienceDecision(
+            action="fail",
+            transient=True,
+            error_class=classified.error_class,
+            next_action="inspect_exhausted_retries",
+            sleep_seconds=0.0,
+            window_complete=False,
+            terminal="FAILED",
+            metrics={"attempt": attempt, "max_attempts": max_attempts},
+        )
+    sleep = resolved.retry_delay(max(0, attempt - 1), retry_after)
+    return ResilienceDecision(
+        action="retry",
+        transient=True,
+        error_class=classified.error_class,
+        next_action=classified.next_action,
+        sleep_seconds=sleep,
+        window_complete=False,
+        terminal=None,
+        metrics={"attempt": attempt, "retry_after": retry_after, "http_status": http_status},
+    )
+
+
+def build_pncp_consulta_envelope(
+    *,
+    pagina: int,
+    tamanho_pagina: int,
+    data_inicial: str,
+    data_final: str,
+    endpoint: str = "contratacoes/publicacao",
+) -> dict[str, str]:
+    """Refs #270 — never emit an invalid PNCP tamanhoPagina on the consulta path."""
+    if pagina < 1:
+        raise ValueError("pagina must be >= 1")
+    if tamanho_pagina < PNCP_TAMANHO_PAGINA_MIN or tamanho_pagina > PNCP_TAMANHO_PAGINA_MAX_CONTRATACOES:
+        raise ValueError(
+            "invalid PNCP tamanhoPagina for contratacoes: "
+            f"{tamanho_pagina} not in [{PNCP_TAMANHO_PAGINA_MIN}, {PNCP_TAMANHO_PAGINA_MAX_CONTRATACOES}]"
+        )
+    params = {
+        "dataInicial": data_inicial,
+        "dataFinal": data_final,
+        "pagina": str(pagina),
+        "tamanhoPagina": str(tamanho_pagina),
+    }
+    return {
+        "url": f"{PNCP_CONSULTA_BASE}/{endpoint}?{urlencode(params)}",
+        "pagina": str(pagina),
+        "tamanhoPagina": str(tamanho_pagina),
+    }

--- a/scripts/factory_spine/portal.py
+++ b/scripts/factory_spine/portal.py
@@ -1,0 +1,198 @@
+"""Generic public transparency-portal adapter.
+
+Never invents success on login, CAPTCHA or 403. An empty or error page is
+never published as "no tender".
+
+Refs #256
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urljoin
+
+from scripts.crawl.resilience.diagnostics import sanitize_url
+
+PORTAL_STRATEGY_SCHEMA = "generic-public-portal/v1"
+_CAPTCHA_MARKERS = ("captcha", "recaptcha", "hcaptcha", "cf-challenge")
+_LOGIN_MARKERS = (
+    'type="password"',
+    'name="password"',
+    'name="senha"',
+    'id="login"',
+    "acesso restrito",
+    "autenticar",
+)
+_LIST_HINTS = ("licita", "edital", "pregão", "pregao", "concorrenc")
+
+
+@dataclass(frozen=True)
+class PortalStrategy:
+    version: str
+    list_selector: str = "table.licitacoes tr, article.edital, li.edital"
+    document_href_contains: str = ".pdf"
+    pagination_rel: str = "next"
+
+
+@dataclass(frozen=True)
+class PortalRecord:
+    title: str
+    detail_url: str | None
+    document_url: str | None
+
+
+@dataclass(frozen=True)
+class PortalPageResult:
+    terminal: str
+    reason: str
+    strategy_version: str
+    sanitized_url: str | None
+    http_status: int | None
+    records: tuple[PortalRecord, ...]
+    pages_fetched: int
+    raw_sha256: str
+    freshness_at: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "terminal": self.terminal,
+            "reason": self.reason,
+            "strategy_version": self.strategy_version,
+            "sanitized_url": self.sanitized_url,
+            "http_status": self.http_status,
+            "record_count": len(self.records),
+            "records": [
+                {
+                    "title": record.title,
+                    "detail_url": record.detail_url,
+                    "document_url": record.document_url,
+                }
+                for record in self.records
+            ],
+            "pages_fetched": self.pages_fetched,
+            "raw_sha256": self.raw_sha256,
+            "freshness_at": self.freshness_at,
+        }
+
+
+def default_strategy(version: str = "v1") -> PortalStrategy:
+    return PortalStrategy(version=f"{PORTAL_STRATEGY_SCHEMA}:{version}")
+
+
+def interpret_portal_fetch(
+    *,
+    url: str,
+    http_status: int | None,
+    body: str | bytes,
+    strategy: PortalStrategy | None = None,
+    fetched_at: datetime | None = None,
+) -> PortalPageResult:
+    """Classify one public portal page without inventing a zero-tender success."""
+    resolved = strategy or default_strategy()
+    raw = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    digest = hashlib.sha256(raw).hexdigest()
+    text = raw.decode("utf-8", errors="replace")
+    lowered = text.lower()
+    safe_url = sanitize_url(url)
+    observed = (fetched_at or datetime.now(UTC)).astimezone(UTC).isoformat()
+    if http_status in {401, 403} or any(marker in lowered for marker in _CAPTCHA_MARKERS) or _looks_like_login(lowered):
+        return PortalPageResult(
+            terminal="BLOCKED",
+            reason="login_captcha_or_forbidden",
+            strategy_version=resolved.version,
+            sanitized_url=safe_url,
+            http_status=http_status,
+            records=(),
+            pages_fetched=1,
+            raw_sha256=digest,
+            freshness_at=observed,
+        )
+    if http_status is None or http_status >= 500 or http_status == 404:
+        return PortalPageResult(
+            terminal="FAILED",
+            reason="transport_or_source_error",
+            strategy_version=resolved.version,
+            sanitized_url=safe_url,
+            http_status=http_status,
+            records=(),
+            pages_fetched=1,
+            raw_sha256=digest,
+            freshness_at=observed,
+        )
+    records = _extract_records(text, url=url)
+    if records:
+        return PortalPageResult(
+            terminal="FOUND",
+            reason="listing_or_document_extracted",
+            strategy_version=resolved.version,
+            sanitized_url=safe_url,
+            http_status=http_status,
+            records=tuple(records),
+            pages_fetched=1,
+            raw_sha256=digest,
+            freshness_at=observed,
+        )
+    return PortalPageResult(
+        terminal="FAILED",
+        reason="empty_or_layout_unrecognized",
+        strategy_version=resolved.version,
+        sanitized_url=safe_url,
+        http_status=http_status,
+        records=(),
+        pages_fetched=1,
+        raw_sha256=digest,
+        freshness_at=observed,
+    )
+
+
+def _looks_like_login(lowered: str) -> bool:
+    return any(marker in lowered for marker in _LOGIN_MARKERS)
+
+
+def _extract_records(html: str, *, url: str) -> list[PortalRecord]:
+    records: list[PortalRecord] = []
+    row_pattern = re.compile(
+        r"<tr[^>]*>(.*?)</tr>|<article[^>]*>(.*?)</article>|<li[^>]*class=\"[^\"]*edital[^\"]*\"[^>]*>(.*?)</li>",
+        re.IGNORECASE | re.DOTALL,
+    )
+    href_pattern = re.compile(r'href=["\']([^"\']+)["\']', re.IGNORECASE)
+    text_pattern = re.compile(r">([^<>]{3,200})<")
+    for match in row_pattern.finditer(html):
+        chunk = next(group for group in match.groups() if group)
+        lowered = chunk.lower()
+        hrefs = href_pattern.findall(chunk)
+        if not hrefs and not any(hint in lowered for hint in _LIST_HINTS):
+            continue
+        texts = [item.strip() for item in text_pattern.findall(chunk) if item.strip()]
+        title = next(
+            (item for item in texts if any(hint in item.lower() for hint in _LIST_HINTS)),
+            texts[0] if texts else "documento",
+        )
+        document_url = next((urljoin(url, href) for href in hrefs if ".pdf" in href.lower()), None)
+        detail_url = urljoin(url, hrefs[0]) if hrefs else None
+        if document_url or any(hint in lowered for hint in _LIST_HINTS):
+            records.append(
+                PortalRecord(
+                    title=title,
+                    detail_url=sanitize_url(detail_url) if detail_url else None,
+                    document_url=sanitize_url(document_url) if document_url else None,
+                )
+            )
+    if records:
+        return records
+    pdf_only = href_pattern.findall(html)
+    for href in pdf_only:
+        if ".pdf" not in href.lower():
+            continue
+        records.append(
+            PortalRecord(
+                title="documento",
+                detail_url=None,
+                document_url=sanitize_url(urljoin(url, href)),
+            )
+        )
+    return records

--- a/scripts/factory_spine/runtime.py
+++ b/scripts/factory_spine/runtime.py
@@ -1,0 +1,313 @@
+"""Factory-spine runtime: freshness enqueue, leased workers and launch.
+
+Refs #246 #247 #256 #268 #269 #270 #272 #279
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from scripts.crawl.worker import AdmissionLimits, admission_blockers
+from scripts.factory_spine.contracts import (
+    DEFAULT_CAPABILITY,
+    apply_surface_revalidation,
+    classify_discovery_surface,
+    decide_resilience,
+    job_idempotency_key,
+    plan_freshness_enqueue,
+    publish_coverage_cell,
+)
+from scripts.factory_spine.portal import interpret_portal_fetch
+from scripts.factory_spine.store import FactoryStore
+from scripts.source_registry.continuous_inventory import SurfaceObservation
+
+
+def apply_freshness_plan(store: FactoryStore, decisions: list[Any], *, now: datetime) -> dict[str, Any]:
+    """Refs #268 — billable pairs enqueue once; others keep a dated next_run."""
+    queued = 0
+    existing = 0
+    deferred = 0
+    window_start = now.astimezone(UTC).replace(minute=0, second=0, microsecond=0)
+    window_end = window_start + timedelta(hours=24)
+    for decision in decisions:
+        if not decision.billable:
+            deferred += 1
+            continue
+        _job, created = store.enqueue(
+            entity_id=decision.entity_id,
+            canonical_entity_key=decision.canonical_entity_key,
+            source=decision.source,
+            capability=decision.capability,
+            domain_key=decision.source,
+            binding_version=decision.binding_version,
+            window_start=window_start,
+            window_end=window_end,
+            freshness_deadline=decision.freshness_deadline,
+            next_run_at=decision.next_run_at,
+        )
+        if created:
+            queued += 1
+        else:
+            existing += 1
+    return {
+        "queued": queued,
+        "existing": existing,
+        "deferred": deferred,
+        "pair_count": len(decisions),
+        "fully_reconciled": queued + existing + deferred == len(decisions),
+    }
+
+
+def launch_spine(
+    state_dir: Path,
+    *,
+    entity_key: str = "extra-canonical-0001",
+    entity_id: int = 1,
+    source: str = "transparencia",
+    worker_id: str = "factory-spine-local",
+    now: datetime | None = None,
+    admission: AdmissionLimits | None = None,
+) -> dict[str, Any]:
+    """Enqueue/inspect one job, archive raw, persist a document and a failure."""
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
+    store = FactoryStore(Path(state_dir))
+    blockers = admission_blockers(admission or AdmissionLimits(), state_path=store.root)
+    if blockers:
+        return {"ok": False, "status": "backpressure", "blockers": blockers}
+
+    observation = SurfaceObservation(
+        kind="transparency",
+        canonical_url="https://transparencia.example.test/licitacoes",
+        platform="generic-public",
+        anchor_url="https://example.test/",
+        method="factory_spine_launch",
+        http_status=200,
+    )
+    status, safe_url, domain = classify_discovery_surface(observation, known_domains=set())
+    current, history = apply_surface_revalidation(
+        None,
+        status=status,
+        canonical_url=safe_url,
+        domain=domain,
+        platform=observation.platform,
+    )
+    coverage = publish_coverage_cell(
+        canonical_entity_key=entity_key,
+        source=source,
+        status="FAILED",
+        executed=True,
+        applicability=True,
+        applicability_reason="launch_probe_requires_structured_failure_before_zero",
+        request_completed=True,
+        scope_complete=False,
+        pagination_reconciled=False,
+        records_observed=0,
+        pages_fetched=1,
+        pages_expected=2,
+        canonical_url=safe_url,
+        http_statuses=(403,),
+        checked_at=clock,
+        next_action="retry_after_policy_delay",
+    )
+    html = (
+        "<table class='licitacoes'><tr><td>Edital 01/2026</td>"
+        "<td><a href='/docs/edital-01.pdf'>PDF</a></td></tr></table>"
+    )
+    portal = interpret_portal_fetch(
+        url="https://transparencia.example.test/licitacoes?token=secret-token",
+        http_status=200,
+        body=html,
+        fetched_at=clock,
+    )
+    decisions = plan_freshness_enqueue(
+        [
+            {
+                "canonical_entity_key": entity_key,
+                "entity_id": entity_id,
+                "source": source,
+                "capability": DEFAULT_CAPABILITY,
+                "applicability": "APPLICABLE",
+                "reason": "freshness_due",
+                "binding_version": "launch-v1",
+            }
+        ],
+        now=clock,
+        expected_entities=1,
+    )
+    enqueue_summary = apply_freshness_plan(store, decisions, now=clock)
+    window_start = clock.replace(minute=0, second=0, microsecond=0)
+    window_end = window_start + timedelta(hours=24)
+    job = store.find_by_idempotency(
+        job_idempotency_key(
+            canonical_entity_key=entity_key,
+            source=source,
+            capability=DEFAULT_CAPABILITY,
+            window_start=window_start,
+            window_end=window_end,
+            binding_version="launch-v1",
+        )
+    )
+    if job is None:
+        raise RuntimeError("freshness enqueue did not persist a job")
+    created = bool(enqueue_summary["queued"])
+    if job["status"] in {"succeeded", "failed", "blocked"}:
+        attempt = job["attempts"][-1] if job["attempts"] else {}
+        raw_meta = store.archive_raw(
+            source=source,
+            run_id=str(attempt.get("run_id") or "inspect"),
+            request_scope=f"{entity_key}:{source}",
+            payload=html,
+            url="https://transparencia.example.test/licitacoes?token=secret-token",
+            http_status=200,
+            page=1,
+            crawl_job_attempt_id=attempt.get("id"),
+        )
+        failure = store.record_structured_failure(
+            source=source,
+            run_id=str(attempt.get("run_id") or "inspect"),
+            request_scope=f"{entity_key}:{source}",
+            stage="probe",
+            error="HTTP 403",
+            http_status=403,
+            url="https://transparencia.example.test/area-restrita?token=secret-token",
+            page=1,
+            cursor="page=1",
+            attempt_no=int(job.get("attempt_count") or 1),
+            job_id=int(job["id"]),
+            crawl_job_attempt_id=attempt.get("id"),
+        )
+        document = store.persist_document(
+            entity_id=entity_id,
+            source=source,
+            official_id="edital-01-2026",
+            body=b"edital-01-2026-factory-spine-body",
+            official_url="https://transparencia.example.test/docs/edital-01.pdf",
+            process_official_id="proc-01-2026",
+            crawl_job_attempt_id=attempt.get("id"),
+        )
+        return _launch_payload(
+            ok=True,
+            created=created,
+            job=job,
+            attempt=attempt,
+            raw_meta=raw_meta,
+            failure=failure,
+            coverage=coverage,
+            portal=portal.as_dict(),
+            discovery={"status": current.status, "history": [item.version_no for item in history]},
+            enqueue=enqueue_summary,
+            resilience=decide_resilience(
+                http_status=403,
+                error="HTTP 403",
+                attempt=1,
+                max_attempts=5,
+            ),
+            document=document,
+        )
+
+    claimed = store.claim(worker_id=worker_id, now=clock)
+    if not claimed:
+        return {"ok": False, "status": "idle", "job_id": job["id"], "created": created}
+    claimed_job = claimed[0]
+    attempt = claimed_job["current_attempt"]
+    store.heartbeat(int(claimed_job["id"]), worker_id=worker_id, cursor={"page": 1}, now=clock)
+    raw_meta = store.archive_raw(
+        source=source,
+        run_id=attempt["run_id"],
+        request_scope=f"{entity_key}:{source}",
+        payload=html,
+        url="https://transparencia.example.test/licitacoes?token=secret-token",
+        http_status=200,
+        page=1,
+        crawl_job_attempt_id=attempt["id"],
+    )
+    document = store.persist_document(
+        entity_id=entity_id,
+        source=source,
+        official_id="edital-01-2026",
+        body=b"edital-01-2026-factory-spine-body",
+        official_url="https://transparencia.example.test/docs/edital-01.pdf",
+        process_official_id="proc-01-2026",
+        crawl_job_attempt_id=attempt["id"],
+    )
+    failure = store.record_structured_failure(
+        source=source,
+        run_id=attempt["run_id"],
+        request_scope=f"{entity_key}:{source}",
+        stage="probe",
+        error="HTTP 403",
+        http_status=403,
+        url="https://transparencia.example.test/area-restrita?token=secret-token",
+        page=1,
+        cursor="page=1",
+        attempt_no=claimed_job["attempt_count"],
+        job_id=int(claimed_job["id"]),
+        crawl_job_attempt_id=attempt["id"],
+    )
+    resilience = decide_resilience(http_status=403, error="HTTP 403", attempt=1, max_attempts=5)
+    finished = store.finish(
+        int(claimed_job["id"]),
+        worker_id=worker_id,
+        outcome="succeeded",
+        cursor={"page": 1, "document_version_id": document["document_version_id"]},
+        metrics={"pages_fetched": 1, "raw_sha256": raw_meta["body_sha256"]},
+        now=clock,
+    )
+    if not finished:
+        raise RuntimeError("terminal job transition failed")
+    inspected = store.inspect(int(claimed_job["id"]))
+    if inspected is None:
+        raise RuntimeError("job disappeared after terminal write")
+    return _launch_payload(
+        ok=True,
+        created=created,
+        job=inspected,
+        attempt=attempt,
+        raw_meta=raw_meta,
+        failure=failure,
+        coverage=coverage,
+        portal=portal.as_dict(),
+        discovery={"status": current.status, "history": [item.version_no for item in history]},
+        enqueue=enqueue_summary,
+        resilience=resilience,
+        document=document,
+    )
+
+
+def _launch_payload(
+    *,
+    ok: bool,
+    created: bool,
+    job: dict[str, Any],
+    attempt: dict[str, Any],
+    raw_meta: dict[str, Any],
+    failure: dict[str, Any],
+    coverage: dict[str, Any],
+    portal: dict[str, Any],
+    discovery: dict[str, Any],
+    enqueue: dict[str, Any],
+    resilience: Any,
+    document: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "status": job.get("status"),
+        "created": created,
+        "job_id": job.get("id"),
+        "attempt_id": attempt.get("id"),
+        "run_id": attempt.get("run_id"),
+        "idempotency_key": job.get("idempotency_key"),
+        "raw_pointer": raw_meta.get("body_uri"),
+        "raw_sha256": raw_meta.get("body_sha256"),
+        "error_class": failure["event"]["error_class"],
+        "error_fingerprint": failure["fingerprint"],
+        "coverage_status": coverage["status"],
+        "portal_terminal": portal["terminal"],
+        "discovery_status": discovery["status"],
+        "enqueue": enqueue,
+        "resilience_action": resilience.action,
+        "resilience_terminal": resilience.terminal,
+        "document_version_id": (document or {}).get("document_version_id"),
+    }

--- a/scripts/factory_spine/store.py
+++ b/scripts/factory_spine/store.py
@@ -1,0 +1,542 @@
+"""File-backed durable jobs, attempts, raw envelopes and document versions.
+
+PostgreSQL remains the production authority (runtime_queue / raw_http_fetches /
+document_versions). This store is the same contract without a payload column
+and without writing bodies into git.
+
+Refs #246 #247 #269 #272 #279
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from scripts.crawl.resilience.diagnostics import (
+    FailureEvent,
+    FailureRecorder,
+    classify_failure,
+    sanitize_text,
+    sanitize_url,
+)
+from scripts.crawl.resilience.state import RawStore
+from scripts.factory_spine.contracts import (
+    JOB_TERMINALS,
+    RankedJob,
+    job_idempotency_key,
+    rank_claim_candidates,
+)
+from scripts.process_documents.storage import store_blob
+
+
+def utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _atomic_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True, default=str)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp, path)
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if not path.is_file():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@contextmanager
+def _lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+", encoding="utf-8")
+    try:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        except (ImportError, OSError):
+            pass
+        yield
+    finally:
+        try:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except (ImportError, OSError):
+            pass
+        handle.close()
+
+
+def persist_document_metadata(
+    documents: list[dict[str, Any]],
+    *,
+    entity_id: int,
+    source: str,
+    official_id: str,
+    sha256: str,
+    size_bytes: int,
+    body_uri: str,
+    blob_confirmed: bool,
+    official_url: str,
+    process_official_id: str,
+    mime_type: str | None = None,
+    crawl_job_attempt_id: int | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Refs #272 — content change creates a version; never overwrite prior SHA."""
+    if not blob_confirmed:
+        raise ValueError("document job cannot succeed without a confirmed blob")
+    if not body_uri.startswith("cas://"):
+        raise ValueError("document body_uri must be content-addressed")
+    if not sha256 or len(sha256) != 64:
+        raise ValueError("document sha256 must be a 64-char hex digest")
+    safe_url = sanitize_url(official_url)
+    clock = (now or utcnow()).astimezone(UTC)
+    existing_doc = next(
+        (
+            item
+            for item in documents
+            if item["source"] == source and item["official_id"] == official_id and item["entity_id"] == entity_id
+        ),
+        None,
+    )
+    if existing_doc is None:
+        document_id = hashlib.sha256(f"{source}|{entity_id}|{official_id}".encode()).hexdigest()
+        existing_doc = {
+            "document_id": document_id,
+            "entity_id": entity_id,
+            "source": source,
+            "official_id": official_id,
+            "official_url": safe_url,
+            "process_official_id": process_official_id,
+            "versions": [],
+        }
+        documents.append(existing_doc)
+    versions = list(existing_doc["versions"])
+    same_hash = next((item for item in versions if item["sha256"] == sha256), None)
+    if same_hash is not None:
+        return {
+            **same_hash,
+            "document_id": existing_doc["document_id"],
+            "changed": False,
+            "blob_confirmed": True,
+            "metadata_confirmed": True,
+        }
+    version_no = (versions[-1]["version_no"] + 1) if versions else 1
+    version = {
+        "document_id": existing_doc["document_id"],
+        "document_version_id": f"{existing_doc['document_id']}:v{version_no}:{sha256[:16]}",
+        "version_no": version_no,
+        "sha256": sha256,
+        "size_bytes": size_bytes,
+        "body_uri": body_uri,
+        "mime_type": mime_type,
+        "official_url": safe_url,
+        "process_official_id": process_official_id,
+        "crawl_job_attempt_id": crawl_job_attempt_id,
+        "fetched_at": clock.isoformat(),
+        "blob_confirmed": True,
+        "metadata_confirmed": True,
+        "changed": True,
+    }
+    versions.append(version)
+    existing_doc["versions"] = versions
+    existing_doc["official_url"] = safe_url
+    return version
+
+
+class FactoryStore:
+    """Durable file-backed spine used by the CLI and contract tests."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.jobs_path = root / "jobs.json"
+        self.documents_path = root / "documents.json"
+        self.lock_path = root / ".lock"
+        self.attempts_path = root / "attempts.jsonl"
+        self.raw = RawStore(root / "raw")
+        self.failures = FailureRecorder(root / "failures.jsonl")
+
+    def _read_jobs(self) -> list[dict[str, Any]]:
+        payload = _load_json(self.jobs_path, {"jobs": []})
+        return list(payload.get("jobs") or [])
+
+    def _write_jobs(self, jobs: list[dict[str, Any]]) -> None:
+        _atomic_json(self.jobs_path, {"jobs": jobs})
+
+    def _read_documents(self) -> list[dict[str, Any]]:
+        payload = _load_json(self.documents_path, {"documents": []})
+        return list(payload.get("documents") or [])
+
+    def _write_documents(self, documents: list[dict[str, Any]]) -> None:
+        _atomic_json(self.documents_path, {"documents": documents})
+
+    def enqueue(
+        self,
+        *,
+        entity_id: int,
+        canonical_entity_key: str,
+        source: str,
+        capability: str,
+        domain_key: str,
+        binding_version: str,
+        window_start: datetime,
+        window_end: datetime,
+        freshness_deadline: datetime,
+        next_run_at: datetime,
+        priority: int = 0,
+        cursor: dict[str, Any] | None = None,
+        max_attempts: int = 5,
+        domain_concurrency_limit: int = 1,
+        billable: bool = True,
+    ) -> tuple[dict[str, Any], bool]:
+        if not billable:
+            raise ValueError("non-billable pairs must not create a crawl job")
+        key = job_idempotency_key(
+            canonical_entity_key=canonical_entity_key,
+            source=source,
+            capability=capability,
+            window_start=window_start,
+            window_end=window_end,
+            binding_version=binding_version,
+        )
+        with _lock(self.lock_path):
+            jobs = self._read_jobs()
+            existing = next((item for item in jobs if item["idempotency_key"] == key), None)
+            if existing is not None:
+                return existing, False
+            job: dict[str, Any] = {
+                "id": (max((item["id"] for item in jobs), default=0) + 1),
+                "job_type": "crawl_entity_source",
+                "canonical_entity_key": canonical_entity_key,
+                "entity_id": entity_id,
+                "source": source,
+                "capability": capability,
+                "domain_key": domain_key,
+                "binding_version": binding_version,
+                "window_start": window_start.astimezone(UTC).isoformat(),
+                "window_end": window_end.astimezone(UTC).isoformat(),
+                "freshness_deadline": freshness_deadline.astimezone(UTC).isoformat(),
+                "next_run_at": next_run_at.astimezone(UTC).isoformat(),
+                "priority": priority,
+                "cursor": cursor or {},
+                "max_attempts": max_attempts,
+                "domain_concurrency_limit": domain_concurrency_limit,
+                "idempotency_key": key,
+                "status": "queued",
+                "attempt_count": 0,
+                "lease_owner": None,
+                "lease_expires_at": None,
+                "billable": True,
+                "attempts": [],
+            }
+            jobs.append(job)
+            self._write_jobs(jobs)
+            return job, True
+
+    def expire_leases(self, *, now: datetime | None = None) -> int:
+        clock = (now or utcnow()).astimezone(UTC)
+        with _lock(self.lock_path):
+            return self._expire_locked(clock)
+
+    def _expire_locked(self, clock: datetime) -> int:
+        jobs = self._read_jobs()
+        expired = 0
+        for job in jobs:
+            expires = job.get("lease_expires_at")
+            if job["status"] != "running" or not expires:
+                continue
+            if datetime.fromisoformat(str(expires)) >= clock:
+                continue
+            expired += 1
+            if int(job["attempt_count"]) >= int(job["max_attempts"]):
+                job["status"] = "failed"
+            else:
+                job["status"] = "queued"
+            job["lease_owner"] = None
+            job["lease_expires_at"] = None
+            for attempt in job["attempts"]:
+                if attempt["status"] == "running":
+                    attempt["status"] = "lease_expired"
+                    attempt["finished_at"] = clock.isoformat()
+                    attempt["error_class"] = "LEASE_EXPIRED"
+        if expired:
+            self._write_jobs(jobs)
+        return expired
+
+    def claim(
+        self,
+        *,
+        worker_id: str,
+        limit: int = 1,
+        lease_seconds: int = 300,
+        now: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        clock = (now or utcnow()).astimezone(UTC)
+        with _lock(self.lock_path):
+            self._expire_locked(clock)
+            jobs = self._read_jobs()
+            active: dict[str, int] = {}
+            ranked: list[RankedJob] = []
+            for job in jobs:
+                if job["status"] == "running" and job.get("lease_expires_at"):
+                    if datetime.fromisoformat(str(job["lease_expires_at"])) >= clock:
+                        active[job["domain_key"]] = active.get(job["domain_key"], 0) + 1
+                ranked.append(
+                    RankedJob(
+                        id=int(job["id"]),
+                        domain_key=str(job["domain_key"]),
+                        priority=int(job["priority"]),
+                        freshness_deadline=datetime.fromisoformat(str(job["freshness_deadline"])),
+                        next_run_at=datetime.fromisoformat(str(job["next_run_at"])),
+                        status=str(job["status"]),
+                        domain_concurrency_limit=int(job["domain_concurrency_limit"]),
+                    )
+                )
+            selected = {
+                item.id for item in rank_claim_candidates(ranked, now=clock, active_by_domain=active, limit=limit)
+            }
+            claimed: list[dict[str, Any]] = []
+            lease_expires = clock + timedelta(seconds=lease_seconds)
+            for job in jobs:
+                if job["id"] not in selected:
+                    continue
+                job["status"] = "running"
+                job["lease_owner"] = worker_id
+                job["lease_expires_at"] = lease_expires.isoformat()
+                job["attempt_count"] = int(job["attempt_count"]) + 1
+                attempt = {
+                    "id": len(job["attempts"]) + 1,
+                    "run_id": f"crawl-{uuid4().hex}",
+                    "worker_id": worker_id,
+                    "status": "running",
+                    "started_at": clock.isoformat(),
+                    "lease_expires_at": lease_expires.isoformat(),
+                    "cursor": job.get("cursor") or {},
+                    "metrics": {},
+                }
+                job["attempts"].append(attempt)
+                claimed.append({**job, "current_attempt": attempt})
+                self._append_jsonl(self.attempts_path, {**attempt, "job_id": job["id"]})
+            if claimed:
+                self._write_jobs(jobs)
+            return claimed
+
+    def heartbeat(
+        self,
+        job_id: int,
+        *,
+        worker_id: str,
+        cursor: dict[str, Any] | None = None,
+        lease_seconds: int = 300,
+        now: datetime | None = None,
+    ) -> bool:
+        clock = (now or utcnow()).astimezone(UTC)
+        with _lock(self.lock_path):
+            jobs = self._read_jobs()
+            for job in jobs:
+                if int(job["id"]) != job_id:
+                    continue
+                if job["status"] != "running" or job.get("lease_owner") != worker_id:
+                    return False
+                job["lease_expires_at"] = (clock + timedelta(seconds=lease_seconds)).isoformat()
+                if cursor is not None:
+                    job["cursor"] = cursor
+                self._write_jobs(jobs)
+                return True
+            return False
+
+    def finish(
+        self,
+        job_id: int,
+        *,
+        worker_id: str,
+        outcome: str,
+        cursor: dict[str, Any] | None = None,
+        error_class: str | None = None,
+        error_message: str | None = None,
+        metrics: dict[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> bool:
+        if outcome not in {"succeeded", "failed", "blocked", "interrupted"}:
+            raise ValueError(f"invalid job outcome: {outcome}")
+        clock = (now or utcnow()).astimezone(UTC)
+        with _lock(self.lock_path):
+            jobs = self._read_jobs()
+            for job in jobs:
+                if int(job["id"]) != job_id:
+                    continue
+                if job["status"] != "running" or job.get("lease_owner") != worker_id:
+                    return False
+                if job["status"] in JOB_TERMINALS:
+                    return False
+                status = outcome
+                if outcome == "failed" and int(job["attempt_count"]) < int(job["max_attempts"]):
+                    status = "queued"
+                if outcome == "interrupted":
+                    status = "queued"
+                job["status"] = status
+                job["lease_owner"] = None
+                job["lease_expires_at"] = None
+                job["last_outcome"] = outcome
+                if cursor is not None:
+                    job["cursor"] = cursor
+                for attempt in job["attempts"]:
+                    if attempt["status"] == "running":
+                        attempt["status"] = outcome
+                        attempt["finished_at"] = clock.isoformat()
+                        attempt["error_class"] = error_class
+                        attempt["error_message"] = sanitize_text(error_message) if error_message else None
+                        attempt["metrics"] = metrics or {}
+                        if cursor is not None:
+                            attempt["cursor"] = cursor
+                self._write_jobs(jobs)
+                return True
+            return False
+
+    def inspect(self, job_id: int) -> dict[str, Any] | None:
+        with _lock(self.lock_path):
+            for job in self._read_jobs():
+                if int(job["id"]) == job_id:
+                    return job
+        return None
+
+    def find_by_idempotency(self, key: str) -> dict[str, Any] | None:
+        with _lock(self.lock_path):
+            for job in self._read_jobs():
+                if job["idempotency_key"] == key:
+                    return job
+        return None
+
+    def archive_raw(
+        self,
+        *,
+        source: str,
+        run_id: str,
+        request_scope: str,
+        payload: bytes | str,
+        url: str,
+        http_status: int | None,
+        headers: dict[str, Any] | None = None,
+        page: int | None = None,
+        crawl_job_attempt_id: int | None = None,
+        request_succeeded: bool = True,
+    ) -> dict[str, Any]:
+        path, digest = self.raw.persist(
+            source=source,
+            run_id=run_id,
+            request_scope=request_scope,
+            payload=payload,
+            provenance={
+                "endpoint": url,
+                "response_headers": headers or {},
+                "authorization": "Bearer secret-token",
+            },
+            http_status=http_status,
+            request_succeeded=request_succeeded,
+            page=page,
+            crawl_job_attempt_id=crawl_job_attempt_id,
+        )
+        envelope = json.loads(path.read_text(encoding="utf-8"))
+        if "body" in envelope or "payload" in envelope:
+            raise RuntimeError("raw envelope must not embed the HTTP body")
+        return {
+            "envelope_path": str(path),
+            "body_sha256": digest,
+            "body_uri": envelope["body_uri"],
+            "sanitized_url": envelope["sanitized_url"],
+            "envelope_sha256": envelope["envelope_sha256"],
+        }
+
+    def persist_document(
+        self,
+        *,
+        entity_id: int,
+        source: str,
+        official_id: str,
+        body: bytes,
+        official_url: str,
+        process_official_id: str,
+        crawl_job_attempt_id: int | None = None,
+    ) -> dict[str, Any]:
+        blob = store_blob(body, raw_root=self.root / "document-blobs")
+        with _lock(self.lock_path):
+            documents = self._read_documents()
+            version = persist_document_metadata(
+                documents,
+                entity_id=entity_id,
+                source=source,
+                official_id=official_id,
+                sha256=blob.sha256,
+                size_bytes=blob.size_bytes,
+                body_uri=blob.raw_uri,
+                blob_confirmed=True,
+                official_url=official_url,
+                process_official_id=process_official_id,
+                crawl_job_attempt_id=crawl_job_attempt_id,
+            )
+            self._write_documents(documents)
+            return version
+
+    def record_structured_failure(
+        self,
+        *,
+        source: str,
+        run_id: str,
+        request_scope: str,
+        stage: str,
+        error: Any,
+        http_status: int | None = None,
+        url: str | None = None,
+        page: int | None = None,
+        cursor: str | None = None,
+        attempt_no: int = 1,
+        job_id: int | None = None,
+        crawl_job_attempt_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        classification = classify_failure(http_status=http_status, error=error)
+        event = FailureEvent(
+            source=source,
+            run_id=run_id,
+            request_scope=request_scope,
+            stage=stage,
+            error_class=classification.error_class,
+            transient=classification.transient,
+            next_action=classification.next_action,
+            message=sanitize_text(error),
+            url=url,
+            http_status=http_status,
+            page=page,
+            cursor=cursor,
+            attempt_no=attempt_no,
+            job_id=job_id,
+            crawl_job_attempt_id=crawl_job_attempt_id,
+            metadata=metadata or {},
+        )
+        persisted = self.failures.record(event)
+        record = event.to_record()
+        blob = json.dumps(record)
+        if "secret-token" in blob or "password=" in blob:
+            raise RuntimeError("structured failure leaked a secret")
+        return {**persisted, "event": record}
+
+    @staticmethod
+    def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False, default=str) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())

--- a/tests/test_factory_spine_235_discovery.py
+++ b/tests/test_factory_spine_235_discovery.py
@@ -1,0 +1,125 @@
+"""Refs #235 — versioned public-surface discovery for the canonical 1.093 IDs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from scripts.factory_spine.contracts import (
+    CANONICAL_UNIVERSE_SIZE,
+    DISCOVERY_TERMINALS,
+    apply_surface_revalidation,
+    canonical_entity_ids,
+    classify_discovery_surface,
+    seal_discovery_run,
+)
+from scripts.source_registry.continuous_inventory import SURFACE_KINDS, SurfaceObservation
+
+
+def test_issue_235_new_domain_is_unclassified_never_ignored() -> None:
+    status, url, domain = classify_discovery_surface(
+        SurfaceObservation(
+            kind="institutional",
+            canonical_url="https://prefeitura.novo-dominio.test/",
+            platform=None,
+            anchor_url="https://example.test/",
+            method="anchor",
+            http_status=200,
+        ),
+        known_domains={"pncp.gov.br"},
+    )
+    assert status == "UNCLASSIFIED"
+    assert status in DISCOVERY_TERMINALS
+    assert domain == "prefeitura.novo-dominio.test"
+    assert url is not None
+
+
+def test_issue_235_login_captcha_403_are_blocked() -> None:
+    blocked_403, _, _ = classify_discovery_surface(
+        SurfaceObservation(
+            kind="procurement",
+            canonical_url="https://compras.example.test/",
+            platform="portal",
+            anchor_url=None,
+            method="probe",
+            http_status=403,
+        ),
+        known_domains=set(),
+    )
+    blocked_captcha, _, _ = classify_discovery_surface(
+        SurfaceObservation(
+            kind="transparency",
+            canonical_url="https://transparencia.example.test/",
+            platform="portal",
+            anchor_url=None,
+            method="probe",
+            http_status=200,
+            response_hint="recaptcha challenge",
+        ),
+        known_domains={"transparencia.example.test"},
+    )
+    exhausted, url, _ = classify_discovery_surface(
+        SurfaceObservation(
+            kind="gazette",
+            canonical_url=None,
+            platform=None,
+            anchor_url=None,
+            method="exhausted_seed",
+        ),
+        known_domains=set(),
+    )
+    assert blocked_403 == "BLOCKED"
+    assert blocked_captcha == "BLOCKED"
+    assert exhausted == "DISCOVERY_EXHAUSTED_NO_SURFACE"
+    assert url is None
+
+
+def test_issue_235_revalidation_keeps_history() -> None:
+    first, history = apply_surface_revalidation(
+        None,
+        status="FOUND",
+        canonical_url="https://old.example.test/",
+        domain="old.example.test",
+        platform="betha",
+    )
+    current, versions = apply_surface_revalidation(
+        first,
+        status="UNCLASSIFIED",
+        canonical_url="https://new.example.test/",
+        domain="new.example.test",
+        platform="egov",
+    )
+    assert current.version_no == 2
+    assert versions[0].invalidated is True
+    assert versions[0].canonical_url == "https://old.example.test/"
+    assert versions[0].invalidation_reason == "binding_changed"
+    assert current.domain == "new.example.test"
+    assert len(history) == 1
+
+
+def test_issue_235_seals_exactly_1093_versioned_ids() -> None:
+    universe = canonical_entity_ids()
+    assert len(universe) == CANONICAL_UNIVERSE_SIZE
+    checked = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    results = {}
+    for entity_id in universe:
+        current, versions = apply_surface_revalidation(
+            None,
+            status="DISCOVERY_EXHAUSTED_NO_SURFACE",
+            canonical_url=None,
+            domain=None,
+            platform=None,
+        )
+        results[entity_id] = {
+            "status": current.status,
+            "history": [version.version_no for version in versions],
+            "surfaces": [{"kind": kind} for kind in SURFACE_KINDS],
+            "checked_at": checked.isoformat(),
+            "next_check_at": checked.isoformat(),
+        }
+    sealed = seal_discovery_run(universe, results)
+    assert sealed["entity_count"] == 1093
+    assert sealed["outcome"] == "complete"
+    with pytest.raises(ValueError, match="missing_discovery_results"):
+        seal_discovery_run(universe, {universe[0]: results[universe[0]]})

--- a/tests/test_factory_spine_236_coverage.py
+++ b/tests/test_factory_spine_236_coverage.py
@@ -1,0 +1,89 @@
+"""Refs #236 — ente×fonte matrix is fail-closed; absence is never zero."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from scripts.factory_spine.contracts import (
+    COVERAGE_TERMINALS,
+    assert_publishable_coverage,
+    canonical_entity_ids,
+    publish_coverage_cell,
+    reconcile_coverage_artifacts,
+)
+
+
+def test_issue_236_absence_of_execution_is_never_zero() -> None:
+    with pytest.raises(ValueError, match="absence of execution"):
+        assert_publishable_coverage("ZERO_CONFIRMED", executed=False)
+    with pytest.raises(ValueError, match="absence of execution"):
+        publish_coverage_cell(
+            canonical_entity_key="extra-canonical-0001",
+            source="pncp",
+            status="ZERO_CONFIRMED",
+            executed=False,
+            applicability=True,
+            applicability_reason="not-run",
+        )
+
+
+def test_issue_236_zero_confirmed_requires_complete_raw_proof() -> None:
+    with pytest.raises(ValueError, match="ZERO_CONFIRMED requires"):
+        publish_coverage_cell(
+            canonical_entity_key="extra-canonical-0001",
+            source="pncp",
+            status="ZERO_CONFIRMED",
+            executed=True,
+            applicability=True,
+            applicability_reason="query_ran",
+            request_completed=True,
+            scope_complete=True,
+            pagination_reconciled=False,
+            records_observed=0,
+        )
+    cell = publish_coverage_cell(
+        canonical_entity_key="extra-canonical-0001",
+        source="pncp",
+        status="ZERO_CONFIRMED",
+        executed=True,
+        applicability=True,
+        applicability_reason="complete_empty_scope",
+        request_completed=True,
+        scope_complete=True,
+        pagination_reconciled=True,
+        records_observed=0,
+        raw_uri="cas://raw-http/ab",
+        raw_sha256="a" * 64,
+        history=({"status": "FAILED", "checked_at": "2026-08-01T00:00:00+00:00"},),
+    )
+    assert cell["status"] in COVERAGE_TERMINALS
+    assert cell["history"][0]["status"] == "FAILED"
+
+
+def test_issue_236_excel_manifest_kpi_reconcile_1093_ids() -> None:
+    universe = canonical_entity_ids()
+    checked = datetime(2026, 8, 15, tzinfo=UTC)
+    cells = [
+        publish_coverage_cell(
+            canonical_entity_key=entity_id,
+            source="pncp",
+            status="BLOCKED",
+            executed=True,
+            applicability=True,
+            applicability_reason="probe_blocked_pending_recheck",
+            request_completed=True,
+            http_statuses=(403,),
+            checked_at=checked,
+            next_action="human_review_source_access",
+        )
+        for entity_id in universe
+    ]
+    artifacts = reconcile_coverage_artifacts(universe, cells)
+    assert artifacts["kpi"]["entity_count"] == 1093
+    assert len(artifacts["manifest_ids"]) == 1093
+    assert artifacts["manifest_ids"] == tuple(sorted(universe))
+    assert len(artifacts["excel_rows"]) == 1093
+    assert set(row["canonical_entity_key"] for row in artifacts["excel_rows"]) == set(universe)
+    assert artifacts["kpi"]["by_status"]["BLOCKED"] == 1093

--- a/tests/test_factory_spine_246_jobs.py
+++ b/tests/test_factory_spine_246_jobs.py
@@ -1,0 +1,140 @@
+"""Refs #246 — durable idempotent jobs/attempts with lease and one terminal."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.factory_spine.contracts import job_idempotency_key
+from scripts.factory_spine.runtime import launch_spine
+from scripts.factory_spine.store import FactoryStore
+
+
+def _window() -> tuple[datetime, datetime, datetime, datetime]:
+    start = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    return start, start + timedelta(hours=24), start + timedelta(hours=24), start
+
+
+def test_issue_246_idempotent_enqueue_does_not_duplicate(tmp_path: Path) -> None:
+    store = FactoryStore(tmp_path)
+    start, end, deadline, nxt = _window()
+    first, created = store.enqueue(
+        entity_id=1,
+        canonical_entity_key="extra-canonical-0001",
+        source="pncp",
+        capability="open_tenders",
+        domain_key="pncp.gov.br",
+        binding_version="v1",
+        window_start=start,
+        window_end=end,
+        freshness_deadline=deadline,
+        next_run_at=nxt,
+    )
+    second, created_again = store.enqueue(
+        entity_id=1,
+        canonical_entity_key="extra-canonical-0001",
+        source="pncp",
+        capability="open_tenders",
+        domain_key="pncp.gov.br",
+        binding_version="v1",
+        window_start=start,
+        window_end=end,
+        freshness_deadline=deadline,
+        next_run_at=nxt,
+    )
+    assert created is True
+    assert created_again is False
+    assert first["id"] == second["id"]
+    assert first["idempotency_key"] == job_idempotency_key(
+        canonical_entity_key="extra-canonical-0001",
+        source="pncp",
+        capability="open_tenders",
+        window_start=start,
+        window_end=end,
+        binding_version="v1",
+    )
+    assert len(store._read_jobs()) == 1
+
+
+def test_issue_246_single_terminal_transition_and_lease_expiry(tmp_path: Path) -> None:
+    store = FactoryStore(tmp_path)
+    start, end, deadline, nxt = _window()
+    job, _ = store.enqueue(
+        entity_id=2,
+        canonical_entity_key="extra-canonical-0002",
+        source="ciga_dom",
+        capability="open_tenders",
+        domain_key="ciga.sc.gov.br",
+        binding_version="v1",
+        window_start=start,
+        window_end=end,
+        freshness_deadline=deadline,
+        next_run_at=nxt,
+    )
+    claimed = store.claim(worker_id="w1", now=start, lease_seconds=30)
+    assert len(claimed) == 1
+    assert claimed[0]["attempts"][-1]["run_id"].startswith("crawl-")
+    finished = store.finish(job["id"], worker_id="w1", outcome="succeeded", now=start + timedelta(seconds=1))
+    assert finished is True
+    again = store.finish(job["id"], worker_id="w1", outcome="failed", now=start + timedelta(seconds=2))
+    assert again is False
+    assert store.inspect(job["id"])["status"] == "succeeded"
+
+    other, _ = store.enqueue(
+        entity_id=3,
+        canonical_entity_key="extra-canonical-0003",
+        source="sc_compras",
+        capability="open_tenders",
+        domain_key="compras.sc.gov.br",
+        binding_version="v1",
+        window_start=start,
+        window_end=end,
+        freshness_deadline=deadline,
+        next_run_at=nxt,
+        max_attempts=2,
+    )
+    store.claim(worker_id="w2", now=start, lease_seconds=1)
+    expired = store.expire_leases(now=start + timedelta(seconds=5))
+    assert expired == 1
+    recovered = store.inspect(other["id"])
+    assert recovered is not None
+    assert recovered["status"] == "queued"
+    assert recovered["attempts"][-1]["status"] == "lease_expired"
+    assert recovered["attempts"][-1]["error_class"] == "LEASE_EXPIRED"
+
+
+def test_issue_246_launch_spine_is_idempotent_across_runs(tmp_path: Path) -> None:
+    first = launch_spine(tmp_path)
+    second = launch_spine(tmp_path)
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["created"] is True
+    assert second["created"] is False
+    assert first["job_id"] == second["job_id"]
+    assert first["raw_pointer"]
+    assert first["error_fingerprint"]
+    assert first["error_class"] == "AUTH_BLOCKED"
+    assert first["document_version_id"]
+    assert second["document_version_id"] == first["document_version_id"]
+    assert second["raw_sha256"] == first["raw_sha256"]
+
+
+def test_issue_246_non_billable_pair_cannot_create_job(tmp_path: Path) -> None:
+    store = FactoryStore(tmp_path)
+    start, end, deadline, nxt = _window()
+    with pytest.raises(ValueError, match="non-billable"):
+        store.enqueue(
+            entity_id=4,
+            canonical_entity_key="extra-canonical-0004",
+            source="pncp",
+            capability="open_tenders",
+            domain_key="pncp.gov.br",
+            binding_version="v1",
+            window_start=start,
+            window_end=end,
+            freshness_deadline=deadline,
+            next_run_at=nxt,
+            billable=False,
+        )

--- a/tests/test_factory_spine_247_raw.py
+++ b/tests/test_factory_spine_247_raw.py
@@ -1,0 +1,55 @@
+"""Refs #247 — immutable raw HTTP envelope with revalidatable SHA-256."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from scripts.factory_spine.store import FactoryStore
+
+
+def test_issue_247_raw_cas_dedup_redacts_secrets_and_keeps_body_out_of_envelope(tmp_path: Path) -> None:
+    store = FactoryStore(tmp_path)
+    body = b'{"ok": true, "items": []}'
+    first = store.archive_raw(
+        source="pncp",
+        run_id="run-a",
+        request_scope="entity-1:pncp",
+        payload=body,
+        url="https://pncp.gov.br/api?token=super-secret&pagina=1",
+        http_status=200,
+        headers={"Authorization": "Bearer super-secret", "Content-Type": "application/json"},
+        page=1,
+        crawl_job_attempt_id=9,
+    )
+    second = store.archive_raw(
+        source="pncp",
+        run_id="run-b",
+        request_scope="entity-1:pncp",
+        payload=body,
+        url="https://pncp.gov.br/api?token=super-secret&pagina=1",
+        http_status=200,
+        page=1,
+    )
+    assert first["body_sha256"] == hashlib.sha256(body).hexdigest()
+    assert first["body_sha256"] == second["body_sha256"]
+    assert first["body_uri"].startswith("cas://raw-http/")
+    envelope = json.loads(Path(first["envelope_path"]).read_text(encoding="utf-8"))
+    dumped = json.dumps(envelope)
+    assert "body" not in envelope
+    assert "payload" not in envelope
+    assert "super-secret" not in dumped
+    assert envelope["sanitized_url"] is not None
+    assert "token=" in envelope["sanitized_url"]
+    assert "super-secret" not in envelope["sanitized_url"]
+    assert "redacted" in envelope["sanitized_url"]
+    loaded = store.raw.load_reference(first["envelope_path"])
+    cas_body = (
+        store.raw.root / "cas" / first["body_sha256"][:2] / first["body_sha256"][2:4] / f"{first['body_sha256']}.body"
+    )
+    assert cas_body.read_bytes() == body
+    assert hashlib.sha256(cas_body.read_bytes()).hexdigest() == first["body_sha256"]
+    assert loaded["envelope"]["body_sha256"] == first["body_sha256"]
+    assert cas_body.is_relative_to(tmp_path)
+    assert "payload" not in json.dumps(envelope)

--- a/tests/test_factory_spine_256_portal.py
+++ b/tests/test_factory_spine_256_portal.py
@@ -1,0 +1,67 @@
+"""Refs #256 — generic public portal adapter never invents success."""
+
+from __future__ import annotations
+
+from scripts.factory_spine.portal import PortalStrategy, interpret_portal_fetch
+
+HTML_LISTING = """
+<table class="licitacoes">
+  <tr><td>Edital 10/2026 Pregão Eletrônico</td><td><a href="/docs/edital-10.pdf">PDF</a></td></tr>
+</table>
+"""
+HTML_LOGIN = """
+<form id="login"><input type="password" name="senha" /><button>Entrar</button></form>
+"""
+HTML_CAPTCHA = """
+<div class="g-recaptcha" data-sitekey="x"></div>
+<p>Resolva o captcha para continuar</p>
+"""
+HTML_EMPTY = """
+<html><body><h1>Portal da Transparência</h1><p>Bem-vindo</p></body></html>
+"""
+HTML_LAYOUT_V2 = """
+<section class="cards">
+  <article>Pregão 99/2026 <a href="/anexos/edital-99.pdf">baixar</a></article>
+</section>
+"""
+
+
+def test_issue_256_login_captcha_403_are_blocked_not_empty_success() -> None:
+    login = interpret_portal_fetch(url="https://pref.example.test/licitacoes", http_status=200, body=HTML_LOGIN)
+    captcha = interpret_portal_fetch(url="https://pref.example.test/licitacoes", http_status=200, body=HTML_CAPTCHA)
+    forbidden = interpret_portal_fetch(url="https://pref.example.test/licitacoes", http_status=403, body=HTML_LISTING)
+    assert login.terminal == "BLOCKED"
+    assert captcha.terminal == "BLOCKED"
+    assert forbidden.terminal == "BLOCKED"
+    assert login.records == ()
+    assert forbidden.reason == "login_captcha_or_forbidden"
+
+
+def test_issue_256_empty_or_error_page_is_never_zero_tenders() -> None:
+    empty = interpret_portal_fetch(url="https://pref.example.test/licitacoes", http_status=200, body=HTML_EMPTY)
+    server = interpret_portal_fetch(url="https://pref.example.test/licitacoes", http_status=504, body=HTML_EMPTY)
+    assert empty.terminal == "FAILED"
+    assert empty.reason == "empty_or_layout_unrecognized"
+    assert server.terminal == "FAILED"
+    assert empty.records == ()
+
+
+def test_issue_256_html_pdf_and_layout_change_fixtures() -> None:
+    found = interpret_portal_fetch(
+        url="https://pref.example.test/licitacoes?token=abc", http_status=200, body=HTML_LISTING
+    )
+    assert found.terminal == "FOUND"
+    assert found.records[0].document_url is not None
+    assert found.records[0].document_url.endswith(".pdf")
+    assert found.sanitized_url is not None
+    assert "abc" not in (found.sanitized_url or "") or "token=" in found.sanitized_url
+    v1 = interpret_portal_fetch(
+        url="https://pref.example.test/licitacoes",
+        http_status=200,
+        body=HTML_LAYOUT_V2,
+        strategy=PortalStrategy(version="generic-public-portal/v1:table"),
+    )
+    # v2 listing still extracts the PDF link so a layout change does not invent zero.
+    assert v1.terminal == "FOUND"
+    assert v1.records[0].document_url is not None
+    assert v1.strategy_version.endswith(":table")

--- a/tests/test_factory_spine_268_enqueue.py
+++ b/tests/test_factory_spine_268_enqueue.py
@@ -1,0 +1,87 @@
+"""Refs #268 — continuous enqueue from freshness and applicability."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.factory_spine.contracts import (
+    DEFAULT_SOURCES,
+    canonical_entity_ids,
+    plan_freshness_enqueue,
+)
+from scripts.factory_spine.runtime import apply_freshness_plan
+from scripts.factory_spine.store import FactoryStore
+
+
+def test_issue_268_dry_plan_covers_1093_ids_and_keeps_next_run() -> None:
+    now = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    universe = canonical_entity_ids()
+    pairs = [
+        {
+            "canonical_entity_key": entity_id,
+            "entity_id": index,
+            "source": source,
+            "capability": "open_tenders",
+            "applicability": "APPLICABLE" if source != "transparencia" else "NOT_APPLICABLE",
+            "reason": "applicable_by_current_rule" if source != "transparencia" else "no_own_portal",
+            "binding_version": "fresh-v1",
+        }
+        for index, entity_id in enumerate(universe, start=1)
+        for source in DEFAULT_SOURCES
+    ]
+    decisions = plan_freshness_enqueue(pairs, now=now)
+    assert len(decisions) == 1093 * 4
+    assert {item.canonical_entity_key for item in decisions} == set(universe)
+    assert all(item.next_run_at >= now for item in decisions)
+    assert all(not item.billable for item in decisions if item.applicability == "NOT_APPLICABLE")
+    assert sum(item.billable for item in decisions) == 1093 * 3
+
+
+def test_issue_268_reenqueue_is_idempotent(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    store = FactoryStore(tmp_path)
+    pairs = [
+        {
+            "canonical_entity_key": "extra-canonical-0001",
+            "entity_id": 1,
+            "source": "pncp",
+            "capability": "open_tenders",
+            "applicability": "APPLICABLE",
+            "reason": "freshness_due",
+            "binding_version": "fresh-v1",
+        }
+    ]
+    first = apply_freshness_plan(store, plan_freshness_enqueue(pairs, now=now, expected_entities=1), now=now)
+    second = apply_freshness_plan(store, plan_freshness_enqueue(pairs, now=now, expected_entities=1), now=now)
+    assert first["queued"] == 1
+    assert second["queued"] == 0
+    assert second["existing"] == 1
+    assert first["fully_reconciled"] is True
+    assert len(store._read_jobs()) == 1
+
+
+def test_issue_268_blocked_has_limited_recheck_not_infinite() -> None:
+    now = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    decisions = plan_freshness_enqueue(
+        [
+            {
+                "canonical_entity_key": "extra-canonical-0001",
+                "entity_id": 1,
+                "source": "pncp",
+                "applicability": "BLOCKED",
+                "reason": "captcha",
+                "binding_version": "fresh-v1",
+            }
+        ],
+        now=now,
+        expected_entities=1,
+        recheck_blocked_hours=72,
+    )
+    assert decisions[0].action == "recheck_blocked"
+    assert decisions[0].billable is False
+    assert decisions[0].next_run_at == now + timedelta(hours=72)
+    with pytest.raises(ValueError, match="universe mismatch"):
+        plan_freshness_enqueue([], now=now, expected_entities=1093)

--- a/tests/test_factory_spine_269_workers.py
+++ b/tests/test_factory_spine_269_workers.py
@@ -1,0 +1,94 @@
+"""Refs #269 — concurrent workers with lease, heartbeat and backpressure."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scripts.crawl.worker import AdmissionLimits, admission_blockers
+from scripts.factory_spine.contracts import DEFAULT_SOURCES, RankedJob, rank_claim_candidates
+from scripts.factory_spine.store import FactoryStore
+
+
+def test_issue_269_two_workers_do_not_claim_the_same_job(tmp_path: Path) -> None:
+    store = FactoryStore(tmp_path)
+    now = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    store.enqueue(
+        entity_id=1,
+        canonical_entity_key="extra-canonical-0001",
+        source="pncp",
+        capability="open_tenders",
+        domain_key="pncp.gov.br",
+        binding_version="v1",
+        window_start=now,
+        window_end=now + timedelta(hours=24),
+        freshness_deadline=now + timedelta(hours=24),
+        next_run_at=now,
+        domain_concurrency_limit=1,
+    )
+    first = store.claim(worker_id="w-a", now=now, lease_seconds=60)
+    second = store.claim(worker_id="w-b", now=now, lease_seconds=60)
+    assert len(first) == 1
+    assert second == []
+    assert store.heartbeat(first[0]["id"], worker_id="w-a", cursor={"page": 2}, now=now + timedelta(seconds=5))
+    assert store.heartbeat(first[0]["id"], worker_id="w-b", now=now + timedelta(seconds=6)) is False
+    interrupted = store.finish(
+        first[0]["id"],
+        worker_id="w-a",
+        outcome="interrupted",
+        cursor={"page": 2},
+        now=now + timedelta(seconds=7),
+    )
+    assert interrupted is True
+    recovered = store.inspect(first[0]["id"])
+    assert recovered is not None
+    assert recovered["status"] == "queued"
+    assert recovered["cursor"]["page"] == 2
+    assert recovered["last_outcome"] == "interrupted"
+
+
+def test_issue_269_backpressure_blocks_admission() -> None:
+    blockers = admission_blockers(
+        AdmissionLimits(max_load_per_cpu=0.9),
+        load_average=8.0,
+        cpu_count=4,
+        memory_ratio=0.5,
+        disk_ratio=0.5,
+    )
+    assert blockers == ["cpu_pressure"]
+
+
+def test_issue_269_4372_pairs_have_no_domain_starvation() -> None:
+    now = datetime(2026, 8, 15, 12, 0, tzinfo=UTC)
+    jobs: list[RankedJob] = []
+    job_id = 1
+    for entity in range(1, 1094):
+        for source in DEFAULT_SOURCES:
+            jobs.append(
+                RankedJob(
+                    id=job_id,
+                    domain_key=source,
+                    priority=0,
+                    freshness_deadline=now + timedelta(hours=entity),
+                    next_run_at=now,
+                    status="queued",
+                    domain_concurrency_limit=1,
+                )
+            )
+            job_id += 1
+    assert len(jobs) == 4372
+    remaining = {job.id: job for job in jobs}
+    claimed_ids: list[int] = []
+    seen_domains: set[str] = set()
+    while remaining:
+        batch = rank_claim_candidates(list(remaining.values()), now=now, limit=4)
+        assert batch, "queued jobs remained but ranking returned none"
+        domains = [job.domain_key for job in batch]
+        assert len(domains) == len(set(domains))
+        seen_domains.update(domains)
+        for job in batch:
+            claimed_ids.append(job.id)
+            del remaining[job.id]
+    assert len(claimed_ids) == 4372
+    assert len(set(claimed_ids)) == 4372
+    assert seen_domains == set(DEFAULT_SOURCES)

--- a/tests/test_factory_spine_270_resilience.py
+++ b/tests/test_factory_spine_270_resilience.py
@@ -1,0 +1,118 @@
+"""Refs #270 — per-domain retry, Retry-After, circuit and partial windows."""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+from scripts.crawl.pncp_contract import PNCP_TAMANHO_PAGINA_MAX_CONTRATACOES
+from scripts.crawl.resilience.http_policy import HttpResiliencePolicy
+from scripts.factory_spine.contracts import (
+    build_pncp_consulta_envelope,
+    decide_resilience,
+    window_is_complete,
+)
+
+
+@pytest.mark.parametrize(
+    ("status", "error", "expected_action", "expected_terminal"),
+    [
+        (403, "HTTP 403", "block", "BLOCKED"),
+        (401, "login required", "block", "BLOCKED"),
+        (429, "HTTP 429", "retry", None),
+        (504, "HTTP 504", "retry", None),
+        (None, requests.Timeout("timeout"), "retry", None),
+    ],
+)
+def test_issue_270_status_matrix(
+    status: int | None,
+    error: object,
+    expected_action: str,
+    expected_terminal: str | None,
+) -> None:
+    decision = decide_resilience(
+        http_status=status,
+        error=error,
+        attempt=1,
+        max_attempts=5,
+        retry_after=12.0 if status == 429 else None,
+        pages_fetched=1,
+        pages_expected=4,
+    )
+    assert decision.action == expected_action
+    assert decision.terminal == expected_terminal
+    assert decision.window_complete is False
+    if status == 429:
+        assert decision.sleep_seconds == 12.0
+        assert decision.transient is True
+
+
+def test_issue_270_captcha_is_permanent_block() -> None:
+    decision = decide_resilience(http_status=200, error="captcha required", attempt=1, max_attempts=8)
+    assert decision.action == "block"
+    assert decision.terminal == "BLOCKED"
+    assert decision.transient is False
+
+
+def test_issue_270_partial_fetch_never_closes_window() -> None:
+    assert (
+        window_is_complete(
+            outcome="succeeded",
+            pages_fetched=2,
+            pages_expected=5,
+            request_completed=True,
+            scope_complete=False,
+            pagination_reconciled=False,
+        )
+        is False
+    )
+    decision = decide_resilience(
+        http_status=200,
+        error=None,
+        attempt=1,
+        max_attempts=3,
+        pages_fetched=2,
+        pages_expected=5,
+    )
+    assert decision.action == "succeed"
+    assert decision.window_complete is False
+
+
+def test_issue_270_circuit_open_and_retry_after_policy() -> None:
+    open_circuit = decide_resilience(
+        http_status=504,
+        error="HTTP 504",
+        attempt=1,
+        max_attempts=5,
+        circuit_state="open",
+    )
+    assert open_circuit.action == "wait_circuit"
+    assert open_circuit.window_complete is False
+    policy = HttpResiliencePolicy(max_delay=30.0, retry_after_fallback=60.0)
+    delayed = decide_resilience(
+        http_status=429,
+        error="HTTP 429",
+        attempt=2,
+        max_attempts=5,
+        retry_after=45.0,
+        policy=policy,
+    )
+    assert delayed.sleep_seconds == 30.0
+
+
+def test_issue_270_pncp_envelope_rejects_invalid_tamanho_pagina() -> None:
+    envelope = build_pncp_consulta_envelope(
+        pagina=1,
+        tamanho_pagina=PNCP_TAMANHO_PAGINA_MAX_CONTRATACOES,
+        data_inicial="20260101",
+        data_final="20260107",
+    )
+    assert envelope["tamanhoPagina"] == "50"
+    assert "tamanhoPagina=50" in envelope["url"]
+    with pytest.raises(ValueError, match="invalid PNCP tamanhoPagina"):
+        build_pncp_consulta_envelope(
+            pagina=1,
+            tamanho_pagina=1,
+            data_inicial="20260101",
+            data_final="20260107",
+        )

--- a/tests/test_factory_spine_272_documents.py
+++ b/tests/test_factory_spine_272_documents.py
@@ -1,0 +1,80 @@
+"""Refs #272 — versioned document metadata; job success needs blob + metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.factory_spine.store import FactoryStore, persist_document_metadata
+
+
+def test_issue_272_content_change_creates_version_without_overwrite(tmp_path: Path) -> None:
+    store = FactoryStore(tmp_path)
+    first = store.persist_document(
+        entity_id=10,
+        source="pncp",
+        official_id="doc-1",
+        body=b"edital-v1",
+        official_url="https://pncp.gov.br/docs/doc-1.pdf?token=secret",
+        process_official_id="proc-1",
+        crawl_job_attempt_id=3,
+    )
+    same = store.persist_document(
+        entity_id=10,
+        source="pncp",
+        official_id="doc-1",
+        body=b"edital-v1",
+        official_url="https://pncp.gov.br/docs/doc-1.pdf?token=secret",
+        process_official_id="proc-1",
+    )
+    second = store.persist_document(
+        entity_id=10,
+        source="pncp",
+        official_id="doc-1",
+        body=b"edital-v2-changed",
+        official_url="https://pncp.gov.br/docs/doc-1.pdf",
+        process_official_id="proc-1",
+        crawl_job_attempt_id=4,
+    )
+    assert first["changed"] is True
+    assert same["changed"] is False
+    assert same["version_no"] == first["version_no"]
+    assert second["changed"] is True
+    assert second["version_no"] == first["version_no"] + 1
+    assert second["sha256"] != first["sha256"]
+    assert first["blob_confirmed"] is True
+    assert first["metadata_confirmed"] is True
+    assert first["body_uri"].startswith("cas://")
+    documents = store._read_documents()
+    assert len(documents) == 1
+    assert len(documents[0]["versions"]) == 2
+
+
+def test_issue_272_job_cannot_succeed_without_confirmed_blob() -> None:
+    with pytest.raises(ValueError, match="confirmed blob"):
+        persist_document_metadata(
+            [],
+            entity_id=1,
+            source="pncp",
+            official_id="doc-x",
+            sha256="a" * 64,
+            size_bytes=4,
+            body_uri="cas://process_documents/" + "a" * 64,
+            blob_confirmed=False,
+            official_url="https://example.test/doc.pdf",
+            process_official_id="proc-x",
+        )
+    with pytest.raises(ValueError, match="content-addressed"):
+        persist_document_metadata(
+            [],
+            entity_id=1,
+            source="pncp",
+            official_id="doc-x",
+            sha256="a" * 64,
+            size_bytes=4,
+            body_uri="postgres://payload",
+            blob_confirmed=True,
+            official_url="https://example.test/doc.pdf",
+            process_official_id="proc-x",
+        )

--- a/tests/test_factory_spine_279_diagnostics.py
+++ b/tests/test_factory_spine_279_diagnostics.py
@@ -1,0 +1,64 @@
+"""Refs #279 — structured per-request/page failure, no secrets persisted."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+from scripts.factory_spine.store import FactoryStore
+
+
+@pytest.mark.parametrize(
+    ("status", "error", "error_class", "transient"),
+    [
+        (403, "HTTP 403", "AUTH_BLOCKED", False),
+        (404, "HTTP 404 drift", "SOURCE_DRIFT", False),
+        (429, "HTTP 429", "RATE_LIMITED", True),
+        (504, "HTTP 504", "UPSTREAM_TRANSIENT", True),
+        (None, requests.Timeout("timeout"), "TRANSPORT_TRANSIENT", True),
+        (200, ValueError("json parse failed"), "PARSE_OR_SCHEMA_DRIFT", False),
+        (200, RuntimeError("persist failed writing cas"), "PERSIST_FAILURE", False),
+    ],
+)
+def test_issue_279_structured_failure_matrix(
+    tmp_path: Path,
+    status: int | None,
+    error: object,
+    error_class: str,
+    transient: bool,
+) -> None:
+    store = FactoryStore(tmp_path)
+    recorded = store.record_structured_failure(
+        source="pncp",
+        run_id="run-diag",
+        request_scope="entity-1:page-2",
+        stage="fetch",
+        error=error,
+        http_status=status,
+        url="https://pncp.gov.br/api?token=super-secret&pagina=2",
+        page=2,
+        cursor="pagina=2",
+        attempt_no=3,
+        job_id=88,
+        crawl_job_attempt_id=12,
+        metadata={"authorization": "Bearer super-secret", "password": "hunter2"},
+    )
+    event = recorded["event"]
+    assert event["source"] == "pncp"
+    assert event["error_class"] == error_class
+    assert event["transient"] is transient
+    assert event["page"] == 2
+    assert event["cursor"] == "pagina=2"
+    assert event["attempt_no"] == 3
+    assert event["next_action"]
+    assert event["url"] is not None
+    assert "super-secret" not in json.dumps(event)
+    assert "hunter2" not in json.dumps(event)
+    assert "super-secret" not in (event["url"] or "")
+    assert "redacted" in (event["url"] or "")
+    persisted = (tmp_path / "failures.jsonl").read_text(encoding="utf-8")
+    assert "super-secret" not in persisted
+    assert recorded["fingerprint"]


### PR DESCRIPTION
## Summary

One reviewable capability: a durable fail-closed crawl/pipeline factory spine covering the 10 highest never-worked P2 issues.

Ships versioned contracts plus tests on the real functions (representative IDs plus the 1.093-id seal/reconcile). Does not claim a live national wave or VPS operational.

## Issues

- Refs #235 — versioned public-surface discovery for the 1.093 IDs (`UNCLASSIFIED` / `BLOCKED` / `DISCOVERY_EXHAUSTED_NO_SURFACE`, history kept)
- Refs #236 — ente×fonte matrix terminals only; absence of execution is never published as zero; Excel/manifest/KPI reconcile the same 1.093 IDs
- Refs #246 — durable idempotent jobs/attempts with lease and a single terminal transition
- Refs #247 — immutable raw HTTP envelope with revalidatable SHA-256; secrets redacted; body not in git and not in a PostgreSQL payload column
- Refs #256 — generic public transparency-portal adapter that never invents success on login/CAPTCHA/403
- Refs #268 — continuous enqueue from freshness and applicability
- Refs #269 — concurrent workers with lease, heartbeat and backpressure
- Refs #270 — per-domain retry / Retry-After / circuit-breaker; permanent 403/CAPTCHA/login → `BLOCKED`; partial fetch never closes a window
- Refs #272 — versioned document metadata; content change creates a version; success only after blob + metadata
- Refs #279 — structured per-request/page failure (source, sanitized URL, step, page/cursor, class, HTTP, attempt, next action); no secrets persisted

## CLI

```bash
python3 -m scripts.factory_spine launch --state-dir /tmp/factory-spine
python3 -m scripts.factory_spine launch --state-dir /tmp/factory-spine
```

Second launch is idempotent (`created=false`, same `job_id`).

## Tests

`tests/test_factory_spine_{235,236,246,247,256,268,269,270,272,279}_*.py` drive the shipped functions (403/404-drift/429/504/timeout/parse/persist, lease/idempotency, SHA-256 CAS, invalid PNCP `tamanhoPagina` rejected).
