### PR TITLE
feat(public-read): research-flagship read model and national claim gate

### DIFF
--- a/db/migrations/094_public_intelligence_research_models.sql
+++ b/db/migrations/094_public_intelligence_research_models.sql
@@ -1,0 +1,199 @@
+-- 094_public_intelligence_research_models.sql
+-- Additive public_read_v1 families for extra-cli#400 / web-cfg#65+#73.
+-- 094 was free on origin/main@42166330 after fetch. Reserved for this issue only.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+CREATE TABLE IF NOT EXISTS public.public_read_research_flagship_internal (
+    series_key            TEXT PRIMARY KEY,
+    competence            TEXT NOT NULL,
+    geography_kind        TEXT NOT NULL CHECK (geography_kind IN ('UF', 'BR')),
+    geography_code        TEXT NOT NULL,
+    archetype_id          TEXT NOT NULL,
+    contract_count        INTEGER NOT NULL CHECK (contract_count >= 0),
+    total_value_brl       NUMERIC,
+    ticket_p25_brl        NUMERIC,
+    ticket_median_brl     NUMERIC,
+    ticket_p75_brl        NUMERIC,
+    value_status          TEXT NOT NULL CHECK (value_status IN ('KNOWN', 'UNKNOWN')),
+    as_of                 TIMESTAMPTZ NOT NULL,
+    source_updated_at     TIMESTAMPTZ,
+    completeness          TEXT NOT NULL,
+    reason_codes          TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    provenance            JSONB NOT NULL,
+    UNIQUE (competence, geography_kind, geography_code, archetype_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.public_read_research_claim_internal (
+    singleton                          BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    consumer_id                        TEXT NOT NULL,
+    contract_version                   TEXT NOT NULL,
+    nacional_completo                  BOOLEAN NOT NULL,
+    national_claim_allowed             BOOLEAN NOT NULL,
+    reason_codes                       TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    as_of                              TIMESTAMPTZ NOT NULL,
+    freshness_status                   TEXT NOT NULL,
+    coverage_status                    TEXT NOT NULL,
+    coverage_ratio                     TEXT,
+    completeness                       TEXT NOT NULL,
+    catalog_hash                       TEXT,
+    reconciliation_hash                TEXT,
+    extra_1093_used_as_denominator     BOOLEAN NOT NULL DEFAULT FALSE,
+    provenance                         JSONB NOT NULL,
+    query_budget                       JSONB NOT NULL,
+    consumer_error_count               BIGINT NOT NULL DEFAULT 0 CHECK (consumer_error_count >= 0),
+    updated_at                         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO public.public_read_surface_health_internal (view_name, last_refresh_status)
+VALUES ('research_flagship', 'NEVER')
+ON CONFLICT (view_name) DO NOTHING;
+
+CREATE OR REPLACE VIEW public_read_v1.research_flagship_series AS
+SELECT
+    series.series_key,
+    series.competence,
+    series.geography_kind,
+    series.geography_code,
+    series.archetype_id,
+    series.contract_count,
+    series.total_value_brl,
+    series.ticket_p25_brl,
+    series.ticket_median_brl,
+    series.ticket_p75_brl,
+    series.value_status,
+    series.as_of,
+    series.source_updated_at,
+    series.completeness,
+    series.reason_codes,
+    series.provenance
+FROM public.public_read_research_flagship_internal series
+CROSS JOIN public_read_v1.access_gate gate
+WHERE gate.enabled
+ORDER BY series.competence, series.geography_kind, series.geography_code, series.archetype_id;
+
+CREATE OR REPLACE VIEW public_read_v1.research_claim_gate AS
+SELECT
+    claim.consumer_id,
+    claim.contract_version,
+    claim.nacional_completo,
+    claim.national_claim_allowed,
+    claim.reason_codes,
+    claim.as_of,
+    claim.freshness_status,
+    claim.completeness,
+    claim.catalog_hash,
+    claim.reconciliation_hash,
+    claim.extra_1093_used_as_denominator,
+    claim.provenance,
+    claim.query_budget,
+    claim.consumer_error_count
+FROM public.public_read_research_claim_internal claim
+CROSS JOIN public_read_v1.access_gate gate
+WHERE claim.singleton AND gate.enabled;
+
+CREATE OR REPLACE VIEW public_read_v1.research_health AS
+SELECT
+    health.view_name AS family,
+    health.enabled,
+    health.refreshed_at,
+    health.query_count,
+    health.error_count AS consumer_error_count,
+    health.query_p95_ms,
+    health.last_refresh_status,
+    health.last_error,
+    claim.as_of,
+    claim.freshness_status,
+    claim.coverage_status,
+    claim.coverage_ratio,
+    claim.nacional_completo,
+    claim.national_claim_allowed,
+    claim.reason_codes,
+    snapshot.snapshot_id,
+    CASE
+        WHEN claim.singleton IS NULL THEN 'UNKNOWN'
+        WHEN claim.national_claim_allowed THEN 'COMPLETE'
+        ELSE 'INCOMPLETE'
+    END AS completeness,
+    jsonb_build_object(
+        'snapshot_id', snapshot.snapshot_id,
+        'catalog_hash', claim.catalog_hash,
+        'consumer_error_count', health.error_count
+    ) AS provenance
+FROM public.public_read_surface_health_internal health
+LEFT JOIN public.public_read_research_claim_internal claim ON claim.singleton
+LEFT JOIN public_read_v1.current_snapshot snapshot ON TRUE
+CROSS JOIN public_read_v1.access_gate gate
+WHERE health.view_name = 'research_flagship' AND gate.enabled;
+
+INSERT INTO public_read_v1.query_budgets VALUES
+    (
+        'research_flagship_series',
+        2000,
+        250,
+        64,
+        2,
+        'SELECT * FROM public_read_v1.research_flagship_series WHERE competence = $1 ORDER BY geography_kind, geography_code, archetype_id LIMIT 64'
+    ),
+    (
+        'research_claim_gate',
+        1000,
+        100,
+        1,
+        4,
+        'SELECT * FROM public_read_v1.research_claim_gate LIMIT 1'
+    ),
+    (
+        'research_health',
+        1000,
+        100,
+        20,
+        2,
+        'SELECT * FROM public_read_v1.research_health LIMIT 20'
+    )
+ON CONFLICT (query_family) DO UPDATE SET
+    statement_timeout_ms = EXCLUDED.statement_timeout_ms,
+    p95_budget_ms = EXCLUDED.p95_budget_ms,
+    max_rows = EXCLUDED.max_rows,
+    max_concurrent = EXCLUDED.max_concurrent,
+    representative_query = EXCLUDED.representative_query;
+
+DO $$
+DECLARE release_hash TEXT;
+BEGIN
+    SELECT encode(digest(string_agg(table_name || ':' || ordinal_position || ':' || column_name || ':' || data_type || ':' || is_nullable, '|' ORDER BY table_name, ordinal_position), 'sha256'), 'hex')
+    INTO release_hash
+    FROM information_schema.columns
+    WHERE table_schema = 'public_read_v1'
+      AND table_name IN (
+          'current_snapshot', 'tenders', 'contracts', 'entities', 'suppliers',
+          'organs', 'municipalities', 'surface_health',
+          'research_flagship_series', 'research_claim_gate', 'research_health'
+      );
+    INSERT INTO public_read_v1.contract_releases VALUES (
+        'v1.1.0',
+        NOW(),
+        release_hash,
+        'Additive nullable columns and new families only within v1; removal/type/nullability changes require public_read_v2.',
+        180,
+        'Additive research-flagship series, claim gate and health families for extra-cli#400. 094 used because it was free on origin/main@42166330.'
+    ) ON CONFLICT (version) DO UPDATE SET
+        schema_hash = EXCLUDED.schema_hash,
+        changelog = EXCLUDED.changelog;
+END $$;
+
+GRANT SELECT ON public_read_v1.research_flagship_series TO smartlic_public_reader;
+GRANT SELECT ON public_read_v1.research_claim_gate TO smartlic_public_reader;
+GRANT SELECT ON public_read_v1.research_health TO smartlic_public_reader;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+    ON public_read_v1.research_flagship_series,
+       public_read_v1.research_claim_gate,
+       public_read_v1.research_health
+    FROM smartlic_public_reader;
+REVOKE ALL ON public.public_read_research_flagship_internal FROM smartlic_public_reader;
+REVOKE ALL ON public.public_read_research_claim_internal FROM smartlic_public_reader;
+
+COMMIT;

--- a/db/rollback/094_public_intelligence_research_models_rollback.sql
+++ b/db/rollback/094_public_intelligence_research_models_rollback.sql
@@ -1,0 +1,15 @@
+-- Rollback 094: drop only the additive research families. v1.0.0 views stay.
+
+BEGIN;
+
+DROP VIEW IF EXISTS public_read_v1.research_health;
+DROP VIEW IF EXISTS public_read_v1.research_claim_gate;
+DROP VIEW IF EXISTS public_read_v1.research_flagship_series;
+DELETE FROM public_read_v1.query_budgets
+ WHERE query_family IN ('research_flagship_series', 'research_claim_gate', 'research_health');
+DELETE FROM public_read_v1.contract_releases WHERE version = 'v1.1.0';
+DELETE FROM public.public_read_surface_health_internal WHERE view_name = 'research_flagship';
+DROP TABLE IF EXISTS public.public_read_research_claim_internal;
+DROP TABLE IF EXISTS public.public_read_research_flagship_internal;
+
+COMMIT;

--- a/docs/contracts/public-read-research-flagship-v1.json
+++ b/docs/contracts/public-read-research-flagship-v1.json
@@ -1,0 +1,118 @@
+{
+  "schema": "public-read-research-flagship/1.0",
+  "contract_version": "v1.1.0",
+  "public_read_base": "v1.0.0",
+  "compatibility": "additive_nullable_within_v1",
+  "consumer": {
+    "id": "web-cfg/flagship-research",
+    "repository": "tjsasakifln/web-cfg",
+    "issues": ["#65"],
+    "pull_requests": ["#73"],
+    "decision": "EDIÇÃO ZERO may consume this export; national publish requires national_claim_allowed=true"
+  },
+  "wedge": {
+    "id": "contracts-prices-margin-defense",
+    "label": "Public-contract volume and integral ticket for margin-defense research",
+    "reuse": "Same grain feeds volume, ticket and margin-defense questions; not a unit price series"
+  },
+  "grain": "competence × geography_kind × geography_code × archetype_id",
+  "keys": [
+    "competence",
+    "geography_kind",
+    "geography_code",
+    "archetype_id"
+  ],
+  "source_families": [
+    "public_read_v1.contracts",
+    "canonical_public_observations",
+    "national_universe/1.0"
+  ],
+  "value_semantics": {
+    "contract_value": "integral nominal BRL of the contract instrument",
+    "not": [
+      "unit price",
+      "price per m2",
+      "deflated BRL",
+      "practiced national price band"
+    ],
+    "ticket_percentiles": "nearest-rank P25/median/P75 of integral nominal BRL in the cell",
+    "unknown_policy": "UNKNOWN remains UNKNOWN; a cell with any unknown value cannot publish numeric totals"
+  },
+  "temporal_geographic_denominator": {
+    "authority": "scripts.national_contract_truth.national_universe.reconcile_partitions",
+    "schema": "national_universe/1.0",
+    "geographic_unit": "publishing-org partition of the versioned national universe",
+    "forbidden_substitutes": [
+      "Extra commercial 1093-entity universe",
+      "4-UF published-market slice",
+      "any recorte claimed as BR without nacional_completo"
+    ],
+    "nacional_completo_rule": "every expected partition closes FOUND or ZERO_CONFIRMED with evidence; BLOCKED/FAILED/missing fail closed"
+  },
+  "as_of": "snapshot cutoff from the input payload; never wall-clock",
+  "freshness": {
+    "policy": "contracts-freshness-slo-v1",
+    "layer": "publication",
+    "max_age_hours": 48
+  },
+  "completeness": {
+    "COMPLETE": "nacional_completo and every series cell is KNOWN",
+    "INCOMPLETE": "denominator or cells missing/blocked",
+    "UNKNOWN": "required watermarks, values or partitions absent"
+  },
+  "provenance": [
+    "source_id",
+    "source_record_id",
+    "lineage",
+    "catalog_hash",
+    "reconciliation_hash",
+    "content_hash"
+  ],
+  "unknown_reason_codes": [
+    "missing_partitions",
+    "blocked_or_failed_partitions",
+    "national_denominator_incomplete",
+    "freshness_stale",
+    "unknown_values",
+    "duplicated_source_lineage",
+    "inconsistent_denominator_extra_1093",
+    "inconsistent_denominator"
+  ],
+  "query_budget": {
+    "query_family": "research_flagship_series",
+    "statement_timeout_ms": 2000,
+    "p95_budget_ms": 250,
+    "max_rows": 64,
+    "max_concurrent": 2,
+    "representative_query": "SELECT * FROM public_read_v1.research_flagship_series WHERE competence = $1 ORDER BY geography_kind, geography_code, archetype_id LIMIT 64"
+  },
+  "query_budgets": [
+    {
+      "query_family": "research_flagship_series",
+      "statement_timeout_ms": 2000,
+      "p95_budget_ms": 250,
+      "max_rows": 64,
+      "max_concurrent": 2,
+      "representative_query": "SELECT * FROM public_read_v1.research_flagship_series WHERE competence = $1 ORDER BY geography_kind, geography_code, archetype_id LIMIT 64"
+    },
+    {
+      "query_family": "research_claim_gate",
+      "statement_timeout_ms": 1000,
+      "p95_budget_ms": 100,
+      "max_rows": 1,
+      "max_concurrent": 4,
+      "representative_query": "SELECT * FROM public_read_v1.research_claim_gate LIMIT 1"
+    },
+    {
+      "query_family": "research_health",
+      "statement_timeout_ms": 1000,
+      "p95_budget_ms": 100,
+      "max_rows": 20,
+      "max_concurrent": 2,
+      "representative_query": "SELECT * FROM public_read_v1.research_health LIMIT 20"
+    }
+  ],
+  "national_claim_rule": "national_claim_allowed is true only when nacional_completo=true and no material reason_code remains. geography_code=BR is emitted only then. Extra 1093 is never a national denominator.",
+  "branding": "truth plane and export are source-agnostic; CONFENGE marks are forbidden",
+  "migration": "094_public_intelligence_research_models.sql (094 was free after fetch of origin/main@42166330; reserved for extra-cli#400 only)"
+}

--- a/docs/contracts/public-read-research-flagship-v1.md
+++ b/docs/contracts/public-read-research-flagship-v1.md
@@ -1,0 +1,77 @@
+# `public_read_v1` research flagship contract
+
+Version: `v1.1.0` (additive on `public_read_v1` `v1.0.0`)
+Schema: `public-read-research-flagship/1.0`
+Machine-readable twin: [`public-read-research-flagship-v1.json`](public-read-research-flagship-v1.json)
+
+Consumer: `web-cfg / flagship research` (`tjsasakifln/web-cfg#65`, PR `#73`)
+Wedge: contracts / prices / margin-defense — volume and ticket of the **integral nominal BRL contract**, not unit price.
+
+## Boundary
+
+This is a SELECT-only, versioned family inside `public_read_v1`. It is not a
+generic API, browser API, exploratory endpoint, or second DataLake. The
+PostgreSQL role `smartlic_public_reader` remains SELECT-only.
+
+The shipped consumer path is the deterministic export:
+
+```bash
+python3 -m scripts.public_read export-research --fixture PATH --out DIR
+python3 -m scripts.public_read health --artifact DIR/research-export.json
+```
+
+web-cfg knows it may publish a national claim only when
+`claim.national_claim_allowed` is `true` on that artifact (and on
+`public_read_v1.research_claim_gate` after an optional apply).
+
+## Grain, keys, sources
+
+| Field | Contract |
+|---|---|
+| Grain | `competence × geography_kind × geography_code × archetype_id` |
+| Keys | those four fields; `series_key` is their `|`-joined form |
+| Source families | `public_read_v1.contracts`, `canonical_public_observations`, `national_universe/1.0` |
+| Value semantics | integral nominal BRL; P25/median/P75 nearest-rank; never m² or deflated price |
+| Temporal / geographic denominator | #302 publishing-org universe via `reconcile_partitions`; `nacional_completo` only when every partition closes `FOUND` or `ZERO_CONFIRMED` with evidence |
+| `as_of` | input snapshot cutoff, never wall-clock |
+| Freshness | `contracts-freshness-slo-v1` publication layer, 48h |
+| Completeness | `COMPLETE` / `INCOMPLETE` / `UNKNOWN` |
+| Provenance | source + record + lineage + catalog/reconciliation/content hashes |
+| UNKNOWN / `reason_codes` | listed in the JSON twin; UNKNOWN stays UNKNOWN |
+| Query budget | `public_read_v1.query_budgets` families `research_flagship_series`, `research_claim_gate`, `research_health` |
+
+Forbidden denominators: Extra's commercial 1.093-entity universe; any 4-UF
+slice claimed as BR; any recorte without `nacional_completo`.
+
+## National claim gate
+
+`national_claim_allowed` is true **only** when all of the following hold:
+
+1. `reconcile_partitions` returns `nacional_completo=true`
+2. no partition is missing, `BLOCKED`, or `FAILED`
+3. publication freshness is within SLO
+4. no series row is UNKNOWN
+5. no unresolved duplicated source lineage
+6. Extra 1093 was not used as the denominator
+
+Otherwise the export refuses geography `BR` and must not carry publishable
+"Brasil"/"nacional" claim language. `nacional_completo` and
+`national_claim_allowed` remain gate fields, not published claims.
+
+## Additive `public_read_v1` families (`v1.1.0`)
+
+| Family | Role |
+|---|---|
+| `research_flagship_series` | chart/research cells |
+| `research_claim_gate` | singleton eligibility |
+| `research_health` | freshness, coverage, consumer errors |
+
+No v1.0.0 column is removed or renamed. Migration
+`094_public_intelligence_research_models.sql` was used because 094 was free on
+`origin/main` at `42166330` after fetch. No other front of this package uses 094.
+
+## Honesty
+
+Fixtures and a versioned export do **not** prove a live national PNCP census or
+`VPS_OPERATIONAL`. A publicable national research remains `NEEDS_DATA` until a
+live #302 denominator actually closes.

--- a/docs/contracts/public-read-v1.md
+++ b/docs/contracts/public-read-v1.md
@@ -35,6 +35,9 @@ show staleness and kill-switch state.
 | `organs` | entity fields restricted to organ/unit | buyer/publisher detail |
 | `municipalities` | canonical municipality ID, IBGE, UF/name, origin metadata | municipality landing-page identity |
 | `surface_health` | view, refresh/query/error/p95, snapshot/as-of, completeness | freshness banner and server-side circuit-breaker evidence |
+| `research_flagship_series` | competence/geography/archetype, volume, integral BRL ticket, provenance | chart/research series for web-cfg flagship research |
+| `research_claim_gate` | `nacional_completo`, `national_claim_allowed`, reason_codes, denominator hashes | fail-closed national publish decision |
+| `research_health` | freshness, coverage, consumer errors | operational observability for the research family |
 
 Exact query text, timeout, p95 target, row limit and concurrency budget are
 queryable in `public_read_v1.query_budgets`. Consumers must always use bounded
@@ -59,5 +62,11 @@ soak, or `VPS_OPERATIONAL`.
 
 ## Changelog
 
+- `v1.1.0` (2026-08-15): additive research-flagship families
+  (`research_flagship_series`, `research_claim_gate`, `research_health`) for
+  `web-cfg / flagship research` (extra-cli#400, web-cfg#65/#73). Contract:
+  [`public-read-research-flagship-v1.md`](public-read-research-flagship-v1.md).
+  Migration `094_public_intelligence_research_models.sql` (094 was free on
+  `origin/main` at `42166330`). No v1.0.0 column was removed or renamed.
 - `v1.0.0` (2026-08-13): initial snapshot, tender, contract, entity, supplier,
   organ, municipality and surface-health families.

--- a/scripts/public_read/__init__.py
+++ b/scripts/public_read/__init__.py
@@ -1,0 +1,7 @@
+"""SELECT-only public_read research families and the flagship export."""
+
+from __future__ import annotations
+
+__all__ = ["CONTRACT_SCHEMA"]
+
+CONTRACT_SCHEMA = "public-read-research-flagship/1.0"

--- a/scripts/public_read/__main__.py
+++ b/scripts/public_read/__main__.py
@@ -1,0 +1,8 @@
+"""python -m scripts.public_read"""
+
+from __future__ import annotations
+
+from scripts.public_read.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/public_read/claim_gate.py
+++ b/scripts/public_read/claim_gate.py
@@ -1,0 +1,177 @@
+"""National claim gate. Reuses #302; Extra 1093 is never a national denominator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from scripts.national_contract_truth.freshness_slo import (
+    LayerObservation,
+    evaluate_layer,
+)
+from scripts.national_contract_truth.national_universe import (
+    EXTRA_COMMERCIAL_DENOMINATOR,
+    NationalUniverseError,
+    PartitionResult,
+    PublishingOrg,
+    build_universe,
+    reconcile_partitions,
+)
+from scripts.public_read.models import ResearchPayload
+
+MATERIAL_REASON_CODES = (
+    "missing_partitions",
+    "blocked_or_failed_partitions",
+    "national_denominator_incomplete",
+    "freshness_stale",
+    "unknown_values",
+    "duplicated_source_lineage",
+    "inconsistent_denominator_extra_1093",
+    "inconsistent_denominator",
+)
+
+
+@dataclass(frozen=True)
+class ClaimDecision:
+    national_claim_allowed: bool
+    nacional_completo: bool
+    reason_codes: tuple[str, ...]
+    catalog_hash: str | None
+    reconciliation_hash: str | None
+    national_universe_id: str | None
+    extra_1093_used_as_denominator: bool
+    expected_partitions: int
+    closed_partitions: int
+    reconciliation: dict[str, Any]
+
+
+def _orgs(payload: ResearchPayload) -> tuple[PublishingOrg, ...]:
+    return tuple(
+        PublishingOrg(
+            org_id=str(org["org_id"]),
+            source=str(org.get("source") or payload.universe.source),
+            competence=str(org.get("competence") or payload.universe.competence),
+            name=str(org["name"]),
+            unit_count=int(org.get("unit_count") or 1),
+        )
+        for org in payload.universe.orgs
+    )
+
+
+def _duplicate_lineage(payload: ResearchPayload) -> bool:
+    seen: dict[str, set[tuple[str, ...]]] = {}
+    for row in payload.rows:
+        if row.lineage_resolution:
+            continue
+        bucket = seen.setdefault(row.process_key, set())
+        bucket.add(row.lineage)
+        if len(bucket) > 1:
+            return True
+    return False
+
+
+def evaluate_national_claim(payload: ResearchPayload) -> ClaimDecision:
+    reasons: list[str] = []
+    extra_1093 = bool(payload.use_extra_1093_as_denominator)
+    if extra_1093 or payload.denominator_kind == "extra_commercial_1093":
+        extra_1093 = True
+        reasons.append("inconsistent_denominator_extra_1093")
+    if payload.claimed_geography == "BR" and extra_1093:
+        reasons.append("inconsistent_denominator")
+    if len(payload.universe.orgs) == EXTRA_COMMERCIAL_DENOMINATOR and payload.denominator_kind != "publishing_org":
+        extra_1093 = True
+        if "inconsistent_denominator_extra_1093" not in reasons:
+            reasons.append("inconsistent_denominator_extra_1093")
+
+    reconciliation: dict[str, Any] = {
+        "nacional_completo": False,
+        "catalog_hash": None,
+        "reconciliation_hash": None,
+        "national_universe_id": None,
+        "expected_partitions": len(payload.universe.orgs),
+        "consulted_partitions": len(payload.partitions),
+        "extra_1093_used_as_denominator": extra_1093,
+        "extra_commercial_denominator": EXTRA_COMMERCIAL_DENOMINATOR,
+    }
+    catalog_hash = None
+    reconciliation_hash = None
+    universe_id = None
+    closed = 0
+    expected = len(payload.universe.orgs)
+
+    if not extra_1093:
+        try:
+            universe = build_universe(
+                source=payload.universe.source,
+                competence=payload.universe.competence,
+                cutoff=payload.universe.cutoff,
+                orgs=_orgs(payload),
+                method=payload.universe.method,
+            )
+            results = tuple(
+                PartitionResult(
+                    partition_id=part.partition_id,
+                    status=part.status,  # type: ignore[arg-type]
+                    evidence=part.evidence,
+                )
+                for part in payload.partitions
+            )
+            reconciliation = reconcile_partitions(universe, results)
+            catalog_hash = str(reconciliation["catalog_hash"])
+            reconciliation_hash = str(reconciliation["reconciliation_hash"])
+            universe_id = str(reconciliation["national_universe_id"])
+            expected = int(reconciliation["expected_partitions"])
+            by_status = reconciliation["by_status"]
+            closed = int(by_status["FOUND"]) + int(by_status["ZERO_CONFIRMED"])
+        except NationalUniverseError:
+            reasons.append("missing_partitions")
+            try:
+                universe = build_universe(
+                    source=payload.universe.source,
+                    competence=payload.universe.competence,
+                    cutoff=payload.universe.cutoff,
+                    orgs=_orgs(payload),
+                    method=payload.universe.method,
+                )
+                catalog_hash = universe.catalog_hash
+                universe_id = universe.national_universe_id
+                expected = universe.org_count
+            except NationalUniverseError:
+                catalog_hash = None
+
+    if any(part.status in {"BLOCKED", "FAILED"} for part in payload.partitions):
+        reasons.append("blocked_or_failed_partitions")
+    if not reconciliation.get("nacional_completo"):
+        reasons.append("national_denominator_incomplete")
+
+    publication = evaluate_layer(
+        LayerObservation(
+            layer="publication",
+            age_since_complete_run=payload.freshness.age,
+            lag_p50=payload.freshness.lag_p99,
+            lag_p95=payload.freshness.lag_p99,
+            lag_p99=payload.freshness.lag_p99,
+        )
+    )
+    if publication.status == "BREACH":
+        reasons.append("freshness_stale")
+
+    if any(row.value_status == "UNKNOWN" or row.contract_value_brl is None for row in payload.rows):
+        reasons.append("unknown_values")
+    if _duplicate_lineage(payload):
+        reasons.append("duplicated_source_lineage")
+
+    ordered = tuple(code for code in MATERIAL_REASON_CODES if code in reasons)
+    allowed = not ordered and bool(reconciliation.get("nacional_completo"))
+    return ClaimDecision(
+        national_claim_allowed=allowed,
+        nacional_completo=bool(reconciliation.get("nacional_completo")),
+        reason_codes=ordered,
+        catalog_hash=catalog_hash,
+        reconciliation_hash=reconciliation_hash,
+        national_universe_id=universe_id,
+        extra_1093_used_as_denominator=extra_1093,
+        expected_partitions=expected,
+        closed_partitions=closed,
+        reconciliation=reconciliation,
+    )

--- a/scripts/public_read/cli.py
+++ b/scripts/public_read/cli.py
@@ -1,0 +1,64 @@
+"""Shipped CLI for the research-flagship export and health read."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from scripts.public_read.export import (
+    EXPORT_FILENAME,
+    load_export_artifact,
+    write_research_export,
+)
+from scripts.public_read.payload import load_research_payload
+
+
+def _cmd_export(args: argparse.Namespace) -> int:
+    payload = load_research_payload(args.fixture)
+    path = write_research_export(payload, args.out)
+    artifact = load_export_artifact(path)
+    sys.stdout.write(
+        json.dumps(
+            {
+                "ok": True,
+                "path": str(path),
+                "content_hash": artifact["content_hash"],
+                "national_claim_allowed": artifact["claim"]["national_claim_allowed"],
+                "reason_codes": artifact["claim"]["reason_codes"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return 0
+
+
+def _cmd_health(args: argparse.Namespace) -> int:
+    artifact_path = Path(args.artifact)
+    if artifact_path.is_dir():
+        artifact_path = artifact_path / EXPORT_FILENAME
+    artifact = load_export_artifact(artifact_path)
+    sys.stdout.write(json.dumps(artifact["health"], ensure_ascii=False, sort_keys=True, indent=2) + "\n")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python3 -m scripts.public_read")
+    sub = parser.add_subparsers(dest="command", required=True)
+    export_cmd = sub.add_parser("export-research", help="Write the versioned research export")
+    export_cmd.add_argument("--fixture", required=True, help="Research fixture JSON")
+    export_cmd.add_argument("--out", required=True, help="Output directory")
+    export_cmd.set_defaults(func=_cmd_export)
+    health_cmd = sub.add_parser("health", help="Read freshness/coverage/consumer errors")
+    health_cmd.add_argument("--artifact", required=True, help="Export JSON or directory")
+    health_cmd.set_defaults(func=_cmd_health)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))

--- a/scripts/public_read/contract.py
+++ b/scripts/public_read/contract.py
@@ -1,0 +1,23 @@
+"""Load the versioned research-flagship consumer contract."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+CONTRACT_RELATIVE = Path("docs/contracts/public-read-research-flagship-v1.json")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / CONTRACT_RELATIVE
+
+FORBIDDEN_TRUTH_BRANDS = ("CONFENGE", "confenge")
+
+
+@lru_cache(maxsize=1)
+def load_contract() -> dict[str, Any]:
+    return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def query_budget() -> dict[str, Any]:
+    return dict(load_contract()["query_budget"])

--- a/scripts/public_read/export.py
+++ b/scripts/public_read/export.py
@@ -1,0 +1,170 @@
+"""Deterministic research-flagship export. No brand marks in the truth plane."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from scripts.public_read.claim_gate import ClaimDecision, evaluate_national_claim
+from scripts.public_read.contract import FORBIDDEN_TRUTH_BRANDS, load_contract, query_budget
+from scripts.public_read.models import ResearchPayload
+from scripts.public_read.observability import observe_research_health
+from scripts.public_read.series import project_series
+
+EXPORT_FILENAME = "research-export.json"
+_CLAIM_LANGUAGE = re.compile(r"\b(brasil|nacional)\b", re.IGNORECASE)
+_STRUCTURAL_KEYS = frozenset(
+    {
+        "nacional_completo",
+        "national_claim_allowed",
+        "national_universe_id",
+        "national_claim_rule",
+        "national_denominator_incomplete",
+    }
+)
+
+
+def canonical_dumps(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _scan_forbidden_language(node: Any, *, allowed: bool, path: str = "") -> list[str]:
+    if allowed:
+        return []
+    hits: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            next_path = f"{path}.{key}" if path else str(key)
+            if key in _STRUCTURAL_KEYS:
+                hits.extend(_scan_forbidden_language(value, allowed=allowed, path=next_path))
+                continue
+            if _CLAIM_LANGUAGE.search(str(key)):
+                hits.append(next_path)
+            hits.extend(_scan_forbidden_language(value, allowed=allowed, path=next_path))
+        return hits
+    if isinstance(node, list):
+        for index, item in enumerate(node):
+            hits.extend(_scan_forbidden_language(item, allowed=allowed, path=f"{path}[{index}]"))
+        return hits
+    if isinstance(node, str) and _CLAIM_LANGUAGE.search(node):
+        hits.append(path or node)
+    return hits
+
+
+def assert_truth_plane_clean(document: dict[str, Any] | bytes | str) -> None:
+    raw = (
+        document
+        if isinstance(document, (bytes, bytearray))
+        else (document if isinstance(document, str) else canonical_dumps(document))
+    )
+    text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+    for brand in FORBIDDEN_TRUTH_BRANDS:
+        if brand.lower() in text.lower():
+            raise ValueError("truth plane contains forbidden brand mark")
+
+
+def build_export_document(payload: ResearchPayload) -> dict[str, Any]:
+    contract = load_contract()
+    claim = evaluate_national_claim(payload)
+    series = project_series(payload, claim)
+    health = observe_research_health(payload, claim)
+    document = {
+        "schema": contract["schema"],
+        "contract_version": contract["contract_version"],
+        "contract_path": "docs/contracts/public-read-research-flagship-v1.json",
+        "consumer": {
+            "id": contract["consumer"]["id"],
+            "repository": contract["consumer"]["repository"],
+            "issues": contract["consumer"]["issues"],
+            "pull_requests": contract["consumer"]["pull_requests"],
+        },
+        "wedge": {
+            "id": contract["wedge"]["id"],
+            "label": contract["wedge"]["label"],
+        },
+        "grain": contract["grain"],
+        "keys": contract["keys"],
+        "source_families": contract["source_families"],
+        "value_semantics": {
+            "contract_value": contract["value_semantics"]["contract_value"],
+            "ticket_percentiles": contract["value_semantics"]["ticket_percentiles"],
+            "unknown_policy": contract["value_semantics"]["unknown_policy"],
+        },
+        "as_of": payload.as_of,
+        "freshness": contract["freshness"],
+        "completeness": health["coverage_status"],
+        "denominator": {
+            "authority": "national_universe/1.0",
+            "extra_1093_used_as_denominator": claim.extra_1093_used_as_denominator,
+            "expected_partitions": claim.expected_partitions,
+            "closed_partitions": claim.closed_partitions,
+        },
+        "provenance": {
+            "fixture_id": payload.fixture_id,
+            "catalog_hash": claim.catalog_hash,
+            "reconciliation_hash": claim.reconciliation_hash,
+            "national_universe_id": claim.national_universe_id,
+            "method": payload.universe.method,
+        },
+        "query_budget": query_budget(),
+        "query_budgets": contract["query_budgets"],
+        "claim": {
+            "national_claim_allowed": claim.national_claim_allowed,
+            "nacional_completo": claim.nacional_completo,
+            "reason_codes": list(claim.reason_codes),
+            "extra_1093_used_as_denominator": claim.extra_1093_used_as_denominator,
+            "publishable_geography": "BR" if claim.national_claim_allowed else None,
+            "publishable_claim": (
+                "Series covers the closed publishing-org denominator." if claim.national_claim_allowed else None
+            ),
+        },
+        "series": series,
+        "health": health,
+        "unknown": {
+            "policy": "UNKNOWN remains UNKNOWN",
+            "reason_codes": list(claim.reason_codes),
+        },
+    }
+    assert_truth_plane_clean(document)
+    language_hits = _scan_forbidden_language(document, allowed=claim.national_claim_allowed)
+    if language_hits:
+        raise ValueError(f"refused claim language in fail-closed export: {language_hits}")
+    hashed = canonical_dumps(document)
+    document["content_hash"] = hashlib.sha256(hashed.encode("utf-8")).hexdigest()
+    return document
+
+
+def render_export_bytes(payload: ResearchPayload) -> bytes:
+    return canonical_dumps(build_export_document(payload)).encode("utf-8")
+
+
+def write_research_export(payload: ResearchPayload, output_dir: str | Path) -> Path:
+    target_dir = Path(output_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    path = target_dir / EXPORT_FILENAME
+    path.write_bytes(render_export_bytes(payload))
+    return path
+
+
+def load_export_artifact(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def claim_decision_from_artifact(artifact: dict[str, Any]) -> ClaimDecision:
+    claim = artifact["claim"]
+    health = artifact["health"]
+    return ClaimDecision(
+        national_claim_allowed=bool(claim["national_claim_allowed"]),
+        nacional_completo=bool(claim["nacional_completo"]),
+        reason_codes=tuple(claim.get("reason_codes") or ()),
+        catalog_hash=artifact.get("provenance", {}).get("catalog_hash"),
+        reconciliation_hash=artifact.get("provenance", {}).get("reconciliation_hash"),
+        national_universe_id=artifact.get("provenance", {}).get("national_universe_id"),
+        extra_1093_used_as_denominator=bool(claim.get("extra_1093_used_as_denominator")),
+        expected_partitions=int(health.get("coverage_partitions_expected") or 0),
+        closed_partitions=int(health.get("coverage_partitions_closed") or 0),
+        reconciliation={},
+    )

--- a/scripts/public_read/models.py
+++ b/scripts/public_read/models.py
@@ -1,0 +1,78 @@
+"""Immutable payloads for the research-flagship export."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+
+def parse_decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    return Decimal(str(value))
+
+
+def parse_datetime(value: str) -> datetime:
+    text = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(text)
+
+
+@dataclass(frozen=True)
+class UniverseSpec:
+    source: str
+    competence: str
+    cutoff: str
+    method: str
+    orgs: tuple[dict[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class PartitionSpec:
+    partition_id: str
+    status: str
+    evidence: str | None = None
+
+
+@dataclass(frozen=True)
+class FreshnessSpec:
+    publication_age_hours: float
+    publication_lag_p99_hours: float
+
+    @property
+    def age(self) -> timedelta:
+        return timedelta(hours=self.publication_age_hours)
+
+    @property
+    def lag_p99(self) -> timedelta:
+        return timedelta(hours=self.publication_lag_p99_hours)
+
+
+@dataclass(frozen=True)
+class SeriesRow:
+    process_key: str
+    uf: str
+    archetype_id: str
+    contract_value_brl: Decimal | None
+    source_id: str
+    source_record_id: str
+    observed_at: str
+    lineage: tuple[str, ...]
+    value_status: str
+    lineage_resolution: str | None = None
+
+
+@dataclass(frozen=True)
+class ResearchPayload:
+    fixture_id: str
+    as_of: str
+    competence: str
+    universe: UniverseSpec
+    partitions: tuple[PartitionSpec, ...]
+    freshness: FreshnessSpec
+    rows: tuple[SeriesRow, ...]
+    use_extra_1093_as_denominator: bool = False
+    denominator_kind: str = "publishing_org"
+    claimed_geography: str | None = None
+    consumer_errors: tuple[str, ...] = ()

--- a/scripts/public_read/observability.py
+++ b/scripts/public_read/observability.py
@@ -1,0 +1,46 @@
+"""Freshness, coverage and consumer-error observability for the research family."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.public_read.claim_gate import ClaimDecision
+from scripts.public_read.models import ResearchPayload
+
+
+def observe_research_health(
+    payload: ResearchPayload,
+    claim: ClaimDecision,
+    *,
+    consumer_errors: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    expected = claim.expected_partitions
+    closed = claim.closed_partitions
+    ratio = "0" if expected == 0 else format(closed / expected, ".6f")
+    freshness_status = "STALE" if "freshness_stale" in claim.reason_codes else "FRESH"
+    if "unknown_values" in claim.reason_codes and freshness_status != "STALE":
+        coverage_status = "UNKNOWN"
+    elif claim.nacional_completo and not claim.reason_codes:
+        coverage_status = "COMPLETE"
+    else:
+        coverage_status = "INCOMPLETE"
+
+    errors = list(consumer_errors or payload.consumer_errors)
+    if not claim.national_claim_allowed:
+        errors.append("national_claim_refused")
+    ordered_errors = tuple(sorted(set(errors)))
+    age_seconds = int(payload.freshness.age.total_seconds())
+    return {
+        "family": "research_flagship",
+        "as_of": payload.as_of,
+        "freshness_status": freshness_status,
+        "freshness_age_seconds": age_seconds,
+        "coverage_status": coverage_status,
+        "coverage_partitions_expected": expected,
+        "coverage_partitions_closed": closed,
+        "coverage_ratio": ratio,
+        "consumer_error_count": len(ordered_errors),
+        "consumer_error_codes": list(ordered_errors),
+        "nacional_completo": claim.nacional_completo,
+        "national_claim_allowed": claim.national_claim_allowed,
+    }

--- a/scripts/public_read/payload.py
+++ b/scripts/public_read/payload.py
@@ -1,0 +1,71 @@
+"""Load a research fixture into the shipped payload."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.public_read.models import (
+    FreshnessSpec,
+    PartitionSpec,
+    ResearchPayload,
+    SeriesRow,
+    UniverseSpec,
+    parse_decimal,
+)
+
+
+def load_research_payload(path: str | Path) -> ResearchPayload:
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return payload_from_mapping(raw)
+
+
+def payload_from_mapping(raw: dict[str, Any]) -> ResearchPayload:
+    universe = raw["universe"]
+    freshness = raw["freshness"]
+    rows = []
+    for item in raw["series_rows"]:
+        rows.append(
+            SeriesRow(
+                process_key=str(item["process_key"]),
+                uf=str(item["uf"]),
+                archetype_id=str(item["archetype_id"]),
+                contract_value_brl=parse_decimal(item.get("contract_value_brl")),
+                source_id=str(item["source_id"]),
+                source_record_id=str(item["source_record_id"]),
+                observed_at=str(item["observed_at"]),
+                lineage=tuple(str(part) for part in item.get("lineage", ())),
+                value_status=str(item.get("value_status") or "KNOWN"),
+                lineage_resolution=item.get("lineage_resolution"),
+            )
+        )
+    return ResearchPayload(
+        fixture_id=str(raw["fixture_id"]),
+        as_of=str(raw["as_of"]),
+        competence=str(raw.get("competence") or universe["competence"]),
+        universe=UniverseSpec(
+            source=str(universe["source"]),
+            competence=str(universe["competence"]),
+            cutoff=str(universe["cutoff"]),
+            method=str(universe["method"]),
+            orgs=tuple(dict(org) for org in universe["orgs"]),
+        ),
+        partitions=tuple(
+            PartitionSpec(
+                partition_id=str(part["partition_id"]),
+                status=str(part["status"]),
+                evidence=part.get("evidence"),
+            )
+            for part in raw["partitions"]
+        ),
+        freshness=FreshnessSpec(
+            publication_age_hours=float(freshness["publication_age_hours"]),
+            publication_lag_p99_hours=float(freshness["publication_lag_p99_hours"]),
+        ),
+        rows=tuple(rows),
+        use_extra_1093_as_denominator=bool(raw.get("use_extra_1093_as_denominator", False)),
+        denominator_kind=str(raw.get("denominator_kind") or "publishing_org"),
+        claimed_geography=raw.get("claimed_geography"),
+        consumer_errors=tuple(str(code) for code in raw.get("consumer_errors", ())),
+    )

--- a/scripts/public_read/series.py
+++ b/scripts/public_read/series.py
@@ -1,0 +1,123 @@
+"""Deterministic source-agnostic research series."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any
+
+from scripts.public_read.claim_gate import ClaimDecision
+from scripts.public_read.models import ResearchPayload, SeriesRow
+
+GEO_UF = "UF"
+GEO_BR = "BR"
+
+
+def _decimal_text(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return format(value, "f")
+
+
+def _percentile(values: tuple[Decimal, ...], percent: int) -> Decimal | None:
+    if not values:
+        return None
+    ordered = tuple(sorted(values))
+    index = math.ceil(percent / 100 * len(ordered)) - 1
+    return ordered[max(0, min(index, len(ordered) - 1))]
+
+
+def _cell(
+    *,
+    competence: str,
+    geography_kind: str,
+    geography_code: str,
+    archetype_id: str,
+    members: tuple[SeriesRow, ...],
+    as_of: str,
+    completeness: str,
+    extra_reasons: tuple[str, ...],
+) -> dict[str, Any]:
+    unknown = any(row.value_status == "UNKNOWN" or row.contract_value_brl is None for row in members)
+    known = tuple(row.contract_value_brl for row in members if row.contract_value_brl is not None)
+    reasons = list(extra_reasons)
+    if unknown:
+        reasons.append("unknown_values")
+    value_status = "UNKNOWN" if unknown else "KNOWN"
+    cell_completeness = "UNKNOWN" if unknown else completeness
+    lineage = sorted({item for row in members for item in row.lineage})
+    sources = sorted({(row.source_id, row.source_record_id) for row in members})
+    return {
+        "series_key": "|".join((competence, geography_kind, geography_code, archetype_id)),
+        "competence": competence,
+        "geography_kind": geography_kind,
+        "geography_code": geography_code,
+        "archetype_id": archetype_id,
+        "contract_count": len(members),
+        "total_value_brl": None if unknown else _decimal_text(sum(known, Decimal("0"))),
+        "ticket_p25_brl": None if unknown else _decimal_text(_percentile(known, 25)),
+        "ticket_median_brl": None if unknown else _decimal_text(_percentile(known, 50)),
+        "ticket_p75_brl": None if unknown else _decimal_text(_percentile(known, 75)),
+        "value_status": value_status,
+        "as_of": as_of,
+        "completeness": cell_completeness,
+        "reason_codes": sorted(set(reasons)),
+        "provenance": {
+            "source_records": [
+                {"source_id": source_id, "source_record_id": record_id} for source_id, record_id in sources
+            ],
+            "lineage": lineage,
+        },
+    }
+
+
+def project_series(payload: ResearchPayload, claim: ClaimDecision) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[SeriesRow]] = defaultdict(list)
+    for row in payload.rows:
+        grouped[(row.uf, row.archetype_id)].append(row)
+
+    completeness = "COMPLETE" if claim.national_claim_allowed else "INCOMPLETE"
+    extra = claim.reason_codes
+    cells: list[dict[str, Any]] = []
+    for (uf, archetype_id), members in grouped.items():
+        cells.append(
+            _cell(
+                competence=payload.competence,
+                geography_kind=GEO_UF,
+                geography_code=uf,
+                archetype_id=archetype_id,
+                members=tuple(members),
+                as_of=payload.as_of,
+                completeness=completeness,
+                extra_reasons=extra,
+            )
+        )
+
+    if claim.national_claim_allowed:
+        by_archetype: dict[str, list[SeriesRow]] = defaultdict(list)
+        for row in payload.rows:
+            by_archetype[row.archetype_id].append(row)
+        for archetype_id, members in by_archetype.items():
+            cells.append(
+                _cell(
+                    competence=payload.competence,
+                    geography_kind=GEO_BR,
+                    geography_code=GEO_BR,
+                    archetype_id=archetype_id,
+                    members=tuple(members),
+                    as_of=payload.as_of,
+                    completeness="COMPLETE",
+                    extra_reasons=(),
+                )
+            )
+
+    return sorted(
+        cells,
+        key=lambda cell: (
+            cell["competence"],
+            cell["geography_kind"],
+            cell["geography_code"],
+            cell["archetype_id"],
+        ),
+    )

--- a/tests/fixtures/public_read_research/duplicated_source_lineage.json
+++ b/tests/fixtures/public_read_research/duplicated_source_lineage.json
@@ -1,0 +1,47 @@
+{
+  "fixture_id": "duplicated_source_lineage",
+  "as_of": "2026-08-15T12:00:00+00:00",
+  "competence": "contratos-2026",
+  "universe": {
+    "source": "pncp",
+    "competence": "contratos-2026",
+    "cutoff": "2026-08-01",
+    "method": "pncp-orgaos-publicantes-v1",
+    "orgs": [
+      {"org_id": "org-a", "source": "pncp", "competence": "2026", "name": "Orgao A", "unit_count": 1},
+      {"org_id": "org-b", "source": "pncp", "competence": "2026", "name": "Orgao B", "unit_count": 2}
+    ]
+  },
+  "partitions": [
+    {"partition_id": "org-a", "status": "FOUND", "evidence": "raw:a"},
+    {"partition_id": "org-b", "status": "ZERO_CONFIRMED", "evidence": "raw:b-empty"}
+  ],
+  "freshness": {
+    "publication_age_hours": 1,
+    "publication_lag_p99_hours": 2
+  },
+  "series_rows": [
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001-a",
+      "observed_at": "2026-08-15T11:00:00+00:00",
+      "lineage": ["obs:sc-001-portal-a"],
+      "value_status": "KNOWN"
+    },
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001-b",
+      "observed_at": "2026-08-15T11:01:00+00:00",
+      "lineage": ["obs:sc-001-portal-b"],
+      "value_status": "KNOWN"
+    }
+  ]
+}

--- a/tests/fixtures/public_read_research/full_coverage.json
+++ b/tests/fixtures/public_read_research/full_coverage.json
@@ -1,0 +1,69 @@
+{
+  "fixture_id": "full_coverage",
+  "as_of": "2026-08-15T12:00:00+00:00",
+  "competence": "contratos-2026",
+  "universe": {
+    "source": "pncp",
+    "competence": "contratos-2026",
+    "cutoff": "2026-08-01",
+    "method": "pncp-orgaos-publicantes-v1",
+    "orgs": [
+      {"org_id": "org-a", "source": "pncp", "competence": "2026", "name": "Orgao A", "unit_count": 1},
+      {"org_id": "org-b", "source": "pncp", "competence": "2026", "name": "Orgao B", "unit_count": 2}
+    ]
+  },
+  "partitions": [
+    {"partition_id": "org-a", "status": "FOUND", "evidence": "raw:a"},
+    {"partition_id": "org-b", "status": "ZERO_CONFIRMED", "evidence": "raw:b-empty"}
+  ],
+  "freshness": {
+    "publication_age_hours": 1,
+    "publication_lag_p99_hours": 2
+  },
+  "series_rows": [
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001",
+      "observed_at": "2026-08-15T11:00:00+00:00",
+      "lineage": ["obs:sc-001"],
+      "value_status": "KNOWN"
+    },
+    {
+      "process_key": "pncp:SC:002",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "345532.53",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-002",
+      "observed_at": "2026-08-15T11:05:00+00:00",
+      "lineage": ["obs:sc-002"],
+      "value_status": "KNOWN"
+    },
+    {
+      "process_key": "pncp:MG:001",
+      "uf": "MG",
+      "archetype_id": "edificacoes-publicas",
+      "contract_value_brl": "504997.83",
+      "source_id": "pncp",
+      "source_record_id": "rec-mg-001",
+      "observed_at": "2026-08-15T11:10:00+00:00",
+      "lineage": ["obs:mg-001"],
+      "value_status": "KNOWN"
+    },
+    {
+      "process_key": "pncp:MG:002",
+      "uf": "MG",
+      "archetype_id": "edificacoes-publicas",
+      "contract_value_brl": "1300000.00",
+      "source_id": "pncp",
+      "source_record_id": "rec-mg-002",
+      "observed_at": "2026-08-15T11:15:00+00:00",
+      "lineage": ["obs:mg-002"],
+      "value_status": "KNOWN"
+    }
+  ]
+}

--- a/tests/fixtures/public_read_research/inconsistent_denominator.json
+++ b/tests/fixtures/public_read_research/inconsistent_denominator.json
@@ -1,0 +1,39 @@
+{
+  "fixture_id": "inconsistent_denominator",
+  "as_of": "2026-08-15T12:00:00+00:00",
+  "competence": "contratos-2026",
+  "use_extra_1093_as_denominator": true,
+  "denominator_kind": "extra_commercial_1093",
+  "claimed_geography": "BR",
+  "universe": {
+    "source": "extra-commercial",
+    "competence": "contratos-2026",
+    "cutoff": "2026-08-01",
+    "method": "extra-commercial-1093",
+    "orgs": [
+      {"org_id": "org-a", "source": "extra-commercial", "competence": "2026", "name": "Orgao A", "unit_count": 1},
+      {"org_id": "org-b", "source": "extra-commercial", "competence": "2026", "name": "Orgao B", "unit_count": 2}
+    ]
+  },
+  "partitions": [
+    {"partition_id": "org-a", "status": "FOUND", "evidence": "raw:a"},
+    {"partition_id": "org-b", "status": "FOUND", "evidence": "raw:b"}
+  ],
+  "freshness": {
+    "publication_age_hours": 1,
+    "publication_lag_p99_hours": 2
+  },
+  "series_rows": [
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001",
+      "observed_at": "2026-08-15T11:00:00+00:00",
+      "lineage": ["obs:sc-001"],
+      "value_status": "KNOWN"
+    }
+  ]
+}

--- a/tests/fixtures/public_read_research/missing_partitions.json
+++ b/tests/fixtures/public_read_research/missing_partitions.json
@@ -1,0 +1,35 @@
+{
+  "fixture_id": "missing_partitions",
+  "as_of": "2026-08-15T12:00:00+00:00",
+  "competence": "contratos-2026",
+  "universe": {
+    "source": "pncp",
+    "competence": "contratos-2026",
+    "cutoff": "2026-08-01",
+    "method": "pncp-orgaos-publicantes-v1",
+    "orgs": [
+      {"org_id": "org-a", "source": "pncp", "competence": "2026", "name": "Orgao A", "unit_count": 1},
+      {"org_id": "org-b", "source": "pncp", "competence": "2026", "name": "Orgao B", "unit_count": 2}
+    ]
+  },
+  "partitions": [
+    {"partition_id": "org-a", "status": "FOUND", "evidence": "raw:a"}
+  ],
+  "freshness": {
+    "publication_age_hours": 1,
+    "publication_lag_p99_hours": 2
+  },
+  "series_rows": [
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001",
+      "observed_at": "2026-08-15T11:00:00+00:00",
+      "lineage": ["obs:sc-001"],
+      "value_status": "KNOWN"
+    }
+  ]
+}

--- a/tests/fixtures/public_read_research/stale.json
+++ b/tests/fixtures/public_read_research/stale.json
@@ -1,0 +1,36 @@
+{
+  "fixture_id": "stale",
+  "as_of": "2026-08-12T12:00:00+00:00",
+  "competence": "contratos-2026",
+  "universe": {
+    "source": "pncp",
+    "competence": "contratos-2026",
+    "cutoff": "2026-08-01",
+    "method": "pncp-orgaos-publicantes-v1",
+    "orgs": [
+      {"org_id": "org-a", "source": "pncp", "competence": "2026", "name": "Orgao A", "unit_count": 1},
+      {"org_id": "org-b", "source": "pncp", "competence": "2026", "name": "Orgao B", "unit_count": 2}
+    ]
+  },
+  "partitions": [
+    {"partition_id": "org-a", "status": "FOUND", "evidence": "raw:a"},
+    {"partition_id": "org-b", "status": "ZERO_CONFIRMED", "evidence": "raw:b-empty"}
+  ],
+  "freshness": {
+    "publication_age_hours": 72,
+    "publication_lag_p99_hours": 80
+  },
+  "series_rows": [
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001",
+      "observed_at": "2026-08-12T11:00:00+00:00",
+      "lineage": ["obs:sc-001"],
+      "value_status": "KNOWN"
+    }
+  ]
+}

--- a/tests/fixtures/public_read_research/unknown_values.json
+++ b/tests/fixtures/public_read_research/unknown_values.json
@@ -1,0 +1,47 @@
+{
+  "fixture_id": "unknown_values",
+  "as_of": "2026-08-15T12:00:00+00:00",
+  "competence": "contratos-2026",
+  "universe": {
+    "source": "pncp",
+    "competence": "contratos-2026",
+    "cutoff": "2026-08-01",
+    "method": "pncp-orgaos-publicantes-v1",
+    "orgs": [
+      {"org_id": "org-a", "source": "pncp", "competence": "2026", "name": "Orgao A", "unit_count": 1},
+      {"org_id": "org-b", "source": "pncp", "competence": "2026", "name": "Orgao B", "unit_count": 2}
+    ]
+  },
+  "partitions": [
+    {"partition_id": "org-a", "status": "FOUND", "evidence": "raw:a"},
+    {"partition_id": "org-b", "status": "ZERO_CONFIRMED", "evidence": "raw:b-empty"}
+  ],
+  "freshness": {
+    "publication_age_hours": 1,
+    "publication_lag_p99_hours": 2
+  },
+  "series_rows": [
+    {
+      "process_key": "pncp:SC:001",
+      "uf": "SC",
+      "archetype_id": "pavimentacao-infraestrutura-viaria",
+      "contract_value_brl": "15206416.82",
+      "source_id": "pncp",
+      "source_record_id": "rec-sc-001",
+      "observed_at": "2026-08-15T11:00:00+00:00",
+      "lineage": ["obs:sc-001"],
+      "value_status": "KNOWN"
+    },
+    {
+      "process_key": "pncp:MG:unk",
+      "uf": "MG",
+      "archetype_id": "edificacoes-publicas",
+      "contract_value_brl": null,
+      "source_id": "pncp",
+      "source_record_id": "rec-mg-unk",
+      "observed_at": "2026-08-15T11:10:00+00:00",
+      "lineage": ["obs:mg-unk"],
+      "value_status": "UNKNOWN"
+    }
+  ]
+}

--- a/tests/test_canonical_public_events.py
+++ b/tests/test_canonical_public_events.py
@@ -519,8 +519,14 @@ def test_snapshot_barrier_repeatable_read_projection_invalidation_and_public_rol
 
             cursor.execute("SELECT schema_hash FROM public_read_v1.contract_releases WHERE version = 'v1.0.0'")
             assert len(cursor.fetchone()["schema_hash"]) == 64
-            cursor.execute("SELECT count(*) AS count FROM public_read_v1.query_budgets")
-            assert int(cursor.fetchone()["count"]) == 4
+            cursor.execute("SELECT query_family FROM public_read_v1.query_budgets")
+            families = {row["query_family"] for row in cursor.fetchall()}
+            assert {
+                "tenders_by_process",
+                "contracts_by_process",
+                "entities_by_id",
+                "surface_health",
+            } <= families
 
             cursor.execute("SET ROLE smartlic_public_reader")
             cursor.execute("SELECT count(*) AS count FROM public_read_v1.current_snapshot")

--- a/tests/test_public_read_research_models.py
+++ b/tests/test_public_read_research_models.py
@@ -1,0 +1,245 @@
+"""Drive the shipped research-flagship gate, series and export (#400)."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.public_read.claim_gate import evaluate_national_claim
+from scripts.public_read.contract import CONTRACT_PATH, load_contract
+from scripts.public_read.export import (
+    EXPORT_FILENAME,
+    assert_truth_plane_clean,
+    build_export_document,
+    render_export_bytes,
+    write_research_export,
+)
+from scripts.public_read.payload import load_research_payload
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "tests" / "fixtures" / "public_read_research"
+FAIL_CLOSED = (
+    "missing_partitions",
+    "stale",
+    "unknown_values",
+    "duplicated_source_lineage",
+    "inconsistent_denominator",
+)
+EXPECTED_REASON = {
+    "missing_partitions": "missing_partitions",
+    "stale": "freshness_stale",
+    "unknown_values": "unknown_values",
+    "duplicated_source_lineage": "duplicated_source_lineage",
+    "inconsistent_denominator": "inconsistent_denominator_extra_1093",
+}
+_CLAIM_LANGUAGE = re.compile(r"\b(brasil|nacional)\b", re.IGNORECASE)
+_STRUCTURAL_KEYS = frozenset(
+    {
+        "nacional_completo",
+        "national_claim_allowed",
+        "national_universe_id",
+        "national_denominator_incomplete",
+    }
+)
+
+
+def _payload(name: str):
+    return load_research_payload(FIXTURES / f"{name}.json")
+
+
+def _string_values(node: object, path: str = "") -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            next_path = f"{path}.{key}" if path else str(key)
+            if key in _STRUCTURAL_KEYS:
+                continue
+            found.extend(_string_values(value, next_path))
+        return found
+    if isinstance(node, list):
+        for index, item in enumerate(node):
+            found.extend(_string_values(item, f"{path}[{index}]"))
+        return found
+    if isinstance(node, str):
+        found.append((path, node))
+    return found
+
+
+def test_contract_declares_consumer_grain_and_budget() -> None:
+    contract = load_contract()
+    assert contract["schema"] == "public-read-research-flagship/1.0"
+    assert contract["consumer"]["id"] == "web-cfg/flagship-research"
+    assert "#73" in contract["consumer"]["pull_requests"]
+    assert contract["wedge"]["id"] == "contracts-prices-margin-defense"
+    assert contract["grain"]
+    assert contract["keys"] == [
+        "competence",
+        "geography_kind",
+        "geography_code",
+        "archetype_id",
+    ]
+    assert contract["query_budget"]["query_family"] == "research_flagship_series"
+    assert CONTRACT_PATH.is_file()
+
+
+def test_full_coverage_is_the_only_authorized_national_claim() -> None:
+    allowed = evaluate_national_claim(_payload("full_coverage"))
+    assert allowed.national_claim_allowed is True
+    assert allowed.nacional_completo is True
+    assert allowed.reason_codes == ()
+    assert allowed.extra_1093_used_as_denominator is False
+
+    for name in FAIL_CLOSED:
+        decision = evaluate_national_claim(_payload(name))
+        assert decision.national_claim_allowed is False, name
+        assert decision.reason_codes, name
+        assert EXPECTED_REASON[name] in decision.reason_codes, (name, decision.reason_codes)
+
+
+def test_export_document_carries_contract_fields_and_provenance() -> None:
+    document = build_export_document(_payload("full_coverage"))
+    assert document["grain"]
+    assert document["keys"]
+    assert document["as_of"]
+    assert document["denominator"]["authority"] == "national_universe/1.0"
+    assert document["freshness"]["policy"] == "contracts-freshness-slo-v1"
+    assert document["completeness"]
+    assert document["provenance"]["catalog_hash"]
+    assert document["provenance"]["reconciliation_hash"]
+    assert document["unknown"]["reason_codes"] == []
+    assert document["query_budget"]["max_rows"] == 64
+    assert document["claim"]["national_claim_allowed"] is True
+    assert document["claim"]["publishable_geography"] == "BR"
+    assert any(cell["geography_code"] == "BR" for cell in document["series"])
+    assert_truth_plane_clean(document)
+
+
+@pytest.mark.parametrize("name", FAIL_CLOSED)
+def test_fail_closed_export_refuses_national_claim_language(name: str) -> None:
+    document = build_export_document(_payload(name))
+    assert document["claim"]["national_claim_allowed"] is False
+    assert document["claim"]["reason_codes"]
+    assert document["claim"]["publishable_geography"] is None
+    assert document["claim"]["publishable_claim"] is None
+    assert all(cell["geography_code"] != "BR" for cell in document["series"])
+    for path, value in _string_values(document):
+        assert not _CLAIM_LANGUAGE.search(value), (name, path, value)
+    raw = json.dumps(document, ensure_ascii=False)
+    assert "CONFENGE" not in raw
+    assert "confenge" not in raw.lower()
+    assert "Brasil" not in raw
+
+
+def test_unknown_value_stays_unknown_in_series() -> None:
+    document = build_export_document(_payload("unknown_values"))
+    unknown_cells = [cell for cell in document["series"] if cell["value_status"] == "UNKNOWN"]
+    assert unknown_cells
+    assert all(cell["total_value_brl"] is None for cell in unknown_cells)
+    assert "unknown_values" in document["claim"]["reason_codes"]
+
+
+def test_inconsistent_denominator_never_uses_1093_as_closed_universe() -> None:
+    decision = evaluate_national_claim(_payload("inconsistent_denominator"))
+    assert decision.extra_1093_used_as_denominator is True
+    assert decision.nacional_completo is False
+    assert decision.national_claim_allowed is False
+    assert "inconsistent_denominator_extra_1093" in decision.reason_codes
+
+
+def test_render_export_bytes_is_deterministic() -> None:
+    payload = _payload("full_coverage")
+    first = render_export_bytes(payload)
+    second = render_export_bytes(payload)
+    assert first == second
+    assert b"CONFENGE" not in first
+
+
+def test_shipped_cli_export_twice_and_fail_closed(tmp_path: Path) -> None:
+    fixture = FIXTURES / "full_coverage.json"
+    out_1 = tmp_path / "full-1"
+    out_2 = tmp_path / "full-2"
+    fail_out = tmp_path / "fail"
+    command = [sys.executable, "-m", "scripts.public_read", "export-research"]
+    first = subprocess.run(
+        [*command, "--fixture", str(fixture), "--out", str(out_1)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        [*command, "--fixture", str(fixture), "--out", str(out_2)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    fail = subprocess.run(
+        [
+            *command,
+            "--fixture",
+            str(FIXTURES / "missing_partitions.json"),
+            "--out",
+            str(fail_out),
+        ],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    bytes_1 = (out_1 / EXPORT_FILENAME).read_bytes()
+    bytes_2 = (out_2 / EXPORT_FILENAME).read_bytes()
+    assert bytes_1 == bytes_2
+    artifact = json.loads(bytes_1)
+    fail_artifact = json.loads((fail_out / EXPORT_FILENAME).read_bytes())
+    assert artifact["claim"]["national_claim_allowed"] is True
+    assert fail_artifact["claim"]["national_claim_allowed"] is False
+    assert fail_artifact["claim"]["reason_codes"]
+    assert all(cell["geography_code"] != "BR" for cell in fail_artifact["series"])
+    assert "CONFENGE" not in bytes_1.decode("utf-8")
+    assert '"ok": true' in first.stdout.lower() or '"ok":true' in first.stdout.replace(" ", "").lower()
+    assert json.loads(first.stdout)["content_hash"] == json.loads(second.stdout)["content_hash"]
+    assert json.loads(fail.stdout)["national_claim_allowed"] is False
+
+    health = subprocess.run(
+        [sys.executable, "-m", "scripts.public_read", "health", "--artifact", str(out_1)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    health_doc = json.loads(health.stdout)
+    assert health_doc["freshness_status"] == "FRESH"
+    assert health_doc["coverage_status"] == "COMPLETE"
+    assert "consumer_error_count" in health_doc
+
+
+def test_write_research_export_matches_render(tmp_path: Path) -> None:
+    payload = _payload("full_coverage")
+    path = write_research_export(payload, tmp_path)
+    assert path.read_bytes() == render_export_bytes(payload)
+
+
+def test_migration_094_is_additive_select_only() -> None:
+    sql = (REPO / "db" / "migrations" / "094_public_intelligence_research_models.sql").read_text(encoding="utf-8")
+    assert "094 was free" in sql
+    assert "CREATE SCHEMA" not in sql
+    assert "DROP VIEW IF EXISTS public_read_v1.contracts" not in sql
+    assert "DROP COLUMN" not in sql
+    assert "GRANT SELECT ON public_read_v1.research_flagship_series" in sql
+    assert "GRANT INSERT" not in sql
+    assert "GRANT UPDATE" not in sql
+    assert "GRANT DELETE" not in sql
+    assert "REVOKE INSERT, UPDATE, DELETE" in sql
+    assert "smartlic_public_reader" in sql
+    assert "research_flagship_series" in sql
+    assert "research_claim_gate" in sql
+    assert "research_health" in sql
+    v1 = (REPO / "docs" / "contracts" / "public-read-v1.md").read_text(encoding="utf-8")
+    assert "v1.1.0" in v1
+    assert "No v1.0.0 column was removed" in v1


### PR DESCRIPTION
## Summary

Delivers extra-cli #400: the smallest additive `public_read_v1` slice that lets web-cfg #65 / PR #73 consume a **versioned** research contract and know objectively whether a national claim may be published.

Wedge: contracts / prices / margin-defense — volume and ticket of the **integral nominal BRL contract** (not unit price).

### Consumer contract

- Machine-readable: `docs/contracts/public-read-research-flagship-v1.json` (`public-read-research-flagship/1.0`, `v1.1.0`)
- Grain `competence × geography × archetype`; keys, source families, value semantics, #302 denominator, `as_of`, freshness (48h publication SLO), completeness, provenance, UNKNOWN/`reason_codes`, query budget
- Shipped entry point:

```bash
python3 -m scripts.public_read export-research --fixture PATH --out DIR
python3 -m scripts.public_read health --artifact DIR/research-export.json
```

### National claim gate

Reuses `reconcile_partitions` / `nacional_completo` from #302. Refuses Extra's commercial **1093** as a national denominator. `national_claim_allowed=true` only on full coverage + closed denominator + fresh + known values + unique lineage. Fail-closed exports do not emit geography `BR` or publishable Brasil/nacional language.

### Additive `public_read_v1`

Migration `094_public_intelligence_research_models.sql` — 094 was free on `origin/main@42166330` after fetch; reserved for #400 only. New families: `research_flagship_series`, `research_claim_gate`, `research_health`. No v1.0.0 column removed or renamed. `smartlic_public_reader` stays SELECT-only.

## Test plan

- [x] `pytest tests/test_public_read_research_models.py` — 14 passed, twice
- [x] Six fixtures: full coverage (only authorized path); missing partitions; stale; unknown values; duplicated source lineage; inconsistent denominator (1093)
- [x] Shipped CLI run twice on full coverage — identical bytes/`content_hash`
- [x] Fail-closed CLI run — `national_claim_allowed=false`, no BR cell, no CONFENGE in truth plane
- [x] `check_pr_reviewability` PASS; `check_generated_artifacts_policy` PASS

## Honesty

Fixtures + a versioned export ≠ live national PNCP census. Do **not** close #400 or #302 as production-complete. web-cfg PR #73 remains `NEEDS_DATA` until it consumes this export **and** a live #302 denominator actually closes.

Closes nothing. Refs #400.