### PR TITLE
feat(dui): first-class multi-channel reachability without email

### DIFF
--- a/scripts/decision_unit_intelligence/benchmark.py
+++ b/scripts/decision_unit_intelligence/benchmark.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any
 
-from scripts.decision_unit_intelligence.models import AccountInvestigation, AccountTerminal
+from scripts.decision_unit_intelligence.models import (
+    AccountInvestigation,
+    AccountTerminal,
+    FirstClassRouteKind,
+    FirstClassRouteLabel,
+    ReachabilityClass,
+)
 from scripts.decision_unit_intelligence.reachability import is_actionable_route
 from scripts.decision_unit_intelligence.repository import account_hash
 
@@ -47,50 +53,117 @@ def _best_class(account: AccountInvestigation) -> str:
 
 def funnel(accounts: list[AccountInvestigation]) -> dict[str, Any]:
     n = len(accounts)
-    investigated = [
-        a
-        for a in accounts
-        if a.terminal != AccountTerminal.BLOCKED or a.ledger.stop_reason
-    ]
-    denom = [
-        a
-        for a in accounts
-        if a.terminal != AccountTerminal.BLOCKED
-    ]
+    investigated = [a for a in accounts if a.terminal != AccountTerminal.BLOCKED or a.ledger.stop_reason]
+    denom = [a for a in accounts if a.terminal != AccountTerminal.BLOCKED]
     du = sum(1 for a in denom if a.candidates)
     named = sum(1 for a in denom if any(c.person_name for c in a.candidates))
     role = sum(1 for a in denom if any(c.observed_roles for c in a.candidates))
     reachable = sum(1 for a in denom if any(is_actionable_route(r) for r in a.routes))
     classes = Counter(_best_class(a) for a in accounts)
     actions = Counter(
-        (a.recommendation.action_mode.value if a.recommendation else "NEEDS_ENRICHMENT")
-        for a in accounts
+        (a.recommendation.action_mode.value if a.recommendation else "NEEDS_ENRICHMENT") for a in accounts
     )
     blocked = sum(1 for a in accounts if a.terminal == AccountTerminal.BLOCKED)
     exhausted = sum(1 for a in accounts if a.terminal == AccountTerminal.EXHAUSTED)
     rate = (reachable / len(denom)) if denom else None
+    routed = sum(
+        1
+        for a in denom
+        if any(
+            r.first_class_kind == FirstClassRouteKind.ROUTED_CALL
+            or r.reachability_class == ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+            for r in a.routes
+            if is_actionable_route(r)
+        )
+    )
+    whatsapp = sum(
+        1 for a in denom if any(r.first_class_label == FirstClassRouteLabel.PUBLIC_WHATSAPP for r in a.routes)
+    )
+    from scripts.decision_unit_intelligence.reachability import route_rank
+
+    first_labels: Counter[str] = Counter()
+    for account in denom:
+        actionable_routes = [route for route in account.routes if is_actionable_route(route)]
+        if not actionable_routes:
+            first_labels[FirstClassRouteLabel.UNKNOWN.value] += 1
+        else:
+            first_labels[max(actionable_routes, key=route_rank).first_class_label.value] += 1
+    unresolved = _unresolved_reasons(denom)
+    cost_latency = _cost_latency_per_class(accounts)
+    denom_n = len(denom)
     return {
         "accounts": n,
-        "denominator_investigated_with_budget": len(denom),
+        "denominator": {
+            "accounts": n,
+            "investigated_non_blocked": denom_n,
+            "explicit": True,
+            "note": "Rates use non-blocked investigated accounts as denominator.",
+        },
+        "denominator_investigated_with_budget": denom_n,
         "blocked_excluded_from_rate": blocked,
         "exhausted": exhausted,
         "decision_unit_identified": du,
         "named_person_found": named,
         "relevant_role_found": role,
         "decision_unit_reachability_rate": rate,
+        "actionable_route_per_account": (reachable / denom_n) if denom_n else None,
+        "routed_call_per_account": (routed / denom_n) if denom_n else None,
+        "decision_unit_known_per_account": (du / denom_n) if denom_n else None,
+        "public_whatsapp_per_account": (whatsapp / denom_n) if denom_n else None,
+        "unresolved_reason_distribution": unresolved,
+        "cost_latency_per_route_class": cost_latency,
+        "first_class_labels": dict(first_labels),
         "classes": {k: classes.get(k, 0) for k in CLASSES},
         "action_modes": {k: actions.get(k, 0) for k in ACTION_MODES},
-        "named_person_coverage": (named / len(denom)) if denom else None,
-        "relevant_role_coverage": (role / len(denom)) if denom else None,
-        "direct_route_coverage": (classes.get("R1_DIRECT", 0) / len(denom)) if denom else None,
-        "routed_to_named_person_coverage": (classes.get("R3_ROUTED_TO_NAMED_PERSON", 0) / len(denom)) if denom else None,
-        "role_route_coverage": (classes.get("R4_ROLE_ROUTE", 0) / len(denom)) if denom else None,
-        "generic_only_rate": (classes.get("R5_CORPORATE_ONLY", 0) / len(denom)) if denom else None,
-        "no_actionable_rate": (classes.get("R0_NO_ACTIONABLE_ROUTE", 0) / len(denom)) if denom else None,
+        "named_person_coverage": (named / denom_n) if denom_n else None,
+        "relevant_role_coverage": (role / denom_n) if denom_n else None,
+        "direct_route_coverage": (classes.get("R1_DIRECT", 0) / denom_n) if denom_n else None,
+        "routed_to_named_person_coverage": (classes.get("R3_ROUTED_TO_NAMED_PERSON", 0) / denom_n) if denom_n else None,
+        "role_route_coverage": (classes.get("R4_ROLE_ROUTE", 0) / denom_n) if denom_n else None,
+        "generic_only_rate": (classes.get("R5_CORPORATE_ONLY", 0) / denom_n) if denom_n else None,
+        "no_actionable_rate": (classes.get("R0_NO_ACTIONABLE_ROUTE", 0) / denom_n) if denom_n else None,
         "blocked_rate": (blocked / n) if n else None,
         "investigated": len(investigated),
         "truth": "BLOCKED is not R0. UNKNOWN is not zero. Rate uses non-blocked denominator.",
     }
+
+
+def _unresolved_reasons(accounts: list[AccountInvestigation]) -> dict[str, int]:
+    reasons: Counter[str] = Counter()
+    for account in accounts:
+        if any(is_actionable_route(route) for route in account.routes):
+            continue
+        if not account.candidates:
+            reasons["NO_DECISION_UNIT"] += 1
+        elif account.terminal == AccountTerminal.DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED:
+            reasons["DECISION_UNIT_WITHOUT_ROUTE"] += 1
+        else:
+            reasons["UNRESOLVED"] += 1
+        for code in account.reason_codes:
+            reasons[code] += 1
+    return dict(reasons)
+
+
+def _cost_latency_per_class(accounts: list[AccountInvestigation]) -> dict[str, dict[str, float | int]]:
+    buckets: dict[str, dict[str, float | int]] = {}
+    for account in accounts:
+        klass = _best_class(account)
+        bucket = buckets.setdefault(klass, {"n": 0, "cost_brl": 0.0, "duration_ms": 0})
+        bucket["n"] = int(bucket["n"]) + 1
+        bucket["cost_brl"] = float(bucket["cost_brl"]) + float(account.ledger.cost_brl)
+        bucket["duration_ms"] = int(bucket["duration_ms"]) + int(account.ledger.duration_ms)
+        kinds = {route.first_class_kind.value for route in account.routes} or {
+            FirstClassRouteKind.MANUAL_RESEARCH.value
+        }
+        for kind in kinds:
+            kind_bucket = buckets.setdefault(
+                f"kind:{kind}",
+                {"n": 0, "cost_brl": 0.0, "duration_ms": 0},
+            )
+            kind_bucket["n"] = int(kind_bucket["n"]) + 1
+            kind_bucket["cost_brl"] = float(kind_bucket["cost_brl"]) + float(account.ledger.cost_brl)
+            kind_bucket["duration_ms"] = int(kind_bucket["duration_ms"]) + int(account.ledger.duration_ms)
+    return buckets
 
 
 def replay_report(first: list[dict[str, Any]], second: list[dict[str, Any]]) -> dict[str, Any]:

