### PR TITLE
fix(truth): PNCP probe page size, never≠stale, schema debt inventory

### DIFF
--- a/docs/stories/story-never-worked-critical-10.md
+++ b/docs/stories/story-never-worked-critical-10.md
@@ -1,0 +1,52 @@
+# Story: Never-worked critical issues (P2 fill after unused P0/P1)
+
+**Status:** InProgress
+**Branch:** `feat/never-worked-critical-10`
+**Base:** `origin/main` at `d8bb521e`
+**Capability slices:** quality/truth, complementary-source lake, municipal public portals
+
+## Goal
+
+Ship in-repo acceptance criteria for the ten highest-criticality **never-worked**
+open issues after the 2026-08-15 filter. No unused P0/P1 survived (P1s #347
+#350 #281 #285 #301 #305 and live/VALIDATE issues already have merged work).
+The locked set is P2 fill:
+
+1. #351 — PNCP live probe must use a legal `tamanhoPagina`
+2. #349 — golden path must not label freshness `never` as `stale`
+3. #33 — list schema-blocked suite modules and fix one view baseline gap
+4. #265 — map Licitações-e public surface (or BLOCKED/NOT_APPLICABLE)
+5. #250 — persist official ARP/IRP into the canonical lake path
+6. #253 — inventory and collect Dados Abertos SC licitation resources
+7. #266 — MIDES BigQuery query with explicit budget and missing-cred BLOCKED
+8. #257 — Betha Atende public tenders adapter
+9. #258 — IPM public portal adapter (canonical name, not IPAM mix-up)
+10. #259 — Betha e-Gov adapter distinct from Atende
+
+GitHub issue bodies are authoritative. PRs may reference an issue; they must
+not auto-close when residual live/host ACs remain.
+
+## Scope
+
+### IN
+
+- In-repo contracts, fixtures, CLI entry points and tests for the ten issues
+- Registry + `crawl()`/`transform()` for newly registered sources
+- Honest residual notes for live smoke / VPS / national recall
+
+### OUT
+
+- Already-worked P0 #372, DUI slices, waves 1–3, factory-spine republish
+- New adapters still `state:blocked` on #346 VALIDATE (#252 #254 #255 #260 #261 #331–#335)
+- Greenfield marketplaces #262 #263 #264 (lower 4th-key rank)
+- `LOCAL_READY` / `VPS_OPERATIONAL` / 95% / `CI_GREEN` seals without exact HEAD checks
+- Protocol/AIOX/hook edits
+
+## Acceptance (implementable in-repo)
+
+See each GitHub issue. Residual live criteria stay open on the issue.
+
+## Risks
+
+- Full-suite CI may fail for pre-existing main issues; do not weaken skips.
+- Reviewability: split PRs by capability (≤60 files, ≤10k lines).

--- a/scripts/golden_path.py
+++ b/scripts/golden_path.py
@@ -204,6 +204,79 @@ def assert_sources_persisted(
     }
 
 
+def classify_freshness_summary(details: dict[str, Any] | None) -> dict[str, list[str]]:
+    """Split critical sources into fresh / stale / never / external_failure.
+
+    `never` (zero successful runs and zero persisted rows) is MISSING_EVIDENCE,
+    never stale. Stale requires existing data or a successful run outside SLA.
+    """
+    buckets: dict[str, list[str]] = {
+        "fresh": [],
+        "stale": [],
+        "never": [],
+        "missing_evidence": [],
+        "external_failure": [],
+    }
+    if not isinstance(details, dict):
+        return buckets
+    rows = details.get("critical_sources") or []
+    if not isinstance(rows, list):
+        return buckets
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("source") or "").strip()
+        if not name:
+            continue
+        status = str(row.get("freshness_status") or "").strip().lower()
+        total_records = int(row.get("total_records") or 0)
+        successful_runs = int(row.get("successful_runs") or 0)
+        last_success = row.get("last_success_at")
+        never_like = status == "never" or (
+            last_success in (None, "", "never") and total_records == 0 and successful_runs == 0
+        )
+        if status == "fresh":
+            buckets["fresh"].append(name)
+        elif never_like:
+            buckets["never"].append(name)
+            buckets["missing_evidence"].append(name)
+        elif status == "stale":
+            buckets["stale"].append(name)
+        else:
+            buckets["external_failure"].append(name)
+    return buckets
+
+
+def format_freshness_gate_failure_lines(
+    details: dict[str, Any] | None,
+    *,
+    duration_ms: float,
+) -> list[str]:
+    """Human summary that never prints stale for a never/missing_evidence source."""
+    classes = classify_freshness_summary(details)
+    parts: list[str] = []
+    if classes["stale"]:
+        parts.append("stale")
+    if classes["never"] or classes["missing_evidence"]:
+        parts.append("never/missing_evidence")
+    if classes["external_failure"]:
+        parts.append("external failure")
+    if classes["fresh"]:
+        parts.append("fresh")
+    label = ", ".join(parts) if parts else "not fresh"
+    lines = [f"  Freshness gate: FAIL ({label}) ({duration_ms:.0f}ms)"]
+    if classes["stale"]:
+        lines.append(f"    Sources stale: {', '.join(classes['stale'])}")
+    if classes["never"] or classes["missing_evidence"]:
+        never_names = classes["never"] or classes["missing_evidence"]
+        lines.append(f"    Sources never/missing_evidence: {', '.join(never_names)}")
+    if classes["external_failure"]:
+        lines.append(f"    Sources external failure: {', '.join(classes['external_failure'])}")
+    if classes["fresh"]:
+        lines.append(f"    Sources fresh: {', '.join(classes['fresh'])}")
+    return lines
+
+
 def assert_freshness_gate_executed(
     freshness: FreshnessRecord | None,
 ) -> tuple[bool, dict[str, Any]]:
