### PR TITLE
feat(public-read): live margin-defense facts and fail-closed research export

### DIFF
--- a/docs/contracts/public-read-margin-defense-v1.json
+++ b/docs/contracts/public-read-margin-defense-v1.json
@@ -1,0 +1,77 @@
+{
+  "schema": "public-read-margin-defense/1.0",
+  "contract_version": "v1.0.0",
+  "public_read_base": "v1.0.0",
+  "compatibility": "additive_nullable_within_v1",
+  "consumer": {
+    "id": "web-cfg/diagnostico-defesa-de-margem",
+    "repository": "tjsasakifln/web-cfg",
+    "issues": ["#65"],
+    "decision": "May consume official contract facts. Must not treat UNKNOWN as zero. Must not infer right, imbalance, loss or that an adjustment is due."
+  },
+  "wedge": {
+    "id": "contracts-prices-margin-defense",
+    "label": "Official public-contract facts for margin-defense diagnosis",
+    "reuse": "Same grain as research-flagship contract identity; facts only, no legal conclusion"
+  },
+  "grain": "canonical_contract_id",
+  "keys": ["canonical_contract_id"],
+  "source_families": [
+    "pncp_supplier_contracts",
+    "canonical_public_observations",
+    "public_read_v1.contracts"
+  ],
+  "value_semantics": {
+    "nominal_value": "integral nominal BRL of the contract instrument as published by the source",
+    "not": [
+      "unit price",
+      "deflated BRL",
+      "adjustment due",
+      "economic imbalance",
+      "loss"
+    ],
+    "unknown_policy": "UNKNOWN remains UNKNOWN; absence of evidence is never zero"
+  },
+  "as_of": "snapshot cutoff from the input payload; never wall-clock",
+  "freshness": {
+    "policy": "contracts-freshness-slo-v1",
+    "layer": "publication",
+    "max_age_hours": 48
+  },
+  "provenance": [
+    "source_id",
+    "source_record_id",
+    "evidence_ref",
+    "content_hash"
+  ],
+  "unknown_reason_codes": [
+    "missing_identity",
+    "missing_object",
+    "missing_organ",
+    "missing_contractor",
+    "missing_nominal_value",
+    "missing_signed_at",
+    "missing_start_at",
+    "missing_end_at",
+    "missing_term",
+    "no_explicit_adjustment_rule",
+    "no_explicit_adjustment_document",
+    "no_amendment_signal",
+    "source_does_not_offer_measurements",
+    "source_does_not_offer_payments",
+    "not_observed",
+    "evidence_without_identity",
+    "index_without_document"
+  ],
+  "forbidden_conclusion_fields": [
+    "has_right",
+    "imbalance",
+    "loss",
+    "should_adjust",
+    "direito",
+    "desequilibrio",
+    "perda",
+    "deveria_reajustar"
+  ],
+  "branding": "truth plane and export are source-agnostic; CONFENGE marks are forbidden"
+}

--- a/docs/contracts/public-read-margin-defense-v1.md
+++ b/docs/contracts/public-read-margin-defense-v1.md
@@ -1,0 +1,24 @@
+# `public_read_v1` margin-defense facts contract
+
+Version: `v1.0.0`
+Schema: `public-read-margin-defense/1.0`
+Machine-readable twin: [`public-read-margin-defense-v1.json`](public-read-margin-defense-v1.json)
+
+Consumer: `web-cfg / Diagnóstico de Defesa de Margem` (`tjsasakifln/web-cfg#65`)
+Wedge: official public-contract facts. No legal conclusion.
+
+## Boundary
+
+SELECT-only / file export of official facts. Not a generic API, not a second
+DataLake, not a brand surface. The shipped consumer path is:
+
+```bash
+python3 -m scripts.public_read export-margin --payload PATH --out DIR
+```
+
+## Honesty
+
+- UNKNOWN stays UNKNOWN. Absence of evidence is never zero.
+- Adjustment anniversary / index is KNOWN only from an explicit rule or document.
+- Evidence without identity is refused.
+- The export never emits right-to-adjust, imbalance, loss, or "should adjust".

