### PR TITLE
feat(dui): query planner por yield real (SearXNG primary, DDGS benchmark)

### DIFF
--- a/docs/commercial-intelligence/contact-resolution.md
+++ b/docs/commercial-intelligence/contact-resolution.md
@@ -39,6 +39,16 @@ Operational classes already map to R0-R5. A company switchboard plus a named per
 
 Public search is a first-class bounded provider when explicitly enabled. The cascade uses cached datalake/campaign facts to obtain the legal name and known site, then runs targeted search before a positive early stop. Search remains disabled by default in generic/test commands so no caller silently creates network traffic.
 
+The query planner is a separate module (`scripts/decision_unit_intelligence/query_planner`) versioned by policy (`query-policy.v2` default). It instruments each query (family, backend, account/person, useful URLs, observed/identity-associated email, weak sources, latency, failure, cache) and stops early when downstream yield is sufficient or the marginal gain drops. Ranking never uses SERP count. SearXNG is primary; DDGS is an explicit comparison; fallback is recorded, never silent.
+
+```bash
+python3 -m scripts.decision_unit_intelligence.query_planner \
+  --out /tmp/query-yield-30 \
+  --limit 30 \
+  --primary replay-searxng \
+  --compare replay-ddgs
+```
+
 The query planner records the full contextual plan and executes only the configured budget. It covers:
 
 - company name plus decision roles appropriate to the offer;

--- a/docs/commercial-intelligence/query-yield-report.v2.md
+++ b/docs/commercial-intelligence/query-yield-report.v2.md
@@ -1,0 +1,41 @@
+# Query yield report — query-policy.v2
+
+Fonte: `python -m scripts.decision_unit_intelligence.query_planner` (mesmo entry que `decision_unit_intelligence query-yield`) sobre o Track A de 30 contas reais. O pedido de 100 usou as 30 disponíveis — o índice de campanha neste workspace não tem CNPJs extras; nenhuma conta foi inventada.
+
+Ranking por yield downstream (não por SERP count). SearXNG/DDGS ao vivo falharam neste ambiente (URL SearXNG ausente; DDGS `ConnectTimeout`). O relatório abaixo é o mesmo entry em replay das mesmas contas.
+
+## Famílias
+
+| família | searches | useful/s | observed email/s | identity-associated/s |
+|---|---:|---:|---:|---:|
+| SITE_PATH | 40 | 1.0 | 0.70 | 0.0 |
+| DOCUMENT | 6 | 1.0 | 0.0 | 0.0 |
+| PERSON | 12 | 1.0 | 0.0 | 0.0 |
+| ROLE | 0 | 0.0 | 0.0 | 0.0 |
+| COMPANY | 26 | 0.0 | 0.0 | 0.0 |
+
+Fonte fraca: 2 URLs, série separada. Não entram em observed/identity.
+
+## Top / bottom (shape)
+
+- Top: `site_contato`, `site_diretoria` — 0.82 observed email/search (mailboxes genéricos no site oficial).
+- Bottom: ROLE (0 execuções após early-stop) e COMPANY em contas sem domínio (hits de diretório = fonte fraca).
+
+## SearXNG vs DDGS (replay)
+
+- SearXNG executa `filetype:pdf`; DDGS marca o operador como sem suporte (3 skips, não miss vazio).
+- observed email/search: 0.333 (SearXNG) vs 0.346 (DDGS) — denominador maior no SearXNG por DOCUMENT extra.
+- identity-associated/search: 0.0 vs 0.0.
+- **no_gain = true** para EMAIL OBSERVED / IDENTITY-ASSOCIATED por busca.
+
+## Policy default nova
+
+`query-policy.v2` (contrato #393):
+
+- family_order: SITE_PATH → DOCUMENT → PERSON → ROLE → COMPANY
+- budgets: SITE_PATH 4, DOCUMENT 3, PERSON 3, ROLE 1, COMPANY 4
+- adaptive: pessoa+domínio → SITE_PATH/PERSON/DOCUMENT; sem domínio → COMPANY primeiro
+- early-stop: 1 identity-associated, ou 2 observed emails, ou 2 buscas seguidas sem yield
+- 245 queries planejadas → 84 executadas (161 early-stop)
+
+Identidade associada ficou em zero neste cohort: e-mails publicados são `contato@` / `adm@` / `rh@`, não pessoa↔email. PERSON não ganha volume até haver evidência de associação.

--- a/docs/commercial-intelligence/query-yield-report.v2.md
+++ b/docs/commercial-intelligence/query-yield-report.v2.md
@@ -1,41 +1,42 @@
 # Query yield report — query-policy.v2
 
-Fonte: `python -m scripts.decision_unit_intelligence.query_planner` (mesmo entry que `decision_unit_intelligence query-yield`) sobre o Track A de 30 contas reais. O pedido de 100 usou as 30 disponíveis — o índice de campanha neste workspace não tem CNPJs extras; nenhuma conta foi inventada.
+Fonte: `python -m scripts.decision_unit_intelligence.query_planner` sobre o Track A de 30 contas reais. O pedido de 100 usou as 30 disponíveis — o índice de campanha neste workspace não tem CNPJs extras; nenhuma conta foi inventada.
 
-Ranking por yield downstream (não por SERP count). SearXNG/DDGS ao vivo falharam neste ambiente (URL SearXNG ausente; DDGS `ConnectTimeout`). O relatório abaixo é o mesmo entry em replay das mesmas contas.
+Replay **só devolve URLs de `site`/`fonte` observados**. Não inventa `/equipe` nem `/documentos/ata.pdf`. E-mail no snippet só quando a observação registrou o endereço e a query pede email/`@`.
 
-## Famílias
+SearXNG/DDGS ao vivo falharam neste ambiente (URL SearXNG ausente; DDGS `ConnectTimeout`). Ranking por yield downstream (não SERP count). Duas corridas no mesmo entry: ranking idêntico.
+
+## Famílias (replay honesto)
 
 | família | searches | useful/s | observed email/s | identity-associated/s |
 |---|---:|---:|---:|---:|
-| SITE_PATH | 40 | 1.0 | 0.70 | 0.0 |
-| DOCUMENT | 6 | 1.0 | 0.0 | 0.0 |
-| PERSON | 12 | 1.0 | 0.0 | 0.0 |
+| COMPANY | 66 | 0.88 | **0.42** | 0.0 |
+| PERSON | 6 | 1.67 | 0.0 | 0.0 |
+| SITE_PATH | 3 | 0.0 | 0.0 | 0.0 |
+| DOCUMENT | 0 | 0.0 | 0.0 | 0.0 |
 | ROLE | 0 | 0.0 | 0.0 | 0.0 |
-| COMPANY | 26 | 0.0 | 0.0 | 0.0 |
 
-Fonte fraca: 2 URLs, série separada. Não entram em observed/identity.
+Fonte fraca em série separada. 75 buscas executadas, 106 early-stop.
 
-## Top / bottom (shape)
+## Top / bottom
 
-- Top: `site_contato`, `site_diretoria` — 0.82 observed email/search (mailboxes genéricos no site oficial).
-- Bottom: ROLE (0 execuções após early-stop) e COMPANY em contas sem domínio (hits de diretório = fonte fraca).
+- Top: `cnpj_email`, `company_legal_email` — 0.47 observed email/search (mailboxes genéricos no site/fonte observados).
+- Bottom: SITE_PATH slugs (`contato`/`equipe`) sem path correspondente no URL observado; ROLE/DOCUMENT cortados pelo early-stop.
 
-## SearXNG vs DDGS (replay)
+## SearXNG vs DDGS
 
-- SearXNG executa `filetype:pdf`; DDGS marca o operador como sem suporte (3 skips, não miss vazio).
-- observed email/search: 0.333 (SearXNG) vs 0.346 (DDGS) — denominador maior no SearXNG por DOCUMENT extra.
-- identity-associated/search: 0.0 vs 0.0.
-- **no_gain = true** para EMAIL OBSERVED / IDENTITY-ASSOCIATED por busca.
+- observed/search e identity/search: empate (0.0 uplift).
+- **no_gain = true** para EMAIL OBSERVED / IDENTITY-ASSOCIATED.
+- DDGS continua sem `filetype:`; skips não viram miss vazio.
+
+Identidade associada = 0: e-mails observados são `contato@` / `adm@` / `rh@`.
 
 ## Policy default nova
 
-`query-policy.v2` (contrato #393):
+`query-policy.v2`:
 
-- family_order: SITE_PATH → DOCUMENT → PERSON → ROLE → COMPANY
-- budgets: SITE_PATH 4, DOCUMENT 3, PERSON 3, ROLE 1, COMPANY 4
-- adaptive: pessoa+domínio → SITE_PATH/PERSON/DOCUMENT; sem domínio → COMPANY primeiro
-- early-stop: 1 identity-associated, ou 2 observed emails, ou 2 buscas seguidas sem yield
-- 245 queries planejadas → 84 executadas (161 early-stop)
-
-Identidade associada ficou em zero neste cohort: e-mails publicados são `contato@` / `adm@` / `rh@`, não pessoa↔email. PERSON não ganha volume até haver evidência de associação.
+- family_order: COMPANY → PERSON → SITE_PATH → DOCUMENT → ROLE
+- budgets: COMPANY 4, PERSON 3, SITE_PATH 1, DOCUMENT 1, ROLE 1
+- adaptive: pessoa+domínio → COMPANY/PERSON/SITE_PATH; sem domínio → COMPANY primeiro
+- SITE_PATH reduzido: slugs não batem em homepages observadas
+- PERSON não é desligado: precisa rodar quando há gente nomeada

--- a/docs/stories/dui-query-planner-yield.story.md
+++ b/docs/stories/dui-query-planner-yield.story.md
@@ -1,0 +1,28 @@
+# DUI-QP-01 — Query planner por yield real
+
+Status: InReview
+Risk: STANDARD
+
+## Problem
+
+Public search planejava queries sem instrumentar yield downstream. Volume de SERP não é o norte.
+
+## Scope IN
+
+Planner/benchmark em módulo próprio; famílias COMPANY/PERSON/ROLE/DOCUMENT/SITE_PATH; early-stop; adaptive budget; cache query+backend+policy; SearXNG primary / DDGS comparação; report versionado; policy v2 consumível por #393.
+
+## Scope OUT
+
+Rewrite de crawler, pattern engine, document miner, corroboration, Warmbly, web-cfg, SmartLic.
+
+## AC
+
+1. Cada query carrega família, backend, account/person, result count, useful URL, observed/identity yield, latency, failure, cache.
+2. Família sem yield é reduzida; early-stop e adaptive budget valem; sem query duplicada.
+3. Operador sem suporte não executa como sucesso; fallback nunca silencioso.
+4. Benchmark 30 depois 100 (ou as contas reais disponíveis) produz query-yield-report e policy v2.
+5. Testes: reproducibility, backend failure, unsupported operator, cache, early stop, budget, duplicate.
+
+## DoD
+
+Ver `docs/commercial-intelligence/query-yield-report.v2.md`.

--- a/scripts/decision_unit_intelligence/cli.py
+++ b/scripts/decision_unit_intelligence/cli.py
@@ -87,6 +87,8 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
             site_budget=site_budget,
             site_crawl=not args.no_site_crawl,
             site_crawl_baseline=args.site_crawl_baseline,
+            query_policy_version=args.query_policy_version,
+            search_fallback=args.search_fallback,
         )
         payload = acc.to_dict()
         payload["replay_hash"] = account_hash(payload)

--- a/scripts/decision_unit_intelligence/data/query_policies/query-policy.v1.json
+++ b/scripts/decision_unit_intelligence/data/query_policies/query-policy.v1.json
@@ -1,0 +1,23 @@
+{
+  "schema_id": "confenge.dui.query-planner.v1",
+  "version": "query-policy.v1",
+  "ranking_metric": "identity_associated_per_search",
+  "family_order": ["COMPANY", "PERSON", "ROLE", "DOCUMENT", "SITE_PATH"],
+  "family_budgets": {
+    "COMPANY": 4,
+    "PERSON": 8,
+    "ROLE": 6,
+    "DOCUMENT": 5,
+    "SITE_PATH": 4
+  },
+  "disabled_families": [],
+  "early_stop": {
+    "min_identity_associated": 1,
+    "min_observed_email": 2,
+    "max_zero_yield_streak": 3
+  },
+  "adaptive": {
+    "known_person_and_domain": ["PERSON", "SITE_PATH", "DOCUMENT"],
+    "unknown_domain": ["COMPANY", "DOCUMENT", "ROLE"]
+  }
+}

--- a/scripts/decision_unit_intelligence/data/query_policies/query-policy.v2.json
+++ b/scripts/decision_unit_intelligence/data/query_policies/query-policy.v2.json
@@ -1,0 +1,23 @@
+{
+  "schema_id": "confenge.dui.query-planner.v1",
+  "version": "query-policy.v2",
+  "ranking_metric": "identity_associated_per_search",
+  "family_order": ["SITE_PATH", "DOCUMENT", "PERSON", "ROLE", "COMPANY"],
+  "family_budgets": {
+    "SITE_PATH": 4,
+    "DOCUMENT": 3,
+    "PERSON": 3,
+    "ROLE": 1,
+    "COMPANY": 4
+  },
+  "disabled_families": [],
+  "early_stop": {
+    "min_identity_associated": 1,
+    "min_observed_email": 2,
+    "max_zero_yield_streak": 2
+  },
+  "adaptive": {
+    "known_person_and_domain": ["SITE_PATH", "PERSON", "DOCUMENT"],
+    "unknown_domain": ["COMPANY", "DOCUMENT", "ROLE"]
+  }
+}

--- a/scripts/decision_unit_intelligence/data/query_policies/query-policy.v2.json
+++ b/scripts/decision_unit_intelligence/data/query_policies/query-policy.v2.json
@@ -2,13 +2,13 @@
   "schema_id": "confenge.dui.query-planner.v1",
   "version": "query-policy.v2",
   "ranking_metric": "identity_associated_per_search",
-  "family_order": ["SITE_PATH", "DOCUMENT", "PERSON", "ROLE", "COMPANY"],
+  "family_order": ["COMPANY", "PERSON", "SITE_PATH", "DOCUMENT", "ROLE"],
   "family_budgets": {
-    "SITE_PATH": 4,
-    "DOCUMENT": 3,
+    "COMPANY": 4,
     "PERSON": 3,
-    "ROLE": 1,
-    "COMPANY": 4
+    "SITE_PATH": 1,
+    "DOCUMENT": 1,
+    "ROLE": 1
   },
   "disabled_families": [],
   "early_stop": {
@@ -17,7 +17,7 @@
     "max_zero_yield_streak": 2
   },
   "adaptive": {
-    "known_person_and_domain": ["SITE_PATH", "PERSON", "DOCUMENT"],
+    "known_person_and_domain": ["COMPANY", "PERSON", "SITE_PATH"],
     "unknown_domain": ["COMPANY", "DOCUMENT", "ROLE"]
   }
 }

--- a/scripts/decision_unit_intelligence/providers/public_search.py
+++ b/scripts/decision_unit_intelligence/providers/public_search.py
@@ -8,11 +8,18 @@ from scripts.decision_unit_intelligence.email_discovery import discover_internal
 from scripts.decision_unit_intelligence.evidence import make_evidence
 from scripts.decision_unit_intelligence.models import EpistemicClass, SearchAttempt, normalize_cnpj, now_iso, stable_id
 from scripts.decision_unit_intelligence.providers.base import InvestigationContext, ProviderResult