@@ -1432,11 +1505,8 @@ def run_freshness_gate(dsn: str) -> FreshnessRecord:
                 details=details,
             )
         else:
-            _echo(f"  Freshness gate: FAIL (stale sources) ({dur:.0f}ms)", "warn")
-            if details:
-                failing = details.get("overall", {}).get("failing_sources", [])
-                if failing:
-                    _echo(f"    Sources stale: {', '.join(failing)}", "warn")
+            for line in format_freshness_gate_failure_lines(details, duration_ms=dur):
+                _echo(line, "warn")
             return FreshnessRecord(
                 status="fail",
                 details=details,
@@ -1861,6 +1931,12 @@ def parse_args() -> argparse.Namespace:
         help=("Run only freshness gate + ledger (requires DB; skips crawl/reports/migrations/seeds)"),
     )
     p.add_argument(
+        "--render-freshness-json",
+        type=Path,
+        default=None,
+        help="Print the human freshness summary for a freshness-gate.json (no DB)",
+    )
+    p.add_argument(
         "--execute-coverage-only",
         action="store_true",
         help=(
@@ -1963,6 +2039,20 @@ def main() -> int:
 
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
+
+    if args.render_freshness_json is not None:
+        payload = json.loads(Path(args.render_freshness_json).read_text(encoding="utf-8"))
+        classes = classify_freshness_summary(payload)
+        failed = bool(classes["stale"] or classes["never"] or classes["external_failure"])
+        if failed:
+            lines = format_freshness_gate_failure_lines(payload, duration_ms=0)
+        else:
+            lines = ["  Freshness gate: PASS (0ms)"]
+            if classes["fresh"]:
+                lines.append(f"    Sources fresh: {', '.join(classes['fresh'])}")
+        for line in lines:
+            print(line)
+        return 0 if not failed else 2
 
     # Early path: spreadsheet-only validation (CLI proof for DoD planilha item)
     if args.validate_spreadsheet_only:

--- a/scripts/ops/source_contract_tests.py
+++ b/scripts/ops/source_contract_tests.py
@@ -19,6 +19,10 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.crawl.pncp_contract import (  # noqa: E402
+    PNCP_TAMANHO_PAGINA_MAX,
+    PNCP_TAMANHO_PAGINA_MIN,
+)
 from scripts.crawl.registry import export_registry, lookup  # noqa: E402
 
 PNCP_CONSULTA = "https://pncp.gov.br/api/consulta"
@@ -47,12 +51,19 @@ def http_probe(url: str, *, timeout: float = 15.0, method: str = "GET") -> dict[
                 "error": None,
             }
     except HTTPError as exc:
+        raw = b""
+        try:
+            raw = exc.read(2_000_000)
+        except Exception:  # noqa: BLE001 — probe must still classify the status
+            raw = b""
+        body_text = raw.decode("utf-8", errors="replace")
         return {
             "ok": False,
             "status": exc.code,
             "url": url,
-            "bytes": 0,
-            "body_prefix": "",
+            "bytes": len(raw),
+            "body_prefix": body_text[:200],
+            "body": body_text,
             "error": f"HTTPError:{exc.code}",
             "kind": f"http_{exc.code}",
         }
@@ -121,8 +132,80 @@ def fixture_pncp_payload() -> dict[str, Any]:
     }
 
 
-def classify_http_outcome(status: int | None, kind: str | None, n_records: int | None = None) -> str:
-    """Distinguish transport/errors from legitimate zero-result responses."""
+def pncp_live_page_size() -> int:
+    """Page size for the live PNCP probe — same clamp as the PNCP crawler."""
+    raw = os.getenv("PNCP_PAGE_SIZE", str(PNCP_TAMANHO_PAGINA_MAX))
+    try:
+        configured = int(raw)
+    except ValueError:
+        configured = PNCP_TAMANHO_PAGINA_MAX
+    return max(PNCP_TAMANHO_PAGINA_MIN, min(PNCP_TAMANHO_PAGINA_MAX, configured))
+
+
+def build_pncp_live_probe_url(
+    *,
+    data_inicial: str,
+    data_final: str,
+    uf: str = "SC",
+    modalidade: int = 6,
+    pagina: int = 1,
+    tamanho_pagina: int | None = None,
+) -> str:
+    """Build the PNCP publicacao URL using the crawler's legal page size."""
+    size = pncp_live_page_size() if tamanho_pagina is None else int(tamanho_pagina)
+    if size < PNCP_TAMANHO_PAGINA_MIN:
+        raise ValueError(
+            f"INTERNAL_DEFECT: tamanhoPagina={size} < PNCP minimum {PNCP_TAMANHO_PAGINA_MIN}"
+        )
+    return (
+        f"{PNCP_PUBLICACOES}?dataInicial={data_inicial}&dataFinal={data_final}"
+        f"&codigoModalidadeContratacao={modalidade}&uf={uf}"
+        f"&pagina={pagina}&tamanhoPagina={size}"
+    )
+
+
+def parse_tamanho_pagina(url: str) -> int | None:
+    for part in str(url).split("&"):
+        if part.startswith("tamanhoPagina=") or "tamanhoPagina=" in part:
+            raw = part.rsplit("=", 1)[-1]
+            try:
+                return int(raw)
+            except ValueError:
+                return None
+    return None
+
+
+def classify_http_outcome(
+    status: int | None,
+    kind: str | None,
+    n_records: int | None = None,
+    *,
+    body: str | None = None,
+    requested_page_size: int | None = None,
+    url: str | None = None,
+) -> str:
+    """Distinguish transport/errors from legitimate zero-result responses.
+
+    HTTP 400 caused by our own illegal page size is INTERNAL_DEFECT, never
+    EXTERNAL_TRANSIENT and never success_zero.
+    """
+    page_size = requested_page_size
+    if page_size is None and url:
+        page_size = parse_tamanho_pagina(url)
+    if page_size is not None and page_size < PNCP_TAMANHO_PAGINA_MIN:
+        return "INTERNAL_DEFECT"
+    blob = (body or "").lower()
+    invalid_page = any(
+        token in blob
+        for token in (
+            "must be greater than or equal",
+            "tamanhopagina",
+            "tamanho de página inválido",
+            "tamanho de pagina invalido",
+        )
+    )
+    if status == 400 and invalid_page:
+        return "INTERNAL_DEFECT"
     if kind == "timeout" or kind == "network":
         return "transport_error"
     if status == 403:
@@ -131,6 +214,8 @@ def classify_http_outcome(status: int | None, kind: str | None, n_records: int |
         return "http_429_rate_limited"
     if status is not None and status >= 500:
         return "http_5xx_server_error"
+    if status == 400:
+        return "INTERNAL_DEFECT"
     if status is not None and status >= 400:
         return f"http_{status}_client_error"
     if status in (200, 201, 204) or status is None:
@@ -216,11 +301,28 @@ def run_contract_suite(*, live: bool = False) -> dict[str, Any]:
 
         d_fim = date.today().strftime("%Y%m%d")
         d_ini = (date.today() - timedelta(days=2)).strftime("%Y%m%d")
-        url = (
-            f"{PNCP_PUBLICACOES}?dataInicial={d_ini}&dataFinal={d_fim}"
-            f"&codigoModalidadeContratacao=6&uf=SC&pagina=1&tamanhoPagina=5"
-        )
+        page_size = pncp_live_page_size()
+        url = build_pncp_live_probe_url(data_inicial=d_ini, data_final=d_fim)
         probe = http_probe(url)
+        probe["requested_page_size"] = page_size
+        probe["min_page_size"] = PNCP_TAMANHO_PAGINA_MIN
+        probe["outcome"] = classify_http_outcome(
+            probe.get("status"),
+            probe.get("kind"),
+            body=str(probe.get("body") or probe.get("body_prefix") or ""),
+            requested_page_size=page_size,
+            url=url,
+        )
+        results["checks"]["pncp_live_page_size"] = {
+            "ok": page_size >= PNCP_TAMANHO_PAGINA_MIN
+            and parse_tamanho_pagina(url) == page_size
+            and parse_tamanho_pagina(url) is not None
+            and int(parse_tamanho_pagina(url) or 0) >= PNCP_TAMANHO_PAGINA_MIN,
+            "tamanhoPagina": page_size,
+            "min": PNCP_TAMANHO_PAGINA_MIN,
+            "canonical_crawler_page_size": pncp_live_page_size(),
+            "url": url,
+        }
         results["checks"]["pncp_endpoint_live"] = probe
         if probe.get("ok") and probe.get("bytes", 0) > 0:
             try:
@@ -339,6 +441,28 @@ def run_contract_suite(*, live: bool = False) -> dict[str, Any]:
         and classify_http_outcome(200, None, 0) == "success_zero_records",
         "timeout": classify_http_outcome(None, "timeout"),
         "zero": classify_http_outcome(200, None, 0),
+    }
+    probe_size = pncp_live_page_size()
+    illegal_400 = classify_http_outcome(
+        400,
+        "http_400",
+        body='{"message":"must be greater than or equal to 10","status":"400"}',
+        requested_page_size=5,
+    )
+    results["checks"]["pncp_probe_page_size"] = {
+        "ok": probe_size >= PNCP_TAMANHO_PAGINA_MIN
+        and parse_tamanho_pagina(
+            build_pncp_live_probe_url(data_inicial="20260101", data_final="20260102")
+        )
+        == probe_size,
+        "tamanhoPagina": probe_size,
+        "min": PNCP_TAMANHO_PAGINA_MIN,
+        "canonical_crawler_page_size": probe_size,
+    }
+    results["checks"]["pncp_invalid_page_is_internal_defect"] = {
+        "ok": illegal_400 == "INTERNAL_DEFECT"
+        and illegal_400 not in {"EXTERNAL_TRANSIENT", "success_zero_records"},
+        "outcome": illegal_400,
     }
 
     # summary

--- a/scripts/schema/diagnostics.py
+++ b/scripts/schema/diagnostics.py
@@ -75,6 +75,12 @@ EXPECTED_VIEWS: set[str] = {
     "v_contracts_canonical_v2",  # 077 — competitive_intel_validation.py
     "v_opportunity_coverage_summary",  # 027 — opportunity_intel/cli.py
     "v_target_universe_active",  # 038 — universe_tools.py
+    # Story 1.2 canonical views — exist in 030/041a and db/current-schema.sql
+    # but were missing from this baseline, so full-suite schema checks skipped them.
+    "v_entities_canonical",
+    "v_open_opportunities_canonical",
+    "v_contracts_canonical",
+    "v_suppliers_canonical",
 }
 
 # Functions that MUST exist (created by migrations, consumed by code)

--- a/scripts/schema/full_suite_debt.py
+++ b/scripts/schema/full_suite_debt.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Inventory schema-gated test modules that block the full suite (#33).
+
+Lists modules that skip or fail closed when the isolated PostgreSQL schema
+(or required canonical views) is absent. Does not claim the full suite is green.
+
+Usage:
+    python3 -m scripts.schema.full_suite_debt
+    python3 -m scripts.schema.full_suite_debt --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from scripts.schema.diagnostics import EXPECTED_VIEWS
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _PROJECT_ROOT / "tests"
+
+# Views created by 030/041a and consumed by consulting/coverage code.
+# Absence of these in EXPECTED_VIEWS was the honest schema-debt hole.
+CANONICAL_VIEWS_REQUIRED: tuple[str, ...] = (
+    "v_entities_canonical",
+    "v_open_opportunities_canonical",
+    "v_contracts_canonical",
+    "v_suppliers_canonical",
+)
+
+_SKIP_RE = re.compile(
+    r"skipif\s*\(.*?(REQUIRE_TEST_DB|REQUIRE_REAL_DB|relation|undefinedtable|schema)",
+    re.I | re.S,
+)
+_DB_MARK_RE = re.compile(r"pytest\.mark\.(database|integration|real_db)")
+
+
+def scan_schema_gated_modules(tests_root: Path | None = None) -> list[dict[str, str]]:
+    """Walk tests/ and list modules that are schema/DB gated."""
+    root = tests_root or _TESTS_ROOT
+    found: list[dict[str, str]] = []
+    for path in sorted(root.rglob("test_*.py")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        reasons: list[str] = []
+        if _SKIP_RE.search(text):
+            reasons.append("skipif_schema_or_real_db")
+        if _DB_MARK_RE.search(text) and (
+            "REQUIRE_TEST_DB" in text or "REQUIRE_REAL_DB" in text or "relation" in text.lower()
+        ):
+            reasons.append("db_marker_plus_schema_guard")
+        if "EXPECTED_VIEWS" in text or "v_entities_canonical" in text:
+            reasons.append("canonical_view_consumer")
+        if not reasons:
+            continue
+        rel = path.relative_to(_PROJECT_ROOT).as_posix()
+        found.append(
+            {
+                "module": rel,
+                "reason": ",".join(sorted(set(reasons))),
+                "class": "SKIPPED_SCHEMA",
+            }
+        )
+    return found
+
+
+def canonical_view_gaps(expected: set[str] | None = None) -> list[str]:
+    registered = expected if expected is not None else EXPECTED_VIEWS
+    return [name for name in CANONICAL_VIEWS_REQUIRED if name not in registered]
+
+
+def inventory_schema_debt(tests_root: Path | None = None) -> dict[str, Any]:
+    modules = scan_schema_gated_modules(tests_root)
+    gaps = canonical_view_gaps()
+    next_test = (
+        "tests/integration/test_migration_fresh_install.py"
+        if gaps
+        else "tests/test_full_suite_schema_debt.py"
+    )
+    return {
+        "failing_or_skipped_modules": modules,
+        "module_count": len(modules),
+        "canonical_views_required": list(CANONICAL_VIEWS_REQUIRED),
+        "canonical_view_gaps": gaps,
+        "canonical_views_registered": gaps == [],
+        "blocked": bool(gaps),
+        "blocked_reason": (
+            "EXPECTED_VIEWS missing canonical Story 1.2 views"
+            if gaps
+            else None
+        ),
+        "next_test": next_test,
+        "claims_forbidden": ["full suite green", "LOCAL_READY", "CI_GREEN"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="List schema-gated full-suite debt (#33)")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    report = inventory_schema_debt()
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(f"schema-gated modules: {report['module_count']}")
+        for row in report["failing_or_skipped_modules"]:
+            print(f"  {row['class']}: {row['module']} ({row['reason']})")
+        if report["canonical_view_gaps"]:
+            print(f"BLOCKED views: {', '.join(report['canonical_view_gaps'])}")
+        else:
+            print("canonical views registered in EXPECTED_VIEWS")
+        print(f"next test: {report['next_test']}")
+    return 1 if report["blocked"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_full_suite_schema_debt.py
+++ b/tests/test_full_suite_schema_debt.py
@@ -1,0 +1,41 @@
+"""#33 — list schema-blocked suite modules and keep canonical views in baseline."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from scripts.schema.diagnostics import EXPECTED_VIEWS
+from scripts.schema.full_suite_debt import (
+    CANONICAL_VIEWS_REQUIRED,
+    inventory_schema_debt,
+)
+
+
+def test_canonical_views_are_in_expected_baseline() -> None:
+    missing = [name for name in CANONICAL_VIEWS_REQUIRED if name not in EXPECTED_VIEWS]
+    assert missing == []
+
+
+def test_inventory_lists_real_schema_gated_modules() -> None:
+    report = inventory_schema_debt()
+    assert report["canonical_views_registered"] is True
+    assert report["blocked"] is False
+    modules = {row["module"] for row in report["failing_or_skipped_modules"]}
+    assert report["module_count"] == len(modules) > 0
+    assert any("test_" in name and name.endswith(".py") for name in modules)
+    assert report["next_test"]
+
+
+def test_cli_json_matches_inventory() -> None:
+    cmd = [sys.executable, "-m", "scripts.schema.full_suite_debt", "--json"]
+    first = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    second = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    assert first.returncode == 0
+    assert first.stdout == second.stdout
+    payload = json.loads(first.stdout)
+    live = inventory_schema_debt()
+    assert payload["module_count"] == live["module_count"]
+    assert payload["canonical_view_gaps"] == []
+    assert payload["failing_or_skipped_modules"]

--- a/tests/test_golden_path_freshness_taxonomy.py
+++ b/tests/test_golden_path_freshness_taxonomy.py
@@ -1,0 +1,103 @@
+"""#349 — golden path must not label freshness never as stale."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.golden_path import classify_freshness_summary, format_freshness_gate_failure_lines
+
+_NEVER = {
+    "critical_sources": [
+        {
+            "source": "contracts",
+            "freshness_status": "never",
+            "last_success_at": None,
+            "last_ingested_at": None,
+            "latest_business_date": None,
+            "recent_records": 0,
+            "total_records": 0,
+            "successful_runs": 0,
+            "failure_reason": "No successful ingestion run found for critical source",
+        }
+    ],
+    "overall": {"failing_sources": ["contracts"], "all_critical_sources_fresh": False},
+}
+
+_STALE = {
+    "critical_sources": [
+        {
+            "source": "contracts",
+            "freshness_status": "stale",
+            "last_success_at": "2026-08-01T00:00:00+00:00",
+            "last_ingested_at": "2026-08-01T00:00:00+00:00",
+            "recent_records": 0,
+            "total_records": 12,
+            "successful_runs": 3,
+            "failure_reason": "Last successful run is 300.0h old, above SLA 24h",
+        }
+    ],
+    "overall": {"failing_sources": ["contracts"], "all_critical_sources_fresh": False},
+}
+
+_FRESH = {
+    "critical_sources": [
+        {
+            "source": "pncp",
+            "freshness_status": "fresh",
+            "last_success_at": "2026-08-15T10:00:00+00:00",
+            "last_ingested_at": "2026-08-15T10:00:00+00:00",
+            "recent_records": 8,
+            "total_records": 8,
+            "successful_runs": 1,
+            "failure_reason": None,
+        }
+    ],
+    "overall": {"failing_sources": [], "all_critical_sources_fresh": True},
+}
+
+
+def test_never_is_missing_evidence_not_stale() -> None:
+    classes = classify_freshness_summary(_NEVER)
+    assert classes["never"] == ["contracts"]
+    assert classes["missing_evidence"] == ["contracts"]
+    assert classes["stale"] == []
+    text = "\n".join(format_freshness_gate_failure_lines(_NEVER, duration_ms=12))
+    assert "never/missing_evidence" in text
+    assert "Sources stale:" not in text
+    assert "Sources never/missing_evidence: contracts" in text
+
+
+def test_stale_kept_separate_from_never() -> None:
+    classes = classify_freshness_summary(_STALE)
+    assert classes["stale"] == ["contracts"]
+    assert classes["never"] == []
+    text = "\n".join(format_freshness_gate_failure_lines(_STALE, duration_ms=12))
+    assert "Sources stale: contracts" in text
+    assert "never/missing_evidence" not in text
+
+
+def test_fresh_not_in_failure_buckets() -> None:
+    classes = classify_freshness_summary(_FRESH)
+    assert classes["fresh"] == ["pncp"]
+    assert classes["stale"] == []
+    assert classes["never"] == []
+
+
+def test_cli_render_never_and_stale_twice(tmp_path: Path) -> None:
+    never_path = tmp_path / "never.json"
+    stale_path = tmp_path / "stale.json"
+    never_path.write_text(json.dumps(_NEVER), encoding="utf-8")
+    stale_path.write_text(json.dumps(_STALE), encoding="utf-8")
+    cmd = [sys.executable, "-m", "scripts.golden_path", "--render-freshness-json"]
+    first = subprocess.run([*cmd, str(never_path)], capture_output=True, text=True, check=False)
+    second = subprocess.run([*cmd, str(never_path)], capture_output=True, text=True, check=False)
+    stale = subprocess.run([*cmd, str(stale_path)], capture_output=True, text=True, check=False)
+    assert first.returncode == 2
+    assert first.stdout == second.stdout
+    assert "Sources stale:" not in first.stdout
+    assert "never/missing_evidence" in first.stdout
+    assert "Sources stale: contracts" in stale.stdout
+    assert "Sources never" not in stale.stdout

--- a/tests/test_source_contract_tests.py
+++ b/tests/test_source_contract_tests.py
@@ -40,6 +40,45 @@ def test_http_error_not_confused_with_zero():
     assert classify_http_outcome(200, None, 0) == "success_zero_records"
 
 
+def test_pncp_live_probe_never_sends_page_size_below_minimum():
+    from scripts.crawl.pncp_contract import PNCP_TAMANHO_PAGINA_MIN
+    from scripts.ops.source_contract_tests import (
+        build_pncp_live_probe_url,
+        parse_tamanho_pagina,
+        pncp_live_page_size,
+    )
+
+    size = pncp_live_page_size()
+    url = build_pncp_live_probe_url(data_inicial="20260801", data_final="20260803")
+    parsed = parse_tamanho_pagina(url)
+    assert size >= PNCP_TAMANHO_PAGINA_MIN
+    assert parsed == size
+    assert parsed is not None and parsed >= 10
+    try:
+        build_pncp_live_probe_url(
+            data_inicial="20260801", data_final="20260803", tamanho_pagina=5
+        )
+        raise AssertionError("illegal page size must fail closed")
+    except ValueError as exc:
+        assert "INTERNAL_DEFECT" in str(exc)
+
+
+def test_invalid_pncp_page_size_400_is_internal_defect_not_transient():
+    from scripts.ops.source_contract_tests import classify_http_outcome
+
+    outcome = classify_http_outcome(
+        400,
+        "http_400",
+        body='{"message":"must be greater than or equal to 10","status":"400"}',
+        requested_page_size=5,
+    )
+    assert outcome == "INTERNAL_DEFECT"
+    assert outcome != "EXTERNAL_TRANSIENT"
+    assert outcome != "success_zero_records"
+    # legal page size + unrelated 403 stays forbidden, not defect-from-page-size
+    assert classify_http_outcome(403, "http_403", requested_page_size=10) == "http_403_forbidden"
+
+
 def test_contract_alerts():
     from scripts.ops.source_contract_tests import detect_contract_alerts
 


### PR DESCRIPTION
## Outcome

Quality/truth slice of the never-worked critical-10 campaign.

## Issues

Refs #351 #349 #33

Does **not** auto-close: live PNCP suite on the host, isolated-PG full-suite execution, and DoD seals remain residual.

## What shipped

- Live PNCP probe uses the canonical crawler page size (minimum 10). Illegal `tamanhoPagina` HTTP 400 is `INTERNAL_DEFECT`, never `EXTERNAL_TRANSIENT` or `success_zero`.
- Golden path human summary keeps `fresh`, `stale`, `never/missing_evidence` and external failure separate. A source with zero rows and zero successful runs is never printed as stale.
- `EXPECTED_VIEWS` now includes Story 1.2 canonical views. `python3 -m scripts.schema.full_suite_debt` lists schema-gated test modules honestly.

## Verification

```bash
python3 -m pytest tests/test_source_contract_tests.py tests/test_golden_path_freshness_taxonomy.py tests/test_full_suite_schema_debt.py -o addopts='' -q
```

Local generated-artifacts and reviewability commands completed with zero violations on the previous HEAD (8 files). Required CI jobs are the authority for merge.

## Honesty

No readiness or coverage seal. Full-suite schema validation against live PG remains residual for #33.