--- a/scripts/decision_unit_intelligence/models.py
+++ b/scripts/decision_unit_intelligence/models.py
@@ -125,6 +125,29 @@ class ChannelType(StrEnum):
     OTHER_PUBLIC_BUSINESS_ROUTE = "OTHER_PUBLIC_BUSINESS_ROUTE"
 
 
+class FirstClassRouteLabel(StrEnum):
+    """Exactly one label per emitted route. A general phone is never DIRECT_PERSON_PHONE."""
+
+    DIRECT_PERSON_PHONE = "DIRECT_PERSON_PHONE"
+    ROUTES_TO_NAMED_PERSON = "ROUTES_TO_NAMED_PERSON"
+    CORPORATE_PHONE = "CORPORATE_PHONE"
+    PUBLIC_WHATSAPP = "PUBLIC_WHATSAPP"
+    FORM = "FORM"
+    PROFILE = "PROFILE"
+    UNKNOWN = "UNKNOWN"
+
+
+class FirstClassRouteKind(StrEnum):
+    """Operator-facing route kind. Sits beside R0–R5; does not erase MANUAL_ROUTED_CALL."""
+
+    PHONE = "PHONE"
+    ROUTED_CALL = "ROUTED_CALL"
+    PUBLIC_WHATSAPP = "PUBLIC_WHATSAPP"
+    FORM = "FORM"
+    PROFILE = "PROFILE"
+    MANUAL_RESEARCH = "MANUAL_RESEARCH"
+
+
 class RouteRelation(StrEnum):
     PERSON_OWNS_CHANNEL = "PERSON_OWNS_CHANNEL"
     ROUTES_TO_NAMED_PERSON = "ROUTES_TO_NAMED_PERSON"
@@ -161,9 +184,7 @@ class ActionMode(StrEnum):
 
 class AccountTerminal(StrEnum):
     ACTIONABLE_ROUTE = "ACTIONABLE_ROUTE"
-    DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED = (
-        "DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED"
-    )
+    DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED = "DECISION_UNIT_IDENTIFIED_REACHABILITY_UNRESOLVED"
     EXHAUSTED = "EXHAUSTED"
     BLOCKED = "BLOCKED"
     NEEDS_ENRICHMENT = "NEEDS_ENRICHMENT"
@@ -438,6 +459,10 @@ class ReachabilityRoute:
     suppression: SuppressionState = SuppressionState.NONE
     reason_codes: list[str] = dc_field(default_factory=list)
     next_action: str | None = None
+    first_class_label: FirstClassRouteLabel = FirstClassRouteLabel.UNKNOWN
+    first_class_kind: FirstClassRouteKind = FirstClassRouteKind.MANUAL_RESEARCH
+    observed_at: str | None = None
+    suitability: ConfidenceLevel = ConfidenceLevel.UNKNOWN
     aspects: list[FieldAspect] = dc_field(default_factory=list)
     extra: dict[str, Any] = dc_field(default_factory=dict)
 
@@ -452,6 +477,9 @@ class ReachabilityRoute:
         d["freshness"] = self.freshness.value
         d["ownership"] = self.ownership.value
         d["suppression"] = self.suppression.value
+        d["first_class_label"] = self.first_class_label.value
+        d["first_class_kind"] = self.first_class_kind.value
+        d["suitability"] = self.suitability.value
         d["aspects"] = [a.to_dict() if hasattr(a, "to_dict") else a for a in self.aspects]
         return d
 
@@ -475,9 +503,7 @@ class Recommendation:
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
         d["action_mode"] = self.action_mode.value
-        d["reachability_class"] = (
-            self.reachability_class.value if self.reachability_class else None
-        )
+        d["reachability_class"] = self.reachability_class.value if self.reachability_class else None
         return d
 
 

--- a/scripts/decision_unit_intelligence/operator_pack.py
+++ b/scripts/decision_unit_intelligence/operator_pack.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from scripts.decision_unit_intelligence.models import AccountInvestigation
+from scripts.decision_unit_intelligence.models import (
+    AccountInvestigation,
+    FirstClassRouteKind,
+    FirstClassRouteLabel,
+)
 from scripts.decision_unit_intelligence.repository import write_json
 
 
@@ -23,17 +27,42 @@ def build_card(account: AccountInvestigation) -> dict[str, Any]:
     if route:
         action = route.next_action or ""
     if relation == "ROUTES_TO_NAMED_PERSON":
-        do_not_claim.append(
-            "Não alegar contato direto: o canal apenas roteia até a pessoa nomeada."
-        )
+        do_not_claim.append("Não alegar contato direto: o canal apenas roteia até a pessoa nomeada.")
         if route and route.channel_type.value in {"COMPANY_SWITCHBOARD", "DIRECT_PHONE"}:
             do_not_claim.append("Não alegar que o telefone pertence à pessoa.")
     email_verification = route.extra.get("email_verification") if route else None
     verification_status = _operator_verification_status(email_verification)