+from scripts.decision_unit_intelligence.query_planner import (
+    ExplicitFallbackBackend,
+    aggregate_executions,
+    default_policy,
+    execute_plan,
+    load_policy,
+    plan_queries,
+)
 from scripts.decision_unit_intelligence.web_discovery import (
     SearchBackend,
     SearchBudget,
     WebCrawler,
-    build_query_plan,
     dedupe_search_hits,
     extract_public_evidence,
     rank_crawl_urls,
@@ -31,18 +38,29 @@ class PublicSearchProvider:
         backend: SearchBackend | None = None,
         crawler: WebCrawler | None = None,
         budget: SearchBudget | None = None,
+        policy_version: str | None = None,
+        planner_cache=None,
     ) -> None:
         self.backend = backend
         self.crawler = crawler
         self.budget = budget or SearchBudget()
         self.enabled = backend is not None
+        self.policy = load_policy(policy_version) if policy_version else default_policy()
+        self.planner_cache = planner_cache
 
     def collect(self, context: InvestigationContext) -> ProviderResult:
         cnpj = normalize_cnpj(context.cnpj)
         known_site = str(context.extra.get("company_site") or "") or None
         known_people = [str(name) for name in (context.extra.get("known_people") or []) if name]
-        plan = build_query_plan(context, known_domain=_domain(known_site), known_people=known_people)
-        queries = plan[: self.budget.max_queries]
+        known_domain = _domain(known_site)
+        plan = plan_queries(
+            context,
+            policy=self.policy,
+            known_domain=known_domain,
+            known_people=known_people,
+            max_queries=self.budget.max_queries,
+        )
+        queries = [spec.query for spec in plan.specs]
         attempt = SearchAttempt(
             attempt_id=stable_id("att", self.provider_id, cnpj, "|".join(queries)),
             company_entity_id=cnpj,
@@ -52,7 +70,9 @@ class PublicSearchProvider:
             status="skipped",
             queries=queries,
             extra={
-                "planned_query_count": len(plan),
+                "planned_query_count": len(plan.specs),
+                "query_policy_version": self.policy.version,
+                "adaptive_mode": plan.adaptive_mode,
                 "budget": {
                     "max_queries": self.budget.max_queries,
                     "max_results_per_query": self.budget.max_results_per_query,
@@ -79,23 +99,30 @@ class PublicSearchProvider:
             int(getattr(self.crawler, "cache_hits", 0)),
             int(getattr(self.crawler, "cache_misses", 0)),
         )
-        hits = []
-        failures: list[str] = []
-        for query in queries:
-            try:
-                hits.extend(self.backend.search(query, limit=self.budget.max_results_per_query))
-            except Exception as exc:  # provider failures are preserved, not promoted to evidence
-                failures.append(f"{type(exc).__name__}:{query}")
-        hits = dedupe_search_hits(hits)
+        run = execute_plan(
+            plan,
+            self.backend,
+            policy=self.policy,
+            cache=self.planner_cache,
+            limit=self.budget.max_results_per_query,
+            legal_name=context.legal_name,
+            known_people=known_people,
+        )
+        executed = [row for row in run.executions if row.executed]
+        attempt.queries = [row.spec.query for row in executed]
+        hits = dedupe_search_hits(run.hits)
+        failures = [f"{row.failure}:{row.spec.query}" for row in run.executions if row.failure]
         resolution = resolve_corporate_domain(context, hits, known_site=known_site)
         attempt.extra["search_backend"] = self.backend.backend_id
         attempt.extra["result_count"] = len(hits)
         attempt.extra["failures"] = failures
         attempt.extra["domain_resolution"] = resolution.to_dict()
+        attempt.extra["query_executions"] = [row.to_dict() for row in run.executions]
+        attempt.extra["query_yield"] = aggregate_executions(run.executions)
+        if isinstance(self.backend, ExplicitFallbackBackend) and self.backend.events:
+            attempt.extra["fallback_events"] = [event.to_dict() for event in self.backend.events]
         useful_urls = [
-            hit.url
-            for hit in hits
-            if resolution.canonical_domain and _domain(hit.url) == resolution.canonical_domain
+            hit.url for hit in hits if resolution.canonical_domain and _domain(hit.url) == resolution.canonical_domain
         ]
         attempt.extra["useful_urls"] = useful_urls
 

--- a/scripts/decision_unit_intelligence/query_planner/__init__.py
+++ b/scripts/decision_unit_intelligence/query_planner/__init__.py
@@ -1,0 +1,67 @@
+"""Yield-driven public-search query planner.
+
+Consumable by the #393 batch via policy version. SearXNG is primary; DDGS is
+an explicit comparison. Fallback is never silent.
+"""
+
+from scripts.decision_unit_intelligence.query_planner.planner import (
+    ExplicitFallbackBackend,
+    PlanRun,
+    QueryPlannerError,
+    QuerySearchCache,
+    adaptive_mode,
+    default_policy,
+    execute_plan,
+    load_policy,
+    plan_queries,
+    should_early_stop,
+    write_policy,
+)
+from scripts.decision_unit_intelligence.query_planner.spec import (
+    DEFAULT_POLICY_VERSION,
+    QUERY_PLANNER_SCHEMA,
+    QueryExecution,
+    QueryFamily,
+    QueryPlan,
+    QueryPolicy,
+    QuerySpec,
+    emit_query_specs,
+    normalize_query,
+    operators_for,
+    unsupported_operators,
+)
+from scripts.decision_unit_intelligence.query_planner.yield_eval import (
+    aggregate_executions,
+    evaluate_serp_yield,
+    rank_families,
+    rank_queries,
+)
+
+__all__ = [
+    "DEFAULT_POLICY_VERSION",
+    "QUERY_PLANNER_SCHEMA",
+    "ExplicitFallbackBackend",
+    "PlanRun",
+    "QueryExecution",
+    "QueryFamily",
+    "QueryPlan",
+    "QueryPlannerError",
+    "QueryPolicy",
+    "QuerySearchCache",
+    "QuerySpec",
+    "adaptive_mode",
+    "aggregate_executions",
+    "default_policy",
+    "emit_query_specs",
+    "evaluate_serp_yield",
+    "execute_plan",
+    "load_policy",
+    "normalize_query",
+    "operators_for",
+    "plan_queries",
+    "rank_families",
+    "rank_queries",
+    "should_early_stop",
+    "unsupported_operators",
+    "write_policy",
+]

--- a/scripts/decision_unit_intelligence/query_planner/__main__.py
+++ b/scripts/decision_unit_intelligence/query_planner/__main__.py
@@ -1,0 +1,69 @@
+"""python -m scripts.decision_unit_intelligence.query_planner"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from scripts.decision_unit_intelligence.query_planner.benchmark import run_query_yield
+from scripts.decision_unit_intelligence.query_planner.spec import DEFAULT_POLICY_VERSION
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="dui-query-planner")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--limit", type=int, default=30)
+    parser.add_argument("--query-policy-version", default=DEFAULT_POLICY_VERSION)
+    parser.add_argument(
+        "--primary",
+        choices=("searxng", "ddgs", "replay", "replay-searxng", "replay-ddgs"),
+        default="searxng",
+    )
+    parser.add_argument(
+        "--compare",
+        choices=("ddgs", "searxng", "replay", "replay-ddgs", "replay-searxng", "off"),
+        default="ddgs",
+    )
+    parser.add_argument("--searxng-url")
+    parser.add_argument("--search-results-per-query", type=int, default=5)
+    parser.add_argument("--web-timeout-seconds", type=float, default=8.0)
+    parser.add_argument("--search-cache-dir", default=".cache/confenge-prospect")
+    parser.add_argument("--require-live", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    report = run_query_yield(
+        out_dir=Path(args.out),
+        limit=args.limit,
+        policy_version=args.query_policy_version,
+        primary=args.primary,
+        compare=None if args.compare in {"off", "none", None} else args.compare,
+        searxng_url=args.searxng_url or os.getenv("CONFENGE_SEARXNG_URL"),
+        cache_dir=Path(args.search_cache_dir),
+        results_per_query=args.search_results_per_query,
+        timeout_seconds=args.web_timeout_seconds,
+        allow_replay=not args.require_live,
+    )
+    print(
+        json.dumps(
+            {
+                "out": args.out,
+                "n": report["n"],
+                "paths": report.get("paths"),
+                "uplift": report.get("uplift"),
+                "live_error": report.get("live_error"),
+                "policy_version": report.get("derived_policy_version"),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/decision_unit_intelligence/query_planner/benchmark.py
+++ b/scripts/decision_unit_intelligence/query_planner/benchmark.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from scripts.decision_unit_intelligence.cohort import TRACK_A_CNPJS, build_manifest
 from scripts.decision_unit_intelligence.email_discovery import is_third_party_echo_source
@@ -96,103 +97,18 @@ class ObservationReplayBackend:
     def _hits_for(self, account: BenchmarkAccount, query: str) -> list[SearchHit]:
         if not _query_mentions(account, query):
             return []
-        domain = account.domain
-        email = normalize_email(account.email)
-        fonte = account.fonte or ""
         hits: list[SearchHit] = []
-        if "filetype:pdf" in query.lower():
-            if fonte.lower().endswith(".pdf"):
-                hits.append(
-                    SearchHit(
-                        url=fonte,
-                        title=f"{account.legal_name} contrato",
-                        snippet=_snippet(account, email, document=True),
-                        engine=self.simulate_backend,
-                    )
-                )
-            elif domain:
-                hits.append(
-                    SearchHit(
-                        url=f"https://{domain}/documentos/ata.pdf",
-                        title=f"{account.legal_name} ata",
-                        snippet=_snippet(account, email, document=True),
-                        engine=self.simulate_backend,
-                    )
-                )
-            return hits
-        if domain and (f"site:{domain}" in query or (email and f"@{domain}" in query)):
-            slug = _site_slug(query)
-            url = f"https://{domain}/{slug}" if slug else f"https://{domain}/"
-            person = _person_in_query(account, query)
+        for url in _observed_urls(account):
+            if not _url_matches_query(url, query, account):
+                continue
             hits.append(
                 SearchHit(
                     url=url,
-                    title=f"{account.legal_name} {slug or 'institucional'}",
-                    snippet=_snippet(account, email, person=person, site=True),
+                    title=_observed_title(account, url, query),
+                    snippet=_observed_snippet(account, url, query),
                     engine=self.simulate_backend,
                 )
             )
-            return hits
-        if any(person.lower() in query.lower() for person in account.people):
-            person = _person_in_query(account, query)
-            if fonte and is_third_party_echo_source(fonte):
-                hits.append(
-                    SearchHit(
-                        url=fonte,
-                        title=f"{person} {account.legal_name}",
-                        snippet=f"{person} sócio-administrador. Fonte cadastral.",
-                        engine=self.simulate_backend,
-                    )
-                )
-            elif domain:
-                hits.append(
-                    SearchHit(
-                        url=f"https://{domain}/equipe",
-                        title=f"{person} — {account.legal_name}",
-                        snippet=_snippet(account, email, person=person, site=True),
-                        engine=self.simulate_backend,
-                    )
-                )
-            return hits
-        if account.legal_name and account.legal_name.lower() in query.lower():
-            if domain:
-                hits.append(
-                    SearchHit(
-                        url=f"https://{domain}/contato",
-                        title=f"{account.legal_name} contato",
-                        snippet=_snippet(account, email, site=True),
-                        engine=self.simulate_backend,
-                    )
-                )
-            elif fonte:
-                hits.append(
-                    SearchHit(
-                        url=fonte,
-                        title=account.legal_name or account.cnpj,
-                        snippet=_snippet(account, email),
-                        engine=self.simulate_backend,
-                    )
-                )
-            return hits
-        if account.cnpj in query:
-            if fonte:
-                hits.append(
-                    SearchHit(
-                        url=fonte,
-                        title=f"CNPJ {account.cnpj}",
-                        snippet=_snippet(account, email),
-                        engine=self.simulate_backend,
-                    )
-                )
-            elif domain:
-                hits.append(
-                    SearchHit(
-                        url=f"https://{domain}/",
-                        title=account.legal_name or account.cnpj,
-                        snippet=_snippet(account, email, site=True),
-                        engine=self.simulate_backend,
-                    )
-                )
         return hits
 
 
@@ -217,6 +133,15 @@ def _person_in_query(account: BenchmarkAccount, query: str) -> str | None:
     return None
 
 
+def _observed_urls(account: BenchmarkAccount) -> list[str]:
+    """Only URLs recorded on the observation. Never construct /equipe or /ata.pdf."""
+    urls: list[str] = []
+    for raw in (account.site, account.fonte):
+        if raw and raw not in urls:
+            urls.append(raw)
+    return urls
+
+
 def _site_slug(query: str) -> str | None:
     for slug in ("equipe", "diretoria", "contato", "engenharia"):
         if slug in query.lower():
@@ -224,25 +149,62 @@ def _site_slug(query: str) -> str | None:
     return None
 
 
-def _snippet(
-    account: BenchmarkAccount,
-    email: str | None,
-    *,
-    person: str | None = None,
-    site: bool = False,
-    document: bool = False,
-) -> str:
+def _url_matches_query(url: str, query: str, account: BenchmarkAccount) -> bool:
+    folded = query.lower()
+    path = (urlsplit(url).path or "").lower()
+    host = host_of(url)
+    if "filetype:pdf" in folded:
+        return path.endswith(".pdf") or url.lower().split("?", 1)[0].endswith(".pdf")
+    slug = _site_slug(query)
+    if slug and "site:" in folded:
+        return bool(account.domain and host == account.domain and slug in path)
+    if account.domain and (f"site:{account.domain}" in folded or f"@{account.domain}" in folded):
+        return host == account.domain
+    return True
+
+
+def _include_observed_email(account: BenchmarkAccount, url: str, query: str) -> bool:
+    email = normalize_email(account.email)
+    if not email or is_third_party_echo_source(url):
+        return False
+    folded = query.lower()
+    if "email" not in folded and "@" not in folded:
+        return False
+    person = _person_in_query(account, query)
+    mentions_company = bool(
+        (account.legal_name and account.legal_name.lower() in folded)
+        or account.cnpj in query
+        or (account.domain and account.domain in folded)
+        or (account.trade_name and account.trade_name.lower() in folded)
+    )
+    if person and not mentions_company:
+        return _email_belongs_to_person(email, person)
+    return mentions_company
+
+
+def _observed_title(account: BenchmarkAccount, url: str, query: str) -> str:
+    person = _person_in_query(account, query)
+    label = account.legal_name or account.cnpj
+    if person:
+        return f"{person} {label}"
+    if url.lower().split("?", 1)[0].endswith(".pdf"):
+        return f"{label} documento"
+    return label
+
+
+def _observed_snippet(account: BenchmarkAccount, url: str, query: str) -> str:
     parts = [account.legal_name or account.cnpj]
+    person = _person_in_query(account, query)
     if person:
         parts.append(person)
-    if document:
-        parts.append("ata contrato filetype:pdf")
-    if site and email:
-        parts.append(email)
-        if person and _email_belongs_to_person(email, person):
-            parts.append(f"E-mail de {person}: {email}")
-    elif email and not is_third_party_echo_source(account.fonte or ""):
-        parts.append(email)
+    if url.lower().split("?", 1)[0].endswith(".pdf"):
+        parts.append("documento público")
+    if _include_observed_email(account, url, query):
+        email = normalize_email(account.email)
+        if email:
+            parts.append(email)
+            if person and _email_belongs_to_person(email, person):
+                parts.append(f"E-mail de {person}: {email}")
     return ". ".join(part for part in parts if part)
 
 
@@ -390,12 +352,17 @@ def derive_policy(family_ranking: list[dict[str, Any]], *, version: str = DEFAUL
     if QueryFamily.COMPANY in disabled:
         disabled.remove(QueryFamily.COMPANY)
         budgets[QueryFamily.COMPANY] = 4
+    if QueryFamily.PERSON in disabled:
+        disabled.remove(QueryFamily.PERSON)
+        budgets[QueryFamily.PERSON] = max(budgets.get(QueryFamily.PERSON, 0), 2)
     if QueryFamily.ROLE in disabled:
         disabled.remove(QueryFamily.ROLE)
         budgets[QueryFamily.ROLE] = 1
     ranked_specific = tuple(
-        family for family in order if family in {QueryFamily.PERSON, QueryFamily.SITE_PATH, QueryFamily.DOCUMENT}
-    ) or (QueryFamily.PERSON, QueryFamily.SITE_PATH, QueryFamily.DOCUMENT)
+        family
+        for family in order
+        if family in {QueryFamily.COMPANY, QueryFamily.PERSON, QueryFamily.SITE_PATH, QueryFamily.DOCUMENT}
+    ) or (QueryFamily.COMPANY, QueryFamily.PERSON, QueryFamily.SITE_PATH)
     return QueryPolicy(
         version=version,
         ranking_metric="identity_associated_per_search",

--- a/scripts/decision_unit_intelligence/query_planner/benchmark.py
+++ b/scripts/decision_unit_intelligence/query_planner/benchmark.py
@@ -1,0 +1,626 @@
+"""Benchmark the same 30, then 100, accounts. Replay is the honest live fallback."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.decision_unit_intelligence.cohort import TRACK_A_CNPJS, build_manifest
+from scripts.decision_unit_intelligence.email_discovery import is_third_party_echo_source
+from scripts.decision_unit_intelligence.models import normalize_email, now_iso
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext
+from scripts.decision_unit_intelligence.providers.historical_campaign import load_campaign_index, parse_qsa_blob
+from scripts.decision_unit_intelligence.query_planner.planner import (
+    QueryPlannerError,
+    QuerySearchCache,
+    execute_plan,
+    load_policy,
+    plan_queries,
+)
+from scripts.decision_unit_intelligence.query_planner.spec import (
+    DEFAULT_POLICY_VERSION,
+    QueryExecution,
+    QueryFamily,
+    QueryPolicy,
+    host_of,
+    infer_trade_name,
+    operators_for,
+)
+from scripts.decision_unit_intelligence.query_planner.yield_eval import (
+    aggregate_executions,
+    rank_families,
+    rank_queries,
+)
+from scripts.decision_unit_intelligence.web_discovery import JsonDiscoveryCache, SearchHit
+
+OBSERVATIONS_PATH = Path(__file__).resolve().parents[1] / "data" / "track_a_30.observations.json"
+
+
+@dataclass
+class BenchmarkAccount:
+    cnpj: str
+    legal_name: str | None
+    site: str | None
+    email: str | None
+    fonte: str | None
+    people: list[str]
+    trade_name: str | None = None
+
+    @property
+    def domain(self) -> str | None:
+        return host_of(self.site)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cnpj": self.cnpj,
+            "legal_name": self.legal_name,
+            "site": self.site,
+            "email": self.email,
+            "fonte": self.fonte,
+            "people": list(self.people),
+            "trade_name": self.trade_name,
+            "domain": self.domain,
+        }
+
+
+class ObservationReplayBackend:
+    """Deterministic hits grounded in campaign observations. Does not invent emails."""
+
+    def __init__(
+        self,
+        accounts: list[BenchmarkAccount],
+        *,
+        simulate_backend: str = "searxng",
+        failures: dict[str, Exception] | None = None,
+    ) -> None:
+        self.backend_id = f"replay-{simulate_backend}"
+        self.simulate_backend = simulate_backend
+        self.accounts = {account.cnpj: account for account in accounts}
+        self.failures = failures or {}
+        self.queries: list[str] = []
+
+    def fail(self, query: str, exc: Exception) -> None:
+        self.failures[query] = exc
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        self.queries.append(query)
+        if query in self.failures:
+            raise self.failures[query]
+        hits: list[SearchHit] = []
+        for account in self.accounts.values():
+            hits.extend(self._hits_for(account, query))
+        return hits[:limit]
+
+    def _hits_for(self, account: BenchmarkAccount, query: str) -> list[SearchHit]:
+        if not _query_mentions(account, query):
+            return []
+        domain = account.domain
+        email = normalize_email(account.email)
+        fonte = account.fonte or ""
+        hits: list[SearchHit] = []
+        if "filetype:pdf" in query.lower():
+            if fonte.lower().endswith(".pdf"):
+                hits.append(
+                    SearchHit(
+                        url=fonte,
+                        title=f"{account.legal_name} contrato",
+                        snippet=_snippet(account, email, document=True),
+                        engine=self.simulate_backend,
+                    )
+                )
+            elif domain:
+                hits.append(
+                    SearchHit(
+                        url=f"https://{domain}/documentos/ata.pdf",
+                        title=f"{account.legal_name} ata",
+                        snippet=_snippet(account, email, document=True),
+                        engine=self.simulate_backend,
+                    )
+                )
+            return hits
+        if domain and (f"site:{domain}" in query or (email and f"@{domain}" in query)):
+            slug = _site_slug(query)
+            url = f"https://{domain}/{slug}" if slug else f"https://{domain}/"
+            person = _person_in_query(account, query)
+            hits.append(
+                SearchHit(
+                    url=url,
+                    title=f"{account.legal_name} {slug or 'institucional'}",
+                    snippet=_snippet(account, email, person=person, site=True),
+                    engine=self.simulate_backend,
+                )
+            )
+            return hits
+        if any(person.lower() in query.lower() for person in account.people):
+            person = _person_in_query(account, query)
+            if fonte and is_third_party_echo_source(fonte):
+                hits.append(
+                    SearchHit(
+                        url=fonte,
+                        title=f"{person} {account.legal_name}",
+                        snippet=f"{person} sócio-administrador. Fonte cadastral.",
+                        engine=self.simulate_backend,
+                    )
+                )
+            elif domain:
+                hits.append(
+                    SearchHit(
+                        url=f"https://{domain}/equipe",
+                        title=f"{person} — {account.legal_name}",
+                        snippet=_snippet(account, email, person=person, site=True),
+                        engine=self.simulate_backend,
+                    )
+                )
+            return hits
+        if account.legal_name and account.legal_name.lower() in query.lower():
+            if domain:
+                hits.append(
+                    SearchHit(
+                        url=f"https://{domain}/contato",
+                        title=f"{account.legal_name} contato",
+                        snippet=_snippet(account, email, site=True),
+                        engine=self.simulate_backend,
+                    )
+                )
+            elif fonte:
+                hits.append(
+                    SearchHit(
+                        url=fonte,
+                        title=account.legal_name or account.cnpj,
+                        snippet=_snippet(account, email),
+                        engine=self.simulate_backend,
+                    )
+                )
+            return hits
+        if account.cnpj in query:
+            if fonte:
+                hits.append(
+                    SearchHit(
+                        url=fonte,
+                        title=f"CNPJ {account.cnpj}",
+                        snippet=_snippet(account, email),
+                        engine=self.simulate_backend,
+                    )
+                )
+            elif domain:
+                hits.append(
+                    SearchHit(
+                        url=f"https://{domain}/",
+                        title=account.legal_name or account.cnpj,
+                        snippet=_snippet(account, email, site=True),
+                        engine=self.simulate_backend,
+                    )
+                )
+        return hits
+
+
+def _query_mentions(account: BenchmarkAccount, query: str) -> bool:
+    folded = query.lower()
+    if account.cnpj in query:
+        return True
+    if account.legal_name and account.legal_name.lower() in folded:
+        return True
+    if account.trade_name and account.trade_name.lower() in folded:
+        return True
+    if account.domain and account.domain in folded:
+        return True
+    return any(person.lower() in folded for person in account.people)
+
+
+def _person_in_query(account: BenchmarkAccount, query: str) -> str | None:
+    folded = query.lower()
+    for person in account.people:
+        if person.lower() in folded:
+            return person
+    return None
+
+
+def _site_slug(query: str) -> str | None:
+    for slug in ("equipe", "diretoria", "contato", "engenharia"):
+        if slug in query.lower():
+            return slug
+    return None
+
+
+def _snippet(
+    account: BenchmarkAccount,
+    email: str | None,
+    *,
+    person: str | None = None,
+    site: bool = False,
+    document: bool = False,
+) -> str:
+    parts = [account.legal_name or account.cnpj]
+    if person:
+        parts.append(person)
+    if document:
+        parts.append("ata contrato filetype:pdf")
+    if site and email:
+        parts.append(email)
+        if person and _email_belongs_to_person(email, person):
+            parts.append(f"E-mail de {person}: {email}")
+    elif email and not is_third_party_echo_source(account.fonte or ""):
+        parts.append(email)
+    return ". ".join(part for part in parts if part)
+
+
+def _email_belongs_to_person(email: str, person: str) -> bool:
+    local = email.split("@", 1)[0].replace(".", " ").replace("_", " ")
+    tokens = [tok for tok in person.lower().split() if len(tok) > 2]
+    return bool(tokens) and tokens[0] in local and tokens[-1] in local
+
+
+class LiveBackendError(QueryPlannerError):
+    pass
+
+
+def load_benchmark_accounts(limit: int) -> tuple[list[BenchmarkAccount], dict[str, Any]]:
+    index = load_campaign_index()
+    requested = _cohort_cnpjs(limit)
+    accounts: list[BenchmarkAccount] = []
+    for cnpj in requested:
+        row = index.get(cnpj) or {"cnpj": cnpj}
+        people = [name for name, _role in parse_qsa_blob(row.get("qsa"))]
+        people.extend(name for name, _role in parse_qsa_blob(row.get("qsa2")) if name not in people)
+        legal = row.get("legal_name") or row.get("razao_social") or row.get("Empresa")
+        site = row.get("site")
+        email = row.get("email") or None
+        if isinstance(email, str) and not email.strip():
+            email = None
+        domain = host_of(site) if site else None
+        accounts.append(
+            BenchmarkAccount(
+                cnpj=cnpj,
+                legal_name=str(legal) if legal else None,
+                site=str(site) if site else None,
+                email=str(email) if email else None,
+                fonte=str(row.get("fonte") or "") or None,
+                people=people,
+                trade_name=infer_trade_name(str(legal) if legal else None, domain),
+            )
+        )
+    meta = {
+        "requested": limit,
+        "available": len(accounts),
+        "selection": build_manifest([account.cnpj for account in accounts])["selection"],
+        "shortage": None
+        if len(accounts) >= limit
+        else "campaign index does not contain enough real CNPJs; no invented accounts",
+    }
+    return accounts, meta
+
+
+def _cohort_cnpjs(limit: int) -> list[str]:
+    if limit <= len(TRACK_A_CNPJS):
+        return TRACK_A_CNPJS[:limit]
+    extra = [cnpj for cnpj in load_campaign_index() if cnpj not in TRACK_A_CNPJS]
+    extra.sort()
+    return (TRACK_A_CNPJS + extra)[:limit]
+
+
+def run_backend_benchmark(
+    accounts: list[BenchmarkAccount],
+    *,
+    backend,
+    policy: QueryPolicy,
+    cache: QuerySearchCache | None,
+    results_per_query: int,
+) -> list[QueryExecution]:
+    executions: list[QueryExecution] = []
+    for account in accounts:
+        context = InvestigationContext(cnpj=account.cnpj, legal_name=account.legal_name, service="reajuste_14133")
+        plan = plan_queries(
+            context,
+            policy=policy,
+            known_domain=account.domain,
+            known_people=account.people,
+            trade_name=account.trade_name,
+        )
+        executions.extend(
+            execute_plan(
+                plan,
+                backend,
+                policy=policy,
+                cache=cache,
+                limit=results_per_query,
+                legal_name=account.legal_name,
+                known_people=account.people,
+            ).executions
+        )
+    return executions
+
+
+def compare_backends(
+    primary: dict[str, Any],
+    comparison: dict[str, Any],
+) -> dict[str, Any]:
+    def _uplift(metric: str) -> float | None:
+        base = comparison.get(metric)
+        next_value = primary.get(metric)
+        if base in (None, 0) and next_value in (None, 0):
+            return 0.0
+        if not base:
+            return None
+        return round((float(next_value) - float(base)) / float(base), 4)
+
+    return {
+        "primary": primary.get("backend"),
+        "comparison": comparison.get("backend"),
+        "observed_email_per_search": _uplift("observed_email_per_search"),
+        "identity_associated_per_search": _uplift("identity_associated_per_search"),
+        "useful_pages_per_search": _uplift("useful_pages_per_search"),
+        "observed_email_per_minute": _uplift("observed_email_per_minute"),
+        "identity_associated_per_minute": _uplift("identity_associated_per_minute"),
+        "no_gain": _no_gain(primary, comparison),
+    }
+
+
+def _no_gain(primary: dict[str, Any], comparison: dict[str, Any]) -> bool:
+    keys = ("observed_email_per_search", "identity_associated_per_search")
+    return all(float(primary.get(key) or 0) <= float(comparison.get(key) or 0) for key in keys)
+
+
+def derive_policy(family_ranking: list[dict[str, Any]], *, version: str = DEFAULT_POLICY_VERSION) -> QueryPolicy:
+    budgets: dict[QueryFamily, int] = {}
+    disabled: list[QueryFamily] = []
+    order: list[QueryFamily] = []
+    for row in family_ranking:
+        family = QueryFamily(row["family"])
+        order.append(family)
+        identity = float(row.get("identity_associated_per_search") or 0)
+        observed = float(row.get("observed_email_per_search") or 0)
+        useful = float(row.get("useful_pages_per_search") or 0)
+        if identity >= 0.05 or observed >= 0.10:
+            budgets[family] = 4 if family != QueryFamily.ROLE else 2
+        elif useful >= 0.25:
+            budgets[family] = 3
+        elif family == QueryFamily.COMPANY:
+            budgets[family] = 4
+        else:
+            budgets[family] = 1
+            if useful <= 0 and observed <= 0 and identity <= 0 and family != QueryFamily.COMPANY:
+                disabled.append(family)
+                budgets[family] = 0
+    for family in QueryFamily:
+        if family not in budgets:
+            budgets[family] = 1 if family == QueryFamily.COMPANY else 0
+            order.append(family)
+    if QueryFamily.COMPANY in disabled:
+        disabled.remove(QueryFamily.COMPANY)
+        budgets[QueryFamily.COMPANY] = 4
+    if QueryFamily.ROLE in disabled:
+        disabled.remove(QueryFamily.ROLE)
+        budgets[QueryFamily.ROLE] = 1
+    ranked_specific = tuple(
+        family for family in order if family in {QueryFamily.PERSON, QueryFamily.SITE_PATH, QueryFamily.DOCUMENT}
+    ) or (QueryFamily.PERSON, QueryFamily.SITE_PATH, QueryFamily.DOCUMENT)
+    return QueryPolicy(
+        version=version,
+        ranking_metric="identity_associated_per_search",
+        family_order=tuple(order) or tuple(QueryFamily),
+        family_budgets=budgets,
+        disabled_families=frozenset(family for family in disabled if family != QueryFamily.ROLE),
+        known_person_and_domain_families=ranked_specific,
+    )
+
+
+def build_report(
+    *,
+    n: int,
+    policy: QueryPolicy,
+    primary_name: str,
+    primary_exec: list[QueryExecution],
+    comparison_name: str | None,
+    comparison_exec: list[QueryExecution] | None,
+    cohort_meta: dict[str, Any],
+    live_error: str | None,
+) -> dict[str, Any]:
+    primary_metrics = aggregate_executions(primary_exec)
+    primary_metrics["backend"] = primary_name
+    families = rank_families(primary_exec)
+    queries = rank_queries(primary_exec)
+    comparison_metrics = None
+    uplift = None
+    if comparison_exec is not None and comparison_name:
+        comparison_metrics = aggregate_executions(comparison_exec)
+        comparison_metrics["backend"] = comparison_name
+        uplift = compare_backends(primary_metrics, comparison_metrics)
+    derived = derive_policy(families, version=DEFAULT_POLICY_VERSION)
+    return {
+        "schema_id": "confenge.dui.query-yield-report.v1",
+        "generated_at": now_iso(),
+        "policy_version": policy.version,
+        "derived_policy_version": derived.version,
+        "n": n,
+        "cohort": cohort_meta,
+        "primary": primary_metrics,
+        "comparison": comparison_metrics,
+        "uplift": uplift,
+        "families": families,
+        "queries_ranked": queries,
+        "top_queries": queries[:5],
+        "bottom_queries": list(reversed(queries[-5:])) if queries else [],
+        "operator_support": {
+            "searxng": sorted(op.value for op in operators_for("searxng")),
+            "ddgs": sorted(op.value for op in operators_for("ddgs")),
+        },
+        "weak_sources_separate": True,
+        "ranking_metric": policy.ranking_metric,
+        "live_error": live_error,
+        "derived_policy": derived.to_dict(),
+        "note": (
+            "Ranking is downstream yield (useful pages / observed email / identity-associated), "
+            "never SERP result count."
+        ),
+    }
+
+
+def render_report_markdown(report: dict[str, Any]) -> str:
+    primary = report["primary"]
+    lines = [
+        f"# Query yield report — {report['policy_version']}",
+        "",
+        f"- generated_at: `{report['generated_at']}`",
+        f"- n: **{report['n']}** (requested {report['cohort'].get('requested')}, available {report['cohort'].get('available')})",
+        f"- ranking: `{report['ranking_metric']}` (not SERP count)",
+        f"- derived policy: `{report['derived_policy_version']}`",
+        "",
+        "## Primary backend",
+        "",
+        f"- backend: `{primary.get('backend')}`",
+        f"- searches: {primary.get('searches')}",
+        f"- useful pages/search: {primary.get('useful_pages_per_search')}",
+        f"- observed email/search: {primary.get('observed_email_per_search')}",
+        f"- identity-associated/search: {primary.get('identity_associated_per_search')}",
+        f"- p50/p95 latency ms: {primary.get('latency_p50_ms')} / {primary.get('latency_p95_ms')}",
+        f"- failures / 429: {primary.get('failures')} / {primary.get('http_429')}",
+        f"- weak sources (separate): {primary.get('weak_sources')}",
+        "",
+    ]
+    if report.get("comparison"):
+        other = report["comparison"]
+        uplift = report.get("uplift") or {}
+        lines.extend(
+            [
+                "## SearXNG vs DDGS",
+                "",
+                f"- comparison backend: `{other.get('backend')}`",
+                f"- observed email/search uplift: {uplift.get('observed_email_per_search')}",
+                f"- identity-associated/search uplift: {uplift.get('identity_associated_per_search')}",
+                f"- no_gain: **{uplift.get('no_gain')}**",
+                "",
+            ]
+        )
+    if report.get("live_error"):
+        lines.extend(["## Live backends", "", "```", str(report["live_error"]), "```", ""])
+    lines.extend(
+        [
+            "## Families (downstream yield)",
+            "",
+            "| family | searches | useful/s | observed/s | identity/s |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    for row in report.get("families") or []:
+        lines.append(
+            f"| {row['family']} | {row['searches']} | {row['useful_pages_per_search']} | "
+            f"{row['observed_email_per_search']} | {row['identity_associated_per_search']} |"
+        )
+    lines.extend(["", "## Top queries", ""])
+    for row in report.get("top_queries") or []:
+        lines.append(
+            f"- `{row['shape_id']}` ({row['family']}): identity/s={row['identity_associated_per_search']} "
+            f"observed/s={row['observed_email_per_search']} useful/s={row['useful_pages_per_search']}"
+        )
+    lines.extend(["", "## Bottom queries", ""])
+    for row in report.get("bottom_queries") or []:
+        lines.append(
+            f"- `{row['shape_id']}` ({row['family']}): identity/s={row['identity_associated_per_search']} "
+            f"observed/s={row['observed_email_per_search']} useful/s={row['useful_pages_per_search']}"
+        )
+    if report["cohort"].get("shortage"):
+        lines.extend(["", "## Cohort note", "", report["cohort"]["shortage"], ""])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(report: dict[str, Any], out_dir: Path) -> dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "query-yield-report.json"
+    md_path = out_dir / "query-yield-report.md"
+    policy_path = out_dir / f"{report['derived_policy_version']}.json"
+    json_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    md_path.write_text(render_report_markdown(report), encoding="utf-8")
+    policy_path.write_text(json.dumps(report["derived_policy"], ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {"json": str(json_path), "md": str(md_path), "policy": str(policy_path)}
+
+
+def try_live_backend(name: str, *, searxng_url: str | None, timeout_seconds: float):
+    from scripts.decision_unit_intelligence.web_discovery import DdgsSearchBackend, SearxngSearchBackend
+
+    if name == "searxng":
+        if not searxng_url:
+            raise LiveBackendError("searxng requires --searxng-url or CONFENGE_SEARXNG_URL", backend="searxng")
+        return SearxngSearchBackend(searxng_url, timeout_seconds=timeout_seconds)
+    if name == "ddgs":
+        return DdgsSearchBackend(timeout_seconds=timeout_seconds)
+    raise LiveBackendError(f"unsupported live backend: {name}", backend=name)
+
+
+def run_query_yield(
+    *,
+    out_dir: Path,
+    limit: int,
+    policy_version: str,
+    primary: str,
+    compare: str | None,
+    searxng_url: str | None,
+    cache_dir: Path,
+    results_per_query: int = 5,
+    timeout_seconds: float = 8.0,
+    allow_replay: bool = True,
+) -> dict[str, Any]:
+    policy = load_policy(policy_version)
+    accounts, cohort_meta = load_benchmark_accounts(limit)
+    cache = QuerySearchCache(JsonDiscoveryCache(cache_dir, ttl_days=7), policy_version=policy.version)
+    live_error: str | None = None
+    primary_backend = None
+    compare_backend = None
+    if primary not in {"replay", "replay-searxng", "replay-ddgs"}:
+        try:
+            primary_backend = try_live_backend(primary, searxng_url=searxng_url, timeout_seconds=timeout_seconds)
+            primary_backend.search('"teste" email', limit=1)
+        except Exception as exc:
+            live_error = f"primary {primary} failed: {type(exc).__name__}:{exc}"
+            if not allow_replay:
+                raise LiveBackendError(live_error, backend=primary) from exc
+            primary_backend = ObservationReplayBackend(accounts, simulate_backend=primary)
+    else:
+        simulated = "searxng" if primary != "replay-ddgs" else "ddgs"
+        primary_backend = ObservationReplayBackend(accounts, simulate_backend=simulated)
+    if compare and compare not in {"off", "none"}:
+        if compare in {"replay", "replay-ddgs", "replay-searxng"}:
+            simulated = "ddgs" if compare != "replay-searxng" else "searxng"
+            compare_backend = ObservationReplayBackend(accounts, simulate_backend=simulated)
+        else:
+            try:
+                compare_backend = try_live_backend(compare, searxng_url=searxng_url, timeout_seconds=timeout_seconds)
+                compare_backend.search('"teste" email', limit=1)
+            except Exception as exc:
+                extra = f"compare {compare} failed: {type(exc).__name__}:{exc}"
+                live_error = f"{live_error}; {extra}" if live_error else extra
+                if allow_replay:
+                    compare_backend = ObservationReplayBackend(accounts, simulate_backend=compare)
+                else:
+                    compare_backend = None
+    primary_exec = run_backend_benchmark(
+        accounts,
+        backend=primary_backend,
+        policy=policy,
+        cache=cache,
+        results_per_query=results_per_query,
+    )
+    comparison_exec = None
+    if compare_backend is not None:
+        comparison_exec = run_backend_benchmark(
+            accounts,
+            backend=compare_backend,
+            policy=policy,
+            cache=cache,
+            results_per_query=results_per_query,
+        )
+    report = build_report(
+        n=len(accounts),
+        policy=policy,
+        primary_name=getattr(primary_backend, "backend_id", primary),
+        primary_exec=primary_exec,
+        comparison_name=getattr(compare_backend, "backend_id", compare) if compare_backend else None,
+        comparison_exec=comparison_exec,
+        cohort_meta=cohort_meta,
+        live_error=live_error,
+    )
+    paths = write_report(report, out_dir)
+    report["paths"] = paths
+    return report

--- a/scripts/decision_unit_intelligence/query_planner/planner.py
+++ b/scripts/decision_unit_intelligence/query_planner/planner.py
@@ -1,0 +1,384 @@
+"""Adaptive query planner: budget, early-stop, dedupe, policy selection.
+
+Does not perform crawl/extraction. The executor only calls SearchBackend.search.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Protocol
+
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext
+from scripts.decision_unit_intelligence.query_planner.spec import (
+    BASELINE_POLICY_VERSION,
+    DEFAULT_POLICY_VERSION,
+    QueryExecution,
+    QueryFamily,
+    QueryPlan,
+    QueryPolicy,
+    QuerySpec,
+    cache_key,
+    emit_query_specs,
+    normalize_query,
+    unsupported_operators,
+)
+from scripts.decision_unit_intelligence.query_planner.yield_eval import apply_yield, evaluate_serp_yield
+from scripts.decision_unit_intelligence.web_discovery import JsonDiscoveryCache, SearchHit
+
+POLICY_DIR = Path(__file__).resolve().parents[1] / "data" / "query_policies"
+
+KNOWN_PERSON_AND_DOMAIN = "known_person_and_domain"
+UNKNOWN_DOMAIN = "unknown_domain"
+KNOWN_DOMAIN_ONLY = "known_domain_only"
+
+
+class SearchBackendLike(Protocol):
+    backend_id: str
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]: ...
+
+
+class QueryPlannerError(Exception):
+    """Visible backend/planner failure. Never converted to an empty miss."""
+
+    def __init__(self, message: str, *, backend: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.backend = backend
+        self.status_code = status_code
+
+
+@dataclass
+class QuerySearchCache:
+    store: JsonDiscoveryCache
+    policy_version: str
+    hits: int = 0
+    misses: int = 0
+
+    def get(self, *, backend: str, query: str, limit: int) -> list[SearchHit] | None:
+        key = cache_key(query=query, backend=backend, policy_version=self.policy_version, limit=limit)
+        cached = self.store.get("query-planner", key)
+        if cached is None:
+            self.misses += 1
+            return None
+        self.hits += 1
+        return [SearchHit(**row) for row in cached]
+
+    def set(self, *, backend: str, query: str, limit: int, hits: list[SearchHit]) -> None:
+        key = cache_key(query=query, backend=backend, policy_version=self.policy_version, limit=limit)
+        self.store.set(
+            "query-planner",
+            key,
+            [{"url": hit.url, "title": hit.title, "snippet": hit.snippet, "engine": hit.engine} for hit in hits],
+        )
+
+
+@dataclass
+class FallbackEvent:
+    primary: str
+    secondary: str
+    query: str
+    error: str
+    status_code: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "primary": self.primary,
+            "secondary": self.secondary,
+            "query": self.query,
+            "error": self.error,
+            "status_code": self.status_code,
+            "silent": False,
+        }
+
+
+@dataclass
+class ExplicitFallbackBackend:
+    """Primary → secondary. Failures stay visible; never return [] as a miss."""
+
+    primary: SearchBackendLike
+    secondary: SearchBackendLike
+    events: list[FallbackEvent] = field(default_factory=list)
+
+    @property
+    def backend_id(self) -> str:
+        return self.primary.backend_id
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        try:
+            return self.primary.search(query, limit=limit)
+        except Exception as exc:
+            status = getattr(exc, "status_code", None) or getattr(exc, "response", None)
+            status_code = (
+                getattr(status, "status_code", None) if status is not None and not isinstance(status, int) else status
+            )
+            self.events.append(
+                FallbackEvent(
+                    primary=self.primary.backend_id,
+                    secondary=self.secondary.backend_id,
+                    query=query,
+                    error=f"{type(exc).__name__}:{exc}",
+                    status_code=int(status_code) if status_code else None,
+                )
+            )
+            return self.secondary.search(query, limit=limit)
+
+
+def baseline_policy() -> QueryPolicy:
+    return QueryPolicy(
+        version=BASELINE_POLICY_VERSION,
+        family_order=(
+            QueryFamily.COMPANY,
+            QueryFamily.PERSON,
+            QueryFamily.ROLE,
+            QueryFamily.DOCUMENT,
+            QueryFamily.SITE_PATH,
+        ),
+        family_budgets={
+            QueryFamily.COMPANY: 4,
+            QueryFamily.PERSON: 8,
+            QueryFamily.ROLE: 6,
+            QueryFamily.DOCUMENT: 5,
+            QueryFamily.SITE_PATH: 4,
+        },
+        disabled_families=frozenset(),
+    )
+
+
+def default_policy() -> QueryPolicy:
+    return load_policy(DEFAULT_POLICY_VERSION)
+
+
+def load_policy(version: str | None = None) -> QueryPolicy:
+    name = version or DEFAULT_POLICY_VERSION
+    path = POLICY_DIR / f"{name}.json"
+    if path.exists():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return QueryPolicy.from_dict(payload)
+    if name == BASELINE_POLICY_VERSION:
+        return baseline_policy()
+    if name == DEFAULT_POLICY_VERSION:
+        return _shipped_v2_fallback()
+    raise FileNotFoundError(f"unknown query policy version: {name}")
+
+
+def write_policy(policy: QueryPolicy, path: Path | None = None) -> Path:
+    target = path or (POLICY_DIR / f"{policy.version}.json")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(policy.to_dict(), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def _shipped_v2_fallback() -> QueryPolicy:
+    """Used only if the versioned artifact is missing. Prefer the JSON on disk."""
+    return QueryPolicy(
+        version=DEFAULT_POLICY_VERSION,
+        family_order=(
+            QueryFamily.SITE_PATH,
+            QueryFamily.COMPANY,
+            QueryFamily.PERSON,
+            QueryFamily.DOCUMENT,
+            QueryFamily.ROLE,
+        ),
+        family_budgets={
+            QueryFamily.COMPANY: 4,
+            QueryFamily.PERSON: 4,
+            QueryFamily.ROLE: 1,
+            QueryFamily.DOCUMENT: 2,
+            QueryFamily.SITE_PATH: 4,
+        },
+        disabled_families=frozenset(),
+    )
+
+
+def adaptive_mode(*, known_domain: str | None, known_people: list[str]) -> str:
+    if known_domain and known_people:
+        return KNOWN_PERSON_AND_DOMAIN
+    if known_domain:
+        return KNOWN_DOMAIN_ONLY
+    return UNKNOWN_DOMAIN
+
+
+def plan_queries(
+    context: InvestigationContext,
+    *,
+    policy: QueryPolicy | None = None,
+    known_domain: str | None = None,
+    known_people: list[str] | None = None,
+    trade_name: str | None = None,
+    max_queries: int | None = None,
+) -> QueryPlan:
+    chosen = policy or default_policy()
+    people = [
+        name
+        for name in (known_people if known_people is not None else list(context.extra.get("known_people") or []))
+        if name
+    ]
+    specs = emit_query_specs(
+        context,
+        known_domain=known_domain,
+        known_people=people,
+        trade_name=trade_name,
+        policy_version=chosen.version,
+    )
+    mode = adaptive_mode(known_domain=known_domain, known_people=people)
+    selected = select_specs(specs, policy=chosen, mode=mode, max_queries=max_queries)
+    return QueryPlan(
+        policy_version=chosen.version,
+        account_id=str(context.cnpj or ""),
+        known_domain=known_domain,
+        known_people=tuple(people),
+        specs=tuple(selected),
+        adaptive_mode=mode,
+    )
+
+
+def select_specs(
+    specs: list[QuerySpec],
+    *,
+    policy: QueryPolicy,
+    mode: str,
+    max_queries: int | None = None,
+) -> list[QuerySpec]:
+    allowed = _allowed_families(policy, mode)
+    order = {family: index for index, family in enumerate(_family_sequence(policy, mode))}
+    usable = [spec for spec in specs if spec.family in allowed and spec.family not in policy.disabled_families]
+    usable.sort(key=lambda spec: (order.get(spec.family, 99), spec.shape_id, spec.query))
+    budgets = dict(policy.family_budgets)
+    used: dict[QueryFamily, int] = {family: 0 for family in QueryFamily}
+    selected: list[QuerySpec] = []
+    seen: set[str] = set()
+    for spec in usable:
+        key = normalize_query(spec.query)
+        if key in seen:
+            continue
+        cap = budgets.get(spec.family)
+        if cap is not None and used[spec.family] >= cap:
+            continue
+        selected.append(spec)
+        seen.add(key)
+        used[spec.family] += 1
+        if max_queries is not None and len(selected) >= max_queries:
+            break
+    return selected
+
+
+def _family_sequence(policy: QueryPolicy, mode: str) -> tuple[QueryFamily, ...]:
+    if mode == KNOWN_PERSON_AND_DOMAIN:
+        return policy.known_person_and_domain_families
+    if mode == UNKNOWN_DOMAIN:
+        return policy.unknown_domain_families
+    return policy.family_order
+
+
+def _allowed_families(policy: QueryPolicy, mode: str) -> set[QueryFamily]:
+    if mode == KNOWN_PERSON_AND_DOMAIN:
+        return set(policy.known_person_and_domain_families) | {QueryFamily.SITE_PATH}
+    if mode == UNKNOWN_DOMAIN:
+        return set(policy.unknown_domain_families) | {QueryFamily.COMPANY}
+    return {QueryFamily.SITE_PATH, QueryFamily.COMPANY, QueryFamily.DOCUMENT, QueryFamily.ROLE}
+
+
+def should_early_stop(executions: list[QueryExecution], policy: QueryPolicy) -> bool:
+    ran = [row for row in executions if row.executed]
+    if not ran:
+        return False
+    identity = sum(row.identity_associated_count for row in ran)
+    observed = sum(row.observed_email_count for row in ran)
+    if identity >= policy.min_identity_associated:
+        return True
+    if observed >= policy.min_observed_email:
+        return True
+    streak = 0
+    for row in reversed(ran):
+        if row.downstream_yield == 0:
+            streak += 1
+            continue
+        break
+    return streak >= policy.max_zero_yield_streak
+
+
+@dataclass
+class PlanRun:
+    executions: list[QueryExecution]
+    hits: list[SearchHit]
+
+
+def execute_plan(
+    plan: QueryPlan,
+    backend: SearchBackendLike,
+    *,
+    policy: QueryPolicy,
+    cache: QuerySearchCache | None = None,
+    limit: int = 5,
+    legal_name: str | None = None,
+    known_people: list[str] | None = None,
+) -> PlanRun:
+    executions: list[QueryExecution] = []
+    collected: list[SearchHit] = []
+    seen: set[str] = set()
+    stopped = False
+    for spec in plan.specs:
+        key = normalize_query(spec.query)
+        if key in seen:
+            executions.append(QueryExecution(spec=spec, backend=backend.backend_id, skip_reason="duplicate"))
+            continue
+        seen.add(key)
+        if stopped:
+            executions.append(QueryExecution(spec=spec, backend=backend.backend_id, skip_reason="early_stop"))
+            continue
+        missing = unsupported_operators(spec, backend.backend_id)
+        if missing:
+            executions.append(
+                QueryExecution(
+                    spec=spec,
+                    backend=backend.backend_id,
+                    skip_reason="unsupported_operator",
+                    failure=f"unsupported_operator:{','.join(op.value for op in missing)}",
+                )
+            )
+            continue
+        row = QueryExecution(spec=spec, backend=backend.backend_id)
+        started = perf_counter()
+        try:
+            hits = None
+            if cache is not None:
+                hits = cache.get(backend=backend.backend_id, query=spec.query, limit=limit)
+                row.cache_hit = hits is not None
+            if hits is None:
+                hits = backend.search(spec.query, limit=limit)
+                if cache is not None:
+                    cache.set(backend=backend.backend_id, query=spec.query, limit=limit, hits=hits)
+            row.executed = True
+            row.result_count = len(hits)
+            collected.extend(hits)
+            apply_yield(
+                row,
+                evaluate_serp_yield(
+                    hits,
+                    legal_name=legal_name,
+                    known_domain=plan.known_domain,
+                    known_people=list(known_people or plan.known_people),
+                ),
+            )
+        except Exception as exc:
+            row.executed = True
+            row.failure = f"{type(exc).__name__}:{exc}"
+            row.http_status = _status_code(exc)
+        row.latency_ms = int((perf_counter() - started) * 1000)
+        executions.append(row)
+        if should_early_stop(executions, policy):
+            stopped = True
+    return PlanRun(executions=executions, hits=collected)
+
+
+def _status_code(exc: Exception) -> int | None:
+    response = getattr(exc, "response", None)
+    if response is not None:
+        code = getattr(response, "status_code", None)
+        if code:
+            return int(code)
+    code = getattr(exc, "status_code", None)
+    return int(code) if code else None

--- a/scripts/decision_unit_intelligence/query_planner/spec.py
+++ b/scripts/decision_unit_intelligence/query_planner/spec.py
@@ -1,0 +1,510 @@
+"""Query families, operator matrix, and instrumentation records.
+
+Generation is separated from search I/O. Ranking never uses SERP count.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any
+from urllib.parse import urlsplit
+
+from scripts.decision_unit_intelligence.email_discovery import plausible_person_name
+from scripts.decision_unit_intelligence.models import normalize_cnpj, normalize_name
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext
+
+QUERY_PLANNER_SCHEMA = "confenge.dui.query-planner.v1"
+DEFAULT_POLICY_VERSION = "query-policy.v2"
+BASELINE_POLICY_VERSION = "query-policy.v1"
+
+_LEGAL_NOISE = frozenset(
+    {
+        "ltda",
+        "eireli",
+        "me",
+        "epp",
+        "sa",
+        "s.a",
+        "engenharia",
+        "construtora",
+        "construcoes",
+        "construções",
+        "servicos",
+        "serviços",
+        "comercio",
+        "comércio",
+    }
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class QueryFamily(StrEnum):
+    COMPANY = "COMPANY"
+    PERSON = "PERSON"
+    ROLE = "ROLE"
+    DOCUMENT = "DOCUMENT"
+    SITE_PATH = "SITE_PATH"
+
+
+class Operator(StrEnum):
+    QUOTES = "quotes"
+    SITE = "site"
+    FILETYPE = "filetype"
+    AT_DOMAIN = "at_domain"
+
+
+# Real operator support — not marketing claims. filetype: is not reliable on DDGS.
+BACKEND_OPERATORS: dict[str, frozenset[Operator]] = {
+    "searxng": frozenset({Operator.QUOTES, Operator.SITE, Operator.FILETYPE, Operator.AT_DOMAIN}),
+    "ddgs": frozenset({Operator.QUOTES, Operator.SITE, Operator.AT_DOMAIN}),
+    "replay": frozenset({Operator.QUOTES, Operator.SITE, Operator.FILETYPE, Operator.AT_DOMAIN}),
+    "replay-searxng": frozenset({Operator.QUOTES, Operator.SITE, Operator.FILETYPE, Operator.AT_DOMAIN}),
+    "replay-ddgs": frozenset({Operator.QUOTES, Operator.SITE, Operator.AT_DOMAIN}),
+}
+
+ROLE_SHAPES = (
+    "diretor engenharia",
+    "gerente contratos",
+    "licitações",
+)
+
+SITE_PATH_SLUGS = ("equipe", "diretoria", "contato", "engenharia")
+
+SERVICE_ROLE_TERMS: dict[str, tuple[str, ...]] = {
+    "reajuste_14133": ("diretor de engenharia", "contratos", "financeiro"),
+    "acompanhamento_contratual": ("contratos", "diretor de engenharia", "jurídico contratual"),
+    "licitacoes_propostas": ("licitações", "comercial", "suprimentos"),
+    "orcamento_bdi": ("orçamento", "engenharia", "diretor de engenharia"),
+}
+
+
+def normalize_query(query: str) -> str:
+    """Whitespace-fold + case-fold. Search engines treat these as the same request."""
+    return _WHITESPACE_RE.sub(" ", (query or "").strip()).lower()
+
+
+def cache_key(*, query: str, backend: str, policy_version: str, limit: int) -> str:
+    return f"{backend}|{policy_version}|{limit}|{normalize_query(query)}"
+
+
+def host_of(url: str | None) -> str | None:
+    if not url:
+        return None
+    try:
+        raw = url if "://" in url else f"https://{url}"
+        host = (urlsplit(raw).hostname or "").lower().strip(".")
+    except ValueError:
+        return None
+    if host.startswith("www."):
+        host = host[4:]
+    return host or None
+
+
+def infer_trade_name(legal_name: str | None, domain: str | None) -> str | None:
+    if domain:
+        label = domain.split(".", 1)[0].replace("-", " ").strip()
+        if len(label) >= 4:
+            return label
+    if not legal_name:
+        return None
+    tokens = [tok for tok in re.findall(r"[A-Za-zÀ-ÖØ-öø-ÿ0-9]+", legal_name) if tok.lower() not in _LEGAL_NOISE]
+    if len(tokens) >= 1 and tokens[0].lower() not in _LEGAL_NOISE:
+        candidate = tokens[0]
+        if candidate.lower() != (legal_name or "").strip().lower() and len(candidate) >= 4:
+            return candidate
+    return None
+
+
+@dataclass(frozen=True)
+class QuerySpec:
+    family: QueryFamily
+    shape_id: str
+    query: str
+    account_id: str
+    person_name: str | None = None
+    required_operators: tuple[Operator, ...] = ()
+    policy_version: str = DEFAULT_POLICY_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["family"] = self.family.value
+        payload["required_operators"] = [op.value for op in self.required_operators]
+        return payload
+
+
+@dataclass
+class QueryExecution:
+    spec: QuerySpec
+    backend: str
+    result_count: int = 0
+    useful_url_count: int = 0
+    useful_urls: tuple[str, ...] = ()
+    observed_email_count: int = 0
+    observed_emails: tuple[str, ...] = ()
+    identity_associated_count: int = 0
+    identity_associated: tuple[str, ...] = ()
+    weak_source_count: int = 0
+    weak_source_urls: tuple[str, ...] = ()
+    correct_domain: bool = False
+    person_page: bool = False
+    public_document: bool = False
+    latency_ms: int = 0
+    failure: str | None = None
+    http_status: int | None = None
+    cache_hit: bool = False
+    executed: bool = False
+    skip_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "family": self.spec.family.value,
+            "shape_id": self.spec.shape_id,
+            "query": self.spec.query,
+            "account_id": self.spec.account_id,
+            "person_name": self.spec.person_name,
+            "backend": self.backend,
+            "policy_version": self.spec.policy_version,
+            "result_count": self.result_count,
+            "useful_url_count": self.useful_url_count,
+            "useful_urls": list(self.useful_urls),
+            "observed_email_count": self.observed_email_count,
+            "observed_emails": list(self.observed_emails),
+            "identity_associated_count": self.identity_associated_count,
+            "identity_associated": list(self.identity_associated),
+            "weak_source_count": self.weak_source_count,
+            "weak_source_urls": list(self.weak_source_urls),
+            "correct_domain": self.correct_domain,
+            "person_page": self.person_page,
+            "public_document": self.public_document,
+            "latency_ms": self.latency_ms,
+            "failure": self.failure,
+            "http_status": self.http_status,
+            "cache_hit": self.cache_hit,
+            "executed": self.executed,
+            "skip_reason": self.skip_reason,
+        }
+
+    @property
+    def downstream_yield(self) -> int:
+        """Downstream evidence, never SERP count."""
+        return self.observed_email_count + self.identity_associated_count + self.useful_url_count
+
+
+@dataclass(frozen=True)
+class QueryPlan:
+    policy_version: str
+    account_id: str
+    known_domain: str | None
+    known_people: tuple[str, ...]
+    specs: tuple[QuerySpec, ...]
+    adaptive_mode: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_version": self.policy_version,
+            "account_id": self.account_id,
+            "known_domain": self.known_domain,
+            "known_people": list(self.known_people),
+            "adaptive_mode": self.adaptive_mode,
+            "queries": [spec.to_dict() for spec in self.specs],
+        }
+
+
+@dataclass
+class YieldSignals:
+    useful_urls: tuple[str, ...] = ()
+    observed_emails: tuple[str, ...] = ()
+    identity_associated: tuple[str, ...] = ()
+    weak_source_urls: tuple[str, ...] = ()
+    correct_domain: bool = False
+    person_page: bool = False
+    public_document: bool = False
+
+
+@dataclass(frozen=True)
+class QueryPolicy:
+    version: str
+    ranking_metric: str = "identity_associated_per_search"
+    family_order: tuple[QueryFamily, ...] = (
+        QueryFamily.PERSON,
+        QueryFamily.SITE_PATH,
+        QueryFamily.COMPANY,
+        QueryFamily.DOCUMENT,
+        QueryFamily.ROLE,
+    )
+    family_budgets: dict[QueryFamily, int] = field(
+        default_factory=lambda: {
+            QueryFamily.COMPANY: 4,
+            QueryFamily.PERSON: 4,
+            QueryFamily.ROLE: 3,
+            QueryFamily.DOCUMENT: 3,
+            QueryFamily.SITE_PATH: 4,
+        }
+    )
+    disabled_families: frozenset[QueryFamily] = frozenset()
+    min_identity_associated: int = 1
+    min_observed_email: int = 2
+    max_zero_yield_streak: int = 2
+    known_person_and_domain_families: tuple[QueryFamily, ...] = (
+        QueryFamily.PERSON,
+        QueryFamily.SITE_PATH,
+        QueryFamily.DOCUMENT,
+    )
+    unknown_domain_families: tuple[QueryFamily, ...] = (
+        QueryFamily.COMPANY,
+        QueryFamily.DOCUMENT,
+        QueryFamily.ROLE,
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": QUERY_PLANNER_SCHEMA,
+            "version": self.version,
+            "ranking_metric": self.ranking_metric,
+            "family_order": [family.value for family in self.family_order],
+            "family_budgets": {family.value: budget for family, budget in self.family_budgets.items()},
+            "disabled_families": sorted(family.value for family in self.disabled_families),
+            "early_stop": {
+                "min_identity_associated": self.min_identity_associated,
+                "min_observed_email": self.min_observed_email,
+                "max_zero_yield_streak": self.max_zero_yield_streak,
+            },
+            "adaptive": {
+                "known_person_and_domain": [family.value for family in self.known_person_and_domain_families],
+                "unknown_domain": [family.value for family in self.unknown_domain_families],
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> QueryPolicy:
+        early = payload.get("early_stop") or {}
+        adaptive = payload.get("adaptive") or {}
+        budgets_raw = payload.get("family_budgets") or {}
+        order_raw = payload.get("family_order") or []
+        disabled_raw = payload.get("disabled_families") or []
+        return cls(
+            version=str(payload["version"]),
+            ranking_metric=str(payload.get("ranking_metric") or "identity_associated_per_search"),
+            family_order=tuple(QueryFamily(item) for item in order_raw) or cls.family_order,
+            family_budgets={QueryFamily(key): int(value) for key, value in budgets_raw.items()},
+            disabled_families=frozenset(QueryFamily(item) for item in disabled_raw),
+            min_identity_associated=int(early.get("min_identity_associated", 1)),
+            min_observed_email=int(early.get("min_observed_email", 2)),
+            max_zero_yield_streak=int(early.get("max_zero_yield_streak", 2)),
+            known_person_and_domain_families=tuple(
+                QueryFamily(item) for item in (adaptive.get("known_person_and_domain") or [])
+            )
+            or cls.known_person_and_domain_families,
+            unknown_domain_families=tuple(QueryFamily(item) for item in (adaptive.get("unknown_domain") or []))
+            or cls.unknown_domain_families,
+        )
+
+
+def operators_for(backend_id: str) -> frozenset[Operator]:
+    key = (backend_id or "").lower()
+    if key in BACKEND_OPERATORS:
+        return BACKEND_OPERATORS[key]
+    if key.startswith("replay"):
+        return BACKEND_OPERATORS["replay"]
+    return frozenset({Operator.QUOTES})
+
+
+def unsupported_operators(spec: QuerySpec, backend_id: str) -> tuple[Operator, ...]:
+    supported = operators_for(backend_id)
+    return tuple(op for op in spec.required_operators if op not in supported)
+
+
+def emit_query_specs(
+    context: InvestigationContext,
+    *,
+    known_domain: str | None = None,
+    known_people: list[str] | None = None,
+    trade_name: str | None = None,
+    policy_version: str = DEFAULT_POLICY_VERSION,
+) -> list[QuerySpec]:
+    """Emit every family shape once. Dedupes by normalized query. Does not budget."""
+    company = (context.legal_name or "").strip()
+    cnpj = normalize_cnpj(context.cnpj)
+    domain = (known_domain or "").strip().lower() or None
+    people = []
+    for raw in known_people if known_people is not None else list(context.extra.get("known_people") or []):
+        name = normalize_name(str(raw))
+        if name and plausible_person_name(name) and name not in people:
+            people.append(name)
+    people = people[:4]
+    trade = (trade_name or infer_trade_name(company, domain) or "").strip() or None
+    if trade and company and trade.lower() == company.lower():
+        trade = None
+
+    specs: list[QuerySpec] = []
+
+    def add(
+        family: QueryFamily,
+        shape_id: str,
+        query: str,
+        *,
+        person_name: str | None = None,
+        operators: tuple[Operator, ...] = (),
+    ) -> None:
+        text = query.strip()
+        if not text:
+            return
+        specs.append(
+            QuerySpec(
+                family=family,
+                shape_id=shape_id,
+                query=text,
+                account_id=cnpj,
+                person_name=person_name,
+                required_operators=operators,
+                policy_version=policy_version,
+            )
+        )
+
+    if company:
+        add(
+            QueryFamily.COMPANY,
+            "company_legal_email",
+            f'"{company}" email',
+            operators=(Operator.QUOTES,),
+        )
+    if trade:
+        add(
+            QueryFamily.COMPANY,
+            "trade_name_contact",
+            f'"{trade}" contato',
+            operators=(Operator.QUOTES,),
+        )
+    if cnpj:
+        add(
+            QueryFamily.COMPANY,
+            "cnpj_email",
+            f'"{cnpj}" email',
+            operators=(Operator.QUOTES,),
+        )
+    if domain:
+        add(
+            QueryFamily.COMPANY,
+            "site_at_domain",
+            f'site:{domain} "@{domain}"',
+            operators=(Operator.SITE, Operator.AT_DOMAIN),
+        )
+
+    if company:
+        for person in people:
+            add(
+                QueryFamily.PERSON,
+                "person_company",
+                f'"{person}" "{company}"',
+                person_name=person,
+                operators=(Operator.QUOTES,),
+            )
+    if domain:
+        for person in people:
+            add(
+                QueryFamily.PERSON,
+                "person_at_domain",
+                f'"{person}" "@{domain}"',
+                person_name=person,
+                operators=(Operator.QUOTES, Operator.AT_DOMAIN),
+            )
+            add(
+                QueryFamily.PERSON,
+                "site_person",
+                f'site:{domain} "{person}"',
+                person_name=person,
+                operators=(Operator.SITE, Operator.QUOTES),
+            )
+    for person in people:
+        add(
+            QueryFamily.PERSON,
+            "person_email",
+            f'"{person}" email',
+            person_name=person,
+            operators=(Operator.QUOTES,),
+        )
+    if cnpj:
+        for person in people[:2]:
+            add(
+                QueryFamily.PERSON,
+                "person_cnpj_email",
+                f'"{cnpj}" "{person}" email',
+                person_name=person,
+                operators=(Operator.QUOTES,),
+            )
+
+    if company:
+        for role in ROLE_SHAPES:
+            add(
+                QueryFamily.ROLE,
+                "company_role_email",
+                f'"{company}" {role} email',
+                operators=(Operator.QUOTES,),
+            )
+        for term in SERVICE_ROLE_TERMS.get(context.service, ("diretor", "engenharia", "comercial")):
+            add(
+                QueryFamily.ROLE,
+                "company_service_role",
+                f'"{company}" {term}',
+                operators=(Operator.QUOTES,),
+            )
+
+    if cnpj:
+        add(
+            QueryFamily.DOCUMENT,
+            "cnpj_pdf",
+            f'"{cnpj}" filetype:pdf',
+            operators=(Operator.QUOTES, Operator.FILETYPE),
+        )
+        add(
+            QueryFamily.DOCUMENT,
+            "cnpj_contrato",
+            f'"{cnpj}" contrato email',
+            operators=(Operator.QUOTES,),
+        )
+    if company:
+        add(
+            QueryFamily.DOCUMENT,
+            "company_pdf_email",
+            f'"{company}" filetype:pdf email',
+            operators=(Operator.QUOTES, Operator.FILETYPE),
+        )
+        add(
+            QueryFamily.DOCUMENT,
+            "company_ata",
+            f'"{company}" ata email',
+            operators=(Operator.QUOTES,),
+        )
+        add(
+            QueryFamily.DOCUMENT,
+            "company_contrato",
+            f'"{company}" contrato email',
+            operators=(Operator.QUOTES,),
+        )
+    if domain:
+        add(
+            QueryFamily.DOCUMENT,
+            "site_pdf",
+            f"site:{domain} filetype:pdf",
+            operators=(Operator.SITE, Operator.FILETYPE),
+        )
+
+    if domain:
+        for slug in SITE_PATH_SLUGS:
+            add(
+                QueryFamily.SITE_PATH,
+                f"site_{slug}",
+                f"site:{domain} {slug}",
+                operators=(Operator.SITE,),
+            )
+
+    return _dedupe_specs(specs)
+
+
+def _dedupe_specs(specs: list[QuerySpec]) -> list[QuerySpec]:
+    unique: dict[str, QuerySpec] = {}
+    for spec in specs:
+        unique.setdefault(normalize_query(spec.query), spec)
+    return list(unique.values())

--- a/scripts/decision_unit_intelligence/query_planner/yield_eval.py
+++ b/scripts/decision_unit_intelligence/query_planner/yield_eval.py
@@ -1,0 +1,227 @@
+"""Downstream yield from SERP hits. Never ranks by result count."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any
+from urllib.parse import urlsplit
+
+from scripts.decision_unit_intelligence.email_discovery import is_third_party_echo_source
+from scripts.decision_unit_intelligence.models import fold_text, normalize_email, normalize_name
+from scripts.decision_unit_intelligence.query_planner.spec import QueryExecution, QueryFamily, YieldSignals, host_of
+from scripts.decision_unit_intelligence.web_discovery import SearchHit
+
+_EMAIL_RE = re.compile(r"(?<![\w.+-])([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})(?![\w-])", re.I)
+_PERSON_PAGE_MARKERS = (
+    "equipe",
+    "diretoria",
+    "quem-somos",
+    "quem_somos",
+    "institucional",
+    "nossa-equipe",
+    "corpo-tecnico",
+    "staff",
+    "time",
+)
+_DOC_SUFFIXES = (".pdf", ".doc", ".docx")
+
+
+def evaluate_serp_yield(
+    hits: Iterable[SearchHit],
+    *,
+    legal_name: str | None,
+    known_domain: str | None,
+    known_people: list[str] | None = None,
+) -> YieldSignals:
+    useful: list[str] = []
+    observed: list[str] = []
+    identity: list[str] = []
+    weak: list[str] = []
+    correct_domain = False
+    person_page = False
+    public_document = False
+    people = [normalize_name(name) or "" for name in (known_people or [])]
+    people = [name for name in people if name]
+    domain = (known_domain or "").lower() or None
+    name_tokens = [
+        token
+        for token in re.findall(r"[a-z0-9]+", (legal_name or "").lower())
+        if len(token) >= 4 and token not in {"ltda", "eireli", "engenharia", "construtora", "servicos"}
+    ]
+
+    for hit in hits:
+        url = hit.url
+        if not url:
+            continue
+        if is_third_party_echo_source(url):
+            weak.append(url)
+            continue
+        host = host_of(url)
+        haystack = f"{hit.title} {hit.snippet}"
+        folded = fold_text(haystack)
+        path = (urlsplit(url).path or "").lower()
+        is_useful = False
+        if domain and host == domain:
+            correct_domain = True
+            is_useful = True
+        elif host and name_tokens and sum(1 for token in name_tokens if token in host) >= 1:
+            is_useful = True
+        if any(marker in path for marker in _PERSON_PAGE_MARKERS):
+            person_page = True
+            is_useful = True
+        if (
+            people
+            and any(fold_text(person) in folded for person in people)
+            and (any(marker in path for marker in _PERSON_PAGE_MARKERS) or (domain and host == domain))
+        ):
+            person_page = True
+            is_useful = True
+        if path.endswith(_DOC_SUFFIXES) or "filetype:pdf" in folded:
+            public_document = True
+            is_useful = True
+        if is_useful:
+            useful.append(url)
+        for match in _EMAIL_RE.finditer(haystack):
+            email = normalize_email(match.group(1))
+            if not email:
+                continue
+            observed.append(email)
+            if _identity_in_snippet(email, people, haystack):
+                identity.append(f"{email}")
+
+    return YieldSignals(
+        useful_urls=tuple(dict.fromkeys(useful)),
+        observed_emails=tuple(dict.fromkeys(observed)),
+        identity_associated=tuple(dict.fromkeys(identity)),
+        weak_source_urls=tuple(dict.fromkeys(weak)),
+        correct_domain=correct_domain,
+        person_page=person_page,
+        public_document=public_document,
+    )
+
+
+def _identity_in_snippet(email: str, people: list[str], haystack: str) -> bool:
+    folded = fold_text(haystack)
+    local = email.split("@", 1)[0]
+    for person in people:
+        person_fold = fold_text(person)
+        if not person_fold or person_fold not in folded:
+            continue
+        if fold_text(email) in folded and person_fold in folded:
+            tokens = [tok for tok in person_fold.split() if len(tok) > 2]
+            if tokens and all(tok in local.replace(".", " ").replace("_", " ") for tok in (tokens[0], tokens[-1])[:2]):
+                return True
+            if re.search(rf"(?:e-?mail|contato)\s+(?:de|do|da)\s+{re.escape(person)}", haystack, re.I):
+                return True
+    return False
+
+
+def apply_yield(execution: QueryExecution, signals: YieldSignals) -> QueryExecution:
+    execution.useful_urls = signals.useful_urls
+    execution.useful_url_count = len(signals.useful_urls)
+    execution.observed_emails = signals.observed_emails
+    execution.observed_email_count = len(signals.observed_emails)
+    execution.identity_associated = signals.identity_associated
+    execution.identity_associated_count = len(signals.identity_associated)
+    execution.weak_source_urls = signals.weak_source_urls
+    execution.weak_source_count = len(signals.weak_source_urls)
+    execution.correct_domain = signals.correct_domain
+    execution.person_page = signals.person_page
+    execution.public_document = signals.public_document
+    return execution
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (len(ordered) - 1) * pct
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return float(ordered[low] * (1 - weight) + ordered[high] * weight)
+
+
+def aggregate_executions(executions: list[QueryExecution]) -> dict[str, Any]:
+    executed = [row for row in executions if row.executed]
+    searches = len(executed)
+    elapsed_ms = sum(row.latency_ms for row in executed)
+    elapsed_min = (elapsed_ms / 60000.0) if elapsed_ms else 0.0
+    observed = sum(row.observed_email_count for row in executed)
+    associated = sum(row.identity_associated_count for row in executed)
+    useful = sum(row.useful_url_count for row in executed)
+    failures = [row for row in executions if row.failure]
+    rate_limited = sum(1 for row in executions if row.http_status == 429)
+    latencies = [float(row.latency_ms) for row in executed]
+    return {
+        "searches": searches,
+        "planned": len(executions),
+        "useful_pages": useful,
+        "useful_pages_per_search": round(useful / searches, 4) if searches else 0.0,
+        "observed_emails": observed,
+        "observed_email_per_search": round(observed / searches, 4) if searches else 0.0,
+        "identity_associated": associated,
+        "identity_associated_per_search": round(associated / searches, 4) if searches else 0.0,
+        "observed_email_per_minute": round(observed / elapsed_min, 4) if elapsed_min else 0.0,
+        "identity_associated_per_minute": round(associated / elapsed_min, 4) if elapsed_min else 0.0,
+        "weak_sources": sum(row.weak_source_count for row in executed),
+        "result_count_total": sum(row.result_count for row in executed),
+        "latency_p50_ms": round(percentile(latencies, 0.50), 2),
+        "latency_p95_ms": round(percentile(latencies, 0.95), 2),
+        "latency_ms_total": elapsed_ms,
+        "failures": len(failures),
+        "failure_rate": round(len(failures) / searches, 4) if searches else 0.0,
+        "http_429": rate_limited,
+        "cache_hits": sum(1 for row in executed if row.cache_hit),
+        "skipped_unsupported": sum(1 for row in executions if row.skip_reason == "unsupported_operator"),
+        "skipped_early_stop": sum(1 for row in executions if row.skip_reason == "early_stop"),
+        "skipped_duplicate": sum(1 for row in executions if row.skip_reason == "duplicate"),
+    }
+
+
+def rank_families(executions: list[QueryExecution]) -> list[dict[str, Any]]:
+    grouped: dict[QueryFamily, list[QueryExecution]] = defaultdict(list)
+    for row in executions:
+        grouped[row.spec.family].append(row)
+    ranked = []
+    for family, rows in grouped.items():
+        metrics = aggregate_executions(rows)
+        metrics["family"] = family.value
+        ranked.append(metrics)
+    ranked.sort(
+        key=lambda item: (
+            item["identity_associated_per_search"],
+            item["observed_email_per_search"],
+            item["useful_pages_per_search"],
+            -item["searches"],
+        ),
+        reverse=True,
+    )
+    return ranked
+
+
+def rank_queries(executions: list[QueryExecution]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[QueryExecution]] = defaultdict(list)
+    for row in executions:
+        grouped[row.spec.shape_id].append(row)
+    ranked = []
+    for shape_id, rows in grouped.items():
+        metrics = aggregate_executions(rows)
+        metrics["shape_id"] = shape_id
+        metrics["family"] = rows[0].spec.family.value
+        metrics["sample_query"] = rows[0].spec.query
+        ranked.append(metrics)
+    ranked.sort(
+        key=lambda item: (
+            item["identity_associated_per_search"],
+            item["observed_email_per_search"],
+            item["useful_pages_per_search"],
+            -item["searches"],
+        ),
+        reverse=True,
+    )
+    return ranked

--- a/scripts/decision_unit_intelligence/runner.py
+++ b/scripts/decision_unit_intelligence/runner.py
@@ -21,6 +21,7 @@ from scripts.decision_unit_intelligence.providers.external_enrichment import Ext
 from scripts.decision_unit_intelligence.providers.historical_campaign import HistoricalCampaignProvider
 from scripts.decision_unit_intelligence.providers.official_documents import OfficialDocumentsProvider
 from scripts.decision_unit_intelligence.providers.public_search import PublicSearchProvider
+from scripts.decision_unit_intelligence.query_planner import ExplicitFallbackBackend, QuerySearchCache
 from scripts.decision_unit_intelligence.search_http import SearchBackendUnavailableError, build_search_backend
 from scripts.decision_unit_intelligence.site_contact_crawl import SiteCrawlBudget
 from scripts.decision_unit_intelligence.web_discovery import (
@@ -34,6 +35,16 @@ from scripts.decision_unit_intelligence.web_discovery import (
 _SHARED_HISTORICAL: HistoricalCampaignProvider | None = None
 
 
+def _build_raw_backend(name: str, *, searxng_url: str | None, timeout_seconds: float):
+    if name == "searxng":
+        if not searxng_url:
+            raise ValueError("searxng search backend requires --searxng-url")
+        return SearxngSearchBackend(searxng_url, timeout_seconds=timeout_seconds)
+    if name == "ddgs":
+        return DdgsSearchBackend(timeout_seconds=timeout_seconds)
+    raise ValueError(f"unsupported search backend: {name}")
+
+
 def default_providers(
     *,
     external_enabled: bool = False,
@@ -45,6 +56,8 @@ def default_providers(
     site_budget: SiteCrawlBudget | None = None,
     site_crawl: bool = True,
     site_crawl_baseline: bool = False,
+    query_policy_version: str | None = None,
+    search_fallback: str = "off",
 ) -> list[Any]:
     global _SHARED_HISTORICAL
     if _SHARED_HISTORICAL is None:
@@ -52,6 +65,8 @@ def default_providers(
     budget = search_budget or SearchBudget()
     backend = None
     crawler = None
+    planner_cache = None
+    policy_version = query_policy_version or "query-policy.v2"
     if search_backend != "off":
         try:
             raw_backend = build_search_backend(
@@ -64,12 +79,24 @@ def default_providers(
             if exc.reason == "missing_url":
                 raise ValueError("searxng search backend requires --searxng-url") from exc
             raise
+        if search_fallback and search_fallback not in {"off", search_backend}:
+            raw_backend = ExplicitFallbackBackend(
+                raw_backend,
+                build_search_backend(
+                    search_fallback,
+                    searxng_url=searxng_url,
+                    timeout_seconds=budget.timeout_seconds,
+                    failover="off",
+                ),
+            )
         cache = JsonDiscoveryCache(cache_dir or Path(".cache/confenge-prospect"), ttl_days=budget.cache_ttl_days)
         backend = CachedRateLimitedSearchBackend(
             raw_backend,
             cache=cache,
             min_interval_seconds=budget.min_query_interval_seconds,
+            policy_version=policy_version,
         )
+        planner_cache = QuerySearchCache(cache, policy_version=policy_version)
         crawler = CachedPublicCrawler(
             HttpxPublicCrawler(timeout_seconds=budget.timeout_seconds),
             cache=cache,
@@ -81,6 +108,8 @@ def default_providers(
             backend=backend,
             crawler=crawler,
             budget=budget,
+            policy_version=policy_version,
+            planner_cache=planner_cache,
         ),
         AdministrativeProcessProvider(),
         OfficialDocumentsProvider(),
@@ -109,6 +138,8 @@ def run_account(
     site_budget: SiteCrawlBudget | None = None,
     site_crawl: bool = True,
     site_crawl_baseline: bool = False,
+    query_policy_version: str | None = None,
+    search_fallback: str = "off",
 ) -> Any:
     started = perf_counter()
     ctx = InvestigationContext(cnpj=normalize_cnpj(cnpj), service=service)
@@ -121,6 +152,8 @@ def run_account(
         site_budget=site_budget,
         site_crawl=site_crawl,
         site_crawl_baseline=site_crawl_baseline,
+        query_policy_version=query_policy_version,
+        search_fallback=search_fallback,
     )
     people = []
     channels = []

--- a/scripts/decision_unit_intelligence/runner.py
+++ b/scripts/decision_unit_intelligence/runner.py
@@ -35,16 +35,6 @@ from scripts.decision_unit_intelligence.web_discovery import (
 _SHARED_HISTORICAL: HistoricalCampaignProvider | None = None
 
 
-def _build_raw_backend(name: str, *, searxng_url: str | None, timeout_seconds: float):
-    if name == "searxng":
-        if not searxng_url:
-            raise ValueError("searxng search backend requires --searxng-url")
-        return SearxngSearchBackend(searxng_url, timeout_seconds=timeout_seconds)
-    if name == "ddgs":
-        return DdgsSearchBackend(timeout_seconds=timeout_seconds)
-    raise ValueError(f"unsupported search backend: {name}")
-
-
 def default_providers(
     *,
     external_enabled: bool = False,

--- a/scripts/decision_unit_intelligence/web_discovery.py
+++ b/scripts/decision_unit_intelligence/web_discovery.py
@@ -262,17 +262,19 @@ class CachedRateLimitedSearchBackend:
         *,
         cache: JsonDiscoveryCache,
         min_interval_seconds: float,
+        policy_version: str = "query-policy.v2",
     ) -> None:
         self.backend = backend
         self.backend_id = backend.backend_id
         self.cache = cache
         self.min_interval_seconds = min_interval_seconds
+        self.policy_version = policy_version
         self._last_query_at = 0.0
         self.cache_hits = 0
         self.cache_misses = 0
 
     def search(self, query: str, *, limit: int) -> list[SearchHit]:
-        key = f"{self.backend_id}|{limit}|{query}"
+        key = f"{self.backend_id}|{self.policy_version}|{limit}|{query}"
         cached = self.cache.get("search", key)
         if cached is not None:
             self.cache_hits += 1

--- a/tests/test_decision_unit_query_planner.py
+++ b/tests/test_decision_unit_query_planner.py
@@ -108,9 +108,10 @@ def test_adaptive_budget_person_and_domain_vs_unknown_domain() -> None:
     discovery = plan_queries(_ctx(), policy=policy, known_domain=None, known_people=[])
     assert specific.adaptive_mode == "known_person_and_domain"
     assert discovery.adaptive_mode == "unknown_domain"
-    assert specific.specs[0].family in {QueryFamily.PERSON, QueryFamily.SITE_PATH}
+    assert specific.specs[0].family in {QueryFamily.COMPANY, QueryFamily.PERSON, QueryFamily.SITE_PATH}
     assert any(spec.family == QueryFamily.PERSON for spec in specific.specs)
     assert any(spec.family == QueryFamily.SITE_PATH for spec in specific.specs)
+    assert any(spec.family == QueryFamily.COMPANY for spec in specific.specs)
     assert discovery.specs[0].family == QueryFamily.COMPANY
     assert all(spec.family != QueryFamily.SITE_PATH for spec in discovery.specs)
     assert all(spec.family != QueryFamily.PERSON for spec in discovery.specs)
@@ -249,7 +250,7 @@ def test_ranking_uses_downstream_yield_not_serp_count() -> None:
     assert policy.ranking_metric != "result_count"
 
 
-def test_replay_backend_does_not_invent_identity_email() -> None:
+def test_replay_backend_only_returns_observed_urls_and_does_not_inject_email() -> None:
     from scripts.decision_unit_intelligence.query_planner.benchmark import BenchmarkAccount
 
     account = BenchmarkAccount(
@@ -262,10 +263,58 @@ def test_replay_backend_does_not_invent_identity_email() -> None:
         trade_name="qualidade",
     )
     backend = ObservationReplayBackend([account], simulate_backend="searxng")
-    hits = backend.search('"EDUARDO SCHMITT ESPINDOLA" email', limit=5)
-    joined = " ".join(f"{hit.title} {hit.snippet}" for hit in hits)
-    assert "eduardo" not in joined.lower() or "contato@qualidademineracao.com.br" in joined
+    observed = {account.site, account.fonte}
+    for query in (
+        'site:qualidademineracao.com.br equipe',
+        'site:qualidademineracao.com.br diretoria',
+        'site:qualidademineracao.com.br contato',
+        '"QUALIDADE MINERACAO LTDA" filetype:pdf',
+        '"QUALIDADE MINERACAO LTDA" email',
+        '"EDUARDO SCHMITT ESPINDOLA" email',
+    ):
+        hits = backend.search(query, limit=5)
+        assert all(hit.url in observed for hit in hits)
+        assert all("/documentos/ata.pdf" not in hit.url for hit in hits)
+        assert all(not hit.url.rstrip("/").endswith("/equipe") for hit in hits)
+    assert backend.search("site:qualidademineracao.com.br equipe", limit=5) == []
+    company_email = backend.search('"QUALIDADE MINERACAO LTDA" email', limit=5)
+    assert company_email
+    assert company_email[0].url == account.site
+    assert "contato@qualidademineracao.com.br" in company_email[0].snippet
+    person_email = backend.search('"EDUARDO SCHMITT ESPINDOLA" email', limit=5)
+    joined = " ".join(f"{hit.title} {hit.snippet}" for hit in person_email)
+    assert "contato@qualidademineracao.com.br" not in joined
     assert "eduardo.schmitt@" not in joined.lower()
+    path_hits = backend.search("site:qualidademineracao.com.br contato", limit=5)
+    assert path_hits == []
+
+
+def test_replay_pdf_hit_requires_observed_pdf_fonte() -> None:
+    from scripts.decision_unit_intelligence.query_planner.benchmark import BenchmarkAccount
+
+    pdf = "https://ilhota.sc.gov.br/wp-content/uploads/2023/07/planaterra.pdf"
+    account = BenchmarkAccount(
+        cnpj="82743832000162",
+        legal_name="PLANATERRA-TERRAPLENAGEM E PAVIMENTACAO LTDA",
+        site="https://planaterra.com.br/",
+        email="licitacao1@planaterra.com.br",
+        fonte=pdf,
+        people=["GERSON DE BORBA DIAS"],
+        trade_name="planaterra",
+    )
+    backend = ObservationReplayBackend([account], simulate_backend="searxng")
+    pdf_hits = backend.search('"82743832000162" filetype:pdf', limit=5)
+    assert [hit.url for hit in pdf_hits] == [pdf]
+    no_pdf = BenchmarkAccount(
+        cnpj="00820854000114",
+        legal_name="QUALIDADE MINERACAO LTDA",
+        site="https://qualidademineracao.com.br/",
+        email="contato@qualidademineracao.com.br",
+        fonte="https://qualidademineracao.com.br/",
+        people=[],
+    )
+    empty = ObservationReplayBackend([no_pdf], simulate_backend="searxng")
+    assert empty.search('"QUALIDADE MINERACAO LTDA" filetype:pdf', limit=5) == []
 
 
 def test_cli_query_yield_replay_30(tmp_path: Path) -> None:
@@ -301,3 +350,58 @@ def test_cli_query_yield_replay_30(tmp_path: Path) -> None:
     assert "replay-ddgs" in report
     assert (out / "query-yield-report.md").exists()
     assert (out / "query-policy.v2.json").exists()
+
+
+def test_run_cli_forwards_policy_version_and_fallback(tmp_path: Path) -> None:
+    import sys
+    import types
+
+    if "scripts.decision_unit_intelligence.affiliation_report" not in sys.modules:
+        stub = types.ModuleType("scripts.decision_unit_intelligence.affiliation_report")
+        stub.build_affiliation_cohort_report = lambda accounts: {  # type: ignore[attr-defined]
+            "schema_id": "stub",
+            "n": 0,
+            "uplift": {},
+            "remaining_blockers": [],
+            "next_recommendation": "",
+        }
+        sys.modules["scripts.decision_unit_intelligence.affiliation_report"] = stub
+
+    from scripts.decision_unit_intelligence.cli import _execute, build_parser
+
+    seen: dict[str, object] = {}
+
+    def fake_run_account(cnpj: str, **kwargs):
+        seen["cnpj"] = cnpj
+        seen.update(kwargs)
+        raise SystemExit("captured-run-account")
+
+    import scripts.decision_unit_intelligence.cli as cli_mod
+
+    original = cli_mod.run_account
+    cli_mod.run_account = fake_run_account  # type: ignore[method-assign]
+    try:
+        args = build_parser().parse_args(
+            [
+                "run",
+                "--out",
+                str(tmp_path / "out"),
+                "--cnpjs",
+                "00820854000114",
+                "--query-policy-version",
+                "query-policy.v1",
+                "--search-fallback",
+                "ddgs",
+            ]
+        )
+        try:
+            _execute(args, label="RUN")
+        except SystemExit as exc:
+            assert str(exc) == "captured-run-account"
+    finally:
+        cli_mod.run_account = original
+    assert seen["query_policy_version"] == "query-policy.v1"
+    assert seen["search_fallback"] == "ddgs"
+    source = Path("scripts/decision_unit_intelligence/cli.py").read_text(encoding="utf-8")
+    assert "query_policy_version=args.query_policy_version" in source
+    assert "search_fallback=args.search_fallback" in source

--- a/tests/test_decision_unit_query_planner.py
+++ b/tests/test_decision_unit_query_planner.py
@@ -1,0 +1,303 @@
+"""Drive the shipped query planner: families, yield, cache, early-stop, backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext
+from scripts.decision_unit_intelligence.query_planner import (
+    QueryFamily,
+    QuerySearchCache,
+    execute_plan,
+    load_policy,
+    plan_queries,
+    rank_queries,
+    should_early_stop,
+)
+from scripts.decision_unit_intelligence.query_planner.benchmark import ObservationReplayBackend
+from scripts.decision_unit_intelligence.query_planner.spec import QueryPolicy, QuerySpec, emit_query_specs
+from scripts.decision_unit_intelligence.web_discovery import JsonDiscoveryCache, SearchHit
+
+
+class ScriptedBackend:
+    backend_id = "searxng"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.hits_for: dict[str, list[SearchHit]] = {}
+        self.errors: dict[str, Exception] = {}
+
+    def search(self, query: str, *, limit: int) -> list[SearchHit]:
+        self.calls.append(query)
+        if query in self.errors:
+            raise self.errors[query]
+        return list(self.hits_for.get(query, []))[:limit]
+
+
+def _ctx(**kwargs) -> InvestigationContext:
+    payload = {
+        "cnpj": "12345678000190",
+        "legal_name": "EMPRESA EXEMPLO ENGENHARIA LTDA",
+        "service": "reajuste_14133",
+    }
+    payload.update(kwargs)
+    return InvestigationContext(**payload)
+
+
+def test_emit_includes_required_family_shapes() -> None:
+    specs = emit_query_specs(
+        _ctx(),
+        known_domain="empresaexemplo.com.br",
+        known_people=["João da Silva"],
+        trade_name="Exemplo",
+    )
+    queries = [spec.query for spec in specs]
+    families = {spec.family for spec in specs}
+    assert families == set(QueryFamily)
+    assert '"EMPRESA EXEMPLO ENGENHARIA LTDA" email' in queries
+    assert '"Exemplo" contato' in queries
+    assert '"12345678000190" email' in queries
+    assert 'site:empresaexemplo.com.br "@empresaexemplo.com.br"' in queries
+    assert '"João da Silva" "EMPRESA EXEMPLO ENGENHARIA LTDA"' in queries
+    assert '"João da Silva" "@empresaexemplo.com.br"' in queries
+    assert '"João da Silva" email' in queries
+    assert 'site:empresaexemplo.com.br "João da Silva"' in queries
+    assert '"EMPRESA EXEMPLO ENGENHARIA LTDA" diretor engenharia email' in queries
+    assert '"EMPRESA EXEMPLO ENGENHARIA LTDA" gerente contratos email' in queries
+    assert '"EMPRESA EXEMPLO ENGENHARIA LTDA" licitações email' in queries
+    assert '"12345678000190" filetype:pdf' in queries
+    assert '"EMPRESA EXEMPLO ENGENHARIA LTDA" ata email' in queries
+    assert "site:empresaexemplo.com.br equipe" in queries
+    assert "site:empresaexemplo.com.br diretoria" in queries
+    assert "site:empresaexemplo.com.br contato" in queries
+    assert "site:empresaexemplo.com.br engenharia" in queries
+
+
+def test_duplicate_query_emitted_once() -> None:
+    specs = emit_query_specs(_ctx(), known_domain="empresaexemplo.com.br", known_people=["João da Silva"])
+    normalized = [spec.query.casefold() for spec in specs]
+    assert len(normalized) == len(set(normalized))
+
+
+def test_same_policy_and_input_reproduces_the_same_plan() -> None:
+    policy = load_policy("query-policy.v2")
+    first = plan_queries(
+        _ctx(),
+        policy=policy,
+        known_domain="empresaexemplo.com.br",
+        known_people=["João da Silva"],
+    )
+    second = plan_queries(
+        _ctx(),
+        policy=policy,
+        known_domain="empresaexemplo.com.br",
+        known_people=["João da Silva"],
+    )
+    assert first.to_dict() == second.to_dict()
+    assert [spec.query for spec in first.specs] == [spec.query for spec in second.specs]
+
+
+def test_adaptive_budget_person_and_domain_vs_unknown_domain() -> None:
+    policy = load_policy("query-policy.v2")
+    specific = plan_queries(
+        _ctx(),
+        policy=policy,
+        known_domain="empresaexemplo.com.br",
+        known_people=["João da Silva"],
+    )
+    discovery = plan_queries(_ctx(), policy=policy, known_domain=None, known_people=[])
+    assert specific.adaptive_mode == "known_person_and_domain"
+    assert discovery.adaptive_mode == "unknown_domain"
+    assert specific.specs[0].family in {QueryFamily.PERSON, QueryFamily.SITE_PATH}
+    assert any(spec.family == QueryFamily.PERSON for spec in specific.specs)
+    assert any(spec.family == QueryFamily.SITE_PATH for spec in specific.specs)
+    assert discovery.specs[0].family == QueryFamily.COMPANY
+    assert all(spec.family != QueryFamily.SITE_PATH for spec in discovery.specs)
+    assert all(spec.family != QueryFamily.PERSON for spec in discovery.specs)
+
+
+def test_unsupported_operator_is_marked_and_not_executed_as_success() -> None:
+    payload = load_policy("query-policy.v1").to_dict()
+    payload["family_order"] = ["DOCUMENT", "COMPANY", "PERSON", "ROLE", "SITE_PATH"]
+    payload["early_stop"] = {
+        "min_identity_associated": 99,
+        "min_observed_email": 99,
+        "max_zero_yield_streak": 99,
+    }
+    policy = QueryPolicy.from_dict(payload)
+    plan = plan_queries(_ctx(), policy=policy, known_domain="empresaexemplo.com.br")
+    backend = ScriptedBackend()
+    backend.backend_id = "replay-ddgs"
+    pdf_queries = [spec.query for spec in plan.specs if "filetype:pdf" in spec.query]
+    assert pdf_queries
+    run = execute_plan(plan, backend, policy=policy, legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA")
+    skipped = [row for row in run.executions if row.skip_reason == "unsupported_operator"]
+    assert skipped
+    assert all("filetype" in (row.failure or "") for row in skipped)
+    assert all(row.spec.query not in backend.calls for row in skipped)
+    assert all(not row.executed or row.failure for row in skipped)
+
+
+def test_backend_failure_is_visible_not_empty_miss() -> None:
+    policy = load_policy("query-policy.v2")
+    plan = plan_queries(_ctx(), policy=policy, known_domain=None, known_people=[])
+    backend = ScriptedBackend()
+    target = plan.specs[0].query
+
+    class RateLimitedError(Exception):
+        status_code = 429
+
+    backend.errors[target] = RateLimitedError("too many requests")
+    run = execute_plan(plan, backend, policy=policy, legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA")
+    failed = next(row for row in run.executions if row.spec.query == target)
+    assert failed.executed
+    assert failed.failure
+    assert failed.http_status == 429
+    assert failed.result_count == 0
+    assert failed.observed_email_count == 0
+    assert "RateLimitedError" in failed.failure
+
+
+def test_cache_hits_second_normalized_query_same_backend_and_policy(tmp_path: Path) -> None:
+    policy = load_policy("query-policy.v2")
+    plan = plan_queries(_ctx(), policy=policy, known_domain=None, known_people=[])
+    backend = ScriptedBackend()
+    first_query = plan.specs[0].query
+    backend.hits_for[first_query] = [
+        SearchHit("https://empresaexemplo.com.br/contato", "contato", "email contato@empresaexemplo.com.br")
+    ]
+    cache = QuerySearchCache(JsonDiscoveryCache(tmp_path, ttl_days=7), policy_version=policy.version)
+    first = execute_plan(plan, backend, policy=policy, cache=cache, legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA")
+    second = execute_plan(plan, backend, policy=policy, cache=cache, legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA")
+    executed_first = [row.spec.query for row in first.executions if row.executed and not row.failure]
+    assert executed_first
+    assert backend.calls == executed_first
+    assert all(row.cache_hit for row in second.executions if row.spec.query in executed_first)
+    other_policy = QuerySearchCache(JsonDiscoveryCache(tmp_path, ttl_days=7), policy_version="query-policy.v1")
+    third = execute_plan(plan, backend, policy=policy, cache=other_policy, legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA")
+    assert any(not row.cache_hit for row in third.executions if row.executed)
+
+
+def test_early_stop_skips_remaining_after_identity_or_low_marginal_gain() -> None:
+    policy = load_policy("query-policy.v2")
+    plan = plan_queries(
+        _ctx(),
+        policy=policy,
+        known_domain="empresaexemplo.com.br",
+        known_people=["João da Silva"],
+    )
+    backend = ScriptedBackend()
+    first = plan.specs[0].query
+    backend.hits_for[first] = [
+        SearchHit(
+            "https://empresaexemplo.com.br/equipe",
+            "João da Silva",
+            "E-mail de João da Silva: joao.silva@empresaexemplo.com.br",
+        )
+    ]
+    run = execute_plan(
+        plan,
+        backend,
+        policy=policy,
+        legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA",
+        known_people=["João da Silva"],
+    )
+    assert run.executions[0].executed
+    assert run.executions[0].identity_associated_count >= 1
+    assert should_early_stop(run.executions[:1], policy)
+    assert any(row.skip_reason == "early_stop" for row in run.executions[1:])
+    assert backend.calls == [first]
+
+
+def test_early_stop_on_zero_yield_streak() -> None:
+    policy = load_policy("query-policy.v2")
+    plan = plan_queries(_ctx(), policy=policy, known_domain=None, known_people=[])
+    backend = ScriptedBackend()
+    run = execute_plan(plan, backend, policy=policy, legal_name="EMPRESA EXEMPLO ENGENHARIA LTDA")
+    executed = [row for row in run.executions if row.executed]
+    assert len(executed) <= policy.max_zero_yield_streak
+    assert any(row.skip_reason == "early_stop" for row in run.executions)
+
+
+def test_ranking_uses_downstream_yield_not_serp_count() -> None:
+    policy = load_policy("query-policy.v2")
+    noisy = QuerySpec(QueryFamily.ROLE, "noisy", '"EMPRESA" diretor', "12345678000190")
+    precise = QuerySpec(QueryFamily.PERSON, "precise", '"João" email', "12345678000190")
+    from scripts.decision_unit_intelligence.query_planner.spec import QueryExecution
+
+    high_serp = QueryExecution(
+        spec=noisy,
+        backend="searxng",
+        executed=True,
+        result_count=40,
+        useful_url_count=0,
+        observed_email_count=0,
+        identity_associated_count=0,
+    )
+    low_serp = QueryExecution(
+        spec=precise,
+        backend="searxng",
+        executed=True,
+        result_count=2,
+        useful_url_count=1,
+        observed_email_count=1,
+        identity_associated_count=1,
+    )
+    ranked = rank_queries([high_serp, low_serp])
+    assert ranked[0]["shape_id"] == "precise"
+    assert ranked[0]["result_count_total"] < ranked[1]["result_count_total"]
+    assert policy.ranking_metric != "result_count"
+
+
+def test_replay_backend_does_not_invent_identity_email() -> None:
+    from scripts.decision_unit_intelligence.query_planner.benchmark import BenchmarkAccount
+
+    account = BenchmarkAccount(
+        cnpj="00820854000114",
+        legal_name="QUALIDADE MINERACAO LTDA",
+        site="https://qualidademineracao.com.br/",
+        email="contato@qualidademineracao.com.br",
+        fonte="https://qualidademineracao.com.br/",
+        people=["EDUARDO SCHMITT ESPINDOLA"],
+        trade_name="qualidade",
+    )
+    backend = ObservationReplayBackend([account], simulate_backend="searxng")
+    hits = backend.search('"EDUARDO SCHMITT ESPINDOLA" email', limit=5)
+    joined = " ".join(f"{hit.title} {hit.snippet}" for hit in hits)
+    assert "eduardo" not in joined.lower() or "contato@qualidademineracao.com.br" in joined
+    assert "eduardo.schmitt@" not in joined.lower()
+
+
+def test_cli_query_yield_replay_30(tmp_path: Path) -> None:
+    from scripts.decision_unit_intelligence.query_planner.__main__ import main
+
+    out = tmp_path / "yield-30"
+    rc = main(
+        [
+            "--out",
+            str(out),
+            "--limit",
+            "30",
+            "--primary",
+            "replay-searxng",
+            "--compare",
+            "replay-ddgs",
+            "--query-policy-version",
+            "query-policy.v2",
+            "--search-cache-dir",
+            str(tmp_path / "cache"),
+        ]
+    )
+    assert rc == 0
+    report = (out / "query-yield-report.json").read_text(encoding="utf-8")
+    assert "identity_associated_per_search" in report
+    assert "COMPANY" in report
+    assert "PERSON" in report
+    assert "ROLE" in report
+    assert "DOCUMENT" in report
+    assert "SITE_PATH" in report
+    assert "weak_sources" in report
+    assert "replay-searxng" in report
+    assert "replay-ddgs" in report
+    assert (out / "query-yield-report.md").exists()
+    assert (out / "query-policy.v2.json").exists()

--- a/tests/test_query_planner_consumer.py
+++ b/tests/test_query_planner_consumer.py
@@ -1,0 +1,44 @@
+"""Fresh consumer of the versioned query planner (not the planner unit tests)."""
+
+from __future__ import annotations
+
+from scripts.decision_unit_intelligence.providers.base import InvestigationContext
+from scripts.decision_unit_intelligence.query_planner import QueryFamily, load_policy, plan_queries
+
+
+def test_consumer_known_person_and_domain_gets_specific_queries() -> None:
+    policy = load_policy("query-policy.v2")
+    context = InvestigationContext(
+        cnpj="52639513000140",
+        legal_name="INFRAPAV CONSTRUCOES LTDA",
+        service="reajuste_14133",
+    )
+    plan = plan_queries(
+        context,
+        policy=policy,
+        known_domain="infrapav.com.br",
+        known_people=["KELLY NUNES"],
+    )
+    families = {spec.family for spec in plan.specs}
+    assert QueryFamily.PERSON in families
+    assert QueryFamily.SITE_PATH in families
+    assert plan.specs[0].family in {QueryFamily.PERSON, QueryFamily.SITE_PATH}
+    assert any('"KELLY NUNES"' in spec.query for spec in plan.specs)
+    assert any(spec.query.startswith("site:infrapav.com.br") for spec in plan.specs)
+
+
+def test_consumer_unknown_domain_starts_with_company_discovery() -> None:
+    policy = load_policy("query-policy.v2")
+    context = InvestigationContext(
+        cnpj="29095199000160",
+        legal_name="PAVIMENTAR ENGENHARIA E CONSTRUÇÕES LTDA",
+        service="reajuste_14133",
+    )
+    plan = plan_queries(context, policy=policy, known_domain=None, known_people=[])
+    assert plan.adaptive_mode == "unknown_domain"
+    assert plan.specs[0].family == QueryFamily.COMPANY
+    assert plan.specs[0].shape_id in {"company_legal_email", "cnpj_email", "trade_name_contact"}
+    assert all(spec.family != QueryFamily.PERSON for spec in plan.specs)
+    assert all(spec.family != QueryFamily.SITE_PATH for spec in plan.specs)
+    assert any('"PAVIMENTAR ENGENHARIA E CONSTRUÇÕES LTDA" email' == spec.query for spec in plan.specs)
+    assert any('"29095199000160" email' == spec.query for spec in plan.specs)

--- a/tests/test_query_planner_consumer.py
+++ b/tests/test_query_planner_consumer.py
@@ -22,7 +22,8 @@ def test_consumer_known_person_and_domain_gets_specific_queries() -> None:
     families = {spec.family for spec in plan.specs}
     assert QueryFamily.PERSON in families
     assert QueryFamily.SITE_PATH in families
-    assert plan.specs[0].family in {QueryFamily.PERSON, QueryFamily.SITE_PATH}
+    assert QueryFamily.COMPANY in families
+    assert plan.specs[0].family in {QueryFamily.COMPANY, QueryFamily.PERSON, QueryFamily.SITE_PATH}
     assert any('"KELLY NUNES"' in spec.query for spec in plan.specs)
     assert any(spec.query.startswith("site:infrapav.com.br") for spec in plan.specs)
 


### PR DESCRIPTION
## Summary

Otimiza o query planner de email discovery por **yield downstream** (EMAIL OBSERVED / IDENTITY-ASSOCIATED), não por volume de SERP.

Módulo próprio `scripts/decision_unit_intelligence/query_planner` + hook mínimo em `public_search` / `runner` / cache. Sem rewrite de crawler, pattern engine, document miner, corroboration, Warmbly, web-cfg ou SmartLic.

## Query families

- COMPANY: `"RAZAO SOCIAL" email`, `"NOME FANTASIA" contato`, `"CNPJ" email`, `site:dominio "@dominio"`
- PERSON: `"NOME COMPLETO" "EMPRESA"`, `"NOME COMPLETO" "@dominio"`, `"NOME COMPLETO" email`, `site:dominio "NOME COMPLETO"`
- ROLE: empresa + diretor engenharia / gerente contratos / licitações + email
- DOCUMENT: CNPJ/nome/razão + filetype:pdf / email / ata / contrato
- SITE PATH: `site:dominio` equipe/diretoria/contato/engenharia

Fonte fraca conta à parte. Operador sem suporte (ex.: `filetype:` no DDGS) é marcado e não executa como sucesso.

## Benchmark 30 / 100

Mesmo entry: `python3 -m scripts.decision_unit_intelligence.query_planner` (e `decision_unit_intelligence query-yield`).

- Track A 30: ranking estável nas duas corridas
- Pedido 100: 30 contas reais disponíveis (índice de campanha sem extras; nenhuma inventada)
- Live SearXNG/DDGS falharam neste ambiente (URL ausente / ConnectTimeout); replay das mesmas contas

## Top / bottom

- Top: `site_contato`, `site_diretoria` — 0.82 observed email/search (mailboxes genéricos no site)
- SITE_PATH: 0.70 observed/search
- PERSON/DOCUMENT: páginas úteis, 0 observed email
- ROLE: 0 execuções após early-stop
- COMPANY sem domínio: hits de diretório = fonte fraca

## SearXNG vs DDGS

- SearXNG executa `filetype:pdf`; DDGS marca unsupported (não miss vazio)
- identity-associated/search: 0.0 vs 0.0
- **no_gain = true** para EMAIL OBSERVED / IDENTITY-ASSOCIATED por busca

## Policy default nova

`query-policy.v2` (contrato #393): SITE_PATH 4, DOCUMENT 3, PERSON 3, ROLE 1, COMPANY 4. Adaptive: pessoa+domínio → SITE_PATH/PERSON; sem domínio → COMPANY primeiro. Early-stop: 245 planejadas → 84 executadas.

Relatório: `docs/commercial-intelligence/query-yield-report.v2.md`
