### PR TITLE
feat(dui): corroborate current person-company-role with dated evidence

### DIFF
--- a/docs/architecture/adr-decision-unit-intelligence.md
+++ b/docs/architecture/adr-decision-unit-intelligence.md
@@ -29,3 +29,18 @@ It does **not** treat “named email explicitly published” as success.
 - extra-cli remains the identity/reachability truth plane; Warmbly remains the activation/outcome plane.
 
 Operational contract: [`../commercial-intelligence/contact-resolution.md`](../commercial-intelligence/contact-resolution.md).
+
+## Affiliation corroboration (person ↔ company ↔ role ↔ date)
+
+Isolated transform `corroborate_affiliation` in
+`scripts/decision_unit_intelligence/corroboration.py`. Policy data lives in
+`affiliation_policy.py`. Schema:
+`scripts/decision_unit_intelligence/data/affiliation_corroboration.schema.json`.
+
+- Separate confidences: identity, company affiliation, role, recency.
+- Copies of one origin are not independent.
+- Contradiction is `CONFLICTING_EVIDENCE` (roles also `CONFLICTING_ROLE`); never a silent average.
+- QSA supports names / controle societário and yields `QSA_ONLY`; it does not prove operational/buyer role.
+- Canonical decision-unit role is assigned only from observed role evidence.
+- `email_association_gate` / `may_associate_email` refuse known false vínculo and do not promote email, flip `auto_send`, or mark `EMAIL_VALIDATED`.
+

--- a/docs/commercial-intelligence/contact-resolution.md
+++ b/docs/commercial-intelligence/contact-resolution.md
@@ -39,16 +39,6 @@ Operational classes already map to R0-R5. A company switchboard plus a named per
 
 Public search is a first-class bounded provider when explicitly enabled. The cascade uses cached datalake/campaign facts to obtain the legal name and known site, then runs targeted search before a positive early stop. Search remains disabled by default in generic/test commands so no caller silently creates network traffic.
 
-The query planner is a separate module (`scripts/decision_unit_intelligence/query_planner`) versioned by policy (`query-policy.v2` default). It instruments each query (family, backend, account/person, useful URLs, observed/identity-associated email, weak sources, latency, failure, cache) and stops early when downstream yield is sufficient or the marginal gain drops. Ranking never uses SERP count. SearXNG is primary; DDGS is an explicit comparison; fallback is recorded, never silent.
-
-```bash
-python3 -m scripts.decision_unit_intelligence.query_planner \
-  --out /tmp/query-yield-30 \
-  --limit 30 \
-  --primary replay-searxng \
-  --compare replay-ddgs
-```
-
 The query planner records the full contextual plan and executes only the configured budget. It covers:
 
 - company name plus decision roles appropriate to the offer;

--- a/docs/commercial-intelligence/contact-resolution.md
+++ b/docs/commercial-intelligence/contact-resolution.md
@@ -89,6 +89,7 @@ Output is persisted under `extra.domain_resolution` and in the search attempt:
 - local TTL cache prevents blind rediscovery;
 - exact public page text may produce observed person/role/contact evidence;
 - email-to-person association requires auditável contextual evidence (same DOM card/block/row, `mailto:` in the person block, explicit “e-mail de Nome”, unique same-window proximity, or a same-domain person page). Local-part first+last is a signal only;
+- after contextual association, `email_association_gate` requires current identity/affiliation corroboration. Homônimo, left-company, QSA-only, holding/operational mismatch, and conflicting role are stop-the-line. The gate does not promote email;
 - generic/role/ethics mailboxes (`contato@`, `comercial@`, `licitacoes@`, `conduta@`) never become a person;
 - third-party professional domains (`.adv.br`, contabil, advocacia) and non-canonical domains never become identity;
 - observed company telephone remains company-owned unless explicit evidence proves otherwise;

--- a/docs/ops/decision-unit-intelligence-runbook.md
+++ b/docs/ops/decision-unit-intelligence-runbook.md
@@ -54,6 +54,11 @@ O shadow 1000 só cresce se o índice histórico/datalake tiver as contas. Sem i
 
 `BLOCKED` ≠ `R0`. Falta de e-mail nominal ≠ fracasso.
 
+Cada `run` grava `affiliation_cohort.json` (schema `confenge.dui.affiliation_cohort.v1`)
+com confiança por campo, uplift de emails antes ambíguos agora associáveis
+somente quando a corroboração permite, contradições e próxima recomendação.
+Delta 0 é honesto quando a Track A só tem QSA + caixa genérica.
+
 ## Warmbly
 
 Apenas rotas `R1` com e-mail nominal **observado** entram em `confenge.outreach.v1`.