--- a/scripts/crawl/pncp_entity_scope_live.py
+++ b/scripts/crawl/pncp_entity_scope_live.py
@@ -1,0 +1,135 @@
+"""Representative live #241 pagination proof against official PNCP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from scripts.crawl.pncp_entity_pagination import (
+    expected_pages,
+    proof_report,
+    prove_scope,
+    record_page,
+)
+
+PNCP_CONTRATOS = "https://pncp.gov.br/api/consulta/v1/contratos"
+USER_AGENT = "extra-cli-entity-pagination/1.0"
+PAGE_SIZE = 50
+
+
+def _fetch(url: str, timeout: int = 45) -> tuple[int, bytes]:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": "application/json"})  # noqa: S310
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 — HTTPS official PNCP
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read() if exc.fp else b""
+
+
+def parse_contratos_page(body: bytes) -> tuple[list[dict[str, Any]], int | None]:
+    if not body:
+        return [], None
+    payload = json.loads(body.decode("utf-8"))
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)], len(payload)
+    if not isinstance(payload, dict):
+        return [], None
+    records = payload.get("data") or payload.get("items") or []
+    total = payload.get("totalRegistros")
+    return list(records) if isinstance(records, list) else [], int(total) if total is not None else None
+
+
+def prove_entity_window(
+    *,
+    ente_cnpj: str,
+    data_inicial: str,
+    data_final: str,
+    max_pages: int = 3,
+) -> dict[str, Any]:
+    pages = []
+    found = 0
+    total = None
+    query_complete = True
+    pages_expected = 1
+    for page_no in range(1, max_pages + 1):
+        params = urllib.parse.urlencode(
+            {
+                "dataInicial": data_inicial.replace("-", ""),
+                "dataFinal": data_final.replace("-", ""),
+                "cnpjOrgao": ente_cnpj,
+                "pagina": str(page_no),
+                "tamanhoPagina": str(PAGE_SIZE),
+            }
+        )
+        url = f"{PNCP_CONTRATOS}?{params}"
+        status, body = _fetch(url)
+        try:
+            records, page_total = parse_contratos_page(body)
+        except json.JSONDecodeError:
+            records, page_total = [], None
+            query_complete = False
+        if page_total is not None:
+            total = page_total
+        found += len(records)
+        pages.append(
+            record_page(
+                url=url,
+                status=status,
+                body=body,
+                page=page_no,
+                records=len(records) if isinstance(records, list) else 0,
+            )
+        )
+        if status != 200:
+            query_complete = False
+            break
+        if isinstance(records, list) and len(records) < PAGE_SIZE:
+            break
+    if total is not None:
+        pages_expected = expected_pages(total, PAGE_SIZE)
+    else:
+        pages_expected = len(pages) if pages else 1
+    if pages_expected > max_pages:
+        query_complete = False
+        pages_expected = max_pages
+    proof = prove_scope(
+        ente_id=ente_cnpj,
+        window=f"{data_inicial}_{data_final}",
+        modalidade=None,
+        pages_expected=pages_expected,
+        pages=pages,
+        found_count=found,
+        query_complete=query_complete,
+    )
+    return proof_report([proof])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python3 -m scripts.crawl.pncp_entity_scope_live")
+    parser.add_argument("--ente", required=True, help="Publishing-org CNPJ")
+    parser.add_argument("--data-inicial", required=True)
+    parser.add_argument("--data-final", required=True)
+    parser.add_argument("--max-pages", type=int, default=3)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args(argv)
+    report = prove_entity_window(
+        ente_cnpj=args.ente,
+        data_inicial=args.data_inicial,
+        data_final=args.data_final,
+        max_pages=args.max_pages,
+    )
+    path = args.out
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    sys.stdout.write(json.dumps({"ok": True, "path": path, "verdict": report["scopes"][0]["verdict"]}) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/national_contract_truth/live_universe.py
+++ b/scripts/national_contract_truth/live_universe.py
@@ -1,0 +1,419 @@
+"""#302 live runner: official PNCP publishing-org denominator.
+
+Never substitutes Extra's 1.093-entity commercial universe. nacional_completo
+is true only when every catalog partition closes FOUND or ZERO_CONFIRMED with
+evidence. Unconsulted partitions stay BLOCKED.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.national_contract_truth.national_universe import (
+    EXTRA_COMMERCIAL_DENOMINATOR,
+    NationalUniverseError,
+    PartitionResult,
+    PublishingOrg,
+    build_universe,
+    reconcile_partitions,
+    sha256_payload,
+)
+
+SCHEMA = "national-universe/1.0"
+PNCP_ORGAOS = "https://pncp.gov.br/api/pncp/v1/orgaos"
+USER_AGENT = "extra-cli-national-universe/1.0"
+DEFAULT_PAGE_SIZE = 50
+
+
+class OfficialSourceError(RuntimeError):
+    """Official catalog could not be fetched or parsed."""
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_orgaos_catalog(raw: bytes | str | list[Any] | dict[str, Any]) -> tuple[PublishingOrg, ...]:
+    if isinstance(raw, (bytes, bytearray)):
+        payload = json.loads(raw.decode("utf-8"))
+    elif isinstance(raw, str):
+        payload = json.loads(raw)
+    else:
+        payload = raw
+    if isinstance(payload, dict):
+        items = payload.get("data") or payload.get("orgaos") or payload.get("items") or []
+    else:
+        items = payload
+    if not isinstance(items, list):
+        raise OfficialSourceError("official orgaos catalog is not a list")
+    orgs: list[PublishingOrg] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        org_id = str(item.get("cnpj") or item.get("org_id") or "").strip()
+        if not org_id or org_id in seen:
+            continue
+        seen.add(org_id)
+        orgs.append(
+            PublishingOrg(
+                org_id=org_id,
+                source="pncp",
+                competence=str(item.get("competence") or ""),
+                name=str(item.get("razaoSocial") or item.get("name") or org_id),
+                unit_count=1,
+            )
+        )
+    if not orgs:
+        raise OfficialSourceError("official orgaos catalog produced zero publishing orgs")
+    return tuple(orgs)
+
+
+def fetch_orgaos_page(*, pagina: int, tamanho: int, timeout: int = 60) -> bytes:
+    params = urllib.parse.urlencode({"pagina": str(pagina), "tamanhoPagina": str(tamanho)})
+    url = f"{PNCP_ORGAOS}?{params}"
+    request = urllib.request.Request(  # noqa: S310
+        url,
+        headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 — HTTPS official PNCP
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        raise OfficialSourceError(f"http_{exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise OfficialSourceError(f"url_error:{exc.reason}") from exc
+
+
+def fetch_official_catalog(*, max_orgs: int | None = None, timeout: int = 90) -> tuple[bytes, tuple[PublishingOrg, ...]]:
+    raw = fetch_orgaos_page(pagina=1, tamanho=DEFAULT_PAGE_SIZE, timeout=timeout)
+    orgs = parse_orgaos_catalog(raw)
+    if max_orgs is not None:
+        orgs = orgs[: max(0, max_orgs)]
+    if not orgs:
+        raise OfficialSourceError("official catalog empty after max_orgs trim")
+    return raw, orgs
+
+
+def close_partitions(
+    orgs: tuple[PublishingOrg, ...],
+    *,
+    observed_org_ids: set[str],
+    observed_evidence: dict[str, str] | None = None,
+    consult_limit: int | None = None,
+) -> tuple[PartitionResult, ...]:
+    evidence_by_org = observed_evidence or {}
+    results: list[PartitionResult] = []
+    for index, org in enumerate(orgs):
+        if consult_limit is not None and index >= consult_limit and org.org_id not in observed_org_ids:
+            results.append(
+                PartitionResult(
+                    partition_id=org.org_id,
+                    status="BLOCKED",
+                    evidence="not_consulted_this_run",
+                )
+            )
+            continue
+        if org.org_id in observed_org_ids:
+            results.append(
+                PartitionResult(
+                    partition_id=org.org_id,
+                    status="FOUND",
+                    evidence=evidence_by_org.get(org.org_id) or f"observed_official_contract:{org.org_id}",
+                )
+            )
+            continue
+        results.append(
+            PartitionResult(
+                partition_id=org.org_id,
+                status="BLOCKED",
+                evidence="not_consulted_this_run",
+            )
+        )
+    return tuple(results)
+
+
+def build_denominator_report(
+    *,
+    competence: str,
+    cutoff: str,
+    orgs: tuple[PublishingOrg, ...],
+    partitions: tuple[PartitionResult, ...],
+    raw_hash: str,
+    method: str = "pncp-orgaos-publicantes-v1",
+    catalog_error: str | None = None,
+) -> dict[str, Any]:
+    tagged = tuple(
+        PublishingOrg(
+            org_id=org.org_id,
+            source=org.source or "pncp",
+            competence=org.competence or competence,
+            name=org.name,
+            unit_count=org.unit_count,
+        )
+        for org in orgs
+    )
+    extra_1093 = False
+    blockers: list[str] = []
+    reconciliation: dict[str, Any] = {
+        "schema_version": SCHEMA,
+        "nacional_completo": False,
+        "extra_1093_used_as_denominator": False,
+        "extra_commercial_denominator": EXTRA_COMMERCIAL_DENOMINATOR,
+        "blockers": blockers,
+    }
+    if catalog_error:
+        blockers.append(catalog_error)
+    try:
+        universe = build_universe(
+            source="pncp",
+            competence=competence,
+            cutoff=cutoff,
+            orgs=tagged,
+            method=method,
+        )
+        try:
+            reconciliation = reconcile_partitions(universe, partitions)
+        except NationalUniverseError as exc:
+            blockers.append(str(exc))
+            reconciliation = {
+                "schema_version": SCHEMA,
+                "national_universe_id": universe.national_universe_id,
+                "source": universe.source,
+                "competence": universe.competence,
+                "cutoff": universe.cutoff,
+                "catalog_hash": universe.catalog_hash,
+                "org_count": universe.org_count,
+                "unit_count": universe.unit_count,
+                "method": universe.method,
+                "expected_partitions": universe.org_count,
+                "consulted_partitions": len(partitions),
+                "by_status": _count_status(partitions),
+                "nacional_completo": False,
+                "extra_1093_used_as_denominator": False,
+                "extra_commercial_denominator": EXTRA_COMMERCIAL_DENOMINATOR,
+                "blockers": blockers,
+            }
+            reconciliation["reconciliation_hash"] = sha256_payload(reconciliation)
+        else:
+            if reconciliation.get("extra_1093_used_as_denominator"):
+                extra_1093 = True
+    except NationalUniverseError as exc:
+        blockers.append(str(exc))
+        reconciliation["blockers"] = blockers
+
+    if extra_1093 or tagged and len(tagged) == EXTRA_COMMERCIAL_DENOMINATOR:
+        # A catalog that happens to have 1093 orgs is still official; only the Extra commercial set is forbidden.
+        pass
+
+    by_status = reconciliation.get("by_status") or _count_status(partitions)
+    report = {
+        "schema_version": SCHEMA,
+        "national_universe_id": reconciliation.get("national_universe_id"),
+        "source": "pncp",
+        "competence": competence,
+        "cutoff": cutoff,
+        "method": method,
+        "raw_catalog_hash": raw_hash,
+        "catalog_hash": reconciliation.get("catalog_hash"),
+        "reconciliation_hash": reconciliation.get("reconciliation_hash"),
+        "org_count": reconciliation.get("org_count", len(tagged)),
+        "unit_count": reconciliation.get("unit_count", len(tagged)),
+        "expected_partitions": reconciliation.get("expected_partitions", len(tagged)),
+        "consulted_partitions": reconciliation.get("consulted_partitions", len(partitions)),
+        "by_status": by_status,
+        "nacional_completo": bool(reconciliation.get("nacional_completo")),
+        "extra_1093_used_as_denominator": False,
+        "extra_commercial_denominator": EXTRA_COMMERCIAL_DENOMINATOR,
+        "blockers": list(reconciliation.get("blockers") or blockers),
+        "orgs": [
+            {
+                "org_id": org.org_id,
+                "source": org.source or "pncp",
+                "competence": org.competence or competence,
+                "name": org.name,
+                "unit_count": org.unit_count,
+            }
+            for org in tagged
+        ],
+        "partitions": [
+            {
+                "partition_id": part.partition_id,
+                "status": part.status,
+                "evidence": part.evidence,
+            }
+            for part in partitions
+        ],
+        "publish_blockers": _publish_blockers(by_status, reconciliation.get("nacional_completo"), blockers),
+    }
+    if report["nacional_completo"] is True and (
+        by_status.get("BLOCKED") or by_status.get("FAILED") or report["blockers"]
+    ):
+        report["nacional_completo"] = False
+        report["publish_blockers"].append("nacional_completo_refused")
+    return report
+
+
+def _count_status(partitions: tuple[PartitionResult, ...]) -> dict[str, int]:
+    counts = {"FOUND": 0, "ZERO_CONFIRMED": 0, "BLOCKED": 0, "FAILED": 0}
+    for part in partitions:
+        counts[str(part.status)] = counts.get(str(part.status), 0) + 1
+    return counts
+
+
+def _publish_blockers(by_status: dict[str, Any], nacional_completo: Any, blockers: list[str]) -> list[str]:
+    codes = list(blockers)
+    if by_status.get("BLOCKED"):
+        codes.append("blocked_or_failed_partitions")
+    if by_status.get("FAILED"):
+        codes.append("blocked_or_failed_partitions")
+    if not nacional_completo:
+        codes.append("national_denominator_incomplete")
+    # preserve order, unique
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for code in codes:
+        if code not in seen:
+            seen.add(code)
+            ordered.append(code)
+    return ordered
+
+
+def run_live_universe(
+    *,
+    competence: str,
+    cutoff: str | None = None,
+    observed_org_ids: set[str] | None = None,
+    observed_evidence: dict[str, str] | None = None,
+    max_orgs: int | None = None,
+    consult_limit: int | None = None,
+    catalog_raw: bytes | None = None,
+) -> dict[str, Any]:
+    as_of = cutoff or utc_now()
+    observed = observed_org_ids or set()
+    try:
+        if catalog_raw is None:
+            raw, orgs = fetch_official_catalog(max_orgs=None)
+        else:
+            raw = catalog_raw
+            orgs = parse_orgaos_catalog(raw)
+        official_count = len(orgs)
+        truncated = False
+        if max_orgs is not None and official_count > max_orgs:
+            orgs = orgs[: max(0, max_orgs)]
+            truncated = True
+        raw_hash = sha256_payload({"bytes": len(raw), "sha256": __import__("hashlib").sha256(raw).hexdigest()})
+        partitions = close_partitions(
+            orgs,
+            observed_org_ids=observed,
+            observed_evidence=observed_evidence,
+            consult_limit=consult_limit,
+        )
+        report = build_denominator_report(
+            competence=competence,
+            cutoff=as_of,
+            orgs=orgs,
+            partitions=partitions,
+            raw_hash=raw_hash,
+        )
+        report["official_catalog_org_count"] = official_count
+        report["catalog_truncated"] = truncated
+        if truncated:
+            report["nacional_completo"] = False
+            blockers = list(report.get("blockers") or [])
+            blockers.append("catalog_truncated")
+            report["blockers"] = blockers
+            publish = list(report.get("publish_blockers") or [])
+            if "catalog_truncated" not in publish:
+                publish.append("catalog_truncated")
+            if "national_denominator_incomplete" not in publish:
+                publish.append("national_denominator_incomplete")
+            report["publish_blockers"] = publish
+        return report
+    except OfficialSourceError as exc:
+        failed = PartitionResult(partition_id="catalog", status="FAILED", evidence=str(exc))
+        return build_denominator_report(
+            competence=competence,
+            cutoff=as_of,
+            orgs=(),
+            partitions=(failed,),
+            raw_hash="",
+            catalog_error=f"official_catalog:{exc}",
+        )
+
+
+def load_observed_orgs(path: str | Path) -> set[str]:
+    text = Path(path).read_text(encoding="utf-8")
+    if path and str(path).endswith(".json"):
+        payload = json.loads(text)
+        if isinstance(payload, list):
+            return {str(item) for item in payload}
+        return {str(item) for item in payload.get("org_ids") or payload.get("orgaos") or []}
+    return {line.strip() for line in text.splitlines() if line.strip()}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python3 -m scripts.national_contract_truth.live_universe")
+    parser.add_argument("--competence", required=True)
+    parser.add_argument("--cutoff", default=None)
+    parser.add_argument("--observed-orgs", default=None, help="JSON list or newline CNPJ file")
+    parser.add_argument("--catalog-json", default=None, help="Official catalog JSON (skip HTTP)")
+    parser.add_argument("--max-orgs", type=int, default=None)
+    parser.add_argument("--consult-limit", type=int, default=None)
+    parser.add_argument("--out", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    observed: set[str] = set()
+    if args.observed_orgs:
+        observed = load_observed_orgs(args.observed_orgs)
+    catalog_raw = None
+    if args.catalog_json:
+        catalog_raw = Path(args.catalog_json).read_bytes()
+    report = run_live_universe(
+        competence=args.competence,
+        cutoff=args.cutoff,
+        observed_org_ids=observed,
+        max_orgs=args.max_orgs,
+        consult_limit=args.consult_limit,
+        catalog_raw=catalog_raw,
+    )
+    out = Path(args.out)
+    if out.suffix.lower() == ".json":
+        path = out
+        path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        out.mkdir(parents=True, exist_ok=True)
+        path = out / "national-denominator.json"
+    path.write_text(json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    sys.stdout.write(
+        json.dumps(
+            {
+                "ok": True,
+                "path": str(path),
+                "nacional_completo": report["nacional_completo"],
+                "org_count": report["org_count"],
+                "by_status": report["by_status"],
+                "catalog_hash": report["catalog_hash"],
+                "extra_1093_used_as_denominator": report["extra_1093_used_as_denominator"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/public_read/cli.py
+++ b/scripts/public_read/cli.py
@@ -12,11 +12,49 @@ from scripts.public_read.export import (
     load_export_artifact,
     write_research_export,
 )
+from scripts.public_read.live_payload import (
+    load_contracts_jsonl,
+    load_json_payload,
+    payload_from_live_corpus,
+    payload_from_snapshot_document,
+)
+from scripts.public_read.margin_export import write_margin_export
 from scripts.public_read.payload import load_research_payload
 
 
+def _load_export_payload(args: argparse.Namespace):
+    sources = {
+        "fixture": args.fixture,
+        "payload": args.payload,
+        "snapshot": args.snapshot,
+        "contracts_jsonl": args.contracts_jsonl,
+    }
+    present = [name for name, value in sources.items() if value]
+    if len(present) != 1:
+        raise SystemExit("export-research requires exactly one of --fixture, --payload, --snapshot, --contracts-jsonl")
+    if args.fixture:
+        return load_research_payload(args.fixture)
+    if args.payload:
+        return load_research_payload(args.payload)
+    if args.snapshot:
+        return payload_from_snapshot_document(load_json_payload(args.snapshot))
+    if not args.denominator:
+        raise SystemExit("--contracts-jsonl requires --denominator")
+    denominator = load_json_payload(args.denominator)
+    contracts = load_contracts_jsonl(args.contracts_jsonl)
+    return payload_from_live_corpus(
+        contracts=contracts,
+        denominator=denominator,
+        as_of=str(args.as_of or denominator.get("cutoff")),
+        competence=str(args.competence or denominator.get("competence")),
+        publication_age_hours=float(args.publication_age_hours),
+        publication_lag_p99_hours=float(args.publication_lag_p99_hours),
+        payload_id=str(args.payload_id or "live-corpus"),
+    )
+
+
 def _cmd_export(args: argparse.Namespace) -> int:
-    payload = load_research_payload(args.fixture)
+    payload = _load_export_payload(args)
     path = write_research_export(payload, args.out)
     artifact = load_export_artifact(path)
     sys.stdout.write(
@@ -27,6 +65,27 @@ def _cmd_export(args: argparse.Namespace) -> int:
                 "content_hash": artifact["content_hash"],
                 "national_claim_allowed": artifact["claim"]["national_claim_allowed"],
                 "reason_codes": artifact["claim"]["reason_codes"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return 0
+
+
+def _cmd_export_margin(args: argparse.Namespace) -> int:
+    raw = json.loads(Path(args.payload).read_text(encoding="utf-8"))
+    path = write_margin_export(raw, args.out)
+    artifact = json.loads(path.read_text(encoding="utf-8"))
+    sys.stdout.write(
+        json.dumps(
+            {
+                "ok": True,
+                "path": str(path),
+                "content_hash": artifact["content_hash"],
+                "record_count": artifact["coverage"]["record_count"],
+                "reason_codes": artifact["reason_codes"],
             },
             ensure_ascii=False,
             sort_keys=True,
@@ -49,9 +108,22 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python3 -m scripts.public_read")
     sub = parser.add_subparsers(dest="command", required=True)
     export_cmd = sub.add_parser("export-research", help="Write the versioned research export")
-    export_cmd.add_argument("--fixture", required=True, help="Research fixture JSON")
+    export_cmd.add_argument("--fixture", help="Research fixture JSON (tests only)")
+    export_cmd.add_argument("--payload", help="Live/snapshot research payload JSON")
+    export_cmd.add_argument("--snapshot", help="READY snapshot document JSON")
+    export_cmd.add_argument("--contracts-jsonl", help="Official live contracts JSONL")
+    export_cmd.add_argument("--denominator", help="#302 national-denominator JSON (with --contracts-jsonl)")
+    export_cmd.add_argument("--as-of", dest="as_of", help="Snapshot cutoff (never wall-clock for live)")
+    export_cmd.add_argument("--competence", help="Competence label for live corpus")
+    export_cmd.add_argument("--payload-id", dest="payload_id", default="live-corpus")
+    export_cmd.add_argument("--publication-age-hours", type=float, default=1.0)
+    export_cmd.add_argument("--publication-lag-p99-hours", type=float, default=1.0)
     export_cmd.add_argument("--out", required=True, help="Output directory")
     export_cmd.set_defaults(func=_cmd_export)
+    margin_cmd = sub.add_parser("export-margin", help="Write the versioned margin-defense facts export")
+    margin_cmd.add_argument("--payload", required=True, help="Official contract facts JSON")
+    margin_cmd.add_argument("--out", required=True, help="Output directory")
+    margin_cmd.set_defaults(func=_cmd_export_margin)
     health_cmd = sub.add_parser("health", help="Read freshness/coverage/consumer errors")
     health_cmd.add_argument("--artifact", required=True, help="Export JSON or directory")
     health_cmd.set_defaults(func=_cmd_health)

--- a/scripts/public_read/live_payload.py
+++ b/scripts/public_read/live_payload.py
@@ -1,0 +1,185 @@
+"""Build a research-flagship payload from live contracts or a READY snapshot.
+
+Fixtures stay a test-only input. This module never labels live rows as fixture
+proof and never substitutes Extra 1093 for the national denominator.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.public_read.models import (
+    PartitionSpec,
+    ResearchPayload,
+    SeriesRow,
+    UniverseSpec,
+    parse_decimal,
+)
+from scripts.public_read.payload import payload_from_mapping
+
+ENGINEERING_ARCHETYPE = "obras-engenharia"
+
+
+def load_json_payload(path: str | Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def load_contracts_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+    return rows
+
+
+def _as_of(raw: dict[str, Any]) -> str:
+    value = raw.get("as_of") or raw.get("cutoff")
+    if value:
+        return str(value)
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _row_from_contract(item: dict[str, Any]) -> SeriesRow:
+    process_key = str(
+        item.get("process_key")
+        or item.get("contrato_id")
+        or item.get("source_record_id")
+        or ""
+    )
+    if not process_key:
+        raise ValueError("live contract missing identity")
+    value = item.get("contract_value_brl")
+    if value is None:
+        value = item.get("valor_total")
+    status = str(item.get("value_status") or ("KNOWN" if value is not None else "UNKNOWN"))
+    return SeriesRow(
+        process_key=process_key,
+        uf=str(item.get("uf") or "UNKNOWN"),
+        archetype_id=str(item.get("archetype_id") or ENGINEERING_ARCHETYPE),
+        contract_value_brl=parse_decimal(value),
+        source_id=str(item.get("source") or item.get("source_id") or "pncp"),
+        source_record_id=str(item.get("source_id") or process_key),
+        observed_at=str(item.get("observed_at") or item.get("last_seen_at") or item.get("ingested_at") or ""),
+        lineage=tuple(str(part) for part in item.get("lineage", (item.get("source") or "pncp", process_key))),
+        value_status=status,
+        lineage_resolution=item.get("lineage_resolution"),
+    )
+
+
+def payload_from_live_corpus(
+    *,
+    contracts: list[dict[str, Any]],
+    denominator: dict[str, Any],
+    as_of: str,
+    competence: str,
+    publication_age_hours: float,
+    publication_lag_p99_hours: float,
+    payload_id: str,
+) -> ResearchPayload:
+    """Map official live rows + a #302 report into the shipped research payload."""
+    orgs = []
+    for org in denominator.get("orgs") or ():
+        orgs.append(
+            {
+                "org_id": org["org_id"],
+                "source": org.get("source") or denominator.get("source") or "pncp",
+                "competence": org.get("competence") or competence,
+                "name": org.get("name") or org["org_id"],
+                "unit_count": int(org.get("unit_count") or 1),
+            }
+        )
+    partitions = []
+    for part in denominator.get("partitions") or ():
+        partitions.append(
+            {
+                "partition_id": part["partition_id"],
+                "status": part["status"],
+                "evidence": part.get("evidence"),
+            }
+        )
+    mapping = {
+        "fixture_id": payload_id,
+        "as_of": as_of,
+        "competence": competence,
+        "universe": {
+            "source": str(denominator.get("source") or "pncp"),
+            "competence": competence,
+            "cutoff": str(denominator.get("cutoff") or as_of),
+            "method": str(denominator.get("method") or "pncp-orgaos-publicantes-v1"),
+            "orgs": orgs,
+        },
+        "partitions": partitions,
+        "freshness": {
+            "publication_age_hours": publication_age_hours,
+            "publication_lag_p99_hours": publication_lag_p99_hours,
+        },
+        "series_rows": [
+            {
+                "process_key": row.process_key,
+                "uf": row.uf,
+                "archetype_id": row.archetype_id,
+                "contract_value_brl": None if row.contract_value_brl is None else format(row.contract_value_brl, "f"),
+                "source_id": row.source_id,
+                "source_record_id": row.source_record_id,
+                "observed_at": row.observed_at,
+                "lineage": list(row.lineage),
+                "value_status": row.value_status,
+                "lineage_resolution": row.lineage_resolution,
+            }
+            for row in (_row_from_contract(item) for item in contracts)
+        ],
+        "use_extra_1093_as_denominator": False,
+        "denominator_kind": "publishing_org",
+        "claimed_geography": "BR" if denominator.get("nacional_completo") else None,
+    }
+    payload = payload_from_mapping(mapping)
+    if payload.use_extra_1093_as_denominator:
+        raise ValueError("live payload refused Extra 1093 as denominator")
+    return payload
+
+
+def snapshot_is_ready(snapshot: dict[str, Any]) -> bool:
+    state = str(snapshot.get("state") or snapshot.get("status") or "")
+    return state in {"READY", "READY_CANONICAL"}
+
+
+def payload_from_snapshot_document(snapshot: dict[str, Any]) -> ResearchPayload:
+    if not snapshot_is_ready(snapshot):
+        raise ValueError(f"snapshot_not_ready:{snapshot.get('state') or snapshot.get('status') or 'missing'}")
+    if "series_rows" in snapshot:
+        return payload_from_mapping(snapshot)
+    contracts = list(snapshot.get("contracts") or snapshot.get("records") or ())
+    denominator = snapshot.get("denominator") or {}
+    return payload_from_live_corpus(
+        contracts=contracts,
+        denominator=denominator,
+        as_of=_as_of(snapshot),
+        competence=str(snapshot.get("competence") or denominator.get("competence") or "unknown"),
+        publication_age_hours=float((snapshot.get("freshness") or {}).get("publication_age_hours") or 0),
+        publication_lag_p99_hours=float((snapshot.get("freshness") or {}).get("publication_lag_p99_hours") or 0),
+        payload_id=str(snapshot.get("snapshot_id") or snapshot.get("payload_id") or "live-snapshot"),
+    )
+
+
+def universe_spec_from_denominator(denominator: dict[str, Any]) -> UniverseSpec:
+    return UniverseSpec(
+        source=str(denominator.get("source") or "pncp"),
+        competence=str(denominator.get("competence") or ""),
+        cutoff=str(denominator.get("cutoff") or ""),
+        method=str(denominator.get("method") or "pncp-orgaos-publicantes-v1"),
+        orgs=tuple(dict(org) for org in denominator.get("orgs") or ()),
+    )
+
+
+def partition_specs(denominator: dict[str, Any]) -> tuple[PartitionSpec, ...]:
+    return tuple(
+        PartitionSpec(
+            partition_id=str(part["partition_id"]),
+            status=str(part["status"]),
+            evidence=part.get("evidence"),
+        )
+        for part in denominator.get("partitions") or ()
+    )

--- a/scripts/public_read/margin_defense.py
+++ b/scripts/public_read/margin_defense.py
@@ -1,0 +1,324 @@
+"""Pure official-fact projector for the margin-defense consumer.
+
+No I/O. Missing source fields stay UNKNOWN with a reason_code.
+Absence of evidence is never coerced to zero. Legal conclusions are refused.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+SCHEMA = "public-read-margin-defense/1.0"
+
+FieldStatus = Literal["KNOWN", "UNKNOWN"]
+
+FACT_FIELDS: tuple[str, ...] = (
+    "canonical_contract_id",
+    "object",
+    "organ",
+    "contractor",
+    "nominal_value",
+    "signed_at",
+    "start_at",
+    "end_at",
+    "term",
+    "adjustment_anniversary",
+    "adjustment_base",
+    "amendments",
+    "value_changes",
+    "term_changes",
+    "scope_changes",
+    "measurement_events",
+    "payment_events",
+    "suspension",
+    "resumption",
+    "extension",
+    "indices",
+)
+
+FORBIDDEN_CONCLUSION_FIELDS = frozenset(
+    {
+        "has_right",
+        "imbalance",
+        "loss",
+        "should_adjust",
+        "direito",
+        "desequilibrio",
+        "perda",
+        "deveria_reajustar",
+    }
+)
+
+_IDENTITY_KEYS = ("canonical_contract_id", "contrato_id", "source_record_id")
+
+
+class EvidenceIdentityError(ValueError):
+    """Evidence was supplied without a contract identity."""
+
+
+class ForbiddenConclusionError(ValueError):
+    """A legal-conclusion field was present on the official record."""
+
+
+@dataclass(frozen=True)
+class FieldFact:
+    name: str
+    status: FieldStatus
+    value: Any
+    reason_code: str | None
+    evidence_ref: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "value": _jsonable(self.value),
+            "reason_code": self.reason_code,
+            "evidence_ref": self.evidence_ref,
+        }
+
+
+@dataclass(frozen=True)
+class MarginFacts:
+    schema: str
+    canonical_contract_id: str | None
+    fields: tuple[FieldFact, ...]
+    source_id: str | None
+    source_record_id: str | None
+    observed_at: str | None
+    as_of: str
+    reason_codes: tuple[str, ...]
+
+    @property
+    def known_count(self) -> int:
+        return sum(1 for fact in self.fields if fact.status == "KNOWN")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "canonical_contract_id": self.canonical_contract_id,
+            "fields": {fact.name: fact.as_dict() for fact in self.fields},
+            "source_id": self.source_id,
+            "source_record_id": self.source_record_id,
+            "observed_at": self.observed_at,
+            "as_of": self.as_of,
+            "reason_codes": list(self.reason_codes),
+            "known_count": self.known_count,
+            "field_count": len(self.fields),
+        }
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _blank(value: Any) -> bool:
+    return value is None or value == "" or value == [] or value == ()
+
+
+def _text(value: Any) -> str | None:
+    if _blank(value):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if _blank(value):
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed
+
+
+def _known(name: str, value: Any, evidence_ref: str | None) -> FieldFact:
+    return FieldFact(name, "KNOWN", value, None, evidence_ref)
+
+
+def _unknown(name: str, reason_code: str, evidence_ref: str | None = None) -> FieldFact:
+    return FieldFact(name, "UNKNOWN", None, reason_code, evidence_ref)
+
+
+def _identity(record: dict[str, Any]) -> str | None:
+    for key in _IDENTITY_KEYS:
+        found = _text(record.get(key))
+        if found:
+            return found
+    return None
+
+
+def _evidence_ref(record: dict[str, Any]) -> str | None:
+    return _text(record.get("evidence_ref") or record.get("source_id"))
+
+
+def _explicit_adjustment_document(record: dict[str, Any]) -> bool:
+    return bool(
+        _text(record.get("adjustment_base_document_id"))
+        or _text(record.get("adjustment_rule_text"))
+        or _text(record.get("adjustment_clause_ref"))
+    )
+
+
+def _explicit_index_document(record: dict[str, Any]) -> bool:
+    return bool(_text(record.get("index_document_id")) or _text(record.get("index_clause_ref")))
+
+
+def project_margin_facts(record: dict[str, Any], *, as_of: str) -> MarginFacts:
+    """Project one official contract record into UNKNOWN-safe facts."""
+    forbidden = FORBIDDEN_CONCLUSION_FIELDS.intersection(record)
+    if forbidden:
+        raise ForbiddenConclusionError(f"forbidden_conclusion_fields:{sorted(forbidden)}")
+
+    identity = _identity(record)
+    evidence_hint = _text(record.get("evidence_ref"))
+    if evidence_hint and not identity:
+        raise EvidenceIdentityError("evidence_without_identity")
+
+    evidence = _evidence_ref(record) if identity else None
+    fields: list[FieldFact] = []
+
+    if identity:
+        fields.append(_known("canonical_contract_id", identity, evidence))
+    else:
+        fields.append(_unknown("canonical_contract_id", "missing_identity"))
+
+    objeto = _text(record.get("objeto_contrato") or record.get("object") or record.get("objeto"))
+    fields.append(_known("object", objeto, evidence) if objeto else _unknown("object", "missing_object"))
+
+    organ_id = _text(record.get("orgao_cnpj"))
+    organ_name = _text(record.get("orgao_nome"))
+    if organ_id or organ_name:
+        fields.append(
+            _known(
+                "organ",
+                {"cnpj": organ_id, "name": organ_name},
+                evidence,
+            )
+        )
+    else:
+        fields.append(_unknown("organ", "missing_organ"))
+
+    contractor_id = _text(record.get("fornecedor_cnpj") or record.get("contractor_id"))
+    contractor_name = _text(record.get("fornecedor_nome") or record.get("contractor_name"))
+    if contractor_id or contractor_name:
+        fields.append(
+            _known(
+                "contractor",
+                {"cnpj": contractor_id, "name": contractor_name},
+                evidence,
+            )
+        )
+    else:
+        fields.append(_unknown("contractor", "missing_contractor"))
+
+    nominal = _decimal(record.get("valor_total") if "valor_total" in record else record.get("nominal_value"))
+    if nominal is None:
+        fields.append(_unknown("nominal_value", "missing_nominal_value"))
+    else:
+        fields.append(
+            _known(
+                "nominal_value",
+                {
+                    "amount": nominal,
+                    "currency": "BRL",
+                    "semantics": "integral_nominal_instrument",
+                },
+                evidence,
+            )
+        )
+
+    signed = _text(record.get("data_assinatura") or record.get("signed_at"))
+    fields.append(_known("signed_at", signed, evidence) if signed else _unknown("signed_at", "missing_signed_at"))
+
+    start = _text(record.get("data_inicio") or record.get("start_at"))
+    fields.append(_known("start_at", start, evidence) if start else _unknown("start_at", "missing_start_at"))
+
+    end = _text(record.get("data_fim") or record.get("end_at"))
+    fields.append(_known("end_at", end, evidence) if end else _unknown("end_at", "missing_end_at"))
+
+    term = _text(record.get("term") or record.get("vigencia"))
+    if term:
+        fields.append(_known("term", term, evidence))
+    elif start and end:
+        fields.append(_known("term", {"start": start, "end": end, "derivation": "start_end_interval"}, evidence))
+    else:
+        fields.append(_unknown("term", "missing_term"))
+
+    if _explicit_adjustment_document(record) and _text(record.get("adjustment_anniversary")):
+        fields.append(_known("adjustment_anniversary", _text(record.get("adjustment_anniversary")), evidence))
+    else:
+        fields.append(_unknown("adjustment_anniversary", "no_explicit_adjustment_document"))
+
+    if _explicit_adjustment_document(record) and _text(record.get("adjustment_base")):
+        fields.append(_known("adjustment_base", _text(record.get("adjustment_base")), evidence))
+    else:
+        fields.append(_unknown("adjustment_base", "no_explicit_adjustment_rule"))
+
+    amendments = record.get("amendments") or record.get("aditivos") or ()
+    if amendments:
+        fields.append(_known("amendments", tuple(amendments), evidence))
+    else:
+        fields.append(_unknown("amendments", "no_amendment_signal"))
+
+    for name, key, reason in (
+        ("value_changes", "value_changes", "no_amendment_signal"),
+        ("term_changes", "term_changes", "no_amendment_signal"),
+        ("scope_changes", "scope_changes", "no_amendment_signal"),
+        ("suspension", "suspension", "not_observed"),
+        ("resumption", "resumption", "not_observed"),
+        ("extension", "extension", "not_observed"),
+    ):
+        observed = record.get(key)
+        if observed:
+            fields.append(_known(name, observed, evidence))
+        else:
+            fields.append(_unknown(name, reason))
+
+    if record.get("measurement_events"):
+        fields.append(_known("measurement_events", record["measurement_events"], evidence))
+    else:
+        fields.append(_unknown("measurement_events", "source_does_not_offer_measurements"))
+
+    if record.get("payment_events"):
+        fields.append(_known("payment_events", record["payment_events"], evidence))
+    else:
+        fields.append(_unknown("payment_events", "source_does_not_offer_payments"))
+
+    indices = record.get("indices")
+    if indices and _explicit_index_document(record):
+        fields.append(_known("indices", indices, evidence))
+    elif indices and not _explicit_index_document(record):
+        fields.append(_unknown("indices", "index_without_document"))
+    else:
+        fields.append(_unknown("indices", "index_without_document"))
+
+    names = {fact.name for fact in fields}
+    if names != set(FACT_FIELDS):
+        raise ValueError(f"projector_field_set_mismatch:{sorted(set(FACT_FIELDS) ^ names)}")
+
+    reasons = tuple(fact.reason_code for fact in fields if fact.reason_code)
+    return MarginFacts(
+        schema=SCHEMA,
+        canonical_contract_id=identity,
+        fields=tuple(fields),
+        source_id=_text(record.get("source") or record.get("source_id")),
+        source_record_id=_text(record.get("source_id") or identity),
+        observed_at=_text(record.get("observed_at") or record.get("last_seen_at") or record.get("ingested_at")),
+        as_of=as_of,
+        reason_codes=reasons,
+    )

--- a/scripts/public_read/margin_export.py
+++ b/scripts/public_read/margin_export.py
@@ -1,0 +1,125 @@
+"""Deterministic margin-defense export. No brand marks in the truth plane."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.public_read.export import assert_truth_plane_clean, canonical_dumps
+from scripts.public_read.margin_defense import (
+    FORBIDDEN_CONCLUSION_FIELDS,
+    SCHEMA,
+    project_margin_facts,
+)
+
+EXPORT_FILENAME = "margem-export.json"
+CONTRACT_PATH = "docs/contracts/public-read-margin-defense-v1.json"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_FILE = REPO_ROOT / CONTRACT_PATH
+
+
+def load_margin_contract() -> dict[str, Any]:
+    return json.loads(CONTRACT_FILE.read_text(encoding="utf-8"))
+
+
+def _payload_records(raw: dict[str, Any] | list[dict[str, Any]]) -> tuple[str, list[dict[str, Any]]]:
+    if isinstance(raw, list):
+        raise ValueError("payload as_of is required")
+    records = raw.get("records") or raw.get("contracts") or []
+    as_of = str(raw.get("as_of") or "")
+    if not as_of:
+        raise ValueError("payload as_of is required")
+    return as_of, list(records)
+
+
+def _freshness_hours(as_of: str, observed_at: str | None) -> float | None:
+    if not observed_at:
+        return None
+    try:
+        cutoff = datetime.fromisoformat(as_of.replace("Z", "+00:00"))
+        observed = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0.0, (cutoff - observed).total_seconds() / 3600.0)
+
+
+def build_margin_export(raw: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any]:
+    contract = load_margin_contract()
+    as_of, records = _payload_records(raw)
+    facts = [project_margin_facts(record, as_of=as_of) for record in records]
+    reason_codes = sorted({code for item in facts for code in item.reason_codes})
+    known = sum(item.known_count for item in facts)
+    field_total = sum(len(item.fields) for item in facts)
+    coverage_ratio = "0" if field_total == 0 else format(known / field_total, ".6f")
+    ages = [_freshness_hours(as_of, item.observed_at) for item in facts]
+    measured_ages = [age for age in ages if age is not None]
+    freshness_hours = max(measured_ages) if measured_ages else None
+    stale = freshness_hours is not None and freshness_hours > float(contract["freshness"]["max_age_hours"])
+    document = {
+        "schema": SCHEMA,
+        "contract_version": contract["contract_version"],
+        "contract_path": CONTRACT_PATH,
+        "consumer": {
+            "id": contract["consumer"]["id"],
+            "repository": contract["consumer"]["repository"],
+            "issues": contract["consumer"]["issues"],
+        },
+        "wedge": contract["wedge"],
+        "grain": contract["grain"],
+        "keys": contract["keys"],
+        "source_families": contract["source_families"],
+        "value_semantics": contract["value_semantics"],
+        "as_of": as_of,
+        "freshness": {
+            **contract["freshness"],
+            "publication_age_hours": freshness_hours,
+            "status": "STALE" if stale else "FRESH" if freshness_hours is not None else "UNKNOWN",
+        },
+        "coverage": {
+            "record_count": len(facts),
+            "known_fields": known,
+            "field_total": field_total,
+            "ratio": coverage_ratio,
+            "status": "INCOMPLETE" if reason_codes else "COMPLETE",
+        },
+        "provenance": {
+            "input_kind": "payload",
+            "record_count": len(facts),
+            "source_ids": sorted({item.source_id for item in facts if item.source_id}),
+        },
+        "reason_codes": reason_codes,
+        "unknown": {
+            "policy": contract["value_semantics"]["unknown_policy"],
+            "reason_codes": reason_codes,
+        },
+        "forbidden_conclusion_fields": sorted(FORBIDDEN_CONCLUSION_FIELDS),
+        "records": [item.as_dict() for item in facts],
+    }
+    assert_truth_plane_clean(document)
+    present = set(document) & FORBIDDEN_CONCLUSION_FIELDS
+    if present:
+        raise ValueError(f"forbidden_conclusion_fields:{sorted(present)}")
+    for item in document["records"]:
+        leaked = FORBIDDEN_CONCLUSION_FIELDS.intersection(item) | FORBIDDEN_CONCLUSION_FIELDS.intersection(
+            item.get("fields", {})
+        )
+        if leaked:
+            raise ValueError(f"forbidden_conclusion_fields:{sorted(leaked)}")
+    hashed = canonical_dumps(document)
+    document["content_hash"] = hashlib.sha256(hashed.encode("utf-8")).hexdigest()
+    return document
+
+
+def render_margin_bytes(raw: dict[str, Any] | list[dict[str, Any]]) -> bytes:
+    return canonical_dumps(build_margin_export(raw)).encode("utf-8")
+
+
+def write_margin_export(raw: dict[str, Any] | list[dict[str, Any]], output_dir: str | Path) -> Path:
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / EXPORT_FILENAME
+    path.write_bytes(render_margin_bytes(raw))
+    return path

--- a/tests/test_margin_defense.py
+++ b/tests/test_margin_defense.py
@@ -1,0 +1,163 @@
+"""Drive the shipped margin-defense projector and export."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.public_read.margin_defense import (
+    FACT_FIELDS,
+    FORBIDDEN_CONCLUSION_FIELDS,
+    EvidenceIdentityError,
+    ForbiddenConclusionError,
+    project_margin_facts,
+)
+from scripts.public_read.margin_export import (
+    EXPORT_FILENAME,
+    build_margin_export,
+    render_margin_bytes,
+    write_margin_export,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+AS_OF = "2026-08-15T00:00:00+00:00"
+
+
+def _complete_record() -> dict:
+    return {
+        "contrato_id": "83102277000152-2-000626/2026",
+        "orgao_cnpj": "83102277000152",
+        "orgao_nome": "PREFEITURA MUNICIPAL DE ITAJAI - SC",
+        "fornecedor_cnpj": "42275797000180",
+        "fornecedor_nome": "GHIMM TEC LTDA",
+        "objeto_contrato": "Servicos de engenharia para reforma do auditorio",
+        "valor_total": "740874.59",
+        "data_assinatura": "2026-08-13",
+        "data_inicio": "2026-08-13",
+        "data_fim": "2027-01-10",
+        "source": "pncp_contracts",
+        "source_id": "83102277000152-2-000626/2026",
+        "ingested_at": "2026-08-14T11:27:51+00:00",
+        "adjustment_base_document_id": "clause-4.1",
+        "adjustment_rule_text": "reajuste anual na data-base de 13 de agosto",
+        "adjustment_anniversary": "2027-08-13",
+        "adjustment_base": "2026-08-13",
+        "amendments": [{"id": "aditivo-1", "at": "2026-09-01", "kind": "prazo"}],
+        "value_changes": [{"at": "2026-09-01", "delta": "0"}],
+        "term_changes": [{"at": "2026-09-01", "days": 30}],
+        "scope_changes": [{"at": "2026-09-01", "note": "cobertura telhado"}],
+        "measurement_events": [{"at": "2026-09-15", "ref": "med-1"}],
+        "payment_events": [{"at": "2026-09-20", "ref": "pag-1"}],
+        "suspension": {"at": "2026-10-01"},
+        "resumption": {"at": "2026-10-15"},
+        "extension": {"at": "2026-11-01"},
+        "indices": [{"name": "SINAPI", "competence": "2026-07"}],
+        "index_document_id": "clause-4.1",
+    }
+
+
+def test_complete_official_record_is_known() -> None:
+    facts = project_margin_facts(_complete_record(), as_of=AS_OF)
+    assert facts.canonical_contract_id == "83102277000152-2-000626/2026"
+    assert {field.name for field in facts.fields} == set(FACT_FIELDS)
+    assert all(field.status == "KNOWN" for field in facts.fields)
+    assert facts.reason_codes == ()
+    assert facts.fields[4].value["semantics"] == "integral_nominal_instrument"
+
+
+def test_missing_fields_stay_unknown_with_reason_codes() -> None:
+    facts = project_margin_facts({"contrato_id": "x-1", "source_id": "x-1"}, as_of=AS_OF)
+    by_name = {field.name: field for field in facts.fields}
+    assert by_name["object"].status == "UNKNOWN"
+    assert by_name["object"].reason_code == "missing_object"
+    assert by_name["nominal_value"].reason_code == "missing_nominal_value"
+    assert by_name["adjustment_anniversary"].reason_code == "no_explicit_adjustment_document"
+    assert by_name["indices"].reason_code == "index_without_document"
+    assert by_name["measurement_events"].reason_code == "source_does_not_offer_measurements"
+    assert by_name["payment_events"].reason_code == "source_does_not_offer_payments"
+    assert all(field.value is None for field in facts.fields if field.status == "UNKNOWN")
+    assert "missing_object" in facts.reason_codes
+
+
+def test_evidence_without_identity_is_refused() -> None:
+    with pytest.raises(EvidenceIdentityError, match="evidence_without_identity"):
+        project_margin_facts({"evidence_ref": "cas://pncp/abc", "objeto_contrato": "obra"}, as_of=AS_OF)
+
+
+def test_index_and_anniversary_without_document_remain_unknown() -> None:
+    record = {
+        "contrato_id": "x-2",
+        "source_id": "x-2",
+        "adjustment_anniversary": "2027-01-01",
+        "adjustment_base": "2026-01-01",
+        "indices": [{"name": "SINAPI"}],
+    }
+    facts = project_margin_facts(record, as_of=AS_OF)
+    by_name = {field.name: field for field in facts.fields}
+    assert by_name["adjustment_anniversary"].status == "UNKNOWN"
+    assert by_name["adjustment_base"].status == "UNKNOWN"
+    assert by_name["indices"].status == "UNKNOWN"
+    assert by_name["indices"].reason_code == "index_without_document"
+
+
+def test_legal_conclusion_fields_are_refused() -> None:
+    for field in ("has_right", "imbalance", "loss", "should_adjust"):
+        with pytest.raises(ForbiddenConclusionError):
+            project_margin_facts({"contrato_id": "x-3", field: True}, as_of=AS_OF)
+
+
+def test_export_is_deterministic_and_consumer_shaped() -> None:
+    payload = {"as_of": AS_OF, "records": [_complete_record(), {"contrato_id": "sparse-1", "source_id": "sparse-1"}]}
+    first = render_margin_bytes(payload)
+    second = render_margin_bytes(payload)
+    assert first == second
+    document = build_margin_export(payload)
+    assert document["consumer"]["id"] == "web-cfg/diagnostico-defesa-de-margem"
+    assert document["grain"] == "canonical_contract_id"
+    assert document["value_semantics"]["unknown_policy"]
+    assert document["provenance"]["record_count"] == 2
+    assert document["freshness"]["policy"] == "contracts-freshness-slo-v1"
+    assert document["coverage"]["record_count"] == 2
+    assert document["reason_codes"]
+    raw = first.decode("utf-8")
+    assert "CONFENGE" not in raw
+    for banned in FORBIDDEN_CONCLUSION_FIELDS:
+        assert f'"{banned}"' not in json.dumps(document["records"])
+    sparse = document["records"][1]
+    assert sparse["fields"]["nominal_value"]["status"] == "UNKNOWN"
+    assert sparse["fields"]["nominal_value"]["value"] is None
+
+
+def test_shipped_cli_export_margin_twice(tmp_path: Path) -> None:
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text(
+        json.dumps({"as_of": AS_OF, "records": [_complete_record()]}),
+        encoding="utf-8",
+    )
+    out_1 = tmp_path / "a"
+    out_2 = tmp_path / "b"
+    command = [sys.executable, "-m", "scripts.public_read", "export-margin"]
+    first = subprocess.run(
+        [*command, "--payload", str(payload_path), "--out", str(out_1)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        [*command, "--payload", str(payload_path), "--out", str(out_2)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    bytes_1 = (out_1 / EXPORT_FILENAME).read_bytes()
+    bytes_2 = (out_2 / EXPORT_FILENAME).read_bytes()
+    assert bytes_1 == bytes_2
+    assert json.loads(first.stdout)["content_hash"] == json.loads(second.stdout)["content_hash"]
+    written = write_margin_export({"as_of": AS_OF, "records": [_complete_record()]}, tmp_path / "c")
+    assert written.read_bytes() == bytes_1

--- a/tests/test_national_universe_live.py
+++ b/tests/test_national_universe_live.py
@@ -1,0 +1,111 @@
+"""Drive the shipped #302 live denominator builder."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.national_contract_truth.live_universe import (
+    build_denominator_report,
+    close_partitions,
+    parse_orgaos_catalog,
+    run_live_universe,
+)
+from scripts.national_contract_truth.national_universe import sha256_payload
+
+REPO = Path(__file__).resolve().parents[1]
+
+OFFICIAL_CATALOG = [
+    {"cnpj": "83102277000152", "razaoSocial": "PREFEITURA MUNICIPAL DE ITAJAI"},
+    {"cnpj": "03563335000106", "razaoSocial": "PREFEITURA MUNICIPAL DE APARECIDA DO TABOADO"},
+    {"cnpj": "99999999000191", "razaoSocial": "ORGAO AINDA NAO CONSULTADO"},
+]
+
+
+def test_parse_official_catalog_and_replay_hash() -> None:
+    raw = json.dumps(OFFICIAL_CATALOG).encode("utf-8")
+    orgs = parse_orgaos_catalog(raw)
+    assert [org.org_id for org in orgs] == [
+        "83102277000152",
+        "03563335000106",
+        "99999999000191",
+    ]
+    again = parse_orgaos_catalog(raw)
+    assert again == orgs
+
+
+def test_unconsulted_partitions_block_nacional_completo() -> None:
+    orgs = parse_orgaos_catalog(OFFICIAL_CATALOG)
+    partitions = close_partitions(orgs, observed_org_ids={"83102277000152", "03563335000106"})
+    report = build_denominator_report(
+        competence="contratos-2026",
+        cutoff="2026-08-15",
+        orgs=orgs,
+        partitions=partitions,
+        raw_hash=sha256_payload(OFFICIAL_CATALOG),
+    )
+    assert report["extra_1093_used_as_denominator"] is False
+    assert report["nacional_completo"] is False
+    assert report["by_status"]["FOUND"] == 2
+    assert report["by_status"]["BLOCKED"] == 1
+    assert "blocked_or_failed_partitions" in report["publish_blockers"]
+    replay = build_denominator_report(
+        competence="contratos-2026",
+        cutoff="2026-08-15",
+        orgs=orgs,
+        partitions=partitions,
+        raw_hash=sha256_payload(OFFICIAL_CATALOG),
+    )
+    assert replay["catalog_hash"] == report["catalog_hash"]
+    assert replay["reconciliation_hash"] == report["reconciliation_hash"]
+
+
+def test_run_live_universe_from_official_bytes() -> None:
+    raw = json.dumps(OFFICIAL_CATALOG).encode("utf-8")
+    report = run_live_universe(
+        competence="contratos-2026",
+        cutoff="2026-08-15T00:00:00Z",
+        observed_org_ids={"83102277000152"},
+        catalog_raw=raw,
+    )
+    assert report["source"] == "pncp"
+    assert report["nacional_completo"] is False
+    assert report["extra_1093_used_as_denominator"] is False
+    assert report["org_count"] == 3
+
+
+def test_shipped_cli_writes_denominator(tmp_path: Path) -> None:
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text(json.dumps(OFFICIAL_CATALOG), encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    observed.write_text("83102277000152\n", encoding="utf-8")
+    out = tmp_path / "national-denominator.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.national_contract_truth.live_universe",
+            "--competence",
+            "contratos-2026",
+            "--cutoff",
+            "2026-08-15T00:00:00Z",
+            "--catalog-json",
+            str(catalog),
+            "--observed-orgs",
+            str(observed),
+            "--out",
+            str(out),
+        ],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    summary = json.loads(result.stdout)
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert summary["nacional_completo"] is False
+    assert report["extra_1093_used_as_denominator"] is False
+    assert report["by_status"]["FOUND"] == 1
+    assert report["by_status"]["BLOCKED"] == 2

--- a/tests/test_pncp_entity_pagination.py
+++ b/tests/test_pncp_entity_pagination.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 from scripts.crawl.pncp_entity_pagination import (
@@ -15,6 +16,7 @@ from scripts.crawl.pncp_entity_pagination import (
     sanitize_url,
     sla_status,
 )
+from scripts.crawl.pncp_entity_scope_live import parse_contratos_page
 
 
 def _page(n: int, records: int = 2) -> object:
@@ -25,6 +27,14 @@ def _page(n: int, records: int = 2) -> object:
         page=n,
         records=records,
     )
+
+
+def test_parse_official_contratos_page() -> None:
+    body = json.dumps({"data": [{"numeroControlePNCP": "a"}, {"numeroControlePNCP": "b"}], "totalRegistros": 2}).encode()
+    records, total = parse_contratos_page(body)
+    assert len(records) == 2
+    assert total == 2
+    assert expected_pages(total or 0, 50) == 1
 
 
 def test_pages_expected_equals_pages_fetched() -> None:

--- a/tests/test_public_read_live_export.py
+++ b/tests/test_public_read_live_export.py
@@ -1,0 +1,161 @@
+"""Live/snapshot path of the shipped research-flagship export."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.public_read.claim_gate import evaluate_national_claim
+from scripts.public_read.export import EXPORT_FILENAME, render_export_bytes, write_research_export
+from scripts.public_read.live_payload import payload_from_live_corpus, payload_from_snapshot_document
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _denominator() -> dict:
+    return {
+        "source": "pncp",
+        "competence": "contratos-2026",
+        "cutoff": "2026-08-15T00:00:00Z",
+        "method": "pncp-orgaos-publicantes-v1",
+        "nacional_completo": False,
+        "orgs": [
+            {
+                "org_id": "83102277000152",
+                "source": "pncp",
+                "competence": "contratos-2026",
+                "name": "PREFEITURA MUNICIPAL DE ITAJAI",
+                "unit_count": 1,
+            },
+            {
+                "org_id": "99999999000191",
+                "source": "pncp",
+                "competence": "contratos-2026",
+                "name": "ORGAO BLOQUEADO",
+                "unit_count": 1,
+            },
+        ],
+        "partitions": [
+            {
+                "partition_id": "83102277000152",
+                "status": "FOUND",
+                "evidence": "observed_official_contract:83102277000152",
+            },
+            {
+                "partition_id": "99999999000191",
+                "status": "BLOCKED",
+                "evidence": "not_consulted_this_run",
+            },
+        ],
+    }
+
+
+def _contracts() -> list[dict]:
+    return [
+        {
+            "contrato_id": "83102277000152-2-000626/2026",
+            "uf": "SC",
+            "valor_total": "740874.59",
+            "source": "pncp_contracts",
+            "source_id": "83102277000152-2-000626/2026",
+            "ingested_at": "2026-08-14T11:27:51+00:00",
+        }
+    ]
+
+
+def test_live_corpus_refuses_national_claim_when_302_incomplete() -> None:
+    payload = payload_from_live_corpus(
+        contracts=_contracts(),
+        denominator=_denominator(),
+        as_of="2026-08-15T00:00:00Z",
+        competence="contratos-2026",
+        publication_age_hours=2.0,
+        publication_lag_p99_hours=2.0,
+        payload_id="live-corpus",
+    )
+    decision = evaluate_national_claim(payload)
+    assert decision.nacional_completo is False
+    assert decision.national_claim_allowed is False
+    document = json.loads(render_export_bytes(payload))
+    assert document["schema"] == "public-read-research-flagship/1.0"
+    assert document["claim"]["national_claim_allowed"] is False
+    assert document["claim"]["publishable_geography"] is None
+    assert all(cell["geography_code"] != "BR" for cell in document["series"])
+    assert "national_denominator_incomplete" in document["claim"]["reason_codes"]
+    assert "CONFENGE" not in json.dumps(document)
+
+
+def test_snapshot_not_ready_is_explicit() -> None:
+    with pytest.raises(ValueError, match="snapshot_not_ready"):
+        payload_from_snapshot_document({"state": "BUILDING", "contracts": []})
+
+
+def test_shipped_cli_live_contracts_twice(tmp_path: Path) -> None:
+    contracts = tmp_path / "contracts.jsonl"
+    contracts.write_text(json.dumps(_contracts()[0]) + "\n", encoding="utf-8")
+    denominator = tmp_path / "denom.json"
+    denominator.write_text(json.dumps(_denominator()), encoding="utf-8")
+    out_1 = tmp_path / "r1"
+    out_2 = tmp_path / "r2"
+    command = [
+        sys.executable,
+        "-m",
+        "scripts.public_read",
+        "export-research",
+        "--contracts-jsonl",
+        str(contracts),
+        "--denominator",
+        str(denominator),
+        "--as-of",
+        "2026-08-15T00:00:00Z",
+        "--competence",
+        "contratos-2026",
+        "--publication-age-hours",
+        "2",
+        "--publication-lag-p99-hours",
+        "2",
+    ]
+    first = subprocess.run(
+        [*command, "--out", str(out_1)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        [*command, "--out", str(out_2)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    bytes_1 = (out_1 / EXPORT_FILENAME).read_bytes()
+    bytes_2 = (out_2 / EXPORT_FILENAME).read_bytes()
+    assert bytes_1 == bytes_2
+    artifact = json.loads(bytes_1)
+    assert artifact["claim"]["national_claim_allowed"] is False
+    assert json.loads(first.stdout)["content_hash"] == json.loads(second.stdout)["content_hash"]
+    health = subprocess.run(
+        [sys.executable, "-m", "scripts.public_read", "health", "--artifact", str(out_1)],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    health_doc = json.loads(health.stdout)
+    assert health_doc["national_claim_allowed"] is False
+    assert health_doc["coverage_status"] in {"INCOMPLETE", "UNKNOWN"}
+    payload = payload_from_live_corpus(
+        contracts=_contracts(),
+        denominator=_denominator(),
+        as_of="2026-08-15T00:00:00Z",
+        competence="contratos-2026",
+        publication_age_hours=2.0,
+        publication_lag_p99_hours=2.0,
+        payload_id="live-corpus",
+    )
+    assert write_research_export(payload, tmp_path / "r3").read_bytes() == bytes_1


### PR DESCRIPTION
## Summary

Consumer-bound live data plane for web-cfg Diagnóstico de Defesa de Margem and flagship research. Official facts only. No legal conclusions. No fixture-as-production. Extra 1.093 is never the national denominator.

## What shipped
- `public-read-margin-defense/1.0` projector + CLI `export-margin`
- #302 live runner `python3 -m scripts.national_contract_truth.live_universe` against official PNCP orgaos
- `export-research` accepts `--payload` / `--snapshot` / `--contracts-jsonl` + `--denominator` (fixture remains tests-only)
- Representative #241 live scope CLI

## Live evidence (this session)
- Host AUTH_OK as root on `:2222`. Deployed SHA `f06ffba0` vs `origin/main` `d62b15a7`. Did **not** fast-forward: `extra-issue-249-resume` is running.
- #249: 2/20 windows completed (`20250101_20250130`, `20250131_20250301`); current window open `20250302`; totals fetched 271674 / persisted 365. Partial ≠ success.
- #241 representative (Itajaí `83102277000152`, 2026-08-01..14): `FOUND`.
- #302 official catalog: **98.437** publishing orgs. FOUND 20 / BLOCKED 98.417 / `nacional_completo=false` / `extra_1093_used_as_denominator=false`.
- Research export `public-read-research-flagship/1.0`: `national_claim_allowed=false`; health INCOMPLETE 20/98437; identical hashes on two runs.
- Margin export: 20 live obras/engenharia contracts from `pncp_supplier_contracts`; UNKNOWN+reason_codes for missing amendment/index/measurement; identical hashes.
- #346: real XLS `alertaLicitacao-12082026-213400.xls` **not found**; fixture of 11 lines is not the 197.

## Tests
`pytest` focal: 38 passed (margin projector, #302 live builder, live research export, existing flagship + universe + #241 parse).

## Out of scope
- Email discovery / #370
- New generic API / second public DB
- Completing the national PNCP census or claiming `nacional_completo`
- Fast-forwarding the host while #249 is live