### PR TITLE
feat(market): operational penetration snapshot on ICP contract (#381)

### DIFF
--- a/scripts/market_penetration/__init__.py
+++ b/scripts/market_penetration/__init__.py
@@ -1,1 +1,19 @@
 """Versioned ICP / reachability market-penetration snapshots (#381)."""
+
+from scripts.market_penetration.icp_denominator import (
+    DEFAULT_RULES,
+    STAGES,
+    AccountFact,
+    IcpRules,
+    classify_stage,
+    snapshot_penetration,
+)
+
+__all__ = [
+    "DEFAULT_RULES",
+    "STAGES",
+    "AccountFact",
+    "IcpRules",
+    "classify_stage",
+    "snapshot_penetration",
+]

--- a/scripts/market_penetration/__main__.py
+++ b/scripts/market_penetration/__main__.py
@@ -1,0 +1,8 @@
+"""python -m scripts.market_penetration"""
+
+from __future__ import annotations
+
+from scripts.market_penetration.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/market_penetration/baseline.py
+++ b/scripts/market_penetration/baseline.py
@@ -1,0 +1,286 @@
+"""Assemble the versioned operational penetration snapshot and emit artifacts.
+
+Wraps the merged #388 snapshot_penetration with dimensions, hashes, sanity,
+and a PII-free executive view. Does not reclassify stages.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from scripts.market_penetration.facts import (
+    BASELINE_SCHEMA,
+    UNKNOWN,
+    WARMBLY_EVENT_TO_STAGE,
+    JoinResult,
+    facts_from_join,
+)
+from scripts.market_penetration.icp_denominator import (
+    DEFAULT_RULES,
+    IcpRules,
+    PenetrationError,
+    classify_stage,
+    sha256_payload,
+    snapshot_penetration,
+)
+from scripts.market_penetration.sanity import cumulative_from_exclusive, run_sanity
+
+DIMENSION_ORDER = ("region", "size_portfolio", "trigger", "wedge", "route_class")
+
+
+def rollup_with_rules(join: JoinResult, stage_by_id: dict[str, str]) -> dict[str, list[dict[str, Any]]]:
+    views: dict[str, list[dict[str, Any]]] = {}
+    for dimension in DIMENSION_ORDER:
+        grouped: dict[str, Counter[str]] = {}
+        for account in join.accounts:
+            value = getattr(account.dimensions, dimension) or UNKNOWN
+            grouped.setdefault(value, Counter())
+            grouped[value][stage_by_id[account.account_id]] += 1
+        rows: list[dict[str, Any]] = []
+        for value in sorted(grouped):
+            counts = grouped[value]
+            icp = sum(counts[stage] for stage in counts if stage != UNKNOWN)
+            reachable_stages = (
+                "ACTIONABLE_ROUTE",
+                "CONTACTED",
+                "QUALIFIED_CONVERSATION",
+                "MEETING",
+                "PROPOSAL",
+                "CLIENT",
+                "EXPANDED_CLIENT",
+            )
+            rows.append(
+                {
+                    "value": value,
+                    "accounts": sum(counts.values()),
+                    "icp": icp,
+                    "reachable": sum(counts[stage] for stage in reachable_stages),
+                    "contacted_plus": sum(
+                        counts[stage]
+                        for stage in (
+                            "CONTACTED",
+                            "QUALIFIED_CONVERSATION",
+                            "MEETING",
+                            "PROPOSAL",
+                            "CLIENT",
+                            "EXPANDED_CLIENT",
+                        )
+                    ),
+                    "conversations": counts["QUALIFIED_CONVERSATION"],
+                    "proposals": counts["PROPOSAL"],
+                    "clients": counts["CLIENT"] + counts["EXPANDED_CLIENT"],
+                    "unknown": counts[UNKNOWN],
+                }
+            )
+        views[dimension] = rows
+    return views
+
+
+def _counts_match_exclusive(snapshot: dict[str, Any]) -> None:
+    by_stage = snapshot["by_stage"]
+    counts = snapshot["counts"]
+    icp = sum(
+        by_stage[stage]
+        for stage in (
+            "ICP_ACCOUNT",
+            "DECISION_UNIT_KNOWN",
+            "ACTIONABLE_ROUTE",
+            "CONTACTED",
+            "QUALIFIED_CONVERSATION",
+            "MEETING",
+            "PROPOSAL",
+            "CLIENT",
+            "EXPANDED_CLIENT",
+        )
+    )
+    reachable = cumulative_from_exclusive(by_stage)["ACTIONABLE_ROUTE"]
+    if counts["X_icp"] != icp:
+        raise PenetrationError("counts_X_icp_mismatch")
+    if counts["Y_reachable"] != reachable:
+        raise PenetrationError("counts_Y_reachable_mismatch")
+    if counts["Z_contacted"] != by_stage["CONTACTED"]:
+        raise PenetrationError("counts_Z_contacted_not_exclusive")
+    if counts["N_conversations"] != by_stage["QUALIFIED_CONVERSATION"]:
+        raise PenetrationError("counts_N_conversations_mismatch")
+    if counts["P_proposals"] != by_stage["PROPOSAL"]:
+        raise PenetrationError("counts_P_proposals_mismatch")
+    if counts["C_clients"] != by_stage["CLIENT"] + by_stage["EXPANDED_CLIENT"]:
+        raise PenetrationError("counts_C_clients_mismatch")
+
+
+def build_operational_snapshot(
+    join: JoinResult,
+    *,
+    as_of: str,
+    rules: IcpRules = DEFAULT_RULES,
+    explanations: tuple[str, ...] = (),
+    inputs: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Versioned snapshot: #388 core + dimensions + sanity + hashes."""
+    facts = facts_from_join(join)
+    core = snapshot_penetration(facts, as_of=as_of, rules=rules)
+    _counts_match_exclusive(core)
+    stage_by_id = {account.account_id: classify_stage(account.fact, rules) for account in join.accounts}
+    dimensions = rollup_with_rules(join, stage_by_id)
+    sanity = run_sanity(join, core, dimensions, explanations=explanations, fail_closed=True)
+    policy = {
+        "icp_rules": rules.as_dict(),
+        "warmbly_authoritative_from": "CONTACTED",
+        "warmbly_event_map": dict(sorted(WARMBLY_EVENT_TO_STAGE.items())),
+        "warmbly_status": join.warmbly_status,
+        "warmbly_freshness": {
+            "status": join.warmbly_freshness.status,
+            "latest_at": join.warmbly_freshness.latest_at,
+            "stale": join.warmbly_freshness.stale,
+            "reason": join.warmbly_freshness.reason,
+        },
+        "invented_tam": False,
+        "z_contacted_is_exclusive_bucket": True,
+        "extra_cli_authority_through": "ACTIONABLE_ROUTE",
+    }
+    hashes = {
+        "snapshot_hash": core["snapshot_hash"],
+        "universe_input": join.input_hashes.get("universe"),
+        "dui_input": join.input_hashes.get("dui"),
+        "warmbly_input": join.input_hashes.get("warmbly"),
+    }
+    payload: dict[str, Any] = {
+        "schema_version": BASELINE_SCHEMA,
+        "core_schema_version": core["schema_version"],
+        "universe_version": join.universe_version,
+        "as_of": as_of,
+        "rules_version": rules.version,
+        "policy": policy,
+        "dimensions": dimensions,
+        "denominator": core["denominator"],
+        "counts": core["counts"],
+        "by_stage": core["by_stage"],
+        "uncaptured_account_ids": core["uncaptured_account_ids"],
+        "sanity": sanity,
+        "inputs": inputs or {},
+        "warmbly_authoritative_from": core["warmbly_authoritative_from"],
+        "hashes": hashes,
+    }
+    assembly_body = {
+        "as_of": payload["as_of"],
+        "universe_version": payload["universe_version"],
+        "policy": payload["policy"],
+        "dimensions": payload["dimensions"],
+        "counts": payload["counts"],
+        "by_stage": payload["by_stage"],
+        "sanity": [{"name": item["name"], "passed": item["passed"]} for item in sanity],
+        "hashes": hashes,
+        "invented_tam": False,
+    }
+    payload["hashes"] = {**hashes, "assembly_hash": sha256_payload(assembly_body)}
+    return payload
+
+
+def render_executive_report(payload: dict[str, Any]) -> str:
+    counts = payload["counts"]
+    policy = payload["policy"]
+    warmbly = policy.get("warmbly_freshness") or {}
+    lines = [
+        "# CONFENGE commercial penetration snapshot",
+        "",
+        f"- as_of: `{payload['as_of']}`",
+        f"- universe_version: `{payload['universe_version']}`",
+        f"- schema: `{payload['schema_version']}`",
+        f"- invented_tam: `{policy.get('invented_tam')}`",
+        f"- extra-cli authority through: `{policy.get('extra_cli_authority_through')}`",
+        f"- Warmbly authoritative from: `{payload.get('warmbly_authoritative_from')}`",
+        f"- Warmbly status: `{policy.get('warmbly_status')}` ({warmbly.get('reason')})",
+        f"- assembly_hash: `{payload['hashes']['assembly_hash']}`",
+        "",
+        "## Headline (exclusive #388 buckets)",
+        "",
+        f"- X ICP accounts: **{counts['X_icp']}**",
+        f"- Y reachable (ACTIONABLE_ROUTE+): **{counts['Y_reachable']}**",
+        f"- Z contacted (exclusive CONTACTED, not cumulative): **{counts['Z_contacted']}**",
+        f"- N conversations: **{counts['N_conversations']}**",
+        f"- P proposals: **{counts['P_proposals']}**",
+        f"- C clients: **{counts['C_clients']}**",
+        f"- UNKNOWN (queryable): **{counts['UNKNOWN']}**",
+        "",
+        "## By exclusive stage",
+        "",
+    ]
+    for stage, value in payload["by_stage"].items():
+        lines.append(f"- `{stage}`: {value}")
+    lines.extend(["", "## Dimensions (aggregates only, no PII)", ""])
+    for dimension in DIMENSION_ORDER:
+        lines.append(f"### {dimension}")
+        lines.append("")
+        lines.append(
+            "| value | accounts | icp | reachable | contacted+ | conversations | proposals | clients | unknown |"
+        )
+        lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+        for row in payload["dimensions"].get(dimension) or []:
+            lines.append(
+                "| {value} | {accounts} | {icp} | {reachable} | {contacted_plus} | {conversations} | {proposals} | {clients} | {unknown} |".format(
+                    **row
+                )
+            )
+        lines.append("")
+    lines.extend(["## Sanity", ""])
+    for check in payload["sanity"]:
+        mark = "PASS" if check["passed"] else "FAIL"
+        lines.append(f"- `{check['name']}`: **{mark}** — {check['detail']}")
+    lines.extend(
+        [
+            "",
+            "## Honesty",
+            "",
+            "- extra-cli does not re-derive CONTACTED+; missing or empty Warmbly is 0 observed / UNKNOWN.",
+            "- This file is a consumer snapshot. Warmbly remains the action/outcome authority.",
+            "- Uncaptured canonical IDs live in the JSON (`uncaptured_account_ids`); they are not a CRM.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_aggregates_csv(payload: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "dimension",
+        "value",
+        "accounts",
+        "icp",
+        "reachable",
+        "contacted_plus",
+        "conversations",
+        "proposals",
+        "clients",
+        "unknown",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for dimension in DIMENSION_ORDER:
+            for row in payload["dimensions"].get(dimension) or []:
+                writer.writerow({"dimension": dimension, **row})
+
+
+def emit_snapshot(payload: dict[str, Any], out_dir: Path) -> dict[str, str]:
+    if payload.get("denominator", {}).get("invented_tam") is not False:
+        raise PenetrationError("invented_tam_must_be_false")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "penetration-snapshot.json"
+    csv_path = out_dir / "penetration-aggregates.csv"
+    md_path = out_dir / "penetration-executive.md"
+    json_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_aggregates_csv(payload, csv_path)
+    md_path.write_text(render_executive_report(payload), encoding="utf-8")
+    return {
+        "json": str(json_path),
+        "csv": str(csv_path),
+        "report": str(md_path),
+    }

--- a/scripts/market_penetration/cli.py
+++ b/scripts/market_penetration/cli.py
@@ -1,0 +1,117 @@
+"""CLI: python -m scripts.market_penetration snapshot
+
+Read-only assembly of the versioned ICP / reachability / Warmbly snapshot.
+Does not send mail, mutate Warmbly, or invent TAM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.market_penetration.baseline import build_operational_snapshot, emit_snapshot
+from scripts.market_penetration.facts import (
+    DEFAULT_WARMBLY_MAX_AGE_DAYS,
+    join_from_paths,
+)
+from scripts.market_penetration.icp_denominator import DEFAULT_RULES, PenetrationError
+from scripts.warmbly_bridge.io_jsonl import InputError
+
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_USAGE = 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.market_penetration",
+        description=(
+            "Build a reproducible CONFENGE penetration snapshot from universe, "
+            "DUI, and optional Warmbly facts. extra-cli is authority only through "
+            "ACTIONABLE_ROUTE."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    snap = sub.add_parser("snapshot", help="Join facts and write JSON + CSV + executive report")
+    snap.add_argument("--universe", required=True, help="Universe JSON/JSONL (canonical accounts)")
+    snap.add_argument("--universe-manifest", default=None, help="Optional universe manifest for universe_version")
+    snap.add_argument("--dui", default=None, help="DUI accounts dir, cards.json, or JSONL")
+    snap.add_argument("--warmbly", default=None, help="Warmbly outcome JSON/JSONL")
+    snap.add_argument(
+        "--warmbly-absent",
+        action="store_true",
+        help="Declare Warmbly facts unavailable. CONTACTED+ become 0 observed.",
+    )
+    snap.add_argument("--as-of", required=True, help="Snapshot date (YYYY-MM-DD)")
+    snap.add_argument("--out", required=True, help="Output directory (not committed)")
+    snap.add_argument(
+        "--max-warmbly-age-days",
+        type=int,
+        default=DEFAULT_WARMBLY_MAX_AGE_DAYS,
+        help=f"Fail-closed if latest Warmbly event is older than this (default {DEFAULT_WARMBLY_MAX_AGE_DAYS})",
+    )
+    return parser
+
+
+def cmd_snapshot(args: argparse.Namespace) -> int:
+    if bool(args.warmbly) == bool(args.warmbly_absent):
+        _print({"ok": False, "error": "pass exactly one of --warmbly or --warmbly-absent"})
+        return EXIT_USAGE
+    try:
+        join = join_from_paths(
+            as_of=args.as_of,
+            universe_path=Path(args.universe),
+            dui_path=Path(args.dui) if args.dui else None,
+            warmbly_path=Path(args.warmbly) if args.warmbly else None,
+            warmbly_absent=bool(args.warmbly_absent),
+            universe_manifest_path=Path(args.universe_manifest) if args.universe_manifest else None,
+            max_warmbly_age_days=args.max_warmbly_age_days,
+        )
+        payload = build_operational_snapshot(
+            join,
+            as_of=args.as_of,
+            rules=DEFAULT_RULES,
+            inputs={
+                "universe": args.universe,
+                "universe_manifest": args.universe_manifest,
+                "dui": args.dui,
+                "warmbly": args.warmbly,
+                "warmbly_absent": bool(args.warmbly_absent),
+            },
+        )
+        paths = emit_snapshot(payload, Path(args.out))
+    except InputError as exc:
+        _print({"ok": False, "error": str(exc)})
+        return EXIT_USAGE
+    except PenetrationError as exc:
+        _print({"ok": False, "error": str(exc)})
+        return EXIT_FAIL
+    _print(
+        {
+            "ok": True,
+            "as_of": payload["as_of"],
+            "universe_version": payload["universe_version"],
+            "invented_tam": payload["policy"]["invented_tam"],
+            "counts": payload["counts"],
+            "hashes": payload["hashes"],
+            "paths": paths,
+            "warmbly_status": payload["policy"]["warmbly_status"],
+        }
+    )
+    return EXIT_OK
+
+
+def _print(data: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(data, indent=2, ensure_ascii=False, default=str) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "snapshot":
+        return cmd_snapshot(args)
+    parser.error(f"unknown command {args.command}")
+    return EXIT_USAGE

--- a/scripts/market_penetration/facts.py
+++ b/scripts/market_penetration/facts.py
@@ -1,0 +1,657 @@
+"""Load and join universe / DUI / Warmbly rows into AccountFact tuples.
+
+I/O and join only. Stage classification stays in icp_denominator.classify_stage.
+Does not invent TAM, contacts, or Warmbly outcomes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.company_registry.normalization import normalize_cnpj14
+from scripts.market_penetration.icp_denominator import (
+    STAGES,
+    AccountFact,
+    PenetrationError,
+    sha256_payload,
+)
+from scripts.warmbly_bridge.io_jsonl import InputError, read_jsonl, require_readable_file
+
+BASELINE_SCHEMA = "penetration-baseline/1.0"
+UNKNOWN = "UNKNOWN"
+DEFAULT_WARMBLY_MAX_AGE_DAYS = 90
+
+# Warmbly wire types → #388 exclusive stages. Unmapped events leave warmbly_stage empty.
+WARMBLY_EVENT_TO_STAGE: dict[str, str] = {
+    "CONTACTED": "CONTACTED",
+    "SENT": "CONTACTED",
+    "BOUNCED": "CONTACTED",
+    "BOUNCE": "CONTACTED",
+    "REPLIED": "QUALIFIED_CONVERSATION",
+    "QUALIFIED_CONVERSATION": "QUALIFIED_CONVERSATION",
+    "MEETING": "MEETING",
+    "PROPOSAL": "PROPOSAL",
+    "WON": "CLIENT",
+    "ACTIVE_CLIENT": "CLIENT",
+    "CLIENT": "CLIENT",
+    "EXPANDED_CLIENT": "EXPANDED_CLIENT",
+}
+
+ACTIONABLE_ROUTE_CLASSES = frozenset(
+    {
+        "R1_DIRECT",
+        "R2_HIGH_CONFIDENCE_DIRECT",
+        "R3_ROUTED_TO_NAMED_PERSON",
+        "R4_ROLE_ROUTE",
+        "R5_CORPORATE_ONLY",
+        "ACTIONABLE_ROUTE",
+    }
+)
+
+_CODE_LIKE = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+PII_DIMENSION_KEYS = frozenset(
+    {
+        "email",
+        "phone",
+        "telefone",
+        "name",
+        "nome",
+        "razao_social",
+        "nome_fantasia",
+        "message",
+        "body",
+        "contact",
+        "person",
+        "person_name",
+    }
+)
+
+
+@dataclass(frozen=True)
+class DimensionTags:
+    region: str
+    size_portfolio: str
+    trigger: str
+    wedge: str
+    route_class: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "region": self.region,
+            "size_portfolio": self.size_portfolio,
+            "trigger": self.trigger,
+            "wedge": self.wedge,
+            "route_class": self.route_class,
+        }
+
+
+@dataclass(frozen=True)
+class JoinedAccount:
+    account_id: str
+    fact: AccountFact
+    dimensions: DimensionTags
+
+
+@dataclass(frozen=True)
+class JoinIssue:
+    kind: str
+    source: str
+    detail: str
+    account_id: str | None = None
+
+
+@dataclass(frozen=True)
+class WarmblyFreshness:
+    status: str
+    latest_at: str | None
+    stale: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class JoinResult:
+    accounts: tuple[JoinedAccount, ...]
+    issues: tuple[JoinIssue, ...]
+    universe_row_count: int
+    dui_row_count: int
+    warmbly_event_count: int
+    warmbly_status: str
+    warmbly_freshness: WarmblyFreshness
+    universe_version: str
+    input_hashes: dict[str, str]
+
+
+def canonical_account_id(row: dict[str, Any]) -> str | None:
+    """CNPJ14 preferred; otherwise a non-empty explicit account_id."""
+    company = row.get("company") if isinstance(row.get("company"), dict) else {}
+    raw = row.get("cnpj14") or row.get("cnpj") or row.get("account_id") or company.get("cnpj14")
+    if raw is None:
+        return None
+    normalized = normalize_cnpj14(raw)
+    if normalized:
+        return normalized
+    text = str(raw).strip()
+    return text or None
+
+
+def _is_code_token(value: str) -> bool:
+    if not value or len(value) > 48:
+        return False
+    if value != value.upper():
+        return False
+    if value[0] not in "ABCDEFGHIJKLMNOPQRSTUVWXYZ":
+        return False
+    return all(ch in _CODE_LIKE for ch in value)
+
+
+def _code_or_unknown(raw: Any) -> str:
+    if raw is None:
+        return UNKNOWN
+    if isinstance(raw, dict):
+        return _code_or_unknown(raw.get("code") or raw.get("service_code"))
+    text = str(raw).strip()
+    if not text:
+        return UNKNOWN
+    token = text.replace("-", "_").replace(" ", "_").upper()
+    if _is_code_token(token):
+        return token
+    return "UNSTRUCTURED"
+
+
+def portfolio_size_bucket(contract_count: int | None) -> str:
+    if contract_count is None:
+        return UNKNOWN
+    if contract_count <= 0:
+        return "ZERO"
+    if contract_count <= 4:
+        return "1_4"
+    if contract_count <= 19:
+        return "5_19"
+    if contract_count <= 99:
+        return "20_99"
+    return "100_plus"
+
+
+def _int_or_none(raw: Any) -> int | None:
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _universe_portfolio_count(row: dict[str, Any]) -> int | None:
+    portfolio = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+    for key in ("contract_count_total", "contract_count", "active_contract_count"):
+        value = _int_or_none(portfolio.get(key))
+        if value is not None:
+            return value
+    value = _int_or_none(row.get("contract_count"))
+    if value is not None:
+        return value
+    evidence = row.get("construction_evidence") if isinstance(row.get("construction_evidence"), dict) else {}
+    return _int_or_none(evidence.get("relevant_contract_count") or evidence.get("total_contract_count"))
+
+
+def has_public_portfolio(row: dict[str, Any]) -> bool:
+    if row.get("has_public_portfolio") is True:
+        return True
+    if row.get("has_public_portfolio") is False:
+        return False
+    count = _universe_portfolio_count(row)
+    if count is not None:
+        return count > 0
+    portfolio = row.get("portfolio") if isinstance(row.get("portfolio"), dict) else {}
+    if portfolio.get("last_contract_date") or portfolio.get("first_contract_date"):
+        return True
+    return str(row.get("schema_version") or "") == "confenge-universe-v1"
+
+
+def _dui_decision_unit_known(row: dict[str, Any]) -> bool:
+    if row.get("decision_unit_known") is True:
+        return True
+    if row.get("primary_decision_unit_target"):
+        return True
+    terminal = str(row.get("terminal") or "")
+    if terminal in {
+        "ACTIONABLE_ROUTE",
+        "DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED",
+    }:
+        return True
+    candidates = row.get("candidates")
+    if isinstance(candidates, list):
+        for candidate in candidates:
+            if isinstance(candidate, dict) and (candidate.get("person_name") or candidate.get("canonical_name")):
+                return True
+    return False
+
+
+def _dui_route_class(row: dict[str, Any]) -> str:
+    extra = row.get("extra") if isinstance(row.get("extra"), dict) else {}
+    raw = (
+        row.get("route_class")
+        or extra.get("account_reachability_class")
+        or row.get("account_reachability_class")
+        or (row.get("terminal") if row.get("terminal") == "ACTIONABLE_ROUTE" else None)
+    )
+    code = _code_or_unknown(raw)
+    return code if code != "UNSTRUCTURED" else UNKNOWN
+
+
+def _dui_actionable_route(row: dict[str, Any]) -> bool:
+    if row.get("actionable_route") is True:
+        return True
+    if str(row.get("terminal") or "") == "ACTIONABLE_ROUTE":
+        return True
+    return _dui_route_class(row) in ACTIONABLE_ROUTE_CLASSES
+
+
+def _dui_trigger(row: dict[str, Any]) -> str:
+    if "why_now" in row:
+        return _code_or_unknown(row.get("why_now"))
+    extra = row.get("extra") if isinstance(row.get("extra"), dict) else {}
+    return _code_or_unknown(extra.get("why_now") or extra.get("trigger"))
+
+
+def _dui_wedge(row: dict[str, Any]) -> str:
+    offer = row.get("offer") if isinstance(row.get("offer"), dict) else {}
+    raw = offer.get("service_code") or row.get("service_context") or row.get("oferta_recomendada") or row.get("wedge")
+    code = _code_or_unknown(raw)
+    return code if code != "UNSTRUCTURED" else UNKNOWN
+
+
+def map_warmbly_event(event_type: str | None) -> str | None:
+    if not event_type:
+        return None
+    mapped = WARMBLY_EVENT_TO_STAGE.get(str(event_type).strip().upper())
+    if mapped is None:
+        return None
+    if mapped not in STAGES:
+        raise PenetrationError(f"warmbly_map_not_in_stages:{mapped}")
+    return mapped
+
+
+def _stage_rank(stage: str | None) -> int:
+    if not stage or stage not in STAGES:
+        return -1
+    return STAGES.index(stage)
+
+
+def _parse_iso_datetime(raw: Any) -> datetime | None:
+    if raw is None or raw == "":
+        return None
+    text = str(raw).strip()
+    if len(text) == 10:
+        try:
+            return datetime.fromisoformat(text).replace(tzinfo=UTC)
+        except ValueError:
+            return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def assess_warmbly_freshness(
+    events: tuple[dict[str, Any], ...],
+    *,
+    as_of: str,
+    max_age_days: int = DEFAULT_WARMBLY_MAX_AGE_DAYS,
+    absent: bool = False,
+) -> WarmblyFreshness:
+    if absent:
+        return WarmblyFreshness(status="absent", latest_at=None, stale=False, reason="warmbly_explicitly_absent")
+    if not events:
+        return WarmblyFreshness(status="empty", latest_at=None, stale=False, reason="no_warmbly_events")
+    stamps = [
+        _parse_iso_datetime(event.get("occurred_at") or event.get("as_of") or event.get("imported_at"))
+        for event in events
+    ]
+    present = [stamp for stamp in stamps if stamp is not None]
+    if not present:
+        return WarmblyFreshness(
+            status="stale",
+            latest_at=None,
+            stale=True,
+            reason="warmbly_events_missing_occurred_at",
+        )
+    latest = max(present)
+    as_of_dt = _parse_iso_datetime(as_of)
+    if as_of_dt is None:
+        raise PenetrationError("as_of_unparseable_for_freshness")
+    age = (as_of_dt.date() - latest.date()).days
+    if age > max_age_days:
+        return WarmblyFreshness(
+            status="stale",
+            latest_at=latest.date().isoformat(),
+            stale=True,
+            reason=f"warmbly_latest_{latest.date().isoformat()}_older_than_{max_age_days}d",
+        )
+    return WarmblyFreshness(
+        status="consumed",
+        latest_at=latest.date().isoformat(),
+        stale=False,
+        reason="within_max_age",
+    )
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _dir_sha256(root: Path) -> str:
+    digest = hashlib.sha256()
+    for item in sorted(path for path in root.rglob("*") if path.is_file()):
+        digest.update(item.relative_to(root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(item.read_bytes())
+    return digest.hexdigest()
+
+
+def _load_json_document(path: Path, *, label: str) -> Any:
+    require_readable_file(path, label=label)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise InputError(f"invalid JSON in {label} path={path}: {exc}") from exc
+
+
+def _rows_from_payload(payload: Any, *, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = None
+        for key in keys:
+            if isinstance(payload.get(key), list):
+                rows = payload[key]
+                break
+        if rows is None:
+            rows = [payload]
+    else:
+        raise InputError("payload must be object or array")
+    out: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise InputError(f"row {index} is not an object")
+        out.append(row)
+    return out
+
+
+def load_json_or_jsonl(path: Path, *, label: str, keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if path.suffix.lower() == ".jsonl":
+        return read_jsonl(path, label=label)
+    return _rows_from_payload(_load_json_document(path, label=label), keys=keys)
+
+
+def load_universe_rows(path: Path) -> list[dict[str, Any]]:
+    return load_json_or_jsonl(path, label="universe", keys=("accounts", "records", "universe"))
+
+
+def load_dui_rows(path: Path) -> list[dict[str, Any]]:
+    if path.is_dir():
+        accounts_dir = path / "accounts"
+        cards = path / "cards.json"
+        operator_cards = path / "operator" / "cards.json"
+        if accounts_dir.is_dir():
+            rows = [json.loads(item.read_text(encoding="utf-8")) for item in sorted(accounts_dir.glob("*.json"))]
+            return [row for row in rows if isinstance(row, dict)]
+        if cards.is_file():
+            return load_json_or_jsonl(cards, label="dui-cards", keys=("cards", "accounts"))
+        if operator_cards.is_file():
+            return load_json_or_jsonl(operator_cards, label="dui-operator-cards", keys=("cards", "accounts"))
+        collected: list[dict[str, Any]] = []
+        for item in sorted(path.glob("*.json")) + sorted(path.glob("*.jsonl")):
+            collected.extend(load_json_or_jsonl(item, label=f"dui:{item.name}", keys=("cards", "accounts")))
+        return collected
+    return load_json_or_jsonl(path, label="dui", keys=("cards", "accounts"))
+
+
+def load_warmbly_events(path: Path) -> list[dict[str, Any]]:
+    return load_json_or_jsonl(path, label="warmbly", keys=("events", "outcomes", "records"))
+
+
+def load_universe_version(manifest_path: Path | None, universe_hash: str) -> str:
+    if manifest_path is None:
+        return f"input:{universe_hash}" if universe_hash else "UNKNOWN"
+    payload = _load_json_document(manifest_path, label="universe-manifest")
+    if not isinstance(payload, dict):
+        raise InputError("universe manifest must be an object")
+    rule = str(payload.get("rule_version") or payload.get("universe_schema_version") or "UNKNOWN")
+    as_of = str(payload.get("as_of") or (payload.get("source") or {}).get("as_of") or "UNKNOWN")
+    jsonl_sha = ""
+    outputs = payload.get("outputs") if isinstance(payload.get("outputs"), dict) else {}
+    jsonl_meta = outputs.get("jsonl") if isinstance(outputs.get("jsonl"), dict) else {}
+    jsonl_sha = str(jsonl_meta.get("sha256") or "")
+    if not jsonl_sha:
+        jsonl_sha = universe_hash or "UNKNOWN"
+    return f"{rule}:{as_of}:{jsonl_sha}"
+
+
+def _index_by_account(
+    rows: list[dict[str, Any]],
+    *,
+    source: str,
+    issues: list[JoinIssue],
+) -> dict[str, dict[str, Any]]:
+    indexed: dict[str, dict[str, Any]] = {}
+    for offset, row in enumerate(rows):
+        account_id = canonical_account_id(row)
+        if not account_id:
+            issues.append(
+                JoinIssue(
+                    kind="missing_canonical_id",
+                    source=source,
+                    detail=f"row_{offset}_missing_cnpj14",
+                    account_id=None,
+                )
+            )
+            continue
+        if account_id in indexed:
+            issues.append(
+                JoinIssue(
+                    kind="duplicate_join",
+                    source=source,
+                    detail=f"duplicate_{source}:{account_id}",
+                    account_id=account_id,
+                )
+            )
+            continue
+        indexed[account_id] = row
+    return indexed
+
+
+def join_account_facts(
+    universe_rows: tuple[dict[str, Any], ...],
+    dui_rows: tuple[dict[str, Any], ...],
+    warmbly_events: tuple[dict[str, Any], ...],
+    *,
+    as_of: str,
+    universe_version: str,
+    input_hashes: dict[str, str],
+    warmbly_absent: bool = False,
+    max_warmbly_age_days: int = DEFAULT_WARMBLY_MAX_AGE_DAYS,
+) -> JoinResult:
+    """Reconcile one joined row per canonical account ID."""
+    if not as_of:
+        raise PenetrationError("as_of is required")
+    issues: list[JoinIssue] = []
+    universe_index = _index_by_account(list(universe_rows), source="universe", issues=issues)
+    dui_index = _index_by_account(list(dui_rows), source="dui", issues=issues)
+
+    warmbly_by_account: dict[str, list[dict[str, Any]]] = {}
+    if not warmbly_absent:
+        for offset, event in enumerate(warmbly_events):
+            account_id = canonical_account_id(event)
+            if not account_id:
+                issues.append(
+                    JoinIssue(
+                        kind="missing_canonical_id",
+                        source="warmbly",
+                        detail=f"event_{offset}_missing_cnpj14",
+                        account_id=None,
+                    )
+                )
+                continue
+            warmbly_by_account.setdefault(account_id, []).append(event)
+
+    freshness = assess_warmbly_freshness(
+        warmbly_events if not warmbly_absent else (),
+        as_of=as_of,
+        max_age_days=max_warmbly_age_days,
+        absent=warmbly_absent,
+    )
+    if warmbly_absent:
+        warmbly_status = "absent"
+    elif not warmbly_events:
+        warmbly_status = "empty"
+    else:
+        warmbly_status = "consumed"
+
+    account_ids = sorted({*universe_index, *dui_index, *warmbly_by_account})
+    joined: list[JoinedAccount] = []
+    for account_id in account_ids:
+        universe = universe_index.get(account_id)
+        dui = dui_index.get(account_id)
+        events = tuple(warmbly_by_account.get(account_id) or ())
+        evidence: list[str] = []
+        if universe is not None:
+            evidence.append("universe")
+        if dui is not None:
+            evidence.append("dui")
+
+        uf = None
+        public_portfolio = False
+        region = UNKNOWN
+        size = UNKNOWN
+        if universe is not None:
+            uf_raw = universe.get("uf")
+            uf = str(uf_raw).strip().upper() if uf_raw else None
+            region = uf or UNKNOWN
+            public_portfolio = has_public_portfolio(universe)
+            size = portfolio_size_bucket(_universe_portfolio_count(universe))
+
+        decision_unit_known = _dui_decision_unit_known(dui) if dui is not None else False
+        actionable_route = _dui_actionable_route(dui) if dui is not None else False
+        trigger = _dui_trigger(dui) if dui is not None else UNKNOWN
+        wedge = _dui_wedge(dui) if dui is not None else UNKNOWN
+        route_class = _dui_route_class(dui) if dui is not None else UNKNOWN
+
+        warmbly_stage = None
+        if not warmbly_absent:
+            for event in events:
+                mapped = map_warmbly_event(str(event.get("event_type") or event.get("warmbly_stage") or ""))
+                if _stage_rank(mapped) > _stage_rank(warmbly_stage):
+                    warmbly_stage = mapped
+            if events:
+                evidence.append("warmbly")
+
+        if not evidence:
+            issues.append(
+                JoinIssue(
+                    kind="missing_canonical_id",
+                    source="join",
+                    detail="account_without_source_facts",
+                    account_id=account_id,
+                )
+            )
+            continue
+
+        fact = AccountFact(
+            account_id=account_id,
+            uf=uf,
+            has_public_portfolio=public_portfolio,
+            decision_unit_known=decision_unit_known,
+            actionable_route=actionable_route,
+            warmbly_stage=warmbly_stage,
+            evidence=tuple(evidence),
+        )
+        joined.append(
+            JoinedAccount(
+                account_id=account_id,
+                fact=fact,
+                dimensions=DimensionTags(
+                    region=region,
+                    size_portfolio=size,
+                    trigger=trigger,
+                    wedge=wedge,
+                    route_class=route_class,
+                ),
+            )
+        )
+
+    return JoinResult(
+        accounts=tuple(joined),
+        issues=tuple(issues),
+        universe_row_count=len(universe_rows),
+        dui_row_count=len(dui_rows),
+        warmbly_event_count=0 if warmbly_absent else len(warmbly_events),
+        warmbly_status=warmbly_status,
+        warmbly_freshness=freshness,
+        universe_version=universe_version,
+        input_hashes=dict(input_hashes),
+    )
+
+
+def join_from_paths(
+    *,
+    as_of: str,
+    universe_path: Path,
+    dui_path: Path | None = None,
+    warmbly_path: Path | None = None,
+    warmbly_absent: bool = False,
+    universe_manifest_path: Path | None = None,
+    max_warmbly_age_days: int = DEFAULT_WARMBLY_MAX_AGE_DAYS,
+) -> JoinResult:
+    universe_file = require_readable_file(universe_path, label="universe")
+    universe_rows = tuple(load_universe_rows(universe_file))
+    universe_hash = _file_sha256(universe_file)
+    dui_rows: tuple[dict[str, Any], ...] = ()
+    dui_hash = sha256_payload({"dui": "absent"})
+    if dui_path is not None:
+        dui_target = Path(dui_path)
+        if dui_target.is_dir():
+            dui_rows = tuple(load_dui_rows(dui_target))
+            dui_hash = _dir_sha256(dui_target)
+        else:
+            dui_file = require_readable_file(dui_target, label="dui")
+            dui_rows = tuple(load_dui_rows(dui_file))
+            dui_hash = _file_sha256(dui_file)
+    if warmbly_absent and warmbly_path is not None:
+        raise PenetrationError("warmbly_path_and_absent_are_mutually_exclusive")
+    if not warmbly_absent and warmbly_path is None:
+        raise PenetrationError("warmbly_path_required_or_pass_warmbly_absent")
+    warmbly_events: tuple[dict[str, Any], ...] = ()
+    warmbly_hash = sha256_payload({"warmbly": "absent"})
+    if not warmbly_absent and warmbly_path is not None:
+        warmbly_file = require_readable_file(warmbly_path, label="warmbly")
+        warmbly_events = tuple(load_warmbly_events(warmbly_file))
+        warmbly_hash = _file_sha256(warmbly_file)
+    version = load_universe_version(universe_manifest_path, universe_hash)
+    return join_account_facts(
+        universe_rows,
+        dui_rows,
+        warmbly_events,
+        as_of=as_of,
+        universe_version=version,
+        input_hashes={
+            "universe": universe_hash,
+            "dui": dui_hash,
+            "warmbly": warmbly_hash,
+        },
+        warmbly_absent=warmbly_absent,
+        max_warmbly_age_days=max_warmbly_age_days,
+    )
+
+
+def facts_from_join(join: JoinResult) -> tuple[AccountFact, ...]:
+    return tuple(account.fact for account in join.accounts)

--- a/scripts/market_penetration/sanity.py
+++ b/scripts/market_penetration/sanity.py
@@ -1,0 +1,167 @@
+"""Fail-closed sanity checks for the operational penetration snapshot."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from scripts.market_penetration.facts import (
+    PII_DIMENSION_KEYS,
+    JoinResult,
+    WarmblyFreshness,
+)
+from scripts.market_penetration.icp_denominator import (
+    DEFAULT_RULES,
+    STAGES,
+    IcpRules,
+    PenetrationError,
+    classify_stage,
+)
+
+_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+_PHONE_RE = re.compile(r"\+?\d[\d\s().-]{8,}\d")
+
+
+def cumulative_from_exclusive(by_stage: dict[str, int]) -> dict[str, int]:
+    """Cumulative funnel from exclusive #388 buckets. Later stages are subsets."""
+    cumulative: dict[str, int] = {}
+    running = 0
+    for stage in reversed(STAGES):
+        running += int(by_stage.get(stage) or 0)
+        cumulative[stage] = running
+    return cumulative
+
+
+def _check_monotonic(by_stage: dict[str, int], explanations: tuple[str, ...]) -> dict[str, Any]:
+    cumulative = cumulative_from_exclusive(by_stage)
+    violations: list[str] = []
+    previous: int | None = None
+    previous_name = ""
+    for stage in STAGES:
+        value = cumulative[stage]
+        if previous is not None and value > previous:
+            violations.append(f"{stage}_cumulative={value}>{previous_name}={previous}")
+        previous = value
+        previous_name = stage
+    icp = sum(int(by_stage.get(stage) or 0) for stage in STAGES)
+    reachable = cumulative["ACTIONABLE_ROUTE"]
+    contacted_plus = cumulative["CONTACTED"]
+    if reachable > icp:
+        violations.append(f"reachable={reachable}>icp={icp}")
+    if contacted_plus > reachable:
+        violations.append(f"contacted_plus={contacted_plus}>reachable={reachable}")
+    if violations and not explanations:
+        return {"name": "monotonic_stages", "passed": False, "detail": ";".join(violations)}
+    if violations:
+        return {
+            "name": "monotonic_stages",
+            "passed": True,
+            "detail": "explained:" + ",".join(explanations) + ";" + ";".join(violations),
+        }
+    return {"name": "monotonic_stages", "passed": True, "detail": "cumulative_non_increasing"}
+
+
+def _check_duplicates(join: JoinResult) -> dict[str, Any]:
+    dupes = [issue for issue in join.issues if issue.kind == "duplicate_join"]
+    if dupes:
+        return {
+            "name": "duplicate_joins",
+            "passed": False,
+            "detail": ",".join(f"{item.source}:{item.account_id}" for item in dupes),
+        }
+    return {"name": "duplicate_joins", "passed": True, "detail": "none"}
+
+
+def _check_missing_ids(join: JoinResult) -> dict[str, Any]:
+    missing = [issue for issue in join.issues if issue.kind == "missing_canonical_id"]
+    if missing:
+        return {
+            "name": "missing_canonical_id",
+            "passed": False,
+            "detail": ",".join(f"{item.source}:{item.detail}" for item in missing),
+        }
+    return {"name": "missing_canonical_id", "passed": True, "detail": "none"}
+
+
+def _check_stale_warmbly(freshness: WarmblyFreshness) -> dict[str, Any]:
+    if freshness.stale:
+        return {"name": "stale_warmbly_import", "passed": False, "detail": freshness.reason}
+    return {"name": "stale_warmbly_import", "passed": True, "detail": freshness.reason}
+
+
+def _unknown_expected(join: JoinResult, rules: IcpRules = DEFAULT_RULES) -> bool:
+    return any(classify_stage(account.fact, rules) == "UNKNOWN" for account in join.accounts)
+
+
+def _check_unknown_preserved(join: JoinResult, snapshot: dict[str, Any]) -> dict[str, Any]:
+    unknown = int(snapshot.get("by_stage", {}).get("UNKNOWN") or 0)
+    uncaptured = snapshot.get("uncaptured_account_ids") or []
+    if _unknown_expected(join) and unknown == 0:
+        return {
+            "name": "unknown_preserved",
+            "passed": False,
+            "detail": "expected_UNKNOWN_dropped_or_recoded",
+        }
+    if unknown > 0 and not uncaptured:
+        return {
+            "name": "unknown_preserved",
+            "passed": False,
+            "detail": "UNKNOWN_not_queryable",
+        }
+    if unknown != int(snapshot.get("counts", {}).get("UNKNOWN") or 0):
+        return {
+            "name": "unknown_preserved",
+            "passed": False,
+            "detail": "UNKNOWN_count_mismatch",
+        }
+    return {
+        "name": "unknown_preserved",
+        "passed": True,
+        "detail": f"UNKNOWN={unknown}",
+    }
+
+
+def collect_pii_hits(dimensions: dict[str, Any]) -> list[str]:
+    hits: list[str] = []
+    for name, rows in dimensions.items():
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            for key in row:
+                if str(key).lower() in PII_DIMENSION_KEYS:
+                    hits.append(f"{name}.{key}")
+            value = str(row.get("value") or "")
+            if _EMAIL_RE.search(value) or _PHONE_RE.search(value):
+                hits.append(f"{name}.value")
+    return hits
+
+
+def _check_no_pii(dimensions: dict[str, Any]) -> dict[str, Any]:
+    hits = collect_pii_hits(dimensions)
+    if hits:
+        return {"name": "aggregates_pii_free", "passed": False, "detail": ",".join(hits)}
+    return {"name": "aggregates_pii_free", "passed": True, "detail": "no_pii_keys_or_values"}
+
+
+def run_sanity(
+    join: JoinResult,
+    snapshot: dict[str, Any],
+    dimensions: dict[str, Any],
+    *,
+    explanations: tuple[str, ...] = (),
+    fail_closed: bool = True,
+) -> list[dict[str, Any]]:
+    checks = [
+        _check_monotonic(snapshot.get("by_stage") or {}, explanations),
+        _check_duplicates(join),
+        _check_missing_ids(join),
+        _check_stale_warmbly(join.warmbly_freshness),
+        _check_unknown_preserved(join, snapshot),
+        _check_no_pii(dimensions),
+    ]
+    failed = [check["name"] for check in checks if not check["passed"]]
+    if fail_closed and failed:
+        raise PenetrationError("sanity_failed:" + ",".join(failed))
+    return checks

--- a/tests/fixtures/penetration/dui_accounts.json
+++ b/tests/fixtures/penetration/dui_accounts.json
@@ -1,0 +1,28 @@
+{
+  "accounts": [
+    {
+      "cnpj": "11222333000181",
+      "terminal": "ACTIONABLE_ROUTE",
+      "extra": {"account_reachability_class": "R3_ROUTED_TO_NAMED_PERSON"},
+      "why_now": {"code": "CONTRACT_EXTENSION"},
+      "offer": {"service_code": "acompanhamento_admin"},
+      "candidates": [{"person_name": "redacted"}]
+    },
+    {
+      "cnpj": "22333444000155",
+      "terminal": "DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED",
+      "extra": {"account_reachability_class": "R0_NO_ACTIONABLE_ROUTE"},
+      "why_now": {"code": "MULTI_CONTRACT_PATTERN"},
+      "offer": {"service_code": "monitoramento"},
+      "candidates": [{"person_name": "redacted"}]
+    },
+    {
+      "cnpj": "33445566000186",
+      "terminal": "ACTIONABLE_ROUTE",
+      "extra": {"account_reachability_class": "R4_ROLE_ROUTE"},
+      "why_now": {"code": "ADDITIVE_SIGNED"},
+      "offer": {"service_code": "auditoria_orcamento"},
+      "candidates": [{"person_name": "redacted"}]
+    }
+  ]
+}

--- a/tests/fixtures/penetration/universe.jsonl
+++ b/tests/fixtures/penetration/universe.jsonl
@@ -1,0 +1,6 @@
+{"cnpj14":"11222333000181","uf":"SC","portfolio":{"contract_count_total":12},"entity_key":"ek-acme"}
+{"cnpj14":"22333444000155","uf":"SC","portfolio":{"contract_count_total":3},"entity_key":"ek-ics"}
+{"cnpj14":"33445566000186","uf":"SC","portfolio":{"contract_count_total":25},"entity_key":"ek-delta"}
+{"cnpj14":"99888777000166","uf":"SP","portfolio":{"contract_count_total":8},"entity_key":"ek-eni"}
+{"cnpj14":"55444333000122","uf":"SC","portfolio":{"contract_count_total":0},"entity_key":"ek-planalto"}
+{"cnpj14":"44555666000181","uf":"SC","portfolio":{"contract_count_total":5},"entity_key":"ek-mega"}

--- a/tests/fixtures/penetration/universe_manifest.json
+++ b/tests/fixtures/penetration/universe_manifest.json
@@ -1,0 +1,11 @@
+{
+  "as_of": "2026-08-15",
+  "rule_version": "confenge-universe-rules-v1",
+  "universe_schema_version": "confenge-universe-v1",
+  "outputs": {
+    "jsonl": {
+      "filename": "universe.jsonl",
+      "sha256": "fixture"
+    }
+  }
+}

--- a/tests/fixtures/penetration/warmbly_outcomes.jsonl
+++ b/tests/fixtures/penetration/warmbly_outcomes.jsonl
@@ -1,0 +1,3 @@
+{"schema_version":"confenge.outcome.v1","event_id":"evt-acme-1","idempotency_key":"warmbly:fixture:acme:1","occurred_at":"2026-08-10T12:00:00Z","source":"warmbly","cnpj14":"11222333000181","event_type":"CONTACTED","channel":"email"}
+{"schema_version":"confenge.outcome.v1","event_id":"evt-delta-1","idempotency_key":"warmbly:fixture:delta:1","occurred_at":"2026-08-11T12:00:00Z","source":"warmbly","cnpj14":"33445566000186","event_type":"PROPOSAL","channel":"email"}
+{"schema_version":"confenge.outcome.v1","event_id":"evt-delta-2","idempotency_key":"warmbly:fixture:delta:2","occurred_at":"2026-08-12T12:00:00Z","source":"warmbly","cnpj14":"33445566000186","event_type":"REPLIED","channel":"email"}

--- a/tests/test_penetration_baseline.py
+++ b/tests/test_penetration_baseline.py
@@ -1,0 +1,360 @@
+"""Tests for the #381 operational penetration snapshot (reuses #388 classify)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.market_penetration.baseline import (
+    build_operational_snapshot,
+    emit_snapshot,
+    render_executive_report,
+)
+from scripts.market_penetration.cli import main as penetration_main
+from scripts.market_penetration.facts import (
+    WARMBLY_EVENT_TO_STAGE,
+    assess_warmbly_freshness,
+    join_account_facts,
+    join_from_paths,
+    map_warmbly_event,
+)
+from scripts.market_penetration.icp_denominator import STAGES, PenetrationError
+from scripts.market_penetration.sanity import collect_pii_hits, run_sanity
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "penetration"
+AS_OF = "2026-08-15"
+
+
+def _hashes() -> dict[str, str]:
+    return {"universe": "u", "dui": "d", "warmbly": "w"}
+
+
+def _join(
+    universe: list[dict],
+    dui: list[dict] | None = None,
+    warmbly: list[dict] | None = None,
+    *,
+    absent: bool = False,
+    max_age: int = 90,
+    version: str = "fixture:v1",
+):
+    return join_account_facts(
+        tuple(universe),
+        tuple(dui or []),
+        tuple(warmbly or []),
+        as_of=AS_OF,
+        universe_version=version,
+        input_hashes=_hashes(),
+        warmbly_absent=absent,
+        max_warmbly_age_days=max_age,
+    )
+
+
+def test_shipped_map_only_uses_388_stages() -> None:
+    assert set(WARMBLY_EVENT_TO_STAGE.values()) <= set(STAGES)
+    assert map_warmbly_event("REPLIED") == "QUALIFIED_CONVERSATION"
+    assert map_warmbly_event("WON") == "CLIENT"
+    assert map_warmbly_event("LEAD_REVIEWED") is None
+    assert map_warmbly_event("LOST") is None
+
+
+def test_in_process_facts_cover_each_stage_without_invented_tam() -> None:
+    join = _join(
+        [
+            {"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 2}},
+            {"cnpj14": "22333444000155", "uf": "SC", "portfolio": {"contract_count_total": 2}},
+            {"cnpj14": "33445566000186", "uf": "SC", "portfolio": {"contract_count_total": 2}},
+            {"cnpj14": "44555666000181", "uf": "SC", "portfolio": {"contract_count_total": 2}},
+            {"cnpj14": "77888999000181", "uf": "SC", "portfolio": {"contract_count_total": 2}},
+            {"cnpj14": "99888777000166", "uf": "PR", "portfolio": {"contract_count_total": 2}},
+        ],
+        [
+            {"cnpj": "22333444000155", "terminal": "DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED"},
+            {
+                "cnpj": "33445566000186",
+                "terminal": "ACTIONABLE_ROUTE",
+                "extra": {"account_reachability_class": "R4_ROLE_ROUTE"},
+            },
+            {
+                "cnpj": "44555666000181",
+                "terminal": "ACTIONABLE_ROUTE",
+                "extra": {"account_reachability_class": "R3_ROUTED_TO_NAMED_PERSON"},
+            },
+            {
+                "cnpj": "77888999000181",
+                "terminal": "ACTIONABLE_ROUTE",
+                "extra": {"account_reachability_class": "R1_DIRECT"},
+            },
+        ],
+        [
+            {"cnpj14": "44555666000181", "event_type": "CONTACTED", "occurred_at": "2026-08-10T00:00:00Z"},
+            {"cnpj14": "77888999000181", "event_type": "PROPOSAL", "occurred_at": "2026-08-10T00:00:00Z"},
+        ],
+    )
+    first = build_operational_snapshot(join, as_of=AS_OF)
+    second = build_operational_snapshot(join, as_of=AS_OF)
+    assert first["hashes"]["assembly_hash"] == second["hashes"]["assembly_hash"]
+    assert first["hashes"]["snapshot_hash"] == second["hashes"]["snapshot_hash"]
+    assert first["denominator"]["invented_tam"] is False
+    assert first["policy"]["invented_tam"] is False
+    constructed_icp = sum(1 for account in join.accounts if account.fact.uf == "SC")
+    assert first["counts"]["X_icp"] == constructed_icp
+    assert first["by_stage"]["ICP_ACCOUNT"] == 1
+    assert first["by_stage"]["DECISION_UNIT_KNOWN"] == 1
+    assert first["by_stage"]["ACTIONABLE_ROUTE"] == 1
+    assert first["by_stage"]["CONTACTED"] == 1
+    assert first["by_stage"]["PROPOSAL"] == 1
+    assert first["counts"]["Z_contacted"] == 1
+    assert first["counts"]["P_proposals"] == 1
+    assert first["counts"]["Y_reachable"] == 3
+    assert first["by_stage"]["UNKNOWN"] == 1
+    assert "99888777000166" in first["uncaptured_account_ids"]
+    assert set(first["dimensions"]) == {"region", "size_portfolio", "trigger", "wedge", "route_class"}
+
+
+def test_missing_evidence_stays_unknown_and_queryable() -> None:
+    join = _join(
+        [
+            {
+                "cnpj14": "11222333000181",
+                "uf": "SC",
+                "has_public_portfolio": False,
+                "portfolio": {"contract_count_total": 0},
+            }
+        ],
+    )
+    snap = build_operational_snapshot(join, as_of=AS_OF)
+    assert snap["by_stage"]["UNKNOWN"] == 1
+    assert snap["counts"]["X_icp"] == 0
+    assert "11222333000181" in snap["uncaptured_account_ids"]
+
+
+def test_warmbly_absent_zeros_contacted_plus_and_keeps_unknown() -> None:
+    join = _join(
+        [
+            {"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 4}},
+            {"cnpj14": "99888777000166", "uf": "SP", "portfolio": {"contract_count_total": 4}},
+        ],
+        [
+            {
+                "cnpj": "11222333000181",
+                "terminal": "ACTIONABLE_ROUTE",
+                "extra": {"account_reachability_class": "R5_CORPORATE_ONLY"},
+            }
+        ],
+        [{"cnpj14": "11222333000181", "event_type": "CLIENT", "occurred_at": "2026-08-10T00:00:00Z"}],
+        absent=True,
+    )
+    snap = build_operational_snapshot(join, as_of=AS_OF)
+    assert join.warmbly_status == "absent"
+    assert snap["policy"]["warmbly_status"] == "absent"
+    assert snap["by_stage"]["CONTACTED"] == 0
+    assert snap["by_stage"]["QUALIFIED_CONVERSATION"] == 0
+    assert snap["by_stage"]["MEETING"] == 0
+    assert snap["by_stage"]["PROPOSAL"] == 0
+    assert snap["by_stage"]["CLIENT"] == 0
+    assert snap["by_stage"]["EXPANDED_CLIENT"] == 0
+    assert snap["by_stage"]["ACTIONABLE_ROUTE"] == 1
+    assert snap["by_stage"]["UNKNOWN"] == 1
+    assert snap["counts"]["UNKNOWN"] == 1
+    assert "99888777000166" in snap["uncaptured_account_ids"]
+
+
+def test_warmbly_stage_not_overwritten_by_reachability() -> None:
+    join = _join(
+        [{"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 9}}],
+        [
+            {
+                "cnpj": "11222333000181",
+                "terminal": "ACTIONABLE_ROUTE",
+                "extra": {"account_reachability_class": "R3_ROUTED_TO_NAMED_PERSON"},
+            }
+        ],
+        [{"cnpj14": "11222333000181", "event_type": "CLIENT", "occurred_at": "2026-08-10T00:00:00Z"}],
+    )
+    snap = build_operational_snapshot(join, as_of=AS_OF)
+    assert snap["by_stage"]["CLIENT"] == 1
+    assert snap["by_stage"]["ACTIONABLE_ROUTE"] == 0
+    assert snap["warmbly_authoritative_from"] == "CONTACTED"
+
+
+def test_duplicate_join_fail_closed() -> None:
+    join = _join(
+        [
+            {"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 1}},
+            {"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 2}},
+        ]
+    )
+    with pytest.raises(PenetrationError, match="duplicate_joins"):
+        build_operational_snapshot(join, as_of=AS_OF)
+
+
+def test_missing_canonical_id_fail_closed() -> None:
+    join = _join([{"uf": "SC", "portfolio": {"contract_count_total": 1}}])
+    with pytest.raises(PenetrationError, match="missing_canonical_id"):
+        build_operational_snapshot(join, as_of=AS_OF)
+
+
+def test_stale_warmbly_import_fail_closed() -> None:
+    join = _join(
+        [{"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 1}}],
+        warmbly=[{"cnpj14": "11222333000181", "event_type": "CONTACTED", "occurred_at": "2025-01-01T00:00:00Z"}],
+        max_age=30,
+    )
+    assert join.warmbly_freshness.stale is True
+    with pytest.raises(PenetrationError, match="stale_warmbly_import"):
+        build_operational_snapshot(join, as_of=AS_OF)
+
+
+def test_warmbly_events_without_timestamp_are_stale() -> None:
+    freshness = assess_warmbly_freshness(
+        ({"cnpj14": "11222333000181", "event_type": "CONTACTED"},),
+        as_of=AS_OF,
+    )
+    assert freshness.stale is True
+    assert freshness.status == "stale"
+
+
+def test_aggregates_have_no_pii_keys_or_values() -> None:
+    join = _join(
+        [{"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 6}}],
+        [
+            {
+                "cnpj": "11222333000181",
+                "terminal": "ACTIONABLE_ROUTE",
+                "primary_decision_unit_target": "Ana Silva",
+                "why_now": {"code": "CONTRACT_EXTENSION"},
+                "offer": {"service_code": "acompanhamento_admin"},
+                "extra": {"account_reachability_class": "R3_ROUTED_TO_NAMED_PERSON"},
+            }
+        ],
+    )
+    snap = build_operational_snapshot(join, as_of=AS_OF)
+    assert collect_pii_hits(snap["dimensions"]) == []
+    dumped = json.dumps(snap["dimensions"])
+    assert "Ana Silva" not in dumped
+    assert "@" not in dumped
+    assert "email" not in dumped
+    report = render_executive_report(snap)
+    assert "Ana Silva" not in report
+
+
+def test_replay_equality_from_same_rows() -> None:
+    rows = ([{"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 3}}],)
+    first = _join(*rows)
+    second = _join(*rows)
+    a = build_operational_snapshot(first, as_of=AS_OF)
+    b = build_operational_snapshot(second, as_of=AS_OF)
+    assert a["hashes"]["snapshot_hash"] == b["hashes"]["snapshot_hash"]
+    assert a["hashes"]["assembly_hash"] == b["hashes"]["assembly_hash"]
+    assert a["universe_version"] == b["universe_version"]
+    assert a["as_of"] == b["as_of"]
+
+
+def test_no_hardcoded_tam_constants_in_shipped_modules() -> None:
+    root = Path(__file__).resolve().parents[1] / "scripts" / "market_penetration"
+    banned = ("1093", "1.093", "48748", "401923")
+    for path in root.glob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for token in banned:
+            assert token not in text, f"{path.name} contains banned TAM token {token}"
+
+
+def test_cli_snapshot_twice_same_hashes(tmp_path: Path) -> None:
+    out1 = tmp_path / "run1"
+    out2 = tmp_path / "run2"
+    common = [
+        "snapshot",
+        "--universe",
+        str(FIXTURES / "universe.jsonl"),
+        "--universe-manifest",
+        str(FIXTURES / "universe_manifest.json"),
+        "--dui",
+        str(FIXTURES / "dui_accounts.json"),
+        "--warmbly",
+        str(FIXTURES / "warmbly_outcomes.jsonl"),
+        "--as-of",
+        AS_OF,
+    ]
+    assert penetration_main([*common, "--out", str(out1)]) == 0
+    assert penetration_main([*common, "--out", str(out2)]) == 0
+    snap1 = json.loads((out1 / "penetration-snapshot.json").read_text(encoding="utf-8"))
+    snap2 = json.loads((out2 / "penetration-snapshot.json").read_text(encoding="utf-8"))
+    assert snap1["hashes"]["assembly_hash"] == snap2["hashes"]["assembly_hash"]
+    assert snap1["hashes"]["snapshot_hash"] == snap2["hashes"]["snapshot_hash"]
+    assert snap1["as_of"] == AS_OF
+    assert snap1["universe_version"].startswith("confenge-universe-rules-v1:2026-08-15:")
+    assert snap1["policy"]["invented_tam"] is False
+    assert "region" in snap1["dimensions"]
+    assert (out1 / "penetration-aggregates.csv").is_file()
+    assert "X ICP accounts" in (out1 / "penetration-executive.md").read_text(encoding="utf-8")
+    assert all(check["passed"] for check in snap1["sanity"])
+    assert snap1["counts"]["Z_contacted"] == snap1["by_stage"]["CONTACTED"]
+    assert snap1["counts"]["P_proposals"] == snap1["by_stage"]["PROPOSAL"]
+    assert snap1["by_stage"]["CLIENT"] == 0
+
+
+def test_cli_warmbly_absent_flag(tmp_path: Path) -> None:
+    out = tmp_path / "absent"
+    code = penetration_main(
+        [
+            "snapshot",
+            "--universe",
+            str(FIXTURES / "universe.jsonl"),
+            "--dui",
+            str(FIXTURES / "dui_accounts.json"),
+            "--warmbly-absent",
+            "--as-of",
+            AS_OF,
+            "--out",
+            str(out),
+        ]
+    )
+    assert code == 0
+    snap = json.loads((out / "penetration-snapshot.json").read_text(encoding="utf-8"))
+    assert snap["policy"]["warmbly_status"] == "absent"
+    assert snap["counts"]["Z_contacted"] == 0
+    assert snap["counts"]["N_conversations"] == 0
+    assert snap["counts"]["P_proposals"] == 0
+    assert snap["counts"]["C_clients"] == 0
+    assert snap["counts"]["UNKNOWN"] >= 1
+
+
+def test_join_from_paths_matches_in_process() -> None:
+    from_disk = join_from_paths(
+        as_of=AS_OF,
+        universe_path=FIXTURES / "universe.jsonl",
+        dui_path=FIXTURES / "dui_accounts.json",
+        warmbly_path=FIXTURES / "warmbly_outcomes.jsonl",
+        universe_manifest_path=FIXTURES / "universe_manifest.json",
+    )
+    snap = build_operational_snapshot(from_disk, as_of=AS_OF)
+    assert snap["by_stage"]["CONTACTED"] == 1
+    assert snap["by_stage"]["PROPOSAL"] == 1
+    assert snap["by_stage"]["ICP_ACCOUNT"] == 1
+    assert snap["by_stage"]["DECISION_UNIT_KNOWN"] == 1
+    assert snap["by_stage"]["ACTIONABLE_ROUTE"] == 0
+    assert snap["by_stage"]["UNKNOWN"] == 2
+
+
+def test_emit_snapshot_writes_three_artifacts(tmp_path: Path) -> None:
+    join = _join([{"cnpj14": "11222333000181", "uf": "SC", "portfolio": {"contract_count_total": 1}}])
+    payload = build_operational_snapshot(join, as_of=AS_OF)
+    paths = emit_snapshot(payload, tmp_path)
+    assert Path(paths["json"]).is_file()
+    assert Path(paths["csv"]).is_file()
+    assert Path(paths["report"]).is_file()
+
+
+def test_sanity_fail_closed_unknown_recoded() -> None:
+    join = _join([{"cnpj14": "99888777000166", "uf": "SP", "portfolio": {"contract_count_total": 1}}])
+    fake_core = {
+        "by_stage": {stage: 0 for stage in (*STAGES, "UNKNOWN")},
+        "counts": {"UNKNOWN": 0},
+        "uncaptured_account_ids": [],
+    }
+    fake_core["by_stage"]["ICP_ACCOUNT"] = 1
+    with pytest.raises(PenetrationError, match="unknown_preserved"):
+        run_sanity(join, fake_core, {"region": []}, fail_closed=True)


### PR DESCRIPTION
## Outcome

First reviewable, reproducible **assembly** of a CONFENGE commercial-penetration snapshot on top of the merged PR #388 stage contract. extra-cli remains authority only through `ACTIONABLE_ROUTE`. `CONTACTED+` is consumed from Warmbly when present; if Warmbly is absent or has no events, those stages are `0` observed / `UNKNOWN`.

## Issues

Refs #381 — **does not close**. Fixture/replay proof is not the operational production baseline.

## What shipped

- Join universe + DUI + optional Warmbly by canonical CNPJ14 into the existing `AccountFact` / `classify_stage` / `snapshot_penetration` contract. No new ICP or reachability heuristics.
- Versioned payload: `universe_version`, `as_of`, `policy`, `dimensions`, content hashes. Replay of the same inputs yields the same hashes.
- PII-free rollups: region, size/portfolio, trigger, offer/service wedge, route class.
- Fail-closed sanity: monotonic cumulative funnel, duplicate joins, missing canonical ID, stale Warmbly import, UNKNOWN preserved, aggregates PII-free.
- CLI: `python3 -m scripts.market_penetration snapshot --universe … --dui … (--warmbly … | --warmbly-absent) --as-of YYYY-MM-DD --out DIR` writes JSON + CSV + executive markdown. Consumers must read this snapshot; they must not become a second source of truth.

## Verification

```bash
python3 -m pytest tests/test_penetration_baseline.py tests/test_icp_denominator.py -o addopts='' -q
```

21 passed, twice. Policy gates: generated-artifacts PASS, pr-reviewability PASS.

CLI launched twice on the same fixture inputs: identical `snapshot_hash` / `assembly_hash`. `--warmbly-absent` zeros `CONTACTED+` and keeps UNKNOWN queryable. Official `confenge_universe` fixture builder output is also consumable (2 ICP / 0 reachable / 0 contacted / 4 UNKNOWN; Warmbly absent).

## Honesty

- `invented_tam` is false. DEFAULT_RULES remain `UF=SC` + public portfolio (PR/RS not silently widened).
- `Z_contacted` is the exclusive `CONTACTED` bucket from #388, not a cumulative contacted total.
- Live national universe JSONL, operational DUI run artifacts, and live Warmbly outcomes were **not** available in this environment. Counts below are fixture-driven, not production penetration.
- No migrations, reachability adapters, CRM UI, auto-send, or Warmbly copy.

## Residual on #381

Re-run the shipped CLI against the real universe JSONL + DUI accounts + Warmbly outcomes (or `--warmbly-absent` if Warmbly has no events). Close #381 only when that real baseline answers X/Y/Z/N/P/C with provenance.