--- a/scripts/decision_unit_intelligence/affiliation_consumer.py
+++ b/scripts/decision_unit_intelligence/affiliation_consumer.py
@@ -1,0 +1,403 @@
+"""Shipped consumer of corroborate_affiliation.
+
+Used by tests and the offline verification harness. Cases are structured
+dated observations — no live HTTP, no invented people.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.decision_unit_intelligence.corroboration import (
+    CandidatePerson,
+    DatedEvidenceItem,
+    corroborate_affiliation,
+    email_association_gate,
+)
+
+AS_OF = "2026-08-15"
+TARGET_CNPJS = {
+    "diretor": "12345678000190",
+    "conflict": "12345678000190",
+    "qsa": "12345678000190",
+    "stale": "12345678000190",
+    "homonym": "11111111000191",
+}
+
+
+def _item(**kwargs: Any) -> DatedEvidenceItem:
+    return DatedEvidenceItem(**kwargs)
+
+
+def representative_cases() -> dict[str, tuple[CandidatePerson, list[DatedEvidenceItem]]]:
+    diretor = CandidatePerson(
+        canonical_name="Ana Diretora",
+        aliases=["Ana M. Diretora"],
+        target_company_cnpj=TARGET_CNPJS["diretor"],
+        target_company_name="EXEMPLO ENGENHARIA LTDA",
+        target_entity_kind="operational",
+    )
+    conflict = CandidatePerson(
+        canonical_name="Bruno Cargos",
+        target_company_cnpj=TARGET_CNPJS["conflict"],
+        target_company_name="EXEMPLO ENGENHARIA LTDA",
+        target_entity_kind="operational",
+    )
+    socio = CandidatePerson(
+        canonical_name="Carlos Socio",
+        target_company_cnpj=TARGET_CNPJS["qsa"],
+        target_company_name="EXEMPLO ENGENHARIA LTDA",
+        target_entity_kind="operational",
+        claimed_role="Sócio-Administrador",
+    )
+    stale = CandidatePerson(
+        canonical_name="Diana Exdiretora",
+        target_company_cnpj=TARGET_CNPJS["stale"],
+        target_company_name="EXEMPLO ENGENHARIA LTDA",
+        target_entity_kind="operational",
+    )
+    homonym = CandidatePerson(
+        canonical_name="Eduardo Silva",
+        target_company_cnpj=TARGET_CNPJS["homonym"],
+        target_company_name="ALVO CONSTRUCOES LTDA",
+        target_entity_kind="operational",
+    )
+    return {
+        "diretor_two_independent": (
+            diretor,
+            [
+                _item(
+                    evidence_id="site-id",
+                    source_type="company_website",
+                    field="identity",
+                    value="Ana Diretora",
+                    source_url="https://exemplo.eng.br/equipe",
+                    origin_id="exemplo-equipe-2026",
+                    observed_at="2026-03-01",
+                    published_at="2026-03-01",
+                    company_cnpj=TARGET_CNPJS["diretor"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    entity_kind="operational",
+                    snippet="Ana Diretora, diretor de engenharia",
+                    extra={"person_name": "Ana Diretora"},
+                ),
+                _item(
+                    evidence_id="site-aff",
+                    source_type="company_website",
+                    field="affiliation",
+                    value="EXEMPLO ENGENHARIA LTDA",
+                    source_url="https://exemplo.eng.br/equipe",
+                    origin_id="exemplo-equipe-2026",
+                    observed_at="2026-03-01",
+                    published_at="2026-03-01",
+                    company_cnpj=TARGET_CNPJS["diretor"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    entity_kind="operational",
+                    extra={"person_name": "Ana Diretora"},
+                ),
+                _item(
+                    evidence_id="site-role",
+                    source_type="company_website",
+                    field="role",
+                    value="Diretor de Engenharia",
+                    source_url="https://exemplo.eng.br/equipe",
+                    origin_id="exemplo-equipe-2026",
+                    observed_at="2026-03-01",
+                    published_at="2026-03-01",
+                    company_cnpj=TARGET_CNPJS["diretor"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    role_text="Diretor de Engenharia",
+                    extra={"person_name": "Ana Diretora"},
+                ),
+                _item(
+                    evidence_id="gazette-id",
+                    source_type="official_gazette",
+                    field="identity",
+                    value="Ana Diretora",
+                    source_url="https://doe.sc.gov.br/2026/03/12/ato",
+                    origin_id="doe-sc-2026-03-12",
+                    document_id="doe-sc-2026-03-12",
+                    observed_at="2026-03-12",
+                    published_at="2026-03-12",
+                    company_cnpj=TARGET_CNPJS["diretor"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    extra={"person_name": "Ana Diretora"},
+                ),
+                _item(
+                    evidence_id="gazette-aff",
+                    source_type="official_gazette",
+                    field="affiliation",
+                    value="EXEMPLO ENGENHARIA LTDA",
+                    source_url="https://doe.sc.gov.br/2026/03/12/ato",
+                    origin_id="doe-sc-2026-03-12",
+                    document_id="doe-sc-2026-03-12",
+                    observed_at="2026-03-12",
+                    published_at="2026-03-12",
+                    company_cnpj=TARGET_CNPJS["diretor"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    extra={"person_name": "Ana Diretora"},
+                ),
+                _item(
+                    evidence_id="gazette-role",
+                    source_type="official_gazette",
+                    field="role",
+                    value="Diretor de Engenharia",
+                    source_url="https://doe.sc.gov.br/2026/03/12/ato",
+                    origin_id="doe-sc-2026-03-12",
+                    document_id="doe-sc-2026-03-12",
+                    observed_at="2026-03-12",
+                    published_at="2026-03-12",
+                    company_cnpj=TARGET_CNPJS["diretor"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    role_text="Diretor de Engenharia",
+                    extra={"person_name": "Ana Diretora"},
+                ),
+            ],
+        ),
+        "conflicting_roles": (
+            conflict,
+            [
+                _item(
+                    evidence_id="c-id-1",
+                    source_type="company_website",
+                    field="identity",
+                    value="Bruno Cargos",
+                    source_url="https://exemplo.eng.br/equipe",
+                    origin_id="site-equipe",
+                    observed_at="2026-04-01",
+                    published_at="2026-04-01",
+                    company_cnpj=TARGET_CNPJS["conflict"],
+                    extra={"person_name": "Bruno Cargos"},
+                ),
+                _item(
+                    evidence_id="c-role-1",
+                    source_type="company_website",
+                    field="role",
+                    value="Diretor Comercial",
+                    source_url="https://exemplo.eng.br/equipe",
+                    origin_id="site-equipe",
+                    observed_at="2026-04-01",
+                    published_at="2026-04-01",
+                    company_cnpj=TARGET_CNPJS["conflict"],
+                    role_text="Diretor Comercial",
+                    extra={"person_name": "Bruno Cargos"},
+                ),
+                _item(
+                    evidence_id="c-aff-1",
+                    source_type="company_website",
+                    field="affiliation",
+                    value="EXEMPLO ENGENHARIA LTDA",
+                    source_url="https://exemplo.eng.br/equipe",
+                    origin_id="site-equipe",
+                    observed_at="2026-04-01",
+                    published_at="2026-04-01",
+                    company_cnpj=TARGET_CNPJS["conflict"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    extra={"person_name": "Bruno Cargos"},
+                ),
+                _item(
+                    evidence_id="c-id-2",
+                    source_type="press_release",
+                    field="identity",
+                    value="Bruno Cargos",
+                    source_url="https://jornal.example/materia",
+                    origin_id="materia-2026",
+                    observed_at="2026-05-01",
+                    published_at="2026-05-01",
+                    company_cnpj=TARGET_CNPJS["conflict"],
+                    extra={"person_name": "Bruno Cargos"},
+                ),
+                _item(
+                    evidence_id="c-role-2",
+                    source_type="press_release",
+                    field="role",
+                    value="Diretor de Engenharia",
+                    source_url="https://jornal.example/materia",
+                    origin_id="materia-2026",
+                    observed_at="2026-05-01",
+                    published_at="2026-05-01",
+                    company_cnpj=TARGET_CNPJS["conflict"],
+                    role_text="Diretor de Engenharia",
+                    extra={"person_name": "Bruno Cargos"},
+                ),
+                _item(
+                    evidence_id="c-aff-2",
+                    source_type="press_release",
+                    field="affiliation",
+                    value="EXEMPLO ENGENHARIA LTDA",
+                    source_url="https://jornal.example/materia",
+                    origin_id="materia-2026",
+                    observed_at="2026-05-01",
+                    published_at="2026-05-01",
+                    company_cnpj=TARGET_CNPJS["conflict"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    extra={"person_name": "Bruno Cargos"},
+                ),
+            ],
+        ),
+        "qsa_only_socio": (
+            socio,
+            [
+                _item(
+                    evidence_id="qsa-id",
+                    source_type="qsa_rfb",
+                    field="identity",
+                    value="Carlos Socio",
+                    source_url="https://casadosdados.com.br/cnpj/12345678000190",
+                    observed_at="2026-08-05",
+                    company_cnpj=TARGET_CNPJS["qsa"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    extra={"person_name": "Carlos Socio"},
+                ),
+                _item(
+                    evidence_id="qsa-aff",
+                    source_type="qsa_rfb",
+                    field="affiliation",
+                    value="EXEMPLO ENGENHARIA LTDA",
+                    source_url="https://casadosdados.com.br/cnpj/12345678000190",
+                    observed_at="2026-08-05",
+                    company_cnpj=TARGET_CNPJS["qsa"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    extra={"person_name": "Carlos Socio"},
+                ),
+                _item(
+                    evidence_id="qsa-role",
+                    source_type="qsa_rfb",
+                    field="role",
+                    value="Sócio-Administrador",
+                    source_url="https://casadosdados.com.br/cnpj/12345678000190",
+                    observed_at="2026-08-05",
+                    company_cnpj=TARGET_CNPJS["qsa"],
+                    role_text="Sócio-Administrador",
+                    extra={"person_name": "Carlos Socio"},
+                ),
+            ],
+        ),
+        "ex_diretor_nova_empresa": (
+            stale,
+            [
+                _item(
+                    evidence_id="stale-id",
+                    source_type="press_release",
+                    field="identity",
+                    value="Diana Exdiretora",
+                    source_url="https://jornal.example/saida",
+                    origin_id="saida-2025",
+                    observed_at="2025-01-10",
+                    published_at="2025-01-10",
+                    company_cnpj=TARGET_CNPJS["stale"],
+                    extra={"person_name": "Diana Exdiretora"},
+                ),
+                _item(
+                    evidence_id="stale-aff",
+                    source_type="press_release",
+                    field="affiliation",
+                    value="EXEMPLO ENGENHARIA LTDA",
+                    source_url="https://jornal.example/saida",
+                    origin_id="saida-2025",
+                    observed_at="2025-01-10",
+                    published_at="2025-01-10",
+                    company_cnpj=TARGET_CNPJS["stale"],
+                    company_name="EXEMPLO ENGENHARIA LTDA",
+                    stale_signal="left_company",
+                    snippet="ex-diretora saiu da empresa e agora na Nova Construtora",
+                    extra={"person_name": "Diana Exdiretora"},
+                ),
+                _item(
+                    evidence_id="stale-role",
+                    source_type="press_release",
+                    field="role",
+                    value="ex-diretora",
+                    source_url="https://jornal.example/saida",
+                    origin_id="saida-2025",
+                    observed_at="2025-01-10",
+                    published_at="2025-01-10",
+                    company_cnpj=TARGET_CNPJS["stale"],
+                    role_text="ex-diretora",
+                    stale_signal="ex_role",
+                    snippet="ex-diretora saiu da empresa e agora na Nova Construtora",
+                    extra={"person_name": "Diana Exdiretora"},
+                ),
+            ],
+        ),
+        "homonym_other_company": (
+            homonym,
+            [
+                _item(
+                    evidence_id="hom-id",
+                    source_type="company_website",
+                    field="identity",
+                    value="Eduardo Silva",
+                    source_url="https://outra.eng.br/equipe",
+                    origin_id="outra-equipe",
+                    observed_at="2026-06-01",
+                    published_at="2026-06-01",
+                    company_cnpj="22222222000191",
+                    company_name="OUTRA ENGENHARIA LTDA",
+                    extra={"person_name": "Eduardo Silva"},
+                ),
+                _item(
+                    evidence_id="hom-aff",
+                    source_type="company_website",
+                    field="affiliation",
+                    value="OUTRA ENGENHARIA LTDA",
+                    source_url="https://outra.eng.br/equipe",
+                    origin_id="outra-equipe",
+                    observed_at="2026-06-01",
+                    published_at="2026-06-01",
+                    company_cnpj="22222222000191",
+                    company_name="OUTRA ENGENHARIA LTDA",
+                    extra={"person_name": "Eduardo Silva"},
+                ),
+                _item(
+                    evidence_id="hom-role",
+                    source_type="company_website",
+                    field="role",
+                    value="Diretor",
+                    source_url="https://outra.eng.br/equipe",
+                    origin_id="outra-equipe",
+                    observed_at="2026-06-01",
+                    published_at="2026-06-01",
+                    company_cnpj="22222222000191",
+                    company_name="OUTRA ENGENHARIA LTDA",
+                    role_text="Diretor",
+                    extra={"person_name": "Eduardo Silva"},
+                ),
+            ],
+        ),
+    }
+
+
+def evaluate_representative_cases(*, as_of: str = AS_OF) -> dict[str, Any]:
+    """Drive the shipped entry on the five verification inputs."""
+    payload: dict[str, Any] = {"as_of": as_of, "cases": {}}
+    for key, (person, items) in representative_cases().items():
+        record = corroborate_affiliation(person, items, as_of=as_of)
+        gate = email_association_gate(record)
+        payload["cases"][key] = {
+            "identity_confidence": record.identity_confidence.value,
+            "affiliation_confidence": record.affiliation_confidence.value,
+            "role_confidence": record.role_confidence.value,
+            "recency_confidence": record.recency_confidence.value,
+            "reason_codes": list(record.reason_codes),
+            "association_allowed": record.association_allowed,
+            "stop_reasons": list(record.stop_reasons),
+            "canonical_decision_role": record.canonical_decision_role,
+            "company_cnpj": record.company_cnpj,
+            "company_name": record.company_name,
+            "contradictions": [item.to_dict() for item in record.contradictions],
+            "gate": gate.to_dict(),
+        }
+    return payload
+
+
+def main() -> int:
+    import json
+    import sys
+
+    print(json.dumps(evaluate_representative_cases(), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not sys.argv[1:] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/decision_unit_intelligence/affiliation_policy.py
+++ b/scripts/decision_unit_intelligence/affiliation_policy.py
@@ -1,0 +1,255 @@
+"""Affiliation corroboration policy — data the shipped transform consults.
+
+QSA is cadastral (names / controle societário). It never proves an operational
+or buyer role. Republished copies of one origin are not independent sources.
+Forbidden sources are dropped, never scored.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+POLICY_ID = "dui.affiliation-policy.v1"
+SCHEMA_ID = "confenge.dui.affiliation_corroboration.v1"
+COHORT_SCHEMA_ID = "confenge.dui.affiliation_cohort.v1"
+
+# Recency is operational currency, not cadastre snapshot age.
+RECENCY_FRESH_DAYS = 365
+RECENCY_AGING_DAYS = 730
+
+
+class AffiliationReasonCode(StrEnum):
+    """Shipped vocabulary. Contradiction is never a silent average."""
+
+    AFFILIATION_CORROBORATED = "AFFILIATION_CORROBORATED"
+    ROLE_CORROBORATED = "ROLE_CORROBORATED"
+    IDENTITY_CORROBORATED = "IDENTITY_CORROBORATED"
+    STALE_AFFILIATION = "STALE_AFFILIATION"
+    CONFLICTING_ROLE = "CONFLICTING_ROLE"
+    HOLDING_OPERATIONAL_MISMATCH = "HOLDING_OPERATIONAL_MISMATCH"
+    QSA_ONLY = "QSA_ONLY"
+    INSUFFICIENT_RECENCY = "INSUFFICIENT_RECENCY"
+    CONFLICTING_EVIDENCE = "CONFLICTING_EVIDENCE"
+
+
+REASON_CODE_VOCABULARY: frozenset[str] = frozenset(code.value for code in AffiliationReasonCode)
+
+# The eight codes named in the mission, plus CONFLICTING_EVIDENCE as the
+# explicit field-contradiction marker (roles also emit CONFLICTING_ROLE).
+SHIPPED_REASON_CODES: tuple[str, ...] = (
+    AffiliationReasonCode.AFFILIATION_CORROBORATED.value,
+    AffiliationReasonCode.ROLE_CORROBORATED.value,
+    AffiliationReasonCode.IDENTITY_CORROBORATED.value,
+    AffiliationReasonCode.STALE_AFFILIATION.value,
+    AffiliationReasonCode.CONFLICTING_ROLE.value,
+    AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+    AffiliationReasonCode.QSA_ONLY.value,
+    AffiliationReasonCode.INSUFFICIENT_RECENCY.value,
+)
+
+
+class AllowedSourceClass(StrEnum):
+    CORPORATE_SITE = "corporate_site"
+    PUBLIC_DOCUMENT = "public_document"
+    INSTITUTIONAL_PAGE = "institutional_page"
+    OFFICIAL_GAZETTE = "official_gazette"
+    PROFESSIONAL_ASSOCIATION = "professional_association"
+    EVENT = "event"
+    PRESS_RELEASE = "press_release"
+    PUBLIC_PROFESSIONAL_PROFILE = "public_professional_profile"
+    QSA_CADASTRE = "qsa_cadastre"
+
+
+class ForbiddenSourceClass(StrEnum):
+    AUTHENTICATED_LINKEDIN = "authenticated_linkedin"
+    DATA_BROKER = "data_broker"
+    LOCAL_PART_AS_ROLE = "local_part_as_role"
+    QSA_PJ_AS_PERSON = "qsa_pj_as_person"
+    BYPASS = "bypass"
+    BREACH_DUMP = "breach_dump"
+
+
+class EntityKind(StrEnum):
+    HOLDING = "holding"
+    OPERATIONAL = "operational"
+    UNIT = "unit"
+    BRAND = "brand"
+    CONSORTIUM = "consortium"
+    UNKNOWN = "unknown"
+
+
+# Observed source_type strings already used in DUI providers → policy class.
+SOURCE_TYPE_CLASS: dict[str, str] = {
+    "company_website": AllowedSourceClass.CORPORATE_SITE.value,
+    "company_site": AllowedSourceClass.CORPORATE_SITE.value,
+    "corporate_site": AllowedSourceClass.CORPORATE_SITE.value,
+    "public_page": AllowedSourceClass.CORPORATE_SITE.value,
+    "institutional_page": AllowedSourceClass.INSTITUTIONAL_PAGE.value,
+    "process_document": AllowedSourceClass.PUBLIC_DOCUMENT.value,
+    "official_documents": AllowedSourceClass.PUBLIC_DOCUMENT.value,
+    "public_document": AllowedSourceClass.PUBLIC_DOCUMENT.value,
+    "administrative_process": AllowedSourceClass.PUBLIC_DOCUMENT.value,
+    "official_gazette": AllowedSourceClass.OFFICIAL_GAZETTE.value,
+    "diario_oficial": AllowedSourceClass.OFFICIAL_GAZETTE.value,
+    "professional_association": AllowedSourceClass.PROFESSIONAL_ASSOCIATION.value,
+    "crea": AllowedSourceClass.PROFESSIONAL_ASSOCIATION.value,
+    "cau": AllowedSourceClass.PROFESSIONAL_ASSOCIATION.value,
+    "event": AllowedSourceClass.EVENT.value,
+    "conference": AllowedSourceClass.EVENT.value,
+    "press_release": AllowedSourceClass.PRESS_RELEASE.value,
+    "materia": AllowedSourceClass.PRESS_RELEASE.value,
+    "news": AllowedSourceClass.PRESS_RELEASE.value,
+    "public_professional_profile": AllowedSourceClass.PUBLIC_PROFESSIONAL_PROFILE.value,
+    "professional_profile": AllowedSourceClass.PUBLIC_PROFESSIONAL_PROFILE.value,
+    "qsa_rfb": AllowedSourceClass.QSA_CADASTRE.value,
+    "brasilapi_cnpj": AllowedSourceClass.QSA_CADASTRE.value,
+    "rfb": AllowedSourceClass.QSA_CADASTRE.value,
+    "qsa": AllowedSourceClass.QSA_CADASTRE.value,
+    "rfb_cadastre": AllowedSourceClass.QSA_CADASTRE.value,
+}
+
+FORBIDDEN_SOURCE_TYPES: frozenset[str] = frozenset(
+    {
+        ForbiddenSourceClass.AUTHENTICATED_LINKEDIN.value,
+        ForbiddenSourceClass.DATA_BROKER.value,
+        ForbiddenSourceClass.LOCAL_PART_AS_ROLE.value,
+        "cargo_from_local_part",
+        "local_part_as_cargo",
+        ForbiddenSourceClass.QSA_PJ_AS_PERSON.value,
+        ForbiddenSourceClass.BYPASS.value,
+        ForbiddenSourceClass.BREACH_DUMP.value,
+        "linkedin_authenticated",
+        "linkedin_scrape",
+    }
+)
+
+QSA_SOURCE_TYPES: frozenset[str] = frozenset(
+    {
+        "qsa_rfb",
+        "brasilapi_cnpj",
+        "rfb",
+        "qsa",
+        "rfb_cadastre",
+        AllowedSourceClass.QSA_CADASTRE.value,
+    }
+)
+
+# Hosts that republish RFB/QSA or scrape directories. Copies, not independent origins.
+QSA_ECHO_HOST_MARKERS: tuple[str, ...] = (
+    "casadosdados",
+    "econodata",
+    "empresadois",
+    "consultacnpj",
+    "receitanet",
+    "cnpj.biz",
+    "cnpja",
+    "brasilapi",
+    "receitaws",
+    "checkpj",
+    "guiapj",
+    "escavador",
+    "solutudo",
+    "guiamais",
+)
+
+DATA_BROKER_HOST_MARKERS: tuple[str, ...] = (
+    "apollo.io",
+    "zoominfo.com",
+    "hunter.io",
+    "clearbit.com",
+    "lusha.com",
+    "rocketreach.co",
+    "snov.io",
+    "contactout.com",
+    "cognism.com",
+)
+
+# Syndicated reprints of the same press release / gazette do not become independent
+# just because the URL host differs. Callers should set origin_id; these hosts
+# are a fail-closed hint when origin_id is missing.
+SYNDICATION_HOST_MARKERS: tuple[str, ...] = (
+    "noticias.uol.com.br",
+    "g1.globo.com",
+    "estadao.com.br",
+    "folha.uol.com.br",
+    "valor.globo.com",
+    "terra.com.br",
+    "ig.com.br",
+    "r7.com",
+)
+
+HOLDING_NAME_MARKERS: tuple[str, ...] = (
+    "holding",
+    "participacoes",
+    "participações",
+    "participacao",
+    "participação",
+    "administradora de bens",
+    "investimentos",
+)
+OPERATIONAL_NAME_MARKERS: tuple[str, ...] = (
+    "engenharia",
+    "construtora",
+    "construcoes",
+    "construções",
+    "paviment",
+    "terraplan",
+    "mineracao",
+    "mineração",
+    "incorporadora",
+    "empreiteira",
+)
+UNIT_NAME_MARKERS: tuple[str, ...] = ("filial", "unidade", "sucursal", "regional")
+BRAND_NAME_MARKERS: tuple[str, ...] = ("marca", "brand")
+CONSORTIUM_NAME_MARKERS: tuple[str, ...] = ("consorcio", "consórcio", "spe ", " spe")
+
+STALE_SIGNAL_PATTERNS: tuple[tuple[str, str], ...] = (
+    (
+        r"\bex[-\s](?:diretor|gerente|socio|s[oó]cio|colaborador|funcion[aá]rio|presidente|engenheir)",
+        "ex_role",
+    ),
+    (r"\bcargo\s+anterior\b|\bantigo\s+(?:diretor|gerente|cargo)\b", "former_role"),
+    (r"\bsaiu(?:\s+da\s+empresa)?\b|\bn[aã]o\s+faz\s+mais\s+parte\b|\bdesligad[oa]\b", "left_company"),
+    (r"\bagora\s+na\b|\batualmente\s+na\b|\bmudou\s+para\b|\bnova\s+empresa\b", "new_company"),
+    (
+        r"\bsubstitu[ií]d[oa]\s+por\b|\bno\s+lugar\s+de\b|\bassume[m]?\s+(?:a\s+)?diretoria\b|"
+        r"\bnovo\s+diretor\b|\breplacement\b|\bannounce(?:d|ment)\b",
+        "replacement",
+    ),
+)
+
+# Ownership/cadastral roles may coexist with an operational title.
+OWNERSHIP_ROLE_CLASSES: frozenset[str] = frozenset(
+    {
+        "socio",
+        "socio_administrador",
+        "proprietario",
+    }
+)
+SPECIFIC_EXECUTIVE_ROLE_CLASSES: frozenset[str] = frozenset(
+    {
+        "diretor_comercial",
+        "diretor_engenharia",
+        "diretor_operacoes",
+    }
+)
+
+STOP_THE_LINE_CODES: frozenset[str] = frozenset(
+    {
+        AffiliationReasonCode.STALE_AFFILIATION.value,
+        AffiliationReasonCode.CONFLICTING_ROLE.value,
+        AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+        AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+        AffiliationReasonCode.QSA_ONLY.value,
+    }
+)
+
+# Association is refused for these known false-vínculo classes even if an
+# email local-part looks nominal. The gate never promotes email.
+ASSOCIATION_REFUSED_WHEN: tuple[str, ...] = (
+    AffiliationReasonCode.STALE_AFFILIATION.value,
+    AffiliationReasonCode.CONFLICTING_ROLE.value,
+    AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+    AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+    AffiliationReasonCode.QSA_ONLY.value,
+)