+    evidence = _lean_evidence(account, route)
+    lean_route = {
+        "kind": (route.first_class_kind.value if route else FirstClassRouteKind.MANUAL_RESEARCH.value),
+        "label": (route.first_class_label.value if route else FirstClassRouteLabel.UNKNOWN.value),
+        "channel": route.channel_value if route else None,
+        "channel_type": route.channel_type.value if route else None,
+        "reachability_class": route.reachability_class.value if route else None,
+        "action_mode": rec.action_mode.value if rec else None,
+        "relation": relation,
+        "source": route.source_type if route else None,
+        "observed_at": route.observed_at if route else None,
+        "freshness": route.freshness.value if route else None,
+        "epistemic_class": route.epistemic_class.value if route else None,
+        "suitability": route.suitability.value if route else None,
+        "suppression": route.suppression.value if route else None,
+        "reason_codes": list(route.reason_codes) if route else [],
+    }
     return {
+        "who": primary.person_name if primary else None,
+        "why_now": account.why_now,
+        "offer": account.service_context,
+        "decision_unit": {
+            "person": primary.person_name if primary else None,
+            "role": primary.decision_role_class.value if primary else None,
+            "observed_roles": primary.observed_roles if primary else [],
+        },
+        "route": lean_route,
+        "confidence": route.route_confidence.value if route else None,
+        "evidence": evidence,
         "empresa": account.legal_name,
         "cnpj": account.cnpj,
-        "why_now": account.why_now,
         "oferta_recomendada": account.service_context,
         "primary_decision_unit_target": primary.person_name if primary else None,
         "role_evidence": {
@@ -94,6 +123,38 @@ def build_card(account: AccountInvestigation) -> dict[str, Any]:
     }
 
 
+def _lean_evidence(account: AccountInvestigation, route: object) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    if route is not None:
+        items.append(
+            {
+                "source": getattr(route, "source_type", None),
+                "url": getattr(route, "source_url", None),
+                "observed_at": getattr(route, "observed_at", None),
+                "channel": getattr(route, "channel_value", None),
+            }
+        )
+    for ev in account.evidence:
+        items.append(
+            {
+                "source": ev.source_type,
+                "url": ev.source_url,
+                "observed_at": ev.observed_at,
+                "field": ev.field,
+                "value": ev.value,
+            }
+        )
+    seen: set[tuple[object, object, object]] = set()
+    unique: list[dict[str, Any]] = []
+    for item in items:
+        key = (item.get("source"), item.get("url"), item.get("value") or item.get("channel"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return unique[:8]
+
+
 def _operator_verification_status(report: object) -> str:
     if not isinstance(report, dict):
         return "NOT_FOUND"
@@ -114,8 +175,14 @@ def render_markdown(cards: list[dict[str, Any]]) -> str:
         lines.extend(
             [
                 f"## {card.get('empresa') or card.get('cnpj')}",
-                f"- CNPJ: `{card.get('cnpj')}`",
+                f"- Who: **{card.get('who') or '—'}**",
                 f"- Why now: {card.get('why_now') or 'n/d'}",
+                f"- Offer: `{card.get('offer') or card.get('oferta_recomendada')}`",
+                f"- Decision unit: {card.get('decision_unit')}",
+                f"- Route: `{((card.get('route') or {}).get('kind'))}` / `{((card.get('route') or {}).get('label'))}` `{((card.get('route') or {}).get('channel'))}`",
+                f"- Confidence: `{card.get('confidence')}`",
+                f"- Evidence: {card.get('evidence')}",
+                f"- CNPJ: `{card.get('cnpj')}`",
                 f"- Oferta: `{card.get('oferta_recomendada')}`",
                 f"- Primary target: **{card.get('primary_decision_unit_target') or '—'}**",
                 f"- Papel/evidência: {card.get('role_evidence')}",

--- a/scripts/decision_unit_intelligence/orchestrator.py
+++ b/scripts/decision_unit_intelligence/orchestrator.py
@@ -166,7 +166,9 @@ def _stamp_email_discovery_classes(routes: list[ReachabilityRoute]) -> None:
         ).value
         if extra.get("affiliation_association_refused"):
             extra["identity_explicitly_associated"] = False
-        elif extra.get("identity_explicitly_associated") is None and route.route_relation.value == "PERSON_OWNS_CHANNEL":
+        elif (
+            extra.get("identity_explicitly_associated") is None and route.route_relation.value == "PERSON_OWNS_CHANNEL"
+        ):
             extra["identity_explicitly_associated"] = route.channel_type == ChannelType.DIRECT_EMAIL
         route.extra = extra
 
@@ -505,6 +507,8 @@ def recommend(
         dims["ownership"] = primary_route.ownership.value
         dims["suppression"] = primary_route.suppression.value
         dims["freshness"] = primary_route.freshness.value
+        dims["first_class_label"] = primary_route.first_class_label.value
+        dims["first_class_kind"] = primary_route.first_class_kind.value
         if primary_route.channel_type == ChannelType.INFERRED_DIRECT_EMAIL:
             warnings.append("INFERRED_EMAIL_NOT_OBSERVED")
 
@@ -651,6 +655,12 @@ def investigate_account(
         built_at=now_iso(),
         extra={
             "account_reachability_class": klass.value,
+            "primary_first_class_label": (
+                next((r.first_class_label.value for r in routes if rec.primary_route_id == r.route_id), None)
+            ),
+            "primary_first_class_kind": (
+                next((r.first_class_kind.value for r in routes if rec.primary_route_id == r.route_id), None)
+            ),
             "affiliation_corroboration": [record.to_dict() for record in affiliation_records],
             **(discovery_extra or {}),
         },

--- a/scripts/decision_unit_intelligence/projection.py
+++ b/scripts/decision_unit_intelligence/projection.py
@@ -111,6 +111,29 @@ def project_warmbly_outreach(account: AccountInvestigation) -> dict[str, Any]:
                 "reason_codes": route.reason_codes,
             }
         )
+    first_class_routes = []
+    for route in account.routes:
+        person = people.get(route.decision_unit_candidate_id or "")
+        first_class_routes.append(
+            {
+                "first_class_kind": route.first_class_kind.value,
+                "first_class_label": route.first_class_label.value,
+                "channel_type": route.channel_type.value,
+                "channel_value": route.channel_value,
+                "reachability_class": route.reachability_class.value,
+                "action_mode": route.action_mode.value,
+                "route_relation": route.route_relation.value,
+                "epistemic_class": route.epistemic_class.value,
+                "freshness": route.freshness.value,
+                "suppression": route.suppression.value,
+                "suitability": route.suitability.value,
+                "observed_at": route.observed_at,
+                "source_type": route.source_type,
+                "source_url": route.source_url,
+                "reason_codes": route.reason_codes,
+                "person_name": associated_person_name(route) or (person.person_name if person else None),
+            }
+        )
     return {
         "schema_id": WARMBLY_SCHEMA,
         "account_id": account.company_entity_id,
@@ -121,6 +144,7 @@ def project_warmbly_outreach(account: AccountInvestigation) -> dict[str, Any]:
         "recipient_candidates": recipients,
         "email_safe_count": len(recipients),
         "email_discovery_routes": discovery_routes,
+        "first_class_routes": first_class_routes,
         "non_email_routes_remain_upstream": True,
         "auto_send": False,
     }

--- a/scripts/decision_unit_intelligence/providers/historical_campaign.py
+++ b/scripts/decision_unit_intelligence/providers/historical_campaign.py
@@ -215,6 +215,7 @@ class HistoricalCampaignProvider:
                 source_url=row.get("fonte") or "rfb/brasilapi",
                 source_id=cnpj,
                 evidence_snippet=str(tel),
+                observed_at="2026-08-05",
                 extraction_method="rfb_phone",
             )
             evidence.append(ev)
@@ -230,7 +231,42 @@ class HistoricalCampaignProvider:
                     epistemic_class=EpistemicClass.OBSERVED,
                     ownership=OwnershipStatus.COMPANY_OWNED,
                     evidence_id=ev.evidence_id,
-                    extra={"person_owns_phone": False},
+                    extra={"person_owns_phone": False, "phone_context": "geral"},
+                )
+            )
+        tel2 = row.get("telefone2") or row.get("Telefone 2 / WhatsApp")
+        if tel2 and str(tel2) != str(tel or ""):
+            ev2 = make_evidence(
+                field="company_phone",
+                value=str(tel2),
+                epistemic_class=EpistemicClass.OBSERVED,
+                source_type="rfb_cadastre",
+                source_url=row.get("fonte") or "rfb/brasilapi",
+                source_id=cnpj,
+                evidence_snippet=str(tel2),
+                observed_at="2026-08-05",
+                extraction_method="rfb_secondary_phone",
+            )
+            evidence.append(ev2)
+            channels.append(
+                ChannelObservation(
+                    observation_id=stable_id("tel2", cnpj, str(tel2)),
+                    company_entity_id=cnpj,
+                    channel_type=ChannelType.COMPANY_SWITCHBOARD,
+                    channel_value=str(tel2),
+                    source_type="rfb_cadastre",
+                    source_url=row.get("fonte"),
+                    snippet="Telefone 2 (coluna ambígua Telefone 2 / WhatsApp — não prova WhatsApp)",
+                    observed_at="2026-08-05",
+                    epistemic_class=EpistemicClass.OBSERVED,
+                    ownership=OwnershipStatus.COMPANY_OWNED,
+                    evidence_id=ev2.evidence_id,
+                    extra={
+                        "person_owns_phone": False,
+                        "explicit_whatsapp": False,
+                        "phone_context": "geral",
+                        "reason_codes": ["SECONDARY_CORPORATE_PHONE", "WHATSAPP_NOT_EXPLICITLY_MARKED"],
+                    },
                 )
             )
         email = normalize_email(str(row.get("email") or "") or None)

--- a/scripts/decision_unit_intelligence/reachability.py
+++ b/scripts/decision_unit_intelligence/reachability.py
@@ -16,6 +16,8 @@ from scripts.decision_unit_intelligence.models import (
     ConfidenceLevel,
     DecisionUnitCandidate,
     EpistemicClass,
+    FirstClassRouteKind,
+    FirstClassRouteLabel,
     FreshnessState,
     OwnershipStatus,
     PersonRelation,
@@ -27,6 +29,7 @@ from scripts.decision_unit_intelligence.models import (
     normalize_email,
     stable_id,
 )
+from scripts.decision_unit_intelligence.route_class import finalize_route_draft
 
 ROLE_MAILBOX_LOCALS = frozenset(
     {
@@ -156,7 +159,9 @@ def is_role_mailbox(value: str | None) -> bool:
     base = base.replace(".", "").replace("_", "").replace("-", "")
     # licitacao1 / licitacoes2 still count
     stem = "".join(c for c in base if c.isalpha())
-    return stem in ROLE_MAILBOX_LOCALS or any(stem.startswith(r) and len(stem) <= len(r) + 2 for r in ROLE_MAILBOX_LOCALS)
+    return stem in ROLE_MAILBOX_LOCALS or any(
+        stem.startswith(r) and len(stem) <= len(r) + 2 for r in ROLE_MAILBOX_LOCALS
+    )
 
 
 def is_generic_mailbox(value: str | None) -> bool:
@@ -235,9 +240,33 @@ class RouteDraft:
     reason_codes: list[str]
     next_action: str
     extra: dict
+    first_class_label: FirstClassRouteLabel = FirstClassRouteLabel.UNKNOWN
+    first_class_kind: FirstClassRouteKind = FirstClassRouteKind.MANUAL_RESEARCH
+    observed_at: str | None = None
+    suitability: ConfidenceLevel = ConfidenceLevel.UNKNOWN
 
 
 def classify_channel_observation(
+    obs: ChannelObservation,
+    *,
+    candidate: DecisionUnitCandidate | None,
+    suitable_person: bool,
+) -> RouteDraft:
+    """Project one channel observation into a first-class route. Does not invent association."""
+    draft = _classify_channel_observation_raw(
+        obs,
+        candidate=candidate,
+        suitable_person=suitable_person,
+    )
+    return finalize_route_draft(
+        draft,
+        obs=obs,
+        candidate=candidate,
+        suitable_person=suitable_person,
+    )
+
+
+def _classify_channel_observation_raw(
     obs: ChannelObservation,
     *,
     candidate: DecisionUnitCandidate | None,
@@ -306,10 +335,13 @@ def classify_channel_observation(
                 suppression=SuppressionState.NONE,
                 reason_codes=reasons + (["INFERRED_DIRECT_EMAIL_VERIFIED"] if verified else ["INFERRED_UNVERIFIED"]),
                 next_action=(
-                    f"Revisar humanamente o e-mail inferido {value} para {person_name}. "
-                    "Não enviar automaticamente."
+                    f"Revisar humanamente o e-mail inferido {value} para {person_name}. Não enviar automaticamente."
                 ),
-                extra={**extra, "human_review_required": True, "inferred_class": "INFERRED_DIRECT_EMAIL_VERIFIED" if verified else "INFERRED_DIRECT_EMAIL"},
+                extra={
+                    **extra,
+                    "human_review_required": True,
+                    "inferred_class": "INFERRED_DIRECT_EMAIL_VERIFIED" if verified else "INFERRED_DIRECT_EMAIL",
+                },
             )
 
     if ctype == ChannelType.DIRECT_EMAIL and looks_nominal_local(value) and epistemic == EpistemicClass.OBSERVED:
@@ -503,8 +535,7 @@ def classify_channel_observation(
                 suppression=SuppressionState.NONE,
                 reason_codes=reasons,
                 next_action=(
-                    f"Ligar para {value} e pedir por {person_name}. "
-                    "Não alegar que o telefone pertence à pessoa."
+                    f"Ligar para {value} e pedir por {person_name}. Não alegar que o telefone pertence à pessoa."
                 ),
                 extra={**extra, "person_owns_phone": False},
             )
@@ -556,9 +587,7 @@ def classify_channel_observation(
     # Generic corporate email / leftover
     reasons.append("GENERIC_CORPORATE")
     return RouteDraft(
-        channel_type=ChannelType.GENERIC_CORPORATE_EMAIL
-        if value and "@" in (value or "")
-        else ctype,
+        channel_type=ChannelType.GENERIC_CORPORATE_EMAIL if value and "@" in (value or "") else ctype,
         channel_value=value,
         relation=RouteRelation.ACCOUNT_LEVEL_ONLY,
         epistemic=epistemic,
@@ -609,6 +638,10 @@ def draft_to_route(draft: RouteDraft, *, company_entity_id: str) -> Reachability
         reason_codes=draft.reason_codes,
         next_action=draft.next_action,
         reachability_class=draft.reachability,
+        first_class_label=draft.first_class_label,
+        first_class_kind=draft.first_class_kind,
+        observed_at=draft.observed_at,
+        suitability=draft.suitability,
         extra=draft.extra,
     )
 
@@ -661,8 +694,7 @@ def best_account_class(routes: list[ReachabilityRoute]) -> ReachabilityClass:
 def next_action_text(route: ReachabilityRoute, *, person_name: str | None) -> str:
     if route.reachability_class == ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON and person_name:
         return (
-            f"Ligar para {route.channel_value} e pedir por {person_name}. "
-            "Não alegar que o telefone pertence à pessoa."
+            f"Ligar para {route.channel_value} e pedir por {person_name}. Não alegar que o telefone pertence à pessoa."
         )
     return route.next_action or ""
 

--- a/scripts/decision_unit_intelligence/route_class.py
+++ b/scripts/decision_unit_intelligence/route_class.py
@@ -1,0 +1,350 @@
+"""First-class multi-channel labels. Observation-driven; never invents ownership."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from scripts.decision_unit_intelligence.models import (
+    ActionMode,
+    ChannelObservation,
+    ChannelType,
+    ConfidenceLevel,
+    DecisionUnitCandidate,
+    FirstClassRouteKind,
+    FirstClassRouteLabel,
+    FreshnessState,
+    ReachabilityClass,
+    RouteRelation,
+    fold_text,
+)
+
+FRESH_MAX_DAYS = 180
+AGING_MAX_DAYS = 365
+
+_EXPLICIT_WHATSAPP_TOKENS = (
+    "whatsapp",
+    "wa.me/",
+    "api.whatsapp.com",
+    "web.whatsapp.com",
+    "whats app",
+)
+_PERSONAL_OWNERSHIP_TOKENS = (
+    "celular pessoal",
+    "telefone pessoal",
+    "whatsapp pessoal",
+    "celular do titular",
+)
+_STALE_TOKENS = (
+    "numero antigo",
+    "telefone antigo",
+    "contato antigo",
+    "desatualizado",
+    "nao usa mais",
+    "linha desativada",
+)
+
+
+@dataclass(frozen=True)
+class PhoneContext:
+    kind: str
+    blocks_personal_ownership: bool
+    third_party: bool
+    stale_marked: bool
+    reason_codes: tuple[str, ...]
+
+
+def parse_observed_at(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        try:
+            parsed = datetime.strptime(text[:10], "%Y-%m-%d")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def freshness_from_observed_at(
+    observed_at: str | None,
+    *,
+    now: datetime | None = None,
+) -> FreshnessState:
+    """UNKNOWN only when no parseable observed_at exists."""
+    parsed = parse_observed_at(observed_at)
+    if parsed is None:
+        return FreshnessState.UNKNOWN
+    current = now or datetime.now(UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=UTC)
+    age = current - parsed
+    if age <= timedelta(days=FRESH_MAX_DAYS):
+        return FreshnessState.FRESH
+    if age <= timedelta(days=AGING_MAX_DAYS):
+        return FreshnessState.AGING
+    return FreshnessState.STALE
+
+
+def observation_text(obs: ChannelObservation) -> str:
+    extra = obs.extra or {}
+    parts = [
+        obs.source_type or "",
+        obs.snippet or "",
+        obs.source_url or "",
+        str(extra.get("label") or ""),
+        str(extra.get("phone_label") or ""),
+        str(extra.get("context") or ""),
+        str(extra.get("phone_context") or ""),
+        " ".join(str(code) for code in extra.get("reason_codes") or ()),
+    ]
+    return fold_text(" ".join(parts))
+
+
+def explicit_public_whatsapp(obs: ChannelObservation) -> bool:
+    extra = obs.extra or {}
+    if extra.get("explicit_whatsapp") is True or extra.get("public_whatsapp") is True:
+        return True
+    if extra.get("explicit_whatsapp") is False or extra.get("public_whatsapp") is False:
+        return False
+    text = observation_text(obs)
+    value = fold_text(obs.channel_value or "")
+    haystack = f"{text} {value}"
+    return any(token in haystack for token in _EXPLICIT_WHATSAPP_TOKENS)
+
+
+def infer_phone_context(obs: ChannelObservation) -> PhoneContext:
+    extra = obs.extra or {}
+    text = observation_text(obs)
+    reasons: list[str] = []
+    kind = "unknown"
+    blocks = False
+    stale = bool(extra.get("stale") or extra.get("number_age") == "old")
+
+    declared = fold_text(str(extra.get("phone_context") or ""))
+    third_party_checks: tuple[tuple[str, tuple[str, ...], str], ...] = (
+        ("contador", ("contador", "contabilidade", "escritorio contabil", "crc "), "THIRD_PARTY_ACCOUNTANT_PHONE"),
+        (
+            "juridico",
+            ("escritorio juridico", "advocacia", "advogados associados", "oab/", "oab "),
+            "THIRD_PARTY_LAW_OFFICE_PHONE",
+        ),
+        ("consorcio", ("consorcio", "sociedade de proposito"), "CONSORTIUM_PHONE"),
+    )
+    corporate_checks: tuple[tuple[str, tuple[str, ...], str], ...] = (
+        ("recepcao", ("recepcao", "portaria", "pabx", "pbx", "switchboard", "mesa telefonica"), "RECEPTION_PHONE"),
+        (
+            "geral",
+            ("telefone geral", "tel geral", "central de atendimento", "central telefonica"),
+            "GENERAL_COMPANY_PHONE",
+        ),
+        ("matriz", ("matriz", "sede", "head office", "headquarters"), "HQ_MATRIX_PHONE"),
+        ("filial", ("filial", "unidade ", "branch office"), "BRANCH_PHONE"),
+        ("setor", ("setor de", "departamento de", "ramal do setor"), "SECTORAL_PHONE"),
+    )
+    scan = f"{declared} {text}".strip()
+    third_party = False
+    for name, tokens, code in third_party_checks:
+        if name == declared or any(token in scan for token in tokens):
+            kind = name
+            blocks = True
+            third_party = True
+            reasons.append(code)
+            break
+    if not third_party:
+        for name, tokens, code in corporate_checks:
+            if name == declared or any(token in scan for token in tokens):
+                kind = name
+                blocks = True
+                reasons.append(code)
+                break
+    if any(token in scan for token in _STALE_TOKENS):
+        stale = True
+        reasons.append("STALE_NUMBER_MARKED")
+    if extra.get("person_owns_phone") is True and not blocks and kind == "unknown":
+        kind = "pessoal"
+    return PhoneContext(
+        kind=kind,
+        blocks_personal_ownership=blocks,
+        third_party=third_party,
+        stale_marked=stale,
+        reason_codes=tuple(dict.fromkeys(reasons)),
+    )
+
+
+def first_class_for(
+    *,
+    channel_type: ChannelType,
+    relation: RouteRelation,
+    extra: dict,
+    obs: ChannelObservation,
+) -> tuple[FirstClassRouteLabel, FirstClassRouteKind]:
+    if channel_type == ChannelType.PROFESSIONAL_WHATSAPP and explicit_public_whatsapp(obs):
+        return FirstClassRouteLabel.PUBLIC_WHATSAPP, FirstClassRouteKind.PUBLIC_WHATSAPP
+    if channel_type == ChannelType.CONTACT_FORM:
+        return FirstClassRouteLabel.FORM, FirstClassRouteKind.FORM
+    if channel_type == ChannelType.PROFESSIONAL_PROFILE:
+        return FirstClassRouteLabel.PROFILE, FirstClassRouteKind.PROFILE
+    if channel_type in {ChannelType.COMPANY_SWITCHBOARD, ChannelType.DIRECT_PHONE}:
+        if relation == RouteRelation.PERSON_OWNS_CHANNEL and extra.get("person_owns_phone"):
+            return FirstClassRouteLabel.DIRECT_PERSON_PHONE, FirstClassRouteKind.PHONE
+        if relation == RouteRelation.ROUTES_TO_NAMED_PERSON:
+            return FirstClassRouteLabel.ROUTES_TO_NAMED_PERSON, FirstClassRouteKind.ROUTED_CALL
+        return FirstClassRouteLabel.CORPORATE_PHONE, FirstClassRouteKind.PHONE
+    return FirstClassRouteLabel.UNKNOWN, FirstClassRouteKind.MANUAL_RESEARCH
+
+
+def route_suitability(
+    *,
+    suitable_person: bool,
+    candidate: DecisionUnitCandidate | None,
+    label: FirstClassRouteLabel,
+    suppression_blocked: bool,
+) -> ConfidenceLevel:
+    if suppression_blocked:
+        return ConfidenceLevel.NONE
+    if label == FirstClassRouteLabel.UNKNOWN:
+        return ConfidenceLevel.UNKNOWN
+    if candidate is not None and suitable_person:
+        return candidate.suitability
+    if label in {
+        FirstClassRouteLabel.CORPORATE_PHONE,
+        FirstClassRouteLabel.FORM,
+        FirstClassRouteLabel.PROFILE,
+        FirstClassRouteLabel.PUBLIC_WHATSAPP,
+    }:
+        return ConfidenceLevel.MEDIUM
+    return ConfidenceLevel.LOW
+
+
+def finalize_route_draft(
+    draft: object,
+    *,
+    obs: ChannelObservation,
+    candidate: DecisionUnitCandidate | None,
+    suitable_person: bool,
+) -> object:
+    """Stamp provenance + first-class labels. Does not invent person ownership."""
+    extra = dict(getattr(draft, "extra", None) or {})
+    ctx = infer_phone_context(obs)
+    extra["phone_context"] = ctx.kind
+    extra["source"] = obs.source_type
+    if obs.observed_at:
+        extra["observed_at"] = obs.observed_at
+    reasons = list(getattr(draft, "reason_codes", []) or [])
+    reasons.extend(ctx.reason_codes)
+
+    channel_type = draft.channel_type
+    relation = draft.relation
+    reachability = draft.reachability
+    action = draft.action
+
+    phone_like = channel_type in {
+        ChannelType.DIRECT_PHONE,
+        ChannelType.COMPANY_SWITCHBOARD,
+        ChannelType.PROFESSIONAL_WHATSAPP,
+    }
+    if phone_like and ctx.blocks_personal_ownership:
+        extra["person_owns_phone"] = False
+        extra["person_owns_whatsapp"] = False
+        if ctx.third_party:
+            channel_type = ChannelType.COMPANY_SWITCHBOARD
+            relation = RouteRelation.ACCOUNT_LEVEL_ONLY
+            reachability = ReachabilityClass.R5_CORPORATE_ONLY
+            action = ActionMode.MANUAL_CALL
+            draft.candidate_id = None
+            reasons.append("THIRD_PARTY_PHONE_NOT_COMPANY_ROUTE")
+        elif suitable_person and candidate and candidate.person_name:
+            channel_type = ChannelType.COMPANY_SWITCHBOARD
+            relation = RouteRelation.ROUTES_TO_NAMED_PERSON
+            reachability = ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+            action = ActionMode.MANUAL_ROUTED_CALL
+        else:
+            channel_type = ChannelType.COMPANY_SWITCHBOARD
+            relation = RouteRelation.ACCOUNT_LEVEL_ONLY
+            reachability = ReachabilityClass.R5_CORPORATE_ONLY
+            action = ActionMode.MANUAL_CALL
+        reasons.append("GENERAL_PHONE_NOT_PERSONAL")
+
+    if channel_type == ChannelType.PROFESSIONAL_WHATSAPP:
+        if not explicit_public_whatsapp(obs):
+            reasons.append("WHATSAPP_NOT_EXPLICITLY_MARKED")
+            extra["person_owns_whatsapp"] = False
+            extra["person_owns_phone"] = False
+            if suitable_person and candidate and candidate.person_name:
+                channel_type = ChannelType.COMPANY_SWITCHBOARD
+                relation = RouteRelation.ROUTES_TO_NAMED_PERSON
+                reachability = ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+                action = ActionMode.MANUAL_ROUTED_CALL
+            else:
+                channel_type = ChannelType.COMPANY_SWITCHBOARD
+                relation = RouteRelation.ACCOUNT_LEVEL_ONLY
+                reachability = ReachabilityClass.R5_CORPORATE_ONLY
+                action = ActionMode.MANUAL_CALL
+        elif not extra.get("person_owns_whatsapp"):
+            extra["person_owns_whatsapp"] = False
+            if suitable_person and candidate and candidate.person_name:
+                relation = RouteRelation.ROUTES_TO_NAMED_PERSON
+                reachability = ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+                action = ActionMode.MANUAL_WHATSAPP
+            else:
+                relation = RouteRelation.ACCOUNT_LEVEL_ONLY
+                reachability = ReachabilityClass.R5_CORPORATE_ONLY
+                action = ActionMode.MANUAL_WHATSAPP
+
+    freshness = freshness_from_observed_at(obs.observed_at)
+    if ctx.stale_marked:
+        freshness = FreshnessState.STALE
+        reasons.append("STALE_NUMBER_MARKED")
+
+    label, kind = first_class_for(
+        channel_type=channel_type,
+        relation=relation,
+        extra=extra,
+        obs=obs,
+    )
+    if label == FirstClassRouteLabel.DIRECT_PERSON_PHONE and ctx.blocks_personal_ownership:
+        label = (
+            FirstClassRouteLabel.ROUTES_TO_NAMED_PERSON
+            if relation == RouteRelation.ROUTES_TO_NAMED_PERSON
+            else FirstClassRouteLabel.CORPORATE_PHONE
+        )
+        kind = (
+            FirstClassRouteKind.ROUTED_CALL
+            if label == FirstClassRouteLabel.ROUTES_TO_NAMED_PERSON
+            else FirstClassRouteKind.PHONE
+        )
+
+    if candidate and suitable_person and candidate.person_name:
+        extra.setdefault("associated_person_name", candidate.person_name)
+        extra.setdefault("person_name", candidate.person_name)
+
+    extra["first_class_label"] = label.value
+    extra["first_class_kind"] = kind.value
+    suitability = route_suitability(
+        suitable_person=suitable_person,
+        candidate=candidate,
+        label=label,
+        suppression_blocked=reachability == ReachabilityClass.BLOCKED,
+    )
+
+    draft.channel_type = channel_type
+    draft.relation = relation
+    draft.reachability = reachability
+    draft.action = action
+    draft.freshness = freshness
+    draft.observed_at = obs.observed_at
+    draft.first_class_label = label
+    draft.first_class_kind = kind
+    draft.suitability = suitability
+    draft.reason_codes = list(dict.fromkeys(reasons))
+    draft.extra = extra
+    return draft

--- a/tests/test_decision_unit_intelligence_cli.py
+++ b/tests/test_decision_unit_intelligence_cli.py
@@ -48,7 +48,37 @@ def test_cli_plan_and_run_track_a(tmp_path: Path):
     assert funnel["accounts"] == 30
     assert "decision_unit_reachability_rate" in funnel
     assert funnel["blocked_excluded_from_rate"] == funnel["classes"].get("BLOCKED", 0)
+    assert funnel["denominator"]["explicit"] is True
+    assert funnel["denominator"]["investigated_non_blocked"] == 30
+    assert "actionable_route_per_account" in funnel
+    assert "routed_call_per_account" in funnel
+    assert "decision_unit_known_per_account" in funnel
+    assert "public_whatsapp_per_account" in funnel
+    assert "unresolved_reason_distribution" in funnel
+    assert "cost_latency_per_route_class" in funnel
+    warmbly = json.loads((run_dir / "warmbly_outreach.json").read_text(encoding="utf-8"))
+    assert all(account.get("auto_send") is False for account in warmbly["accounts"])
+    assert any(account.get("first_class_routes") for account in warmbly["accounts"])
+    first_labels = {
+        route["first_class_label"]
+        for account in warmbly["accounts"]
+        for route in account.get("first_class_routes") or []
+    }
+    assert first_labels
+    assert "DIRECT_PERSON_PHONE" not in first_labels
     cards = json.loads((operator / "cards.json").read_text(encoding="utf-8"))
+    sample = next(card for card in cards["cards"] if card.get("who"))
+    for key in ("who", "why_now", "offer", "decision_unit", "route", "confidence", "evidence"):
+        assert key in sample
+    assert sample["route"]["label"] in {
+        "DIRECT_PERSON_PHONE",
+        "ROUTES_TO_NAMED_PERSON",
+        "CORPORATE_PHONE",
+        "PUBLIC_WHATSAPP",
+        "FORM",
+        "PROFILE",
+        "UNKNOWN",
+    }
     assert cards["n"] == 30
     md = (operator / "cards.md").read_text(encoding="utf-8")
     assert "AÇÃO" in md or "AÇÃO:" in md or "**AÇÃO:**" in md
@@ -57,7 +87,9 @@ def test_cli_plan_and_run_track_a(tmp_path: Path):
     for card in cards["cards"]:
         cnpj = card["cnpj"]
         row = index.get(cnpj) or {}
-        has_person_and_phone = bool(row.get("qsa") or row.get("qsa2")) and bool(row.get("telefone") or row.get("Telefone principal"))
+        has_person_and_phone = bool(row.get("qsa") or row.get("qsa2")) and bool(
+            row.get("telefone") or row.get("Telefone principal")
+        )
         if has_person_and_phone:
             assert card["route_class"] != "R0_NO_ACTIONABLE_ROUTE"
             assert card["terminal"] != "EXHAUSTED"

--- a/tests/test_decision_unit_reachability_contract.py
+++ b/tests/test_decision_unit_reachability_contract.py
@@ -1,0 +1,303 @@
+"""Golden/adversarial reachability: first-class labels drive shipped classifier."""
+
+from __future__ import annotations
+
+from scripts.decision_unit_intelligence.benchmark import funnel
+from scripts.decision_unit_intelligence.decision_policy import (
+    SERVICE_REAJUSTE_14133,
+    normalize_observed_role,
+)
+from scripts.decision_unit_intelligence.models import (
+    ActionMode,
+    ChannelObservation,
+    ChannelType,
+    ConfidenceLevel,
+    DecisionRoleClass,
+    DecisionUnitCandidate,
+    EpistemicClass,
+    FirstClassRouteKind,
+    FirstClassRouteLabel,
+    FreshnessState,
+    PersonObservation,
+    PersonRelation,
+    ReachabilityClass,
+    RouteRelation,
+)
+from scripts.decision_unit_intelligence.operator_pack import build_card
+from scripts.decision_unit_intelligence.orchestrator import investigate_account
+from scripts.decision_unit_intelligence.projection import project_warmbly_outreach
+from scripts.decision_unit_intelligence.reachability import (
+    classify_channel_observation,
+    draft_to_route,
+)
+from scripts.decision_unit_intelligence.route_class import freshness_from_observed_at
+
+
+def _person(name: str = "ANA CONTRATOS", role: str = "Gerente de Contratos") -> PersonObservation:
+    return PersonObservation(
+        observation_id=f"p-{name}",
+        company_entity_id="12345678000190",
+        person_name=name,
+        observed_role=role,
+        normalized_role_class=normalize_observed_role(role),
+        relation=PersonRelation.COMPANY_MEMBER,
+        source_type="process_document",
+        document_id="doc-1",
+        observed_at="2026-07-01",
+        epistemic_class=EpistemicClass.OBSERVED,
+        evidence_id=f"ev-{name}",
+    )
+
+
+def _candidate(name: str = "ANA CONTRATOS") -> DecisionUnitCandidate:
+    return DecisionUnitCandidate(
+        candidate_id="cand-ana",
+        company_entity_id="12345678000190",
+        person_id="person-ana",
+        person_name=name,
+        observed_roles=["Gerente de Contratos"],
+        decision_role_class=DecisionRoleClass.GERENTE_CONTRATOS,
+        relation=PersonRelation.COMPANY_MEMBER,
+        suitability=ConfidenceLevel.MEDIUM,
+    )
+
+
+def _obs(
+    value: str,
+    *,
+    snippet: str,
+    ctype: ChannelType = ChannelType.COMPANY_SWITCHBOARD,
+    extra: dict | None = None,
+    observed_at: str | None = "2026-07-01",
+    person: str | None = None,
+) -> ChannelObservation:
+    return ChannelObservation(
+        observation_id=f"c-{value}",
+        company_entity_id="12345678000190",
+        channel_type=ctype,
+        channel_value=value,
+        person_name=person,
+        source_type="company_site",
+        source_url="https://empresa.example/contato",
+        snippet=snippet,
+        observed_at=observed_at,
+        epistemic_class=EpistemicClass.OBSERVED,
+        extra=extra or {"person_owns_phone": False},
+    )
+
+
+def _classify(obs: ChannelObservation, *, suitable: bool = True):
+    return classify_channel_observation(
+        obs,
+        candidate=_candidate() if suitable else None,
+        suitable_person=suitable,
+    )
+
+
+def _assert_not_personal(draft) -> None:
+    assert draft.first_class_label != FirstClassRouteLabel.DIRECT_PERSON_PHONE
+    assert draft.relation != RouteRelation.PERSON_OWNS_CHANNEL
+    assert draft.extra.get("person_owns_phone") is not True
+
+
+def test_matriz_phone_is_routed_call_never_personal():
+    draft = _classify(_obs("4833331000", snippet="Telefone da matriz — sede em Florianópolis"))
+    route = draft_to_route(draft, company_entity_id="12345678000190")
+    assert route.first_class_label == FirstClassRouteLabel.ROUTES_TO_NAMED_PERSON
+    assert route.first_class_kind == FirstClassRouteKind.ROUTED_CALL
+    assert route.reachability_class == ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+    assert route.action_mode == ActionMode.MANUAL_ROUTED_CALL
+    assert "HQ_MATRIX_PHONE" in route.reason_codes
+    _assert_not_personal(draft)
+    assert route.freshness != FreshnessState.UNKNOWN
+    assert route.observed_at == "2026-07-01"
+    assert route.source_type == "company_site"
+    assert route.epistemic_class == EpistemicClass.OBSERVED
+    assert route.suppression.value == "NONE"
+    assert route.suitability == ConfidenceLevel.MEDIUM
+
+
+def test_filial_phone_is_corporate_or_routed_never_personal():
+    draft = _classify(_obs("4733332000", snippet="Filial de Blumenau — telefone da unidade"))
+    assert draft.first_class_label in {
+        FirstClassRouteLabel.ROUTES_TO_NAMED_PERSON,
+        FirstClassRouteLabel.CORPORATE_PHONE,
+    }
+    assert draft.first_class_kind in {FirstClassRouteKind.ROUTED_CALL, FirstClassRouteKind.PHONE}
+    assert "BRANCH_PHONE" in draft.reason_codes
+    _assert_not_personal(draft)
+    assert draft.first_class_label != FirstClassRouteLabel.PUBLIC_WHATSAPP
+
+
+def test_accountant_phone_is_not_company_route_to_named_person():
+    draft = _classify(_obs("4832220000", snippet="Escritório de contabilidade — CRC/SC do contador da empresa"))
+    assert draft.first_class_label == FirstClassRouteLabel.CORPORATE_PHONE
+    assert draft.first_class_kind == FirstClassRouteKind.PHONE
+    assert draft.reachability == ReachabilityClass.R5_CORPORATE_ONLY
+    assert draft.candidate_id is None
+    assert "THIRD_PARTY_ACCOUNTANT_PHONE" in draft.reason_codes
+    _assert_not_personal(draft)
+
+
+def test_law_office_phone_is_not_decisor_phone():
+    draft = _classify(_obs("4832110000", snippet="Escritório jurídico Advogados Associados OAB/SC 1234"))
+    assert draft.first_class_label == FirstClassRouteLabel.CORPORATE_PHONE
+    assert draft.reachability == ReachabilityClass.R5_CORPORATE_ONLY
+    assert "THIRD_PARTY_LAW_OFFICE_PHONE" in draft.reason_codes
+    _assert_not_personal(draft)
+    assert draft.first_class_label != FirstClassRouteLabel.PUBLIC_WHATSAPP
+
+
+def test_consortium_phone_stays_corporate():
+    draft = _classify(_obs("6130001000", snippet="Telefone do consórcio SPE Obras Sul — não é da empresa membro"))
+    assert draft.first_class_label == FirstClassRouteLabel.CORPORATE_PHONE
+    assert "CONSORTIUM_PHONE" in draft.reason_codes
+    _assert_not_personal(draft)
+
+
+def test_stale_number_is_not_personal_and_freshness_stale():
+    draft = _classify(
+        _obs(
+            "4831000000",
+            snippet="Número antigo — telefone antigo, linha desativada",
+            observed_at="2020-01-15",
+        )
+    )
+    assert draft.freshness == FreshnessState.STALE
+    assert "STALE_NUMBER_MARKED" in draft.reason_codes
+    _assert_not_personal(draft)
+    assert draft.first_class_label != FirstClassRouteLabel.PUBLIC_WHATSAPP
+
+
+def test_unproven_whatsapp_is_never_public_whatsapp():
+    draft = _classify(
+        _obs(
+            "48999990000",
+            snippet="Celular publicado no rodapé sem menção ao aplicativo",
+            ctype=ChannelType.PROFESSIONAL_WHATSAPP,
+            extra={"person_owns_phone": False, "explicit_whatsapp": False},
+        )
+    )
+    assert draft.first_class_label != FirstClassRouteLabel.PUBLIC_WHATSAPP
+    assert draft.first_class_kind != FirstClassRouteKind.PUBLIC_WHATSAPP
+    assert "WHATSAPP_NOT_EXPLICITLY_MARKED" in draft.reason_codes
+    _assert_not_personal(draft)
+
+
+def test_general_phone_plus_named_person_is_routed_call():
+    acc = investigate_account(
+        cnpj="12345678000190",
+        legal_name="EXEMPLO LTDA",
+        service=SERVICE_REAJUSTE_14133,
+        why_now="aditivo em janela de reajuste",
+        people=[_person()],
+        channels=[
+            _obs("4833334444", snippet="Telefone geral / central de atendimento da empresa"),
+        ],
+        infer_email=False,
+    )
+    route = next(r for r in acc.routes if r.channel_value == "4833334444")
+    assert route.first_class_label == FirstClassRouteLabel.ROUTES_TO_NAMED_PERSON
+    assert route.first_class_kind == FirstClassRouteKind.ROUTED_CALL
+    assert route.reachability_class == ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+    assert route.action_mode == ActionMode.MANUAL_ROUTED_CALL
+    assert "GENERAL_COMPANY_PHONE" in route.reason_codes
+    assert route.first_class_label != FirstClassRouteLabel.DIRECT_PERSON_PHONE
+    assert "AUTO_SEND" not in route.reason_codes
+    card = build_card(acc)
+    assert card["who"] == "ANA CONTRATOS"
+    assert card["why_now"] == "aditivo em janela de reajuste"
+    assert card["offer"]
+    assert card["decision_unit"]["person"] == "ANA CONTRATOS"
+    assert card["route"]["label"] == "ROUTES_TO_NAMED_PERSON"
+    assert card["route"]["kind"] == "ROUTED_CALL"
+    assert card["confidence"]
+    assert card["evidence"]
+    warmbly = project_warmbly_outreach(acc)
+    assert warmbly["auto_send"] is False
+    labels = {item["first_class_label"] for item in warmbly["first_class_routes"]}
+    assert "ROUTES_TO_NAMED_PERSON" in labels
+    assert any(item["first_class_kind"] == "ROUTED_CALL" for item in warmbly["first_class_routes"])
+
+
+def test_explicit_public_whatsapp_is_first_class_public_whatsapp():
+    draft = _classify(
+        _obs(
+            "48988887777",
+            snippet="Fale conosco no WhatsApp institucional: https://wa.me/5548988887777",
+            ctype=ChannelType.PROFESSIONAL_WHATSAPP,
+            extra={"explicit_whatsapp": True, "person_owns_phone": False},
+        )
+    )
+    assert draft.first_class_label == FirstClassRouteLabel.PUBLIC_WHATSAPP
+    assert draft.first_class_kind == FirstClassRouteKind.PUBLIC_WHATSAPP
+    assert draft.reachability == ReachabilityClass.R3_ROUTED_TO_NAMED_PERSON
+    assert draft.action == ActionMode.MANUAL_WHATSAPP
+    assert draft.relation == RouteRelation.ROUTES_TO_NAMED_PERSON
+    assert draft.first_class_label != FirstClassRouteLabel.DIRECT_PERSON_PHONE
+
+
+def test_freshness_unknown_only_without_observed_at():
+    assert (
+        freshness_from_observed_at(
+            "2026-07-01", now=__import__("datetime").datetime(2026, 8, 15, tzinfo=__import__("datetime").UTC)
+        )
+        == FreshnessState.FRESH
+    )
+    assert (
+        freshness_from_observed_at(
+            "2025-01-01", now=__import__("datetime").datetime(2026, 8, 15, tzinfo=__import__("datetime").UTC)
+        )
+        == FreshnessState.STALE
+    )
+    assert freshness_from_observed_at(None) == FreshnessState.UNKNOWN
+    blank = _classify(_obs("4833330001", snippet="Telefone geral", observed_at=None))
+    assert blank.freshness == FreshnessState.UNKNOWN
+    dated = _classify(_obs("4833330002", snippet="Telefone geral", observed_at="2026-07-01"))
+    assert dated.freshness != FreshnessState.UNKNOWN
+
+
+def test_form_and_profile_are_first_class_and_funnel_has_denominator():
+    acc = investigate_account(
+        cnpj="12345678000190",
+        legal_name="EXEMPLO LTDA",
+        service=SERVICE_REAJUSTE_14133,
+        why_now="contrato ativo",
+        people=[_person()],
+        channels=[
+            _obs(
+                "https://empresa.example/contato#form",
+                snippet="Formulário institucional de contato",
+                ctype=ChannelType.CONTACT_FORM,
+                extra={},
+            ),
+            _obs(
+                "https://empresa.example/equipe/ana",
+                snippet="Perfil institucional público da gerente",
+                ctype=ChannelType.PROFESSIONAL_PROFILE,
+                person="ANA CONTRATOS",
+                extra={},
+            ),
+        ],
+        infer_email=False,
+    )
+    labels = {route.first_class_label for route in acc.routes}
+    kinds = {route.first_class_kind for route in acc.routes}
+    assert FirstClassRouteLabel.FORM in labels
+    assert FirstClassRouteLabel.PROFILE in labels
+    assert FirstClassRouteKind.FORM in kinds
+    assert FirstClassRouteKind.PROFILE in kinds
+    assert FirstClassRouteLabel.DIRECT_PERSON_PHONE not in labels
+    assert FirstClassRouteLabel.PUBLIC_WHATSAPP not in labels
+    metrics = funnel([acc])
+    assert metrics["denominator"]["explicit"] is True
+    assert metrics["denominator"]["investigated_non_blocked"] == 1
+    assert metrics["actionable_route_per_account"] == 1.0
+    assert metrics["decision_unit_known_per_account"] == 1.0
+    assert "unresolved_reason_distribution" in metrics
+    assert "cost_latency_per_route_class" in metrics
+    warmbly = project_warmbly_outreach(acc)
+    assert warmbly["auto_send"] is False
+    exported = {item["first_class_label"] for item in warmbly["first_class_routes"]}
+    assert "FORM" in exported
+    assert "PROFILE" in exported


### PR DESCRIPTION
## Summary

Decision-Unit Intelligence now resolves observed public channels into first-class routes the founder can act on **without email**.

- Labels (exactly one): `DIRECT_PERSON_PHONE` / `ROUTES_TO_NAMED_PERSON` / `CORPORATE_PHONE` / `PUBLIC_WHATSAPP` / `FORM` / `PROFILE` / `UNKNOWN`
- Kinds: `PHONE` / `ROUTED_CALL` / `PUBLIC_WHATSAPP` / `FORM` / `PROFILE` / `MANUAL_RESEARCH` (beside R0–R5; R3/`MANUAL_ROUTED_CALL` kept)
- General / HQ / branch / reception / sectoral phone never becomes the decisor's personal phone
- Accountant / law-office / consortium numbers stay third-party
- WhatsApp is `PUBLIC_WHATSAPP` only with an explicit public marker
- Freshness is derived from `observed_at` (not hardcoded `UNKNOWN`)
- Lean operator pack: who / why now / offer / decision unit / route / confidence / evidence
- Warmbly reexport preserves non-email classes; `auto_send: false`
- Funnel rates with explicit denominator

Email miner / query planner / pattern engine were **not** reimplemented.

Does **not** close #372. Relates to #375 (shadow/benchmark follow-up).

## Track A 30 (explicit denominator = those 30 CNPJs)

Offline (`--search-backend off`) ×2, replay hashes identical:

| metric | value |
|---|---|
| actionable_route/account | 0.967 (29/30) |
| routed_call/account | 0.933 (28/30) |
| decision_unit_known/account | 0.967 (29/30) |
| public_whatsapp/account | 0.0 |
| unresolved | 1 `DECISION_UNIT_WITHOUT_ROUTE` |
| first-class labels | 28 `ROUTES_TO_NAMED_PERSON`, 1 `CORPORATE_PHONE` (consórcio), 1 `UNKNOWN` |
| email-safe Warmbly | 0 |
| auto_send | false |

Live DDGS 30 completed with the **same** first-class rates. SearXNG unset. Shadow 100 not run (no first-class lift vs offline; extra budget not justified).

This is a **manual founder queue**, not production proof of outreach, consent, or revenue. UNKNOWN stays UNKNOWN.

## Tests

- `tests/test_decision_unit_reachability_contract.py` — 10 golden/adversarial cases drive shipped `classify_channel_observation` / `investigate_account` (matriz, filial, contador, jurídico, consórcio, número antigo, WhatsApp não comprovado, telefone geral, WhatsApp explícito, form/profile)
- Existing `tests/test_decision_unit_intelligence_adversarial.py` (switchboard ≠ personal phone)
- CLI Track A 30 asserts funnel keys + Warmbly classes + lean operator fields