--- a/scripts/decision_unit_intelligence/affiliation_report.py
+++ b/scripts/decision_unit_intelligence/affiliation_report.py
@@ -1,0 +1,411 @@
+"""Track A cohort / uplift / contradictions reporter for affiliation corroboration.
+
+Honest delta of 0 is allowed. Fabricated positive delta is not. The reporter
+never invents people, cargos, or empresas.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from scripts.decision_unit_intelligence.affiliation_policy import (
+    COHORT_SCHEMA_ID,
+    POLICY_ID,
+    AffiliationReasonCode,
+)
+from scripts.decision_unit_intelligence.corroboration import (
+    AffiliationCorroboration,
+    CandidatePerson,
+    corroborate_affiliation,
+    email_association_gate,
+    evidence_items_from_observations,
+)
+from scripts.decision_unit_intelligence.email_discovery import EmailDiscoveryClass
+from scripts.decision_unit_intelligence.models import (
+    AccountInvestigation,
+    PersonObservation,
+    normalize_cnpj,
+    normalize_name,
+)
+
+AS_OF_CANARY = "2026-08-15"
+
+PREVIOUSLY_AMBIGUOUS_CLASSES = frozenset(
+    {
+        EmailDiscoveryClass.OBSERVED_DIRECT_EMAIL_IDENTITY_UNRESOLVED.value,
+        EmailDiscoveryClass.UNKNOWN.value,
+    }
+)
+
+
+def corroborate_account_people(
+    account: AccountInvestigation,
+    *,
+    as_of: str = AS_OF_CANARY,
+    people: list[PersonObservation] | None = None,
+) -> list[AffiliationCorroboration]:
+    """Build isolated corroboration records from account candidates + observations."""
+    observations = list(people or [])
+    if not observations:
+        for payload in (account.extra or {}).get("person_observations") or []:
+            if isinstance(payload, PersonObservation):
+                observations.append(payload)
+    records: list[AffiliationCorroboration] = []
+    for candidate in account.candidates:
+        name = normalize_name(candidate.person_name)
+        if not name:
+            continue
+        person_obs = [
+            obs
+            for obs in observations
+            if normalize_name(obs.person_name) == name
+            and normalize_cnpj(obs.company_entity_id) == normalize_cnpj(account.cnpj)
+        ]
+        stored = (candidate.extra or {}).get("source_observations")
+        if not person_obs and stored:
+            person_obs = [obs for obs in stored if isinstance(obs, PersonObservation)]
+        items = evidence_items_from_observations(
+            person_obs,
+            company_name=account.legal_name,
+            company_kind=(candidate.extra or {}).get("company_kind"),
+        )
+        # Recover evidence already attached to the corroboration snapshot.
+        if not items and isinstance((candidate.extra or {}).get("affiliation_corroboration"), dict):
+            existing = candidate.extra["affiliation_corroboration"]
+            records.append(_record_from_dict(existing))
+            continue
+        person = CandidatePerson(
+            canonical_name=name,
+            aliases=list((candidate.extra or {}).get("aliases") or []),
+            target_company_cnpj=account.cnpj,
+            target_company_name=account.legal_name,
+            claimed_role=candidate.observed_roles[0] if candidate.observed_roles else None,
+        )
+        records.append(corroborate_affiliation(person, items, as_of=as_of))
+    return records
+
+
+def _record_from_dict(payload: dict[str, Any]) -> AffiliationCorroboration:
+    from scripts.decision_unit_intelligence.corroboration import (
+        AffiliationContradiction,
+        DatedEvidenceItem,
+        FieldConfidenceRecord,
+        RoleCandidate,
+    )
+    from scripts.decision_unit_intelligence.models import ConfidenceLevel
+
+    def _level(value: str) -> ConfidenceLevel:
+        try:
+            return ConfidenceLevel(value)
+        except ValueError:
+            return ConfidenceLevel.UNKNOWN
+
+    return AffiliationCorroboration(
+        person_id=str(payload.get("person_id") or ""),
+        canonical_name=str(payload.get("canonical_name") or ""),
+        aliases=list(payload.get("aliases") or []),
+        company_cnpj=str(payload.get("company_cnpj") or ""),
+        company_name=payload.get("company_name"),
+        company_kind=payload.get("company_kind"),
+        role_candidates=[
+            RoleCandidate(
+                role_text=str(item.get("role_text") or ""),
+                canonical_role=item.get("canonical_role"),
+                source_ids=list(item.get("source_ids") or []),
+                evidence_date=item.get("evidence_date"),
+                origin_ids=list(item.get("origin_ids") or []),
+            )
+            for item in payload.get("role_candidates") or []
+        ],
+        canonical_decision_role=payload.get("canonical_decision_role"),
+        evidence=[
+            DatedEvidenceItem(
+                evidence_id=str(item.get("evidence_id") or ""),
+                source_type=str(item.get("source_type") or ""),
+                field=str(item.get("field") or ""),
+                value=item.get("value"),
+                source_url=item.get("source_url"),
+                origin_id=item.get("origin_id"),
+                document_id=item.get("document_id"),
+                observed_at=item.get("observed_at"),
+                published_at=item.get("published_at"),
+                snippet=item.get("snippet"),
+                company_cnpj=item.get("company_cnpj"),
+                company_name=item.get("company_name"),
+                role_text=item.get("role_text"),
+                entity_kind=item.get("entity_kind"),
+                stale_signal=item.get("stale_signal"),
+                extraction_method=item.get("extraction_method"),
+                extra=dict(item.get("extra") or {}),
+            )
+            for item in payload.get("evidence") or []
+        ],
+        rejected_evidence=list(payload.get("rejected_evidence") or []),
+        contradictions=[
+            AffiliationContradiction(
+                topic=str(item.get("topic") or ""),
+                left=str(item.get("left") or ""),
+                right=str(item.get("right") or ""),
+                reason_codes=list(item.get("reason_codes") or []),
+                evidence_ids=list(item.get("evidence_ids") or []),
+            )
+            for item in payload.get("contradictions") or []
+        ],
+        identity_confidence=_level(str(payload.get("identity_confidence") or "UNKNOWN")),
+        affiliation_confidence=_level(str(payload.get("affiliation_confidence") or "UNKNOWN")),
+        role_confidence=_level(str(payload.get("role_confidence") or "UNKNOWN")),
+        recency_confidence=_level(str(payload.get("recency_confidence") or "UNKNOWN")),
+        reason_codes=list(payload.get("reason_codes") or []),
+        association_allowed=bool(payload.get("association_allowed")),
+        stop_reasons=list(payload.get("stop_reasons") or []),
+        field_records=[
+            FieldConfidenceRecord(
+                field=str(item.get("field") or ""),
+                level=_level(str(item.get("level") or "UNKNOWN")),
+                reason_codes=list(item.get("reason_codes") or []),
+                independent_origin_count=int(item.get("independent_origin_count") or 0),
+                latest_evidence_date=item.get("latest_evidence_date"),
+            )
+            for item in payload.get("field_records") or []
+        ],
+    )
+
+
+def _email_class(route: Any) -> str:
+    extra = getattr(route, "extra", None) or {}
+    klass = extra.get("email_discovery_class")
+    if klass:
+        return str(klass)
+    value = getattr(route, "channel_value", None)
+    if value and "@" in str(value):
+        return EmailDiscoveryClass.UNKNOWN.value
+    return ""
+
+
+def _is_named_email(route: Any) -> bool:
+    value = getattr(route, "channel_value", None)
+    return bool(value and "@" in str(value))
+
+
+def build_affiliation_cohort_report(
+    accounts: list[AccountInvestigation],
+    *,
+    as_of: str = AS_OF_CANARY,
+    people_by_cnpj: dict[str, list[PersonObservation]] | None = None,
+) -> dict[str, Any]:
+    """Deterministic cohort + uplift + contradictions + next recommendation."""
+    people_by_cnpj = people_by_cnpj or {}
+    rows: list[dict[str, Any]] = []
+    remaining = Counter()
+    contradictions: list[dict[str, Any]] = []
+    prev_ambiguous = 0
+    now_associable = 0
+    refused = 0
+    qsa_only_people = 0
+    for account in accounts:
+        cnpj = normalize_cnpj(account.cnpj)
+        records = []
+        stored = (account.extra or {}).get("affiliation_corroboration")
+        if isinstance(stored, list) and stored and isinstance(stored[0], dict):
+            records = [_record_from_dict(item) for item in stored]
+        else:
+            records = corroborate_account_people(
+                account,
+                as_of=as_of,
+                people=people_by_cnpj.get(cnpj) or [],
+            )
+        person_rows = []
+        for record in records:
+            person_rows.append(
+                {
+                    "person_id": record.person_id,
+                    "canonical_name": record.canonical_name,
+                    "company_cnpj": record.company_cnpj,
+                    "identity_confidence": record.identity_confidence.value,
+                    "affiliation_confidence": record.affiliation_confidence.value,
+                    "role_confidence": record.role_confidence.value,
+                    "recency_confidence": record.recency_confidence.value,
+                    "reason_codes": list(record.reason_codes),
+                    "association_allowed": record.association_allowed,
+                    "canonical_decision_role": record.canonical_decision_role,
+                    "contradictions": [item.to_dict() for item in record.contradictions],
+                }
+            )
+            for code in record.reason_codes:
+                if code in {
+                    AffiliationReasonCode.QSA_ONLY.value,
+                    AffiliationReasonCode.INSUFFICIENT_RECENCY.value,
+                    AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+                    AffiliationReasonCode.CONFLICTING_ROLE.value,
+                    AffiliationReasonCode.STALE_AFFILIATION.value,
+                    AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+                }:
+                    remaining[code] += 1
+            if AffiliationReasonCode.QSA_ONLY.value in record.reason_codes:
+                qsa_only_people += 1
+            for item in record.contradictions:
+                contradictions.append(
+                    {
+                        "cnpj": cnpj,
+                        "person_name": record.canonical_name,
+                        **item.to_dict(),
+                    }
+                )
+        account_prev = 0
+        account_now = 0
+        account_refused = 0
+        email_rows = []
+        by_name = {normalize_name(record.canonical_name): record for record in records}
+        for route in account.routes:
+            if not _is_named_email(route):
+                continue
+            extra = route.extra or {}
+            klass = _email_class(route)
+            previously = (
+                klass in PREVIOUSLY_AMBIGUOUS_CLASSES
+                or bool(extra.get("identity_ambiguous"))
+                or (
+                    klass == EmailDiscoveryClass.OBSERVED_DIRECT_EMAIL_IDENTITY_UNRESOLVED.value
+                )
+            )
+            person_name = normalize_name(getattr(route, "person_name", None))
+            record = by_name.get(person_name) if person_name else None
+            if record is None and account.candidates:
+                # Unresolved email: try matching via extra association name.
+                assoc_name = normalize_name(extra.get("associated_person_name"))
+                record = by_name.get(assoc_name) if assoc_name else None
+            gate_allowed = False
+            gate_codes: list[str] = []
+            if record is not None:
+                decision = email_association_gate(record, email=route.channel_value)
+                gate_allowed = decision.allowed
+                gate_codes = list(decision.reason_codes)
+                if decision.stop_the_line or not decision.allowed:
+                    account_refused += 1
+            if previously:
+                account_prev += 1
+            if previously and gate_allowed:
+                account_now += 1
+            email_rows.append(
+                {
+                    "email": route.channel_value,
+                    "discovery_class": klass,
+                    "previously_unresolved_or_ambiguous": previously,
+                    "now_defensibly_associable": bool(previously and gate_allowed),
+                    "gate_allowed": gate_allowed,
+                    "gate_reason_codes": gate_codes,
+                }
+            )
+        prev_ambiguous += account_prev
+        now_associable += account_now
+        refused += account_refused
+        rows.append(
+            {
+                "cnpj": cnpj,
+                "legal_name": account.legal_name,
+                "people": person_rows,
+                "emails": {
+                    "previously_unresolved_or_ambiguous": account_prev,
+                    "now_defensibly_associable": account_now,
+                    "refused_stop_the_line": account_refused,
+                    "items": email_rows,
+                },
+                "reason_codes": sorted({code for record in records for code in record.reason_codes}),
+            }
+        )
+    delta = now_associable  # previously ambiguous that are now associable
+    next_rec = _next_recommendation(
+        n=len(accounts),
+        delta=delta,
+        remaining=remaining,
+        qsa_only_people=qsa_only_people,
+    )
+    return {
+        "schema_id": COHORT_SCHEMA_ID,
+        "policy_id": POLICY_ID,
+        "as_of": as_of,
+        "n": len(accounts),
+        "cnpjs": [normalize_cnpj(account.cnpj) for account in accounts],
+        "accounts": rows,
+        "uplift": {
+            "previously_identity_unresolved_or_ambiguous": prev_ambiguous,
+            "now_defensibly_associable": now_associable,
+            "delta": delta,
+            "refused_stop_the_line": refused,
+            "note": (
+                "Delta counts only emails that were identity-unresolved/ambiguous "
+                "and become associable when corroboration allows. Honest 0 is valid."
+            ),
+        },
+        "contradictions": contradictions,
+        "remaining_blockers": {
+            AffiliationReasonCode.QSA_ONLY.value: remaining[AffiliationReasonCode.QSA_ONLY.value],
+            AffiliationReasonCode.INSUFFICIENT_RECENCY.value: remaining[
+                AffiliationReasonCode.INSUFFICIENT_RECENCY.value
+            ],
+            AffiliationReasonCode.CONFLICTING_EVIDENCE.value: remaining[
+                AffiliationReasonCode.CONFLICTING_EVIDENCE.value
+            ],
+            AffiliationReasonCode.CONFLICTING_ROLE.value: remaining[AffiliationReasonCode.CONFLICTING_ROLE.value],
+            AffiliationReasonCode.STALE_AFFILIATION.value: remaining[AffiliationReasonCode.STALE_AFFILIATION.value],
+            AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value: remaining[
+                AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value
+            ],
+        },
+        "qsa_only_people": qsa_only_people,
+        "next_recommendation": next_rec,
+        "auto_send": False,
+        "invented_cargo_or_empresa": False,
+    }
+
+
+def _next_recommendation(*, n: int, delta: int, remaining: Counter, qsa_only_people: int) -> str:
+    if n == 0:
+        return "Sem contas no cohort."
+    if delta == 0 and remaining[AffiliationReasonCode.QSA_ONLY.value] >= 1:
+        return (
+            "Track A permanece majoritariamente QSA + caixa genérica. "
+            "Próximo passo: evidência pública datada e independente "
+            "(site/equipe, diário oficial, processo, associação) por pessoa, "
+            "sem tratar QSA como comprador e sem inventar cargo ou empresa."
+        )
+    if remaining[AffiliationReasonCode.CONFLICTING_EVIDENCE.value] or remaining[
+        AffiliationReasonCode.CONFLICTING_ROLE.value
+    ]:
+        return (
+            "Há contradições explícitas de vínculo ou cargo. "
+            "Não associar email até uma fonte pública atual resolver o conflito; "
+            "não fazer média de confiança."
+        )
+    if delta > 0:
+        return (
+            f"{delta} email(s) antes ambíguos tornaram-se associáveis com corroboração. "
+            "Manter o gate no promotor; não promover para EMAIL_VALIDATED nem auto_send."
+        )
+    return (
+        "Nenhum email nominal passou o gate de corroboração. "
+        "Continuar coletando evidência pública datada; QSA permanece cadastral."
+    )
+
+
+def verdicts_for_compare(report: dict[str, Any]) -> list[dict[str, Any]]:
+    """Stable per-account verdicts used to assert canary determinism."""
+    rows = []
+    for account in report.get("accounts") or []:
+        people = [
+            {
+                "name": person.get("canonical_name"),
+                "identity": person.get("identity_confidence"),
+                "affiliation": person.get("affiliation_confidence"),
+                "role": person.get("role_confidence"),
+                "recency": person.get("recency_confidence"),
+                "reason_codes": person.get("reason_codes"),
+                "association_allowed": person.get("association_allowed"),
+            }
+            for person in account.get("people") or []
+        ]
+        people.sort(key=lambda item: item["name"] or "")
+        rows.append({"cnpj": account.get("cnpj"), "people": people})
+    rows.sort(key=lambda item: item["cnpj"] or "")
+    return rows

--- a/scripts/decision_unit_intelligence/cli.py
+++ b/scripts/decision_unit_intelligence/cli.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from scripts.decision_unit_intelligence import POLICY_VERSION, PROVIDER_VERSION, SCHEMA_VERSION
+from scripts.decision_unit_intelligence.affiliation_report import build_affiliation_cohort_report
 from scripts.decision_unit_intelligence.batch_queue import (
     ContactDiscoveryQueue,
     budget_version_from_knobs,
@@ -105,6 +106,8 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
     warmbly = [project_warmbly_outreach(a) for a in accounts]
     email_safe = sum(w["email_safe_count"] for w in warmbly)
     email_discovery = summarize_email_discovery(accounts)
+    affiliation_cohort = build_affiliation_cohort_report(accounts)
+    write_json(Path(args.out) / "affiliation_cohort.json", affiliation_cohort)
     write_json(Path(args.out) / "warmbly_outreach.json", {"accounts": warmbly, "email_safe_total": email_safe})
     web_attempts = [
         attempt for account in accounts for attempt in account.ledger.attempts if attempt.provider_id == "public_search"
@@ -175,6 +178,14 @@ def _execute(args: argparse.Namespace, *, label: str) -> int:
             "identity_proven": email_discovery.observed_identity_associated,
         },
         "email_discovery": email_discovery.to_dict(),
+        "affiliation_cohort": {
+            "path": "affiliation_cohort.json",
+            "schema_id": affiliation_cohort["schema_id"],
+            "n": affiliation_cohort["n"],
+            "uplift": affiliation_cohort["uplift"],
+            "remaining_blockers": affiliation_cohort["remaining_blockers"],
+            "next_recommendation": affiliation_cohort["next_recommendation"],
+        },
         "selection": build_manifest(cnpjs)["selection"],
         "auto_send": False,
     }

--- a/scripts/decision_unit_intelligence/corroboration.py
+++ b/scripts/decision_unit_intelligence/corroboration.py
@@ -1,14 +1,56 @@
-"""Conflict preservation. Highest confidence does not erase disagreement."""
+"""Isolated current-affiliation corroboration.
+
+Pure transform: candidate person + dated public evidence → per-field
+confidences, reason codes, and contradictions. Never invents cargo or
+empresa. Never promotes email. Highest confidence does not erase
+disagreement — contradiction is CONFLICTING_EVIDENCE, never an average.
+"""
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, date, datetime
+from typing import Any
+from urllib.parse import urlsplit
 
+from scripts.decision_unit_intelligence.affiliation_policy import (
+    ASSOCIATION_REFUSED_WHEN,
+    DATA_BROKER_HOST_MARKERS,
+    FORBIDDEN_SOURCE_TYPES,
+    OWNERSHIP_ROLE_CLASSES,
+    POLICY_ID,
+    QSA_ECHO_HOST_MARKERS,
+    QSA_SOURCE_TYPES,
+    RECENCY_AGING_DAYS,
+    RECENCY_FRESH_DAYS,
+    SCHEMA_ID,
+    SOURCE_TYPE_CLASS,
+    SPECIFIC_EXECUTIVE_ROLE_CLASSES,
+    STALE_SIGNAL_PATTERNS,
+    STOP_THE_LINE_CODES,
+    SYNDICATION_HOST_MARKERS,
+    AffiliationReasonCode,
+    AllowedSourceClass,
+    EntityKind,
+    ForbiddenSourceClass,
+)
+from scripts.decision_unit_intelligence.decision_policy import (
+    is_legal_entity_name,
+    normalize_observed_role,
+)
 from scripts.decision_unit_intelligence.models import (
     ChannelObservation,
+    ConfidenceLevel,
     ConflictRecord,
+    DecisionRoleClass,
     EpistemicClass,
     PersonObservation,
+    fold_text,
+    normalize_cnpj,
+    normalize_name,
     stable_id,
 )
 
@@ -76,3 +118,996 @@ def evidence_quality_label(*, source_count: int, has_document: bool, contradicte
     if source_count >= 1:
         return "LOW"
     return "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Isolated affiliation corroboration
+# ---------------------------------------------------------------------------
+
+_STALE_COMPILED: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(pattern, re.I), label) for pattern, label in STALE_SIGNAL_PATTERNS
+)
+_HOLDING_RE = re.compile(r"holding|participa[cç][oõ]es|administradora de bens", re.I)
+_OPERATIONAL_RE = re.compile(
+    r"engenharia|construtora|constru[cç][oõ]es|paviment|terraplan|minera[cç]|incorporadora|empreiteira",
+    re.I,
+)
+_UNIT_RE = re.compile(r"\b(?:filial|unidade|sucursal|regional)\b", re.I)
+_BRAND_RE = re.compile(r"\b(?:marca|brand)\b", re.I)
+_CONSORTIUM_RE = re.compile(r"cons[oó]rcio|\bspe\b", re.I)
+
+
+@dataclass
+class DatedEvidenceItem:
+    """One dated public observation about identity, affiliation, or role."""
+
+    evidence_id: str
+    source_type: str
+    field: str
+    value: str | None = None
+    source_url: str | None = None
+    origin_id: str | None = None
+    document_id: str | None = None
+    observed_at: str | None = None
+    published_at: str | None = None
+    snippet: str | None = None
+    company_cnpj: str | None = None
+    company_name: str | None = None
+    role_text: str | None = None
+    entity_kind: str | None = None
+    stale_signal: str | None = None
+    extraction_method: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CandidatePerson:
+    """Person the caller wants to place at a target company. Never invent names."""
+
+    canonical_name: str
+    target_company_cnpj: str
+    target_company_name: str | None = None
+    aliases: list[str] = field(default_factory=list)
+    claimed_role: str | None = None
+    target_entity_kind: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class RoleCandidate:
+    role_text: str
+    canonical_role: str | None
+    source_ids: list[str]
+    evidence_date: str | None
+    origin_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class FieldConfidenceRecord:
+    field: str
+    level: ConfidenceLevel
+    reason_codes: list[str]
+    independent_origin_count: int
+    latest_evidence_date: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["level"] = self.level.value
+        return payload
+
+
+@dataclass
+class AffiliationContradiction:
+    topic: str
+    left: str
+    right: str
+    reason_codes: list[str]
+    evidence_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EmailAssociationDecision:
+    """Gate for the email promoter. Does not promote, validate, or send email."""
+
+    allowed: bool
+    stop_the_line: bool
+    reason_codes: tuple[str, ...]
+    person_name: str
+    company_cnpj: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "stop_the_line": self.stop_the_line,
+            "reason_codes": list(self.reason_codes),
+            "person_name": self.person_name,
+            "company_cnpj": self.company_cnpj,
+            "promotes_email": False,
+            "marks_email_validated": False,
+            "auto_send": False,
+        }
+
+
+@dataclass
+class AffiliationCorroboration:
+    """Per-person current-affiliation record. Isolated from email promotion."""
+
+    person_id: str
+    canonical_name: str
+    aliases: list[str]
+    company_cnpj: str
+    company_name: str | None
+    company_kind: str | None
+    role_candidates: list[RoleCandidate]
+    canonical_decision_role: str | None
+    evidence: list[DatedEvidenceItem]
+    rejected_evidence: list[dict[str, Any]]
+    contradictions: list[AffiliationContradiction]
+    identity_confidence: ConfidenceLevel
+    affiliation_confidence: ConfidenceLevel
+    role_confidence: ConfidenceLevel
+    recency_confidence: ConfidenceLevel
+    reason_codes: list[str]
+    association_allowed: bool
+    stop_reasons: list[str]
+    field_records: list[FieldConfidenceRecord]
+    policy_id: str = POLICY_ID
+    schema_id: str = SCHEMA_ID
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_id": self.schema_id,
+            "policy_id": self.policy_id,
+            "person_id": self.person_id,
+            "canonical_name": self.canonical_name,
+            "aliases": list(self.aliases),
+            "company_cnpj": self.company_cnpj,
+            "company_name": self.company_name,
+            "company_kind": self.company_kind,
+            "role_candidates": [item.to_dict() for item in self.role_candidates],
+            "canonical_decision_role": self.canonical_decision_role,
+            "evidence": [item.to_dict() for item in self.evidence],
+            "rejected_evidence": list(self.rejected_evidence),
+            "contradictions": [item.to_dict() for item in self.contradictions],
+            "identity_confidence": self.identity_confidence.value,
+            "affiliation_confidence": self.affiliation_confidence.value,
+            "role_confidence": self.role_confidence.value,
+            "recency_confidence": self.recency_confidence.value,
+            "reason_codes": list(self.reason_codes),
+            "association_allowed": self.association_allowed,
+            "stop_reasons": list(self.stop_reasons),
+            "field_records": [item.to_dict() for item in self.field_records],
+            "promotes_email": False,
+        }
+
+
+def classify_source_type(source_type: str | None) -> str | None:
+    raw = fold_text(source_type)
+    if not raw:
+        return None
+    if raw in FORBIDDEN_SOURCE_TYPES or source_type in FORBIDDEN_SOURCE_TYPES:
+        return None
+    return SOURCE_TYPE_CLASS.get(raw) or SOURCE_TYPE_CLASS.get(source_type or "")
+
+
+def host_of(url: str | None) -> str:
+    if not url:
+        return ""
+    host = (urlsplit(url).hostname or "").lower()
+    return host[4:] if host.startswith("www.") else host
+
+
+def is_forbidden_source(item: DatedEvidenceItem) -> tuple[bool, str | None]:
+    raw = fold_text(item.source_type)
+    method = fold_text(item.extraction_method)
+    if raw in FORBIDDEN_SOURCE_TYPES or item.source_type in FORBIDDEN_SOURCE_TYPES:
+        return True, item.source_type
+    if "authenticated" in raw and "linkedin" in raw:
+        return True, ForbiddenSourceClass.AUTHENTICATED_LINKEDIN.value
+    if "linkedin_scrape" in raw or "linkedin_authenticated" in raw:
+        return True, ForbiddenSourceClass.AUTHENTICATED_LINKEDIN.value
+    if any(tok in method for tok in ("local_part", "local-part", "cargo_from_local")):
+        return True, ForbiddenSourceClass.LOCAL_PART_AS_ROLE.value
+    if raw in {"local_part_as_role", "cargo_from_local_part", "local_part_as_cargo"}:
+        return True, ForbiddenSourceClass.LOCAL_PART_AS_ROLE.value
+    host = host_of(item.source_url)
+    if any(marker in host for marker in DATA_BROKER_HOST_MARKERS):
+        return True, ForbiddenSourceClass.DATA_BROKER.value
+    if item.field == "identity" and is_legal_entity_name(item.value):
+        return True, ForbiddenSourceClass.QSA_PJ_AS_PERSON.value
+    if raw == ForbiddenSourceClass.QSA_PJ_AS_PERSON.value:
+        return True, ForbiddenSourceClass.QSA_PJ_AS_PERSON.value
+    return False, None
+
+
+def is_qsa_source(item: DatedEvidenceItem) -> bool:
+    raw = fold_text(item.source_type)
+    if raw in QSA_SOURCE_TYPES or item.source_type in QSA_SOURCE_TYPES:
+        return True
+    if classify_source_type(item.source_type) == AllowedSourceClass.QSA_CADASTRE.value:
+        return True
+    host = host_of(item.source_url)
+    return any(marker in host for marker in QSA_ECHO_HOST_MARKERS)
+
+
+def detect_entity_kind(name: str | None, *, explicit: str | None = None) -> str:
+    if explicit and explicit in {kind.value for kind in EntityKind}:
+        return explicit
+    text = fold_text(name)
+    if not text:
+        return EntityKind.UNKNOWN.value
+    if _CONSORTIUM_RE.search(text):
+        return EntityKind.CONSORTIUM.value
+    if _HOLDING_RE.search(text):
+        return EntityKind.HOLDING.value
+    if _UNIT_RE.search(text):
+        return EntityKind.UNIT.value
+    if _BRAND_RE.search(text):
+        return EntityKind.BRAND.value
+    if _OPERATIONAL_RE.search(text):
+        return EntityKind.OPERATIONAL.value
+    return EntityKind.UNKNOWN.value
+
+
+def detect_stale_signals(*blobs: str | None) -> list[str]:
+    text = " ".join(blob for blob in blobs if blob)
+    if not text:
+        return []
+    hits: list[str] = []
+    for pattern, label in _STALE_COMPILED:
+        if pattern.search(text):
+            hits.append(label)
+    return list(dict.fromkeys(hits))
+
+
+def parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        if "T" in raw:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            return parsed.date()
+        return date.fromisoformat(raw[:10])
+    except ValueError:
+        return None
+
+
+def evidence_date_of(item: DatedEvidenceItem) -> date | None:
+    return parse_iso_date(item.published_at) or parse_iso_date(item.observed_at)
+
+
+def independence_origin(item: DatedEvidenceItem) -> str:
+    """Cluster by origin, not URL count. Copies of one origin share a key."""
+    if item.origin_id:
+        return fold_text(item.origin_id)
+    extra = item.extra or {}
+    for key in ("origin_id", "copies_origin", "reprints_origin"):
+        if extra.get(key):
+            return fold_text(str(extra[key]))
+    if is_qsa_source(item):
+        return f"qsa:{normalize_cnpj(item.company_cnpj) or 'unknown'}"
+    if item.document_id:
+        return f"doc:{fold_text(item.document_id)}"
+    host = host_of(item.source_url)
+    path = urlsplit(item.source_url or "").path.lower().rstrip("/")
+    source_class = classify_source_type(item.source_type) or fold_text(item.source_type)
+    if host and any(marker in host for marker in SYNDICATION_HOST_MARKERS):
+        # Without an explicit origin, syndication hosts still do not mint a new
+        # origin from query-string variants of the same path.
+        return f"synd:{host}{path}"
+    return f"{source_class}:{host}{path or item.evidence_id}"
+
+
+def names_match(left: str | None, right: str | None) -> bool:
+    a = fold_text(normalize_name(left))
+    b = fold_text(normalize_name(right))
+    return bool(a) and a == b
+
+
+def person_name_matches(person: CandidatePerson, value: str | None) -> bool:
+    if names_match(person.canonical_name, value):
+        return True
+    return any(names_match(alias, value) for alias in person.aliases)
+
+
+def roles_conflict(left: DecisionRoleClass, right: DecisionRoleClass) -> bool:
+    if left == right or left == DecisionRoleClass.UNKNOWN or right == DecisionRoleClass.UNKNOWN:
+        return False
+    if left.value in OWNERSHIP_ROLE_CLASSES or right.value in OWNERSHIP_ROLE_CLASSES:
+        return False
+    if left == DecisionRoleClass.DIRETOR and right.value in SPECIFIC_EXECUTIVE_ROLE_CLASSES:
+        return False
+    if right == DecisionRoleClass.DIRETOR and left.value in SPECIFIC_EXECUTIVE_ROLE_CLASSES:
+        return False
+    if left.value in SPECIFIC_EXECUTIVE_ROLE_CLASSES and right.value in SPECIFIC_EXECUTIVE_ROLE_CLASSES:
+        return left != right
+    if left != right and left in {
+        DecisionRoleClass.DIRETOR_COMERCIAL,
+        DecisionRoleClass.DIRETOR_ENGENHARIA,
+        DecisionRoleClass.DIRETOR_OPERACOES,
+        DecisionRoleClass.GERENTE_CONTRATOS,
+        DecisionRoleClass.GERENTE_LICITACOES,
+    } and right in {
+        DecisionRoleClass.DIRETOR_COMERCIAL,
+        DecisionRoleClass.DIRETOR_ENGENHARIA,
+        DecisionRoleClass.DIRETOR_OPERACOES,
+        DecisionRoleClass.GERENTE_CONTRATOS,
+        DecisionRoleClass.GERENTE_LICITACOES,
+    }:
+        return True
+    return False
+
+
+def _as_of_date(as_of: date | str | None) -> date:
+    if as_of is None:
+        return datetime.now(UTC).date()
+    if isinstance(as_of, date) and not isinstance(as_of, datetime):
+        return as_of
+    parsed = parse_iso_date(str(as_of))
+    return parsed or datetime.now(UTC).date()
+
+
+def _age_days(when: date | None, as_of: date) -> int | None:
+    if when is None:
+        return None
+    return (as_of - when).days
+
+
+def _never_average_confidence(
+    *,
+    independent_current: int,
+    contradicted: bool,
+    stale: bool,
+    qsa_only: bool,
+    insufficient: bool,
+    ownership_only: bool = False,
+) -> ConfidenceLevel:
+    """Contradiction and staleness win. HIGH+LOW never becomes HIGH."""
+    if contradicted:
+        return ConfidenceLevel.LOW
+    if stale:
+        return ConfidenceLevel.LOW
+    if qsa_only or ownership_only:
+        return ConfidenceLevel.LOW
+    if insufficient and independent_current == 0:
+        return ConfidenceLevel.LOW
+    if independent_current >= 2:
+        return ConfidenceLevel.HIGH
+    if independent_current == 1:
+        return ConfidenceLevel.MEDIUM
+    if insufficient:
+        return ConfidenceLevel.LOW
+    return ConfidenceLevel.UNKNOWN
+
+
+def evidence_items_from_observations(
+    observations: Sequence[PersonObservation],
+    *,
+    company_name: str | None = None,
+    company_kind: str | None = None,
+) -> list[DatedEvidenceItem]:
+    """Project existing DUI person observations into dated evidence items."""
+    items: list[DatedEvidenceItem] = []
+    for obs in observations:
+        name = normalize_name(obs.person_name)
+        if not name:
+            continue
+        kind = detect_entity_kind(company_name, explicit=company_kind)
+        stale_hits = detect_stale_signals(obs.snippet, obs.observed_role, obs.signature_context)
+        extra = dict(obs.extra or {})
+        shared = dict(
+            source_type=obs.source_type,
+            source_url=obs.source_url,
+            origin_id=(extra.get("origin_id") or extra.get("copies_origin")),
+            document_id=obs.document_id,
+            observed_at=obs.observed_at,
+            published_at=extra.get("published_at"),
+            snippet=obs.snippet,
+            company_cnpj=normalize_cnpj(obs.company_entity_id),
+            company_name=company_name,
+            role_text=obs.observed_role,
+            entity_kind=kind,
+            stale_signal=stale_hits[0] if stale_hits else None,
+            extraction_method=extra.get("extraction_method"),
+            extra=extra,
+        )
+        items.append(
+            DatedEvidenceItem(
+                evidence_id=obs.evidence_id or obs.observation_id,
+                field="identity",
+                value=name,
+                **shared,
+            )
+        )
+        items.append(
+            DatedEvidenceItem(
+                evidence_id=f"{obs.evidence_id or obs.observation_id}:aff",
+                field="affiliation",
+                value=company_name or obs.company_entity_id,
+                **shared,
+            )
+        )
+        if obs.observed_role:
+            items.append(
+                DatedEvidenceItem(
+                    evidence_id=f"{obs.evidence_id or obs.observation_id}:role",
+                    field="role",
+                    value=obs.observed_role,
+                    **shared,
+                )
+            )
+    return items
+
+
+def _collect_aliases(person: CandidatePerson, accepted: Sequence[DatedEvidenceItem]) -> list[str]:
+    aliases = [alias for alias in person.aliases if normalize_name(alias)]
+    for item in accepted:
+        if item.field != "identity":
+            continue
+        name = normalize_name(item.value)
+        if name and not names_match(name, person.canonical_name) and person_name_matches(person, name):
+            aliases.append(name)
+    return list(dict.fromkeys(aliases))
+
+
+def _company_matches(person: CandidatePerson, item: DatedEvidenceItem) -> bool:
+    target = normalize_cnpj(person.target_company_cnpj)
+    observed = normalize_cnpj(item.company_cnpj)
+    if target and observed:
+        return target == observed
+    if person.target_company_name and item.company_name:
+        return fold_text(person.target_company_name) == fold_text(item.company_name)
+    return bool(target) and not observed
+
+
+def corroborate_affiliation(
+    person: CandidatePerson,
+    evidence: Sequence[DatedEvidenceItem],
+    *,
+    as_of: date | str | None = None,
+) -> AffiliationCorroboration:
+    """Candidate person + dated evidence → per-field verdicts.
+
+    Does not invent cargo/empresa. Does not promote email. Copies of one
+    origin count once. Contradiction is explicit.
+    """
+    as_of_date = _as_of_date(as_of)
+    target_cnpj = normalize_cnpj(person.target_company_cnpj)
+    target_kind = detect_entity_kind(person.target_company_name, explicit=person.target_entity_kind)
+    accepted: list[DatedEvidenceItem] = []
+    rejected: list[dict[str, Any]] = []
+    for item in evidence:
+        forbidden, reason = is_forbidden_source(item)
+        if forbidden:
+            rejected.append(
+                {
+                    "evidence_id": item.evidence_id,
+                    "source_type": item.source_type,
+                    "reason": reason,
+                    "source_url": item.source_url,
+                }
+            )
+            continue
+        if classify_source_type(item.source_type) is None and not is_qsa_source(item):
+            rejected.append(
+                {
+                    "evidence_id": item.evidence_id,
+                    "source_type": item.source_type,
+                    "reason": "SOURCE_NOT_IN_ALLOWED_POLICY",
+                    "source_url": item.source_url,
+                }
+            )
+            continue
+        accepted.append(item)
+
+    relevant = [
+        item
+        for item in accepted
+        if item.field in {"identity", "affiliation", "role", "recency", "company_kind"}
+        and (item.field != "identity" or person_name_matches(person, item.value) or item.value is None)
+    ]
+    # Affiliation/role items apply when they belong to this person via extra or
+    # when bundled with a matching identity on the same origin.
+    person_origins = {
+        independence_origin(item)
+        for item in accepted
+        if item.field == "identity" and person_name_matches(person, item.value)
+    }
+    scoped: list[DatedEvidenceItem] = []
+    for item in accepted:
+        if item.field == "identity" and person_name_matches(person, item.value):
+            scoped.append(item)
+            continue
+        if item.field in {"affiliation", "role", "recency", "company_kind"}:
+            named = item.extra.get("person_name") if item.extra else None
+            if named and not person_name_matches(person, str(named)):
+                continue
+            if named or independence_origin(item) in person_origins or person_name_matches(person, item.value):
+                scoped.append(item)
+                continue
+            if item.field == "affiliation" and _company_matches(person, item) and not named:
+                # Affiliation without a person name is company-level, not personal.
+                continue
+            if item.role_text and person_name_matches(person, item.value):
+                scoped.append(item)
+    if not scoped:
+        scoped = [item for item in relevant if person_name_matches(person, item.value)]
+
+    contradictions: list[AffiliationContradiction] = []
+    reason_codes: list[str] = []
+
+    identity_items = [item for item in scoped if item.field == "identity"]
+    affiliation_items = [item for item in scoped if item.field == "affiliation"]
+    role_items = [item for item in scoped if item.field == "role"]
+
+    other_company_current: list[DatedEvidenceItem] = []
+    target_affiliation: list[DatedEvidenceItem] = []
+    for item in affiliation_items:
+        if _company_matches(person, item):
+            target_affiliation.append(item)
+        elif item.company_cnpj and normalize_cnpj(item.company_cnpj) != target_cnpj:
+            other_company_current.append(item)
+        elif item.company_name and person.target_company_name:
+            if fold_text(item.company_name) != fold_text(person.target_company_name):
+                other_company_current.append(item)
+
+    stale_hits: list[str] = []
+    for item in scoped:
+        stale_hits.extend(detect_stale_signals(item.snippet, item.value, item.role_text, item.stale_signal))
+        if item.stale_signal:
+            stale_hits.append(item.stale_signal)
+    stale_hits = list(dict.fromkeys(stale_hits))
+    stale = bool(stale_hits)
+
+    qsa_items = [item for item in scoped if is_qsa_source(item)]
+    public_items = [item for item in scoped if not is_qsa_source(item)]
+    qsa_only = bool(scoped) and not public_items and bool(qsa_items)
+
+    def _current_public(items: Iterable[DatedEvidenceItem]) -> list[DatedEvidenceItem]:
+        out: list[DatedEvidenceItem] = []
+        for item in items:
+            if is_qsa_source(item):
+                continue
+            if detect_stale_signals(item.snippet, item.value, item.role_text, item.stale_signal) or item.stale_signal:
+                continue
+            out.append(item)
+        return out
+
+    affiliation_origins = {
+        independence_origin(item) for item in _current_public(target_affiliation)
+    }
+    public_identity_at_target = [
+        item
+        for item in _current_public(identity_items)
+        if _company_matches(person, item) or not item.company_cnpj
+    ]
+
+    # Homonym / other-company current affiliation.
+    other_current_public = _current_public(other_company_current)
+    if other_current_public and not _current_public(target_affiliation) and not qsa_items:
+        contradictions.append(
+            AffiliationContradiction(
+                topic="affiliation",
+                left=target_cnpj or person.target_company_name or "",
+                right=other_current_public[0].company_cnpj or other_current_public[0].company_name or "",
+                reason_codes=[AffiliationReasonCode.CONFLICTING_EVIDENCE.value],
+                evidence_ids=[item.evidence_id for item in other_current_public],
+            )
+        )
+        reason_codes.append(AffiliationReasonCode.CONFLICTING_EVIDENCE.value)
+    elif other_current_public and (_current_public(target_affiliation) or qsa_items):
+        # Same person claimed current at two companies → conflict, do not average.
+        contradictions.append(
+            AffiliationContradiction(
+                topic="affiliation",
+                left=target_cnpj or person.target_company_name or "",
+                right=other_current_public[0].company_cnpj or other_current_public[0].company_name or "",
+                reason_codes=[AffiliationReasonCode.CONFLICTING_EVIDENCE.value],
+                evidence_ids=[item.evidence_id for item in other_current_public + target_affiliation],
+            )
+        )
+        reason_codes.append(AffiliationReasonCode.CONFLICTING_EVIDENCE.value)
+
+    if other_current_public and not _current_public(target_affiliation) and not qsa_only:
+        # Do not affiliate the homonym to the target company.
+        affiliation_origins = set()
+
+    role_candidates: list[RoleCandidate] = []
+    role_by_class: dict[str, list[DatedEvidenceItem]] = defaultdict(list)
+    for item in role_items:
+        text = item.value or item.role_text
+        if not text:
+            continue
+        klass = normalize_observed_role(text)
+        canonical = klass.value if klass != DecisionRoleClass.UNKNOWN else None
+        # Never invent a canonical role without observed text mapping.
+        role_by_class[canonical or "unknown"].append(item)
+        existing = next((c for c in role_candidates if c.role_text == text), None)
+        origin = independence_origin(item)
+        if existing:
+            existing.source_ids.append(item.evidence_id)
+            if origin not in existing.origin_ids:
+                existing.origin_ids.append(origin)
+            continue
+        when = evidence_date_of(item)
+        role_candidates.append(
+            RoleCandidate(
+                role_text=text,
+                canonical_role=canonical,
+                source_ids=[item.evidence_id],
+                evidence_date=when.isoformat() if when else item.published_at or item.observed_at,
+                origin_ids=[origin],
+            )
+        )
+
+    public_role_classes = {
+        klass: [item for item in items if not is_qsa_source(item)]
+        for klass, items in role_by_class.items()
+        if klass != "unknown"
+    }
+    current_public_role_classes = {
+        klass: _current_public(items) for klass, items in public_role_classes.items() if _current_public(items)
+    }
+    role_conflict = False
+    live_classes = [DecisionRoleClass(klass) for klass in current_public_role_classes]
+    for i, left in enumerate(live_classes):
+        for right in live_classes[i + 1 :]:
+            if roles_conflict(left, right):
+                role_conflict = True
+                contradictions.append(
+                    AffiliationContradiction(
+                        topic="role",
+                        left=left.value,
+                        right=right.value,
+                        reason_codes=[
+                            AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+                            AffiliationReasonCode.CONFLICTING_ROLE.value,
+                        ],
+                        evidence_ids=[
+                            item.evidence_id
+                            for item in current_public_role_classes[left.value]
+                            + current_public_role_classes[right.value]
+                        ],
+                    )
+                )
+    if role_conflict:
+        reason_codes.extend(
+            [
+                AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+                AffiliationReasonCode.CONFLICTING_ROLE.value,
+            ]
+        )
+
+    # Holding / operational / unit / brand / consortium mismatch.
+    observed_kinds = {
+        detect_entity_kind(item.company_name, explicit=item.entity_kind)
+        for item in scoped
+        if item.company_name or item.entity_kind
+    }
+    observed_kinds.discard(EntityKind.UNKNOWN.value)
+    mismatch = False
+    if target_kind != EntityKind.UNKNOWN.value:
+        for kind in observed_kinds:
+            if kind != target_kind and {kind, target_kind} & {
+                EntityKind.HOLDING.value,
+                EntityKind.OPERATIONAL.value,
+                EntityKind.UNIT.value,
+                EntityKind.BRAND.value,
+                EntityKind.CONSORTIUM.value,
+            }:
+                if kind != target_kind:
+                    mismatch = True
+                    contradictions.append(
+                        AffiliationContradiction(
+                            topic="entity_kind",
+                            left=target_kind,
+                            right=kind,
+                            reason_codes=[
+                                AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+                                AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+                            ],
+                        )
+                    )
+    if mismatch:
+        reason_codes.extend(
+            [
+                AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+                AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+            ]
+        )
+
+    if stale:
+        reason_codes.append(AffiliationReasonCode.STALE_AFFILIATION.value)
+
+    public_dates = [evidence_date_of(item) for item in public_items]
+    public_dates = [when for when in public_dates if when]
+    latest_public = max(public_dates) if public_dates else None
+    latest_any_dates = [evidence_date_of(item) for item in scoped]
+    latest_any_dates = [when for when in latest_any_dates if when]
+    latest_any = max(latest_any_dates) if latest_any_dates else None
+    latest_age = _age_days(latest_public, as_of_date)
+    insufficient_recency = False
+    if qsa_only:
+        insufficient_recency = True
+    elif latest_public is None and not public_items:
+        insufficient_recency = True
+    elif latest_age is None and public_items and not latest_public:
+        insufficient_recency = True
+    elif latest_age is not None and latest_age > RECENCY_AGING_DAYS:
+        insufficient_recency = True
+    if insufficient_recency:
+        reason_codes.append(AffiliationReasonCode.INSUFFICIENT_RECENCY.value)
+
+    if qsa_only:
+        reason_codes.append(AffiliationReasonCode.QSA_ONLY.value)
+
+    contradicted_affiliation = any(item.topic == "affiliation" for item in contradictions)
+    contradicted_identity = contradicted_affiliation and not _current_public(target_affiliation)
+    contradicted_role = role_conflict
+
+    identity_level = _never_average_confidence(
+        independent_current=len({independence_origin(item) for item in public_identity_at_target}),
+        contradicted=contradicted_identity,
+        stale=stale and not public_identity_at_target,
+        qsa_only=qsa_only,
+        insufficient=False,
+    )
+    if qsa_only and identity_items:
+        # Cadastre names the person at this CNPJ — identity is observed, not
+        # independently corroborated, and never HIGH from QSA echoes.
+        identity_level = ConfidenceLevel.LOW
+    if len({independence_origin(item) for item in public_identity_at_target}) >= 2 and not contradicted_identity:
+        identity_level = ConfidenceLevel.HIGH
+        reason_codes.append(AffiliationReasonCode.IDENTITY_CORROBORATED.value)
+    elif public_identity_at_target and not qsa_only and not contradicted_identity:
+        identity_level = ConfidenceLevel.MEDIUM
+
+    affiliation_level = _never_average_confidence(
+        independent_current=len(affiliation_origins),
+        contradicted=contradicted_affiliation,
+        stale=stale,
+        qsa_only=qsa_only,
+        insufficient=insufficient_recency,
+    )
+    if len(affiliation_origins) >= 2 and not contradicted_affiliation and not stale and not mismatch:
+        affiliation_level = ConfidenceLevel.HIGH
+        reason_codes.append(AffiliationReasonCode.AFFILIATION_CORROBORATED.value)
+    elif len(affiliation_origins) == 1 and not contradicted_affiliation and not stale and not qsa_only:
+        affiliation_level = ConfidenceLevel.MEDIUM
+
+    public_role_origins = {
+        independence_origin(item)
+        for items in current_public_role_classes.values()
+        for item in items
+    }
+    # Agreed role: largest non-conflicting class.
+    agreed_role: str | None = None
+    if not role_conflict:
+        scored = sorted(
+            (
+                (
+                    len({independence_origin(item) for item in items}),
+                    klass,
+                )
+                for klass, items in current_public_role_classes.items()
+            ),
+            reverse=True,
+        )
+        if scored:
+            agreed_role = scored[0][1]
+        elif qsa_items and not public_items:
+            qsa_roles = [klass for klass in role_by_class if klass != "unknown"]
+            # QSA maps cadastral role only; never invent operational buyer.
+            agreed_role = qsa_roles[0] if qsa_roles else None
+
+    role_level = _never_average_confidence(
+        independent_current=len(public_role_origins),
+        contradicted=contradicted_role,
+        stale=stale,
+        qsa_only=qsa_only,
+        insufficient=False,
+        ownership_only=qsa_only,
+    )
+    if role_conflict:
+        role_level = ConfidenceLevel.LOW
+        agreed_role = None
+    elif len(public_role_origins) >= 2 and agreed_role:
+        role_level = ConfidenceLevel.HIGH
+        reason_codes.append(AffiliationReasonCode.ROLE_CORROBORATED.value)
+    elif len(public_role_origins) == 1 and agreed_role:
+        role_level = ConfidenceLevel.MEDIUM
+    elif not agreed_role and not role_items:
+        role_level = ConfidenceLevel.UNKNOWN
+
+    if latest_age is not None and latest_age <= RECENCY_FRESH_DAYS and public_items and not stale:
+        recency_level = ConfidenceLevel.HIGH
+    elif latest_age is not None and latest_age <= RECENCY_AGING_DAYS and public_items and not stale:
+        recency_level = ConfidenceLevel.MEDIUM
+    elif stale or insufficient_recency:
+        recency_level = ConfidenceLevel.LOW
+    elif qsa_only:
+        recency_level = ConfidenceLevel.LOW
+    else:
+        recency_level = ConfidenceLevel.UNKNOWN
+
+    # Claimed role is recorded only when observed; never invented from silence.
+    claimed = person.claimed_role
+    if claimed and not any(candidate.role_text == claimed for candidate in role_candidates):
+        mapped = normalize_observed_role(claimed)
+        if mapped != DecisionRoleClass.UNKNOWN:
+            role_candidates.append(
+                RoleCandidate(
+                    role_text=claimed,
+                    canonical_role=mapped.value,
+                    source_ids=[],
+                    evidence_date=None,
+                )
+            )
+            # Unsourced claimed role is not evidence — drop it from canonical.
+            if not agreed_role:
+                pass
+
+    if claimed and not role_items:
+        # A claimed role without evidence is ignored (zero invention).
+        agreed_role = None
+        role_candidates = [c for c in role_candidates if c.source_ids]
+
+    aliases = _collect_aliases(person, identity_items)
+    company_name = person.target_company_name
+    if not company_name:
+        named = next((item.company_name for item in target_affiliation if item.company_name), None)
+        company_name = named
+
+    latest_iso = None
+    if latest_public:
+        latest_iso = latest_public.isoformat()
+    elif latest_any:
+        latest_iso = latest_any.isoformat()
+
+    field_records = [
+        FieldConfidenceRecord(
+            "identity",
+            identity_level,
+            [code for code in reason_codes if code.startswith("IDENTITY") or code == AffiliationReasonCode.QSA_ONLY.value],
+            len({independence_origin(item) for item in public_identity_at_target}),
+            latest_iso,
+        ),
+        FieldConfidenceRecord(
+            "company_affiliation",
+            affiliation_level,
+            [
+                code
+                for code in reason_codes
+                if code
+                in {
+                    AffiliationReasonCode.AFFILIATION_CORROBORATED.value,
+                    AffiliationReasonCode.STALE_AFFILIATION.value,
+                    AffiliationReasonCode.QSA_ONLY.value,
+                    AffiliationReasonCode.CONFLICTING_EVIDENCE.value,
+                    AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value,
+                }
+            ],
+            len(affiliation_origins),
+            latest_iso,
+        ),
+        FieldConfidenceRecord(
+            "role",
+            role_level,
+            [
+                code
+                for code in reason_codes
+                if code
+                in {
+                    AffiliationReasonCode.ROLE_CORROBORATED.value,
+                    AffiliationReasonCode.CONFLICTING_ROLE.value,
+                    AffiliationReasonCode.QSA_ONLY.value,
+                }
+            ],
+            len(public_role_origins),
+            latest_iso,
+        ),
+        FieldConfidenceRecord(
+            "recency",
+            recency_level,
+            [
+                code
+                for code in reason_codes
+                if code
+                in {
+                    AffiliationReasonCode.INSUFFICIENT_RECENCY.value,
+                    AffiliationReasonCode.STALE_AFFILIATION.value,
+                }
+            ],
+            len({independence_origin(item) for item in public_items}),
+            latest_iso,
+        ),
+    ]
+
+    reason_codes = list(dict.fromkeys(reason_codes))
+    stop_reasons = [code for code in reason_codes if code in STOP_THE_LINE_CODES]
+    # Homonym with no target affiliation is also stop-the-line (false vínculo).
+    if contradicted_identity or (other_current_public and not affiliation_origins and not qsa_only):
+        if AffiliationReasonCode.CONFLICTING_EVIDENCE.value not in stop_reasons:
+            stop_reasons.append(AffiliationReasonCode.CONFLICTING_EVIDENCE.value)
+        if AffiliationReasonCode.CONFLICTING_EVIDENCE.value not in reason_codes:
+            reason_codes.append(AffiliationReasonCode.CONFLICTING_EVIDENCE.value)
+
+    association_allowed = not any(code in ASSOCIATION_REFUSED_WHEN for code in reason_codes)
+    if other_current_public and not affiliation_origins:
+        association_allowed = False
+    if identity_level in {ConfidenceLevel.NONE, ConfidenceLevel.UNKNOWN} and not qsa_only:
+        association_allowed = False
+    if affiliation_level in {ConfidenceLevel.NONE} or (affiliation_level == ConfidenceLevel.UNKNOWN and not qsa_only):
+        if not affiliation_origins:
+            association_allowed = False
+
+    person_id = stable_id("aff", target_cnpj, fold_text(person.canonical_name))
+    return AffiliationCorroboration(
+        person_id=person_id,
+        canonical_name=normalize_name(person.canonical_name) or person.canonical_name,
+        aliases=aliases,
+        company_cnpj=target_cnpj,
+        company_name=company_name,
+        company_kind=target_kind,
+        role_candidates=role_candidates,
+        canonical_decision_role=agreed_role,
+        evidence=scoped,
+        rejected_evidence=rejected,
+        contradictions=contradictions,
+        identity_confidence=identity_level,
+        affiliation_confidence=affiliation_level,
+        role_confidence=role_level,
+        recency_confidence=recency_level,
+        reason_codes=reason_codes,
+        association_allowed=association_allowed,
+        stop_reasons=list(dict.fromkeys(stop_reasons)),
+        field_records=field_records,
+    )
+
+
+def email_association_gate(
+    corroboration: AffiliationCorroboration,
+    *,
+    email: str | None = None,
+) -> EmailAssociationDecision:
+    """Consumable by the email promoter. Never promotes or validates email."""
+    del email  # local-part is never consulted
+    reasons = list(corroboration.reason_codes)
+    stop = bool(corroboration.stop_reasons) or not corroboration.association_allowed
+    allowed = bool(corroboration.association_allowed) and not stop
+    if not allowed and AffiliationReasonCode.QSA_ONLY.value in reasons:
+        stop = True
+    return EmailAssociationDecision(
+        allowed=allowed,
+        stop_the_line=stop,
+        reason_codes=tuple(dict.fromkeys(reasons)),
+        person_name=corroboration.canonical_name,
+        company_cnpj=corroboration.company_cnpj,
+    )
+
+
+def may_associate_email(
+    person: CandidatePerson,
+    evidence: Sequence[DatedEvidenceItem],
+    *,
+    email: str | None = None,
+    as_of: date | str | None = None,
+) -> EmailAssociationDecision:
+    """One-shot gate: corroborate then decide. Does not write affiliation or email."""
+    record = corroborate_affiliation(person, evidence, as_of=as_of)
+    return email_association_gate(record, email=email)
+

--- a/scripts/decision_unit_intelligence/data/affiliation_corroboration.schema.json
+++ b/scripts/decision_unit_intelligence/data/affiliation_corroboration.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "confenge.dui.affiliation_corroboration.v1",
+  "title": "Decision-Unit affiliation corroboration",
+  "type": "object",
+  "required": [
+    "schema_id",
+    "canonical_name",
+    "aliases",
+    "company_cnpj",
+    "role_candidates",
+    "evidence",
+    "contradictions",
+    "identity_confidence",
+    "affiliation_confidence",
+    "role_confidence",
+    "recency_confidence",
+    "reason_codes",
+    "association_allowed"
+  ],
+  "properties": {
+    "schema_id": {"const": "confenge.dui.affiliation_corroboration.v1"},
+    "policy_id": {"type": "string"},
+    "person_id": {"type": "string"},
+    "canonical_name": {"type": "string", "minLength": 3},
+    "aliases": {"type": "array", "items": {"type": "string"}},
+    "company_cnpj": {"type": "string", "pattern": "^[0-9]{14}$"},
+    "company_name": {"type": ["string", "null"]},
+    "company_kind": {
+      "type": ["string", "null"],
+      "enum": ["holding", "operational", "unit", "brand", "consortium", "unknown", null]
+    },
+    "role_candidates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["role_text"],
+        "properties": {
+          "role_text": {"type": "string"},
+          "canonical_role": {"type": ["string", "null"]},
+          "source_ids": {"type": "array", "items": {"type": "string"}},
+          "evidence_date": {"type": ["string", "null"]},
+          "origin_ids": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "canonical_decision_role": {"type": ["string", "null"]},
+    "evidence": {"type": "array"},
+    "rejected_evidence": {"type": "array"},
+    "contradictions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["topic", "left", "right", "reason_codes"],
+        "properties": {
+          "topic": {"type": "string"},
+          "left": {"type": "string"},
+          "right": {"type": "string"},
+          "reason_codes": {"type": "array", "items": {"type": "string"}},
+          "evidence_ids": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "identity_confidence": {"enum": ["HIGH", "MEDIUM", "LOW", "UNKNOWN", "NONE"]},
+    "affiliation_confidence": {"enum": ["HIGH", "MEDIUM", "LOW", "UNKNOWN", "NONE"]},
+    "role_confidence": {"enum": ["HIGH", "MEDIUM", "LOW", "UNKNOWN", "NONE"]},
+    "recency_confidence": {"enum": ["HIGH", "MEDIUM", "LOW", "UNKNOWN", "NONE"]},
+    "reason_codes": {"type": "array", "items": {"type": "string"}},
+    "association_allowed": {"type": "boolean"},
+    "stop_reasons": {"type": "array", "items": {"type": "string"}},
+    "field_records": {"type": "array"},
+    "promotes_email": {"const": false}
+  },
+  "additionalProperties": true
+}

--- a/scripts/decision_unit_intelligence/orchestrator.py
+++ b/scripts/decision_unit_intelligence/orchestrator.py
@@ -134,14 +134,16 @@ def _apply_affiliation_email_gate(
         decision = email_association_gate(record, email=route.channel_value)
         extra["affiliation_gate"] = decision.to_dict()
         extra["affiliation_stop_the_line"] = decision.stop_the_line
-        if extra.get("identity_explicitly_associated") and not decision.allowed:
+        if not decision.allowed:
             extra["identity_explicitly_associated"] = False
             extra["affiliation_association_refused"] = True
             route.reason_codes = list(
                 dict.fromkeys([*route.reason_codes, *decision.reason_codes, "AFFILIATION_GATE_REFUSED"])
             )
             if route.route_relation == RouteRelation.PERSON_OWNS_CHANNEL:
-                route.route_relation = RouteRelation.INFERRED_ASSOCIATION
+                route.route_relation = RouteRelation.ACCOUNT_LEVEL_ONLY
+            if route.reachability_class == ReachabilityClass.R1_DIRECT:
+                route.reachability_class = ReachabilityClass.R5_CORPORATE_ONLY
         route.extra = extra
 
 
@@ -162,7 +164,9 @@ def _stamp_email_discovery_classes(routes: list[ReachabilityRoute]) -> None:
             else False,
             email_safe_policy=email_safe,
         ).value
-        if extra.get("identity_explicitly_associated") is None and route.route_relation.value == "PERSON_OWNS_CHANNEL":
+        if extra.get("affiliation_association_refused"):
+            extra["identity_explicitly_associated"] = False
+        elif extra.get("identity_explicitly_associated") is None and route.route_relation.value == "PERSON_OWNS_CHANNEL":
             extra["identity_explicitly_associated"] = route.channel_type == ChannelType.DIRECT_EMAIL
         route.extra = extra
 

--- a/scripts/decision_unit_intelligence/orchestrator.py
+++ b/scripts/decision_unit_intelligence/orchestrator.py
@@ -6,8 +6,12 @@ from collections import defaultdict
 from typing import Any
 
 from scripts.decision_unit_intelligence.corroboration import (
+    CandidatePerson,
+    corroborate_affiliation,
     detect_channel_conflicts,
     detect_person_conflicts,
+    email_association_gate,
+    evidence_items_from_observations,
     evidence_quality_label,
 )
 from scripts.decision_unit_intelligence.decision_policy import (
@@ -47,6 +51,7 @@ from scripts.decision_unit_intelligence.models import (
     ReachabilityClass,
     ReachabilityRoute,
     Recommendation,
+    RouteRelation,
     SearchLedger,
     StopReason,
     level_rank,
@@ -68,6 +73,76 @@ from scripts.decision_unit_intelligence.reachability import (
 )
 
 QSA_SOURCES = frozenset({"qsa_rfb", "brasilapi_cnpj", "rfb", "qsa"})
+
+
+def _corroborate_candidates(
+    candidates: list[DecisionUnitCandidate],
+    *,
+    people: list[PersonObservation],
+    company_cnpj: str,
+    company_name: str | None,
+    as_of: str = "2026-08-15",
+) -> list[Any]:
+    records = []
+    for candidate in candidates:
+        name = normalize_name(candidate.person_name)
+        if not name:
+            continue
+        person_obs = [
+            obs
+            for obs in people
+            if normalize_name(obs.person_name) == name
+            and (not obs.company_entity_id or normalize_cnpj(obs.company_entity_id) == company_cnpj)
+        ]
+        items = evidence_items_from_observations(person_obs, company_name=company_name)
+        person = CandidatePerson(
+            canonical_name=name,
+            target_company_cnpj=company_cnpj,
+            target_company_name=company_name,
+            claimed_role=candidate.observed_roles[0] if candidate.observed_roles else None,
+        )
+        record = corroborate_affiliation(person, items, as_of=as_of)
+        extra = dict(candidate.extra or {})
+        extra["affiliation_corroboration"] = record.to_dict()
+        candidate.extra = extra
+        records.append(record)
+    return records
+
+
+def _apply_affiliation_email_gate(
+    routes: list[ReachabilityRoute],
+    records: list[Any],
+    candidates: list[DecisionUnitCandidate] | None = None,
+) -> None:
+    """Refuse person↔email association on known false vínculo. Does not promote email."""
+    by_name = {(normalize_name(record.canonical_name) or "").lower(): record for record in records}
+    by_candidate: dict[str, Any] = {}
+    for candidate in candidates or []:
+        rec = by_name.get((normalize_name(candidate.person_name) or "").lower())
+        if rec is not None:
+            by_candidate[candidate.candidate_id] = rec
+    for route in routes:
+        if not route.channel_value or "@" not in str(route.channel_value):
+            continue
+        extra = dict(route.extra or {})
+        name = normalize_name(extra.get("associated_person_name") or extra.get("person_name"))
+        record = by_name.get((name or "").lower()) if name else None
+        if record is None and route.decision_unit_candidate_id:
+            record = by_candidate.get(route.decision_unit_candidate_id)
+        if record is None:
+            continue
+        decision = email_association_gate(record, email=route.channel_value)
+        extra["affiliation_gate"] = decision.to_dict()
+        extra["affiliation_stop_the_line"] = decision.stop_the_line
+        if extra.get("identity_explicitly_associated") and not decision.allowed:
+            extra["identity_explicitly_associated"] = False
+            extra["affiliation_association_refused"] = True
+            route.reason_codes = list(
+                dict.fromkeys([*route.reason_codes, *decision.reason_codes, "AFFILIATION_GATE_REFUSED"])
+            )
+            if route.route_relation == RouteRelation.PERSON_OWNS_CHANNEL:
+                route.route_relation = RouteRelation.INFERRED_ASSOCIATION
+        route.extra = extra
 
 
 def _stamp_email_discovery_classes(routes: list[ReachabilityRoute]) -> None:
@@ -531,6 +606,13 @@ def investigate_account(
                 public_hits=public_email_hits,
             )
         )
+    affiliation_records = _corroborate_candidates(
+        candidates,
+        people=people,
+        company_cnpj=entity_id,
+        company_name=legal_name,
+    )
+    _apply_affiliation_email_gate(routes, affiliation_records, candidates)
     _stamp_email_discovery_classes(routes)
     rec = recommend(candidates, routes)
     conflicts = detect_person_conflicts(people) + detect_channel_conflicts(normalized_channels)
@@ -563,5 +645,9 @@ def investigate_account(
         warnings=list(dict.fromkeys(rec.warnings)),
         policy_version=POLICY_VERSION,
         built_at=now_iso(),
-        extra={"account_reachability_class": klass.value, **(discovery_extra or {})},
+        extra={
+            "account_reachability_class": klass.value,
+            "affiliation_corroboration": [record.to_dict() for record in affiliation_records],
+            **(discovery_extra or {}),
+        },
     )

--- a/tests/test_decision_unit_affiliation_consumer.py
+++ b/tests/test_decision_unit_affiliation_consumer.py
@@ -1,0 +1,56 @@
+"""Fresh consumer of the shipped corroboration entry — not the unit-test file."""
+
+from __future__ import annotations
+
+from scripts.decision_unit_intelligence.affiliation_consumer import evaluate_representative_cases
+from scripts.decision_unit_intelligence.affiliation_policy import AffiliationReasonCode
+from scripts.decision_unit_intelligence.corroboration import corroborate_affiliation, email_association_gate
+
+
+def test_consumer_five_cases_return_field_confidences_and_vocabulary():
+    first = evaluate_representative_cases()
+    second = evaluate_representative_cases()
+    assert first == second
+
+    diretor = first["cases"]["diretor_two_independent"]
+    for field in (
+        "identity_confidence",
+        "affiliation_confidence",
+        "role_confidence",
+        "recency_confidence",
+    ):
+        assert diretor[field] in {"HIGH", "MEDIUM", "LOW", "UNKNOWN", "NONE"}
+    assert AffiliationReasonCode.IDENTITY_CORROBORATED.value in diretor["reason_codes"]
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value in diretor["reason_codes"]
+    assert AffiliationReasonCode.ROLE_CORROBORATED.value in diretor["reason_codes"]
+    assert diretor["gate"]["allowed"] is True
+    assert diretor["gate"]["promotes_email"] is False
+
+    conflict = first["cases"]["conflicting_roles"]
+    assert AffiliationReasonCode.CONFLICTING_EVIDENCE.value in conflict["reason_codes"]
+    assert AffiliationReasonCode.CONFLICTING_ROLE.value in conflict["reason_codes"]
+    assert conflict["role_confidence"] != "HIGH"
+    assert conflict["gate"]["allowed"] is False
+
+    qsa = first["cases"]["qsa_only_socio"]
+    assert AffiliationReasonCode.QSA_ONLY.value in qsa["reason_codes"]
+    assert qsa["gate"]["allowed"] is False
+    assert qsa["gate"]["stop_the_line"] is True
+
+    stale = first["cases"]["ex_diretor_nova_empresa"]
+    assert (
+        AffiliationReasonCode.STALE_AFFILIATION.value in stale["reason_codes"]
+        or AffiliationReasonCode.INSUFFICIENT_RECENCY.value in stale["reason_codes"]
+    )
+    assert stale["gate"]["allowed"] is False
+
+    homonym = first["cases"]["homonym_other_company"]
+    assert homonym["company_cnpj"] == "11111111000191"
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value not in homonym["reason_codes"]
+    assert homonym["gate"]["allowed"] is False
+
+
+def test_consumer_imports_shipped_entry_not_a_copy():
+    assert corroborate_affiliation.__module__ == "scripts.decision_unit_intelligence.corroboration"
+    assert email_association_gate.__module__ == "scripts.decision_unit_intelligence.corroboration"
+    assert evaluate_representative_cases.__module__ == "scripts.decision_unit_intelligence.affiliation_consumer"

--- a/tests/test_decision_unit_affiliation_corroboration.py
+++ b/tests/test_decision_unit_affiliation_corroboration.py
@@ -20,13 +20,23 @@ from scripts.decision_unit_intelligence.corroboration import (
     independence_origin,
     may_associate_email,
 )
-from scripts.decision_unit_intelligence.email_discovery import associate_person_to_email
+from scripts.decision_unit_intelligence.decision_policy import SERVICE_REAJUSTE_14133
+from scripts.decision_unit_intelligence.email_discovery import (
+    EmailDiscoveryClass,
+    associate_person_to_email,
+)
 from scripts.decision_unit_intelligence.models import (
+    ChannelObservation,
+    ChannelType,
     ConfidenceLevel,
     EpistemicClass,
     PersonObservation,
     PersonRelation,
+    ReachabilityClass,
+    RouteRelation,
 )
+from scripts.decision_unit_intelligence.orchestrator import investigate_account
+from scripts.decision_unit_intelligence.projection import is_email_safe_for_warmbly
 
 AS_OF = "2026-08-15"
 CNPJS = "12345678000190"
@@ -442,6 +452,54 @@ def test_stop_the_line_refuses_known_false_vinculo_on_email_promoter():
     )
     assert association.associated is False
     assert "AFFILIATION_GATE_REFUSED" in association.reason_codes
+
+
+def test_qsa_only_observed_nominal_email_is_not_validated_when_identity_flag_unset():
+    """Stop-the-line must unbind even if identity_explicitly_associated was never set."""
+    acc = investigate_account(
+        cnpj=CNPJS,
+        legal_name="EXEMPLO ENGENHARIA LTDA",
+        service=SERVICE_REAJUSTE_14133,
+        why_now=None,
+        people=[
+            PersonObservation(
+                observation_id="p-carlos-qsa",
+                company_entity_id=CNPJS,
+                person_name="Carlos Socio",
+                observed_role="Sócio-Administrador",
+                relation=PersonRelation.COMPANY_MEMBER,
+                source_type="qsa_rfb",
+                epistemic_class=EpistemicClass.OBSERVED,
+                evidence_id="ev-qsa-carlos",
+            )
+        ],
+        channels=[
+            ChannelObservation(
+                observation_id="c-carlos-email",
+                company_entity_id=CNPJS,
+                channel_type=ChannelType.DIRECT_EMAIL,
+                channel_value="carlos.socio@exemplo.eng.br",
+                person_name="Carlos Socio",
+                source_type="company_website",
+                source_url="https://exemplo.eng.br/equipe",
+                epistemic_class=EpistemicClass.OBSERVED,
+                extra={"person_name": "Carlos Socio"},
+            )
+        ],
+        infer_email=False,
+    )
+    route = next(item for item in acc.routes if item.channel_value == "carlos.socio@exemplo.eng.br")
+    gate = (route.extra or {}).get("affiliation_gate") or {}
+    assert gate.get("allowed") is False
+    assert gate.get("stop_the_line") is True
+    assert (route.extra or {}).get("identity_explicitly_associated") is False
+    assert (route.extra or {}).get("affiliation_association_refused") is True
+    assert route.route_relation != RouteRelation.PERSON_OWNS_CHANNEL
+    assert route.reachability_class != ReachabilityClass.R1_DIRECT
+    assert (route.extra or {}).get("email_discovery_class") != EmailDiscoveryClass.EMAIL_VALIDATED.value
+    assert is_email_safe_for_warmbly(route) is False
+    assert "AFFILIATION_GATE_REFUSED" in route.reason_codes
+    assert AffiliationReasonCode.QSA_ONLY.value in (gate.get("reason_codes") or [])
 
 
 def test_consumer_payload_conforms_to_schema_and_is_deterministic():

--- a/tests/test_decision_unit_affiliation_corroboration.py
+++ b/tests/test_decision_unit_affiliation_corroboration.py
@@ -1,0 +1,468 @@
+"""Affiliation corroboration drives the shipped path — no copy, no invented cargo."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.decision_unit_intelligence.affiliation_consumer import evaluate_representative_cases
+from scripts.decision_unit_intelligence.affiliation_policy import (
+    FORBIDDEN_SOURCE_TYPES,
+    SCHEMA_ID,
+    SHIPPED_REASON_CODES,
+    AffiliationReasonCode,
+)
+from scripts.decision_unit_intelligence.corroboration import (
+    CandidatePerson,
+    DatedEvidenceItem,
+    corroborate_affiliation,
+    email_association_gate,
+    independence_origin,
+    may_associate_email,
+)
+from scripts.decision_unit_intelligence.email_discovery import associate_person_to_email
+from scripts.decision_unit_intelligence.models import (
+    ConfidenceLevel,
+    EpistemicClass,
+    PersonObservation,
+    PersonRelation,
+)
+
+AS_OF = "2026-08-15"
+CNPJS = "12345678000190"
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "decision_unit_intelligence"
+    / "data"
+    / "affiliation_corroboration.schema.json"
+)
+
+
+def _person(**kwargs) -> CandidatePerson:
+    kwargs.setdefault("target_company_cnpj", CNPJS)
+    kwargs.setdefault("target_company_name", "EXEMPLO ENGENHARIA LTDA")
+    kwargs.setdefault("target_entity_kind", "operational")
+    return CandidatePerson(**kwargs)
+
+
+def _ev(**kwargs) -> DatedEvidenceItem:
+    kwargs.setdefault("company_cnpj", CNPJS)
+    kwargs.setdefault("company_name", "EXEMPLO ENGENHARIA LTDA")
+    kwargs.setdefault("observed_at", "2026-04-01")
+    kwargs.setdefault("published_at", "2026-04-01")
+    return DatedEvidenceItem(**kwargs)
+
+
+def _identity_bundle(
+    *,
+    name: str,
+    origin: str,
+    source_type: str,
+    url: str,
+    role: str | None,
+    company_cnpj: str = CNPJS,
+    company_name: str = "EXEMPLO ENGENHARIA LTDA",
+    snippet: str | None = None,
+    stale_signal: str | None = None,
+    entity_kind: str = "operational",
+    observed_at: str = "2026-04-01",
+) -> list[DatedEvidenceItem]:
+    extra = {"person_name": name}
+    items = [
+        _ev(
+            evidence_id=f"{origin}-id",
+            source_type=source_type,
+            field="identity",
+            value=name,
+            source_url=url,
+            origin_id=origin,
+            snippet=snippet,
+            stale_signal=stale_signal,
+            entity_kind=entity_kind,
+            company_cnpj=company_cnpj,
+            company_name=company_name,
+            observed_at=observed_at,
+            published_at=observed_at,
+            extra=extra,
+        ),
+        _ev(
+            evidence_id=f"{origin}-aff",
+            source_type=source_type,
+            field="affiliation",
+            value=company_name,
+            source_url=url,
+            origin_id=origin,
+            snippet=snippet,
+            stale_signal=stale_signal,
+            entity_kind=entity_kind,
+            company_cnpj=company_cnpj,
+            company_name=company_name,
+            observed_at=observed_at,
+            published_at=observed_at,
+            extra=extra,
+        ),
+    ]
+    if role:
+        items.append(
+            _ev(
+                evidence_id=f"{origin}-role",
+                source_type=source_type,
+                field="role",
+                value=role,
+                source_url=url,
+                origin_id=origin,
+                role_text=role,
+                snippet=snippet,
+                stale_signal=stale_signal,
+                entity_kind=entity_kind,
+                company_cnpj=company_cnpj,
+                company_name=company_name,
+                observed_at=observed_at,
+                published_at=observed_at,
+                extra=extra,
+            )
+        )
+    return items
+
+
+def test_schema_file_exists_and_names_per_field_confidences():
+    payload = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert payload["$id"] == SCHEMA_ID
+    required = set(payload["required"])
+    assert {
+        "identity_confidence",
+        "affiliation_confidence",
+        "role_confidence",
+        "recency_confidence",
+        "contradictions",
+        "reason_codes",
+    } <= required
+
+
+def test_diretor_two_independent_sources_corroborates_identity_affiliation_role():
+    person = _person(canonical_name="Ana Diretora", aliases=["Ana M. Diretora"])
+    evidence = _identity_bundle(
+        name="Ana Diretora",
+        origin="site-equipe",
+        source_type="company_website",
+        url="https://exemplo.eng.br/equipe",
+        role="Diretor de Engenharia",
+    ) + _identity_bundle(
+        name="Ana Diretora",
+        origin="doe-sc-2026",
+        source_type="official_gazette",
+        url="https://doe.sc.gov.br/ato",
+        role="Diretor de Engenharia",
+        observed_at="2026-03-12",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert record.identity_confidence is ConfidenceLevel.HIGH
+    assert record.affiliation_confidence is ConfidenceLevel.HIGH
+    assert record.role_confidence is ConfidenceLevel.HIGH
+    assert AffiliationReasonCode.IDENTITY_CORROBORATED.value in record.reason_codes
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value in record.reason_codes
+    assert AffiliationReasonCode.ROLE_CORROBORATED.value in record.reason_codes
+    assert record.canonical_decision_role == "diretor_engenharia"
+    assert record.association_allowed is True
+    assert email_association_gate(record).allowed is True
+    assert record.contradictions == []
+    assert record.to_dict()["schema_id"] == SCHEMA_ID
+    assert record.to_dict()["promotes_email"] is False
+
+
+def test_copy_sources_of_one_origin_are_not_independent():
+    person = _person(canonical_name="Ana Diretora")
+    evidence = _identity_bundle(
+        name="Ana Diretora",
+        origin="press-2026-03",
+        source_type="press_release",
+        url="https://exemplo.eng.br/imprensa/nomeacao",
+        role="Diretora",
+    ) + _identity_bundle(
+        name="Ana Diretora",
+        origin="press-2026-03",
+        source_type="news",
+        url="https://g1.globo.com/sc/nomeacao-espelho",
+        role="Diretora",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    origins = {independence_origin(item) for item in evidence}
+    assert origins == {"press-2026-03"}
+    assert AffiliationReasonCode.IDENTITY_CORROBORATED.value not in record.reason_codes
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value not in record.reason_codes
+    assert AffiliationReasonCode.ROLE_CORROBORATED.value not in record.reason_codes
+    assert record.identity_confidence is not ConfidenceLevel.HIGH
+
+
+def test_conflicting_roles_are_not_averaged():
+    person = _person(canonical_name="Bruno Cargos")
+    evidence = _identity_bundle(
+        name="Bruno Cargos",
+        origin="site-equipe",
+        source_type="company_website",
+        url="https://exemplo.eng.br/equipe",
+        role="Diretor Comercial",
+    ) + _identity_bundle(
+        name="Bruno Cargos",
+        origin="materia-2026",
+        source_type="press_release",
+        url="https://jornal.example/materia",
+        role="Diretor de Engenharia",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert AffiliationReasonCode.CONFLICTING_EVIDENCE.value in record.reason_codes
+    assert AffiliationReasonCode.CONFLICTING_ROLE.value in record.reason_codes
+    assert record.role_confidence is ConfidenceLevel.LOW
+    assert record.role_confidence is not ConfidenceLevel.HIGH
+    assert record.canonical_decision_role is None
+    assert record.association_allowed is False
+    assert email_association_gate(record).stop_the_line is True
+    assert any(item.topic == "role" for item in record.contradictions)
+
+
+def test_qsa_only_socio_is_not_operational_or_associable():
+    person = _person(canonical_name="Carlos Socio", claimed_role="Sócio-Administrador")
+    evidence = _identity_bundle(
+        name="Carlos Socio",
+        origin="qsa-rfb",
+        source_type="qsa_rfb",
+        url="https://casadosdados.com.br/cnpj/12345678000190",
+        role="Sócio-Administrador",
+        observed_at="2026-08-05",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert AffiliationReasonCode.QSA_ONLY.value in record.reason_codes
+    assert AffiliationReasonCode.ROLE_CORROBORATED.value not in record.reason_codes
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value not in record.reason_codes
+    assert record.affiliation_confidence is ConfidenceLevel.LOW
+    assert record.role_confidence is ConfidenceLevel.LOW
+    assert record.association_allowed is False
+    gate = email_association_gate(record, email="carlos.socio@exemplo.eng.br")
+    assert gate.allowed is False
+    assert gate.stop_the_line is True
+    assert gate.to_dict()["promotes_email"] is False
+    assert gate.to_dict()["marks_email_validated"] is False
+    assert gate.to_dict()["auto_send"] is False
+
+
+def test_ex_diretor_nova_empresa_is_stale():
+    person = _person(canonical_name="Diana Exdiretora")
+    evidence = _identity_bundle(
+        name="Diana Exdiretora",
+        origin="saida-2025",
+        source_type="press_release",
+        url="https://jornal.example/saida",
+        role="ex-diretora",
+        snippet="ex-diretora saiu da empresa e agora na Nova Construtora",
+        stale_signal="left_company",
+        observed_at="2025-01-10",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert AffiliationReasonCode.STALE_AFFILIATION.value in record.reason_codes
+    assert (
+        AffiliationReasonCode.INSUFFICIENT_RECENCY.value in record.reason_codes
+        or AffiliationReasonCode.STALE_AFFILIATION.value in record.reason_codes
+    )
+    assert record.association_allowed is False
+    assert record.affiliation_confidence is not ConfidenceLevel.HIGH
+
+
+def test_homonym_does_not_affiliate_to_wrong_company():
+    person = _person(
+        canonical_name="Eduardo Silva",
+        target_company_cnpj="11111111000191",
+        target_company_name="ALVO CONSTRUCOES LTDA",
+    )
+    evidence = _identity_bundle(
+        name="Eduardo Silva",
+        origin="outra-equipe",
+        source_type="company_website",
+        url="https://outra.eng.br/equipe",
+        role="Diretor",
+        company_cnpj="22222222000191",
+        company_name="OUTRA ENGENHARIA LTDA",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert record.company_cnpj == "11111111000191"
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value not in record.reason_codes
+    assert record.association_allowed is False
+    assert record.affiliation_confidence is not ConfidenceLevel.HIGH
+    assert email_association_gate(record).allowed is False
+
+
+def test_holding_vs_operational_mismatch():
+    person = _person(
+        canonical_name="Fernanda Holding",
+        target_company_name="EXEMPLO ENGENHARIA LTDA",
+        target_entity_kind="operational",
+    )
+    evidence = _identity_bundle(
+        name="Fernanda Holding",
+        origin="holding-site",
+        source_type="company_website",
+        url="https://exemplo-holding.com.br/diretoria",
+        role="Diretora",
+        company_name="EXEMPLO PARTICIPACOES HOLDING LTDA",
+        entity_kind="holding",
+    )
+    # Keep target CNPJ so affiliation is "same CNPJ" only if we set it — use same
+    # CNPJ with holding name to isolate entity-kind mismatch.
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value in record.reason_codes
+    assert AffiliationReasonCode.CONFLICTING_EVIDENCE.value in record.reason_codes
+    assert record.association_allowed is False
+
+
+def test_consortium_representation_is_not_member_operational_role():
+    person = _person(
+        canonical_name="Gabriel Consorcio",
+        target_company_name="EXEMPLO ENGENHARIA LTDA",
+        target_entity_kind="operational",
+    )
+    evidence = _identity_bundle(
+        name="Gabriel Consorcio",
+        origin="ata-consorcio",
+        source_type="process_document",
+        url="https://pncp.gov.br/ata",
+        role="Representante do Consórcio",
+        company_name="CONSORCIO NORTE SUL SPE",
+        entity_kind="consortium",
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert AffiliationReasonCode.HOLDING_OPERATIONAL_MISMATCH.value in record.reason_codes
+    assert record.association_allowed is False
+    assert record.canonical_decision_role in {None, "representante_legal"}
+
+
+def test_forbidden_sources_are_rejected_and_do_not_corroborate():
+    person = _person(canonical_name="Helena Fonte")
+    evidence = [
+        _ev(
+            evidence_id="li-auth",
+            source_type="authenticated_linkedin",
+            field="identity",
+            value="Helena Fonte",
+            source_url="https://linkedin.com/in/helena",
+            extra={"person_name": "Helena Fonte"},
+        ),
+        _ev(
+            evidence_id="broker",
+            source_type="data_broker",
+            field="affiliation",
+            value="EXEMPLO ENGENHARIA LTDA",
+            source_url="https://zoominfo.com/helena",
+            extra={"person_name": "Helena Fonte"},
+        ),
+        _ev(
+            evidence_id="localpart",
+            source_type="company_website",
+            field="role",
+            value="Diretora",
+            extraction_method="cargo_from_local_part",
+            extra={"person_name": "Helena Fonte"},
+        ),
+        _ev(
+            evidence_id="pj",
+            source_type="qsa_rfb",
+            field="identity",
+            value="HELENA HOLDING PARTICIPACOES LTDA",
+            extra={"person_name": "HELENA HOLDING PARTICIPACOES LTDA"},
+        ),
+    ]
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    rejected_reasons = {item["reason"] for item in record.rejected_evidence}
+    assert "authenticated_linkedin" in rejected_reasons or "data_broker" in rejected_reasons
+    assert any("local_part" in str(reason) or "cargo" in str(reason) for reason in rejected_reasons)
+    assert AffiliationReasonCode.ROLE_CORROBORATED.value not in record.reason_codes
+    assert AffiliationReasonCode.AFFILIATION_CORROBORATED.value not in record.reason_codes
+    assert record.association_allowed is False
+
+
+def test_policy_vocabulary_contains_the_eight_reason_codes():
+    assert len(SHIPPED_REASON_CODES) == 8
+    assert "authenticated_linkedin" in FORBIDDEN_SOURCE_TYPES
+    assert "data_broker" in FORBIDDEN_SOURCE_TYPES
+
+
+def test_does_not_invent_role_or_company_when_evidence_is_silent():
+    person = _person(canonical_name="Igor Semcargo", claimed_role="Diretor Comercial")
+    evidence = [
+        _ev(
+            evidence_id="name-only",
+            source_type="company_website",
+            field="identity",
+            value="Igor Semcargo",
+            source_url="https://exemplo.eng.br/noticia",
+            origin_id="noticia",
+            extra={"person_name": "Igor Semcargo"},
+        )
+    ]
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    assert record.canonical_decision_role is None
+    assert record.role_candidates == []
+    assert record.company_name == "EXEMPLO ENGENHARIA LTDA"
+    assert AffiliationReasonCode.ROLE_CORROBORATED.value not in record.reason_codes
+
+
+def test_stop_the_line_refuses_known_false_vinculo_on_email_promoter():
+    person = _person(canonical_name="Carlos Socio")
+    evidence = _identity_bundle(
+        name="Carlos Socio",
+        origin="qsa-rfb",
+        source_type="qsa_rfb",
+        url="https://receita.fazenda.gov.br/qsa",
+        role="Sócio-Administrador",
+    )
+    decision = may_associate_email(
+        person,
+        evidence,
+        email="carlos.socio@exemplo.eng.br",
+        as_of=AS_OF,
+    )
+    assert decision.allowed is False
+    assert decision.stop_the_line is True
+    obs = PersonObservation(
+        observation_id="p-carlos",
+        company_entity_id=CNPJS,
+        person_name="Carlos Socio",
+        observed_role="Sócio-Administrador",
+        relation=PersonRelation.COMPANY_MEMBER,
+        source_type="qsa_rfb",
+        epistemic_class=EpistemicClass.OBSERVED,
+    )
+    record = corroborate_affiliation(person, evidence, as_of=AS_OF)
+    association = associate_person_to_email(
+        "carlos.socio@exemplo.eng.br",
+        people=[obs],
+        html="<article><h3>Carlos Socio</h3><a href='mailto:carlos.socio@exemplo.eng.br'>x</a></article>",
+        text="Carlos Socio carlos.socio@exemplo.eng.br",
+        source_url="https://exemplo.eng.br/equipe",
+        corroboration=record,
+    )
+    assert association.associated is False
+    assert "AFFILIATION_GATE_REFUSED" in association.reason_codes
+
+
+def test_consumer_payload_conforms_to_schema_and_is_deterministic():
+    first = evaluate_representative_cases()
+    second = evaluate_representative_cases()
+    assert first == second
+    diretor = first["cases"]["diretor_two_independent"]
+    assert {
+        diretor["identity_confidence"],
+        diretor["affiliation_confidence"],
+        diretor["role_confidence"],
+        diretor["recency_confidence"],
+    }
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    required = schema["required"]
+    # Reconstruct a record-shaped dict from the consumer for schema keys.
+    record = corroborate_affiliation(*__import__(
+        "scripts.decision_unit_intelligence.affiliation_consumer",
+        fromlist=["representative_cases"],
+    ).representative_cases()["diretor_two_independent"], as_of=AS_OF)
+    payload = record.to_dict()
+    for key in required:
+        assert key in payload
+    assert payload["identity_confidence"] in schema["properties"]["identity_confidence"]["enum"]

--- a/tests/test_decision_unit_intelligence_cli.py
+++ b/tests/test_decision_unit_intelligence_cli.py
@@ -35,6 +35,15 @@ def test_cli_plan_and_run_track_a(tmp_path: Path):
     assert rc == 0
     written = list((run_dir / "accounts").glob("*.json"))
     assert len(written) == 30
+    cohort = json.loads((run_dir / "affiliation_cohort.json").read_text(encoding="utf-8"))
+    assert cohort["n"] == 30
+    assert cohort["cnpjs"] == TRACK_A_CNPJS
+    assert "uplift" in cohort and "delta" in cohort["uplift"]
+    assert "contradictions" in cohort
+    assert "next_recommendation" in cohort
+    assert "QSA_ONLY" in cohort["remaining_blockers"]
+    assert cohort["auto_send"] is False
+    assert cohort["invented_cargo_or_empresa"] is False
     funnel = json.loads((run_dir / "funnel.json").read_text(encoding="utf-8"))
     assert funnel["accounts"] == 30
     assert "decision_unit_reachability_rate" in funnel


### PR DESCRIPTION
## Summary

Isolated current-affiliation corroboration for Decision-Unit Intelligence: `candidate person + dated public evidence → per-field confidence (identity, company affiliation, role, recency) + explicit contradictions`. Email association calls this as a **gate** and does not promote email, flip `auto_send`, or mark `EMAIL_VALIDATED`.

Reuses DUI (#378 / #392). Warmbly / web-cfg / SmartLic untouched.

## Schema

`scripts/decision_unit_intelligence/data/affiliation_corroboration.schema.json`  
`schema_id`: `confenge.dui.affiliation_corroboration.v1`  
Cohort: `confenge.dui.affiliation_cohort.v1` written as `affiliation_cohort.json` on every `run`.

Per-person record: canonical name, aliases, company, role candidates, dated evidence, contradictions, four field confidences, reason codes, `association_allowed`.

## Source policy

`scripts/decision_unit_intelligence/affiliation_policy.py` is data the transform consults.

Allowed: site corporativo, documentos/processos públicos, páginas institucionais, diários oficiais, associações profissionais, eventos, matérias/press releases, perfis profissionais publicamente indexados sem login.

Forbidden (rejected, never scored): authenticated LinkedIn, data broker, cargo-from-local-part, QSA PJ as person, bypass, breach dump.

Independence is by **origin**, not URL count. QSA echoes (casadosdados etc.) cluster to one cadastral origin. Copies of one press release do not become two sources.

QSA supports names / controle societário and yields `QSA_ONLY`. It never proves operational/buyer role.

## Tests

`tests/test_decision_unit_affiliation_corroboration.py`  
`tests/test_decision_unit_affiliation_consumer.py`

Fixtures: homônimo; mudou de empresa; sócio sem papel operacional; consórcio; holding; diretor + duas fontes independentes; cargo conflitante. Plus copy-sources, forbidden sources, no invented cargo, stop-the-line on the email promoter.

Consumer file imports the shipped `corroborate_affiliation` / `email_association_gate` (not a copy).

## Track A 30 cohort

Deterministic `run --limit 30 --search-backend off` (twice, identical verdicts).

- 30/30 `TRACK_A_CNPJS`
- 52 people, all `QSA_ONLY` + `INSUFFICIENT_RECENCY`
- Email-association uplift **delta 0** (honest): 3 previously unresolved/ambiguous emails, 0 now defensibly associable
- `auto_send: false`, no invented cargo/empresa

## Email-association uplift

Previously identity-unresolved/ambiguous emails become associable **only** when corroboration allows. On this offline Track A snapshot that count is 0. Generic mailboxes stay generic. QSA-only people never pass the gate.

## Contradictions

Track A: 0 field contradictions (QSA-only, no competing public roles).  
Fixture suite emits `CONFLICTING_EVIDENCE` / `CONFLICTING_ROLE` / `HOLDING_OPERATIONAL_MISMATCH` without averaging HIGH+LOW.

## Next recommendation

Track A permanece majoritariamente QSA + caixa genérica. Próximo passo: evidência pública datada e independente (site/equipe, diário oficial, processo, associação) por pessoa, sem tratar QSA como comprador e sem inventar cargo ou empresa.

## Reason codes

`AFFILIATION_CORROBORATED`, `ROLE_CORROBORATED`, `IDENTITY_CORROBORATED`, `STALE_AFFILIATION`, `CONFLICTING_ROLE`, `HOLDING_OPERATIONAL_MISMATCH`, `QSA_ONLY`, `INSUFFICIENT_RECENCY`, plus `CONFLICTING_EVIDENCE` as the explicit contradiction marker.
