### PR TITLE
fix(test): fail-closed national_intel preflight and crawler sandbox

### DIFF
--- a/scripts/crawl/sandbox.py
+++ b/scripts/crawl/sandbox.py
@@ -1,0 +1,153 @@
+"""#276 — crawler sandbox: URL allowlist, archive limits, BLOCKED, redaction.
+
+I/O stays at the edge. Decision functions are pure so tests drive the
+shipped units with fakes only at the transport boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any
+
+from scripts.crawl.security import validate_public_url, validate_redirect_chain
+from scripts.lib.structured_logging import redact_secrets
+from scripts.ops.validate_crawler_runtime_security import (
+    validate_environment_file,
+)
+from scripts.process_documents.storage import (
+    MAX_PDF_BYTES,
+    MAX_PDF_PAGES,
+    MAX_ZIP_MEMBERS,
+    MAX_ZIP_UNCOMPRESSED,
+    safe_extract_zip,
+    validate_pdf_limits,
+)
+
+__all__ = [
+    "MAX_PDF_BYTES",
+    "MAX_PDF_PAGES",
+    "MAX_ZIP_MEMBERS",
+    "MAX_ZIP_UNCOMPRESSED",
+    "blocked_access_reason",
+    "classify_fetch_outcome",
+    "guard_crawler_url",
+    "redact_crawler_evidence",
+    "validate_archive_limits",
+    "validate_crawler_unit_contract",
+    "validate_environment_file",
+    "validate_pdf_limits",
+    "validate_redirect_chain",
+]
+
+_COOKIE_PATTERN = re.compile(r"(?i)(cookie|set-cookie)\s*[:=]\s*[^\s;]+")
+_DSN_PATTERN = re.compile(r"(?i)(postgres|postgresql|mysql|mongodb)://[^\s]+")
+
+
+def guard_crawler_url(url: str, *, resolve_dns: bool = False) -> str:
+    """Block file://, localhost/RFC1918 and path traversal before fetch."""
+    return validate_public_url(url, resolve_dns=resolve_dns)
+
+
+def blocked_access_reason(
+    *,
+    status: int | None,
+    body: str = "",
+    headers: dict[str, str] | None = None,
+    url: str = "",
+) -> str | None:
+    """Return a BLOCKED reason for login/CAPTCHA/403. Never success."""
+    text = f"{body} {url}".lower()
+    hdrs = {str(k).lower(): str(v).lower() for k, v in (headers or {}).items()}
+    if status in {401, 403}:
+        return "http_forbidden"
+    if "captcha" in text or "recaptcha" in text or "hcaptcha" in text:
+        return "captcha"
+    if "login" in text and any(token in text for token in ("senha", "password", "entrar", "sign in")):
+        return "login_wall"
+    if "www-authenticate" in hdrs:
+        return "auth_challenge"
+    location = hdrs.get("location", "")
+    if status in {301, 302, 303, 307, 308} and any(
+        token in location for token in ("login", "signin", "captcha", "challenge")
+    ):
+        return "auth_redirect"
+    return None
+
+
+def classify_fetch_outcome(
+    *,
+    status: int | None,
+    body: str = "",
+    headers: dict[str, str] | None = None,
+    url: str = "",
+    records: int = 0,
+    scope_complete: bool = False,
+    pagination_reconciled: bool = False,
+) -> str:
+    """Terminal state. ZERO only after a complete reconciled scope."""
+    blocked = blocked_access_reason(status=status, body=body, headers=headers, url=url)
+    if blocked:
+        return "BLOCKED"
+    if status is not None and status >= 500:
+        return "FAILED"
+    if status == 429:
+        return "FAILED"
+    if not scope_complete or not pagination_reconciled:
+        return "partial"
+    if records == 0:
+        return "ZERO"
+    return "success"
+
+
+def redact_crawler_evidence(text: str) -> str:
+    """DSN, tokens and cookies must never appear in logs or evidence."""
+    out = redact_secrets(text)
+    out = _COOKIE_PATTERN.sub(r"\1=[REDACTED]", out)
+    out = _DSN_PATTERN.sub("[REDACTED_DSN]", out)
+    return out
+
+
+def validate_archive_limits(path: Path, dest_dir: Path) -> list[Path]:
+    """ZIP size/expansion limits plus path traversal. Delegates to storage."""
+    return safe_extract_zip(path, dest_dir)
+
+
+def validate_crawler_unit_contract(unit_text: str) -> dict[str, Any]:
+    """Units must run as non-root and load an EnvironmentFile (mode 0600)."""
+    user = None
+    env_file = None
+    for raw in unit_text.splitlines():
+        line = raw.strip()
+        if line.startswith("User="):
+            user = line.split("=", 1)[1].strip()
+        if line.startswith("EnvironmentFile="):
+            env_file = line.split("=", 1)[1].strip().lstrip("-")
+    errors: list[str] = []
+    if not user or user in {"root", "0"}:
+        errors.append("non_root_user_required")
+    if not env_file:
+        errors.append("environment_file_required")
+    return {
+        "user": user,
+        "environment_file": env_file,
+        "environment_file_mode_required": "0600",
+        "passed": not errors,
+        "errors": errors,
+    }
+
+
+def environment_file_mode_ok(path: Path, *, expected_uid: int | None = None) -> bool:
+    result = validate_environment_file(path, expected_uid=expected_uid)
+    if result.get("passed"):
+        return True
+    if not path.exists():
+        return False
+    return stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def running_as_non_root(euid: int | None = None) -> bool:
+    uid = os.geteuid() if euid is None else euid
+    return uid != 0

--- a/scripts/lib/structured_logging.py
+++ b/scripts/lib/structured_logging.py
@@ -27,6 +27,7 @@ _SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?i)(api[_-]?key|token|secret)\s*[:=]\s*\S+"),
     re.compile(r"(?i)(authorization)\s*[:=]\s*\S+"),
     re.compile(r"(?i)(postgres|postgresql|mysql|mongodb)://[^\s]+"),
+    re.compile(r"(?i)(cookie|set-cookie)\s*[:=]\s*[^\s;]+"),
     re.compile(r"(?i)(aws_secret_access_key|private_key)\s*[:=]\s*\S+"),
     re.compile(r"(?i)sk-[a-zA-Z0-9]{20,}"),
     # Compact JWT (header.payload.sig) — residual after partial Bearer redaction

--- a/scripts/national_intel/db.py
+++ b/scripts/national_intel/db.py
@@ -28,12 +28,15 @@ def resolve_dsn(explicit: str | None = None) -> str:
     return dsn
 
 
+CONNECT_TIMEOUT_SECONDS = 2
+
+
 @contextmanager
-def connect(dsn: str) -> Iterator[Any]:
+def connect(dsn: str, *, connect_timeout: int = CONNECT_TIMEOUT_SECONDS) -> Iterator[Any]:
     try:
         import psycopg
 
-        conn = psycopg.connect(dsn)
+        conn = psycopg.connect(dsn, connect_timeout=connect_timeout)
         try:
             yield conn
         finally:
@@ -43,7 +46,7 @@ def connect(dsn: str) -> Iterator[Any]:
         pass
     import psycopg2
 
-    conn = psycopg2.connect(dsn)
+    conn = psycopg2.connect(dsn, connect_timeout=connect_timeout)
     try:
         yield conn
     finally:

--- a/scripts/national_intel/preflight.py
+++ b/scripts/national_intel/preflight.py
@@ -1,0 +1,205 @@
+"""#341 — fail-closed preflight for national_intel PostgreSQL.
+
+A reachable empty database is not a valid environment. Missing schema must
+be reported as an explicit preflight result, never as UndefinedTable inside
+a product test body. Connection probes use a short timeout so an absent
+host cannot hang collection.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Literal
+
+CONNECT_TIMEOUT_SECONDS = 2
+REQUIRED_TABLES: tuple[str, ...] = ("pncp_supplier_contracts",)
+REQUIRED_VIEWS: tuple[str, ...] = (
+    "v_intel_contracts_raw_national",
+    "v_intel_contracts_geo_sc",
+    "v_intel_supplier_geo",
+    "v_intel_agency_profile",
+)
+
+Outcome = Literal["ready", "skip", "fail"]
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def explicit_dsn_provided() -> bool:
+    """True when the caller named a DSN instead of relying on the 5436 default."""
+    for key in ("NATIONAL_INTEL_DSN", "CAMPAIGN_TEST_DSN", "DATABASE_URL", "LOCAL_DATALAKE_DSN"):
+        if os.environ.get(key, "").strip():
+            return True
+    return False
+
+
+def resolve_probe_dsn() -> str:
+    """Prefer an explicit runner DSN over the implicit campaign port 5436."""
+    for key in ("NATIONAL_INTEL_DSN", "CAMPAIGN_TEST_DSN", "DATABASE_URL", "LOCAL_DATALAKE_DSN"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value
+    return "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc"
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    outcome: Outcome
+    reason: str
+    dsn_host: str
+    missing_tables: tuple[str, ...] = ()
+    missing_views: tuple[str, ...] = ()
+
+    @property
+    def ready(self) -> bool:
+        return self.outcome == "ready"
+
+
+def _dsn_host(dsn: str) -> str:
+    # Never return credentials. Host/port/db only for diagnostics.
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(dsn)
+        host = parsed.hostname or "unknown"
+        port = parsed.port
+        db = (parsed.path or "").lstrip("/") or "unknown"
+        if port:
+            return f"{host}:{port}/{db}"
+        return f"{host}/{db}"
+    except Exception:
+        return "unparsed"
+
+
+def _connect(dsn: str, *, timeout: int = CONNECT_TIMEOUT_SECONDS) -> Any:
+    try:
+        import psycopg
+
+        return psycopg.connect(dsn, connect_timeout=timeout)
+    except ImportError:
+        pass
+    import psycopg2
+
+    return psycopg2.connect(dsn, connect_timeout=timeout)
+
+
+def _existing_relations(conn: Any, *, kind: str, names: tuple[str, ...]) -> set[str]:
+    if not names:
+        return set()
+    table_type = "BASE TABLE" if kind == "table" else "VIEW"
+    found: set[str] = set()
+    sql = (
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = 'public' AND table_type = %s AND table_name = %s"
+    )
+    with conn.cursor() as cur:
+        for name in names:
+            cur.execute(sql, (table_type, name))
+            row = cur.fetchone()
+            if not row:
+                continue
+            if isinstance(row, dict):
+                found.add(str(row.get("table_name")))
+            else:
+                found.add(str(row[0]))
+    return found
+
+
+def inspect_schema(conn: Any) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return missing required tables and views. Never executes product SQL."""
+    have_tables = _existing_relations(conn, kind="table", names=REQUIRED_TABLES)
+    have_views = _existing_relations(conn, kind="view", names=REQUIRED_VIEWS)
+    missing_tables = tuple(name for name in REQUIRED_TABLES if name not in have_tables)
+    missing_views = tuple(name for name in REQUIRED_VIEWS if name not in have_views)
+    return missing_tables, missing_views
+
+
+def probe_national_intel(
+    dsn: str | None = None,
+    *,
+    require_real: bool | None = None,
+    timeout: int = CONNECT_TIMEOUT_SECONDS,
+    opener: Any | None = None,
+) -> PreflightResult:
+    """Classify the DSN before any national_intel product test runs.
+
+    Semantics (issue #341):
+    - missing/unreachable DB → skip (optional) or fail if REQUIRE_REAL_DB=1
+      and an explicit DSN was provided;
+    - reachable DB without required schema → skip or fail with preflight
+      reason, never UndefinedTable in the test body;
+    - fully migrated DB → ready.
+    """
+    target = dsn or resolve_probe_dsn()
+    host = _dsn_host(target)
+    required = env_flag("REQUIRE_REAL_DB") if require_real is None else require_real
+    explicit = explicit_dsn_provided() or dsn is not None
+    connect = opener or _connect
+    try:
+        if opener is None:
+            conn = connect(target, timeout=timeout)
+        else:
+            try:
+                conn = opener(target, timeout=timeout)
+            except TypeError:
+                conn = opener(target)
+    except Exception as exc:
+        reason = f"national_intel preflight: database unreachable at {host}: {type(exc).__name__}"
+        if required and explicit:
+            return PreflightResult("fail", reason, host)
+        return PreflightResult("skip", reason, host)
+
+    from unittest.mock import MagicMock
+
+    if isinstance(conn, MagicMock):
+        reason = f"national_intel preflight: database unreachable at {host}: MagicMock"
+        if required and explicit:
+            return PreflightResult("fail", reason, host)
+        return PreflightResult("skip", reason, host)
+
+    try:
+        missing_tables, missing_views = inspect_schema(conn)
+    except Exception as exc:
+        reason = f"national_intel preflight: schema probe failed at {host}: {type(exc).__name__}"
+        closer = getattr(conn, "close", None)
+        if callable(closer):
+            closer()
+        if required and explicit:
+            return PreflightResult("fail", reason, host)
+        return PreflightResult("skip", reason, host)
+
+    closer = getattr(conn, "close", None)
+    if callable(closer):
+        closer()
+
+    if missing_tables:
+        reason = (
+            "national_intel preflight: required schema missing at "
+            f"{host}: tables={list(missing_tables)} views={list(missing_views)}"
+        )
+        if required and explicit:
+            return PreflightResult("fail", reason, host, missing_tables, missing_views)
+        return PreflightResult("skip", reason, host, missing_tables, missing_views)
+
+    return PreflightResult(
+        "ready",
+        f"national_intel preflight: ready at {host}",
+        host,
+        missing_tables,
+        missing_views,
+    )
+
+
+def admit_or_raise(result: PreflightResult) -> PreflightResult:
+    """Translate a preflight result into pytest skip/fail before the test body."""
+    import pytest
+
+    if result.outcome == "ready":
+        return result
+    if result.outcome == "skip":
+        pytest.skip(result.reason)
+    pytest.fail(result.reason)
+    raise AssertionError("unreachable")

--- a/scripts/testing/connection_policy.py
+++ b/scripts/testing/connection_policy.py
@@ -1,0 +1,199 @@
+"""#343 — explicit mock vs real PostgreSQL policy for canonical tests.
+
+A required real DSN is never silently replaced by MagicMock. Missing
+database or schema fails or skips with a named preflight reason.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Literal
+from unittest.mock import MagicMock
+
+Strategy = Literal["real", "skip", "fail", "mock"]
+
+CANONICAL_REAL_SUITES: frozenset[str] = frozenset(
+    {
+        "test_golden_path_concorrentes_report.py",
+        "test_golden_path_valores_report.py",
+        "test_golden_path_idempotency.py",
+        "test_opportunity_integration.py",
+    }
+)
+
+GOLDEN_PATH_TABLES: tuple[str, ...] = ("sc_public_entities",)
+OPPORTUNITY_TABLES: tuple[str, ...] = (
+    "opportunity_intel",
+    "opportunity_runs",
+    "opportunity_checkpoints",
+    "opportunity_coverage",
+)
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
+
+def canonical_dsn() -> str:
+    return (
+        os.environ.get("LOCAL_DATALAKE_DSN")
+        or os.environ.get("DATABASE_URL")
+        or "postgresql://test:test@127.0.0.1:5433/extra_test"
+    )
+
+
+def dsn_is_required() -> bool:
+    return env_flag("REQUIRE_REAL_DB") or env_flag("REQUIRE_OPPORTUNITY_DB")
+
+
+def connection_kind(conn: object) -> str:
+    """Name the live connection type. MagicMock is never reported as PostgreSQL."""
+    if conn is None:
+        return "none"
+    if isinstance(conn, MagicMock):
+        return "MagicMock"
+    module = type(conn).__module__ or ""
+    name = type(conn).__name__
+    if "mock" in module.lower() or name in {"MagicMock", "AsyncMock", "NonCallableMagicMock"}:
+        return "MagicMock"
+    if "psycopg2" in module:
+        return "psycopg2"
+    if module.startswith("psycopg.") or module == "psycopg":
+        return "psycopg"
+    return name
+
+
+def is_magic_mock(conn: object) -> bool:
+    return connection_kind(conn) == "MagicMock"
+
+
+def refuse_silent_mock(conn: object, *, required: bool, context: str) -> str:
+    """Reject a MagicMock when a real DSN is required. Returns the kind used."""
+    kind = connection_kind(conn)
+    if required and kind == "MagicMock":
+        raise RuntimeError(
+            f"{context}: required real DSN was silently replaced by MagicMock "
+            f"(dsn={canonical_dsn()!r})"
+        )
+    return kind
+
+
+@dataclass(frozen=True)
+class SchemaPreflight:
+    ok: bool
+    reason: str
+    missing: tuple[str, ...]
+    kind: str
+
+
+def preflight_tables(conn: object, tables: tuple[str, ...], *, context: str) -> SchemaPreflight:
+    """Probe information_schema. Never runs product report SQL."""
+    kind = connection_kind(conn)
+    if kind == "MagicMock":
+        return SchemaPreflight(
+            False,
+            f"{context}: preflight refused MagicMock (not a schema miss)",
+            tables,
+            kind,
+        )
+    if not tables:
+        return SchemaPreflight(True, f"{context}: no required tables", (), kind)
+    try:
+        cursor = conn.cursor()  # type: ignore[union-attr]
+    except Exception as exc:
+        return SchemaPreflight(False, f"{context}: cursor failed: {type(exc).__name__}", tables, kind)
+    missing: list[str] = []
+    try:
+        with cursor:
+            for name in tables:
+                cursor.execute(
+                    "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = %s)",
+                    (name,),
+                )
+                row = cursor.fetchone()
+                exists = bool(row[0] if row is not None else False)
+                if not exists:
+                    missing.append(name)
+    except Exception as exc:
+        return SchemaPreflight(
+            False,
+            f"{context}: schema probe failed: {type(exc).__name__}",
+            tables,
+            kind,
+        )
+    if missing:
+        return SchemaPreflight(
+            False,
+            f"{context}: missing schema {missing}",
+            tuple(missing),
+            kind,
+        )
+    return SchemaPreflight(True, f"{context}: schema ready via {kind}", (), kind)
+
+
+def decide_suite_strategy(
+    *,
+    filename: str,
+    real_db_marker: bool,
+    integration_marker: bool,
+    require_real: bool,
+    db_available: bool,
+) -> Strategy:
+    """Uniform admission for suites that consult PostgreSQL.
+
+    real_db / the four canonical suites never fall through to MagicMock.
+    """
+    consults = real_db_marker or filename in CANONICAL_REAL_SUITES
+    if consults:
+        if require_real and db_available:
+            return "real"
+        if require_real and not db_available:
+            return "fail"
+        return "skip"
+    if integration_marker and require_real:
+        return "real" if db_available else "fail"
+    return "mock"
+
+
+def open_canonical_connection(
+    *,
+    dsn: str | None = None,
+    required: bool | None = None,
+    connect_timeout: int = 3,
+    opener: Any | None = None,
+) -> tuple[Any, str, str]:
+    """Open the canonical DSN and name the connection that was actually used."""
+    import pytest
+
+    target = dsn or canonical_dsn()
+    must_be_real = dsn_is_required() if required is None else required
+    connect = opener
+    if connect is None:
+        try:
+            import psycopg2
+        except ImportError as exc:
+            if must_be_real:
+                raise pytest.UsageError(f"psycopg2 unavailable but real DSN required: {exc}") from exc
+            pytest.skip(f"psycopg2 unavailable: {exc}")
+        connect = psycopg2.connect
+    try:
+        conn = connect(target, connect_timeout=connect_timeout)
+    except TypeError:
+        try:
+            conn = connect(target)
+        except Exception as exc:
+            if must_be_real:
+                raise pytest.UsageError(
+                    f"required DSN not reachable ({target!r}): {type(exc).__name__}"
+                ) from exc
+            pytest.skip(f"database unreachable: {exc}")
+    except Exception as exc:
+        if must_be_real:
+            raise pytest.UsageError(
+                f"required DSN not reachable ({target!r}): {type(exc).__name__}"
+            ) from exc
+        pytest.skip(f"database unreachable: {exc}")
+    kind = refuse_silent_mock(conn, required=must_be_real, context="open_canonical_connection")
+    return conn, kind, target

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,12 +76,37 @@ def _mock_psycopg2_connect(request):
     # Explicit marker for modules that need real PG without integration/database.
     # #285: real_db never falls through to MagicMock. Missing opt-in is skip
     # or a configuration error, not a silently mocked missing table.
-    if request.node.get_closest_marker("real_db") is not None:
+    # #343: the four canonical suites that consult PostgreSQL share that policy
+    # even if a file still carries only @pytest.mark.integration.
+    from scripts.testing.connection_policy import (
+        CANONICAL_REAL_SUITES,
+        decide_suite_strategy,
+    )
+
+    filename = path_parts[-1] if path_parts else ""
+    consults_pg = request.node.get_closest_marker("real_db") is not None or (
+        filename in CANONICAL_REAL_SUITES
+    )
+    if consults_pg:
         from scripts.testing.real_db_guard import admit_real_db_or_raise
 
         admit_real_db_or_raise(real_db_marker=True, require_real=require_real)
         yield
         return
+
+    if request.node.get_closest_marker("integration") is not None:
+        from scripts.testing.real_db_guard import dsn_is_reachable
+
+        strategy = decide_suite_strategy(
+            filename=filename,
+            real_db_marker=False,
+            integration_marker=True,
+            require_real=require_real,
+            db_available=dsn_is_reachable() if require_real else False,
+        )
+        if strategy == "real":
+            yield
+            return
 
     # Allow TestPostgreSQLFailClosed to test real connection failures
     cls = getattr(request, "cls", None)

--- a/tests/national_intel/conftest.py
+++ b/tests/national_intel/conftest.py
@@ -7,16 +7,16 @@ from collections.abc import Iterator
 
 import pytest
 
-# Prefer campaign isolated DB (5436); fall back to legacy PR121 port 5435.
-DEFAULT_ISOLATED = os.environ.get(
-    "CAMPAIGN_TEST_DSN",
-    "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc",
+from scripts.national_intel.preflight import (
+    admit_or_raise,
+    probe_national_intel,
+    resolve_probe_dsn,
 )
 
 
 @pytest.fixture(scope="session")
 def national_intel_dsn() -> str:
-    dsn = os.environ.get("NATIONAL_INTEL_DSN", DEFAULT_ISOLATED)
+    dsn = resolve_probe_dsn()
     # Refuse accidental HC writer if env forces it without override flag
     if ":5433/" in dsn and os.environ.get("ALLOW_NI_ON_5433") != "1":
         pytest.skip("Refusing tests on port 5433 without ALLOW_NI_ON_5433=1")
@@ -25,17 +25,18 @@ def national_intel_dsn() -> str:
 
 @pytest.fixture(scope="function")
 def pg_conn(national_intel_dsn: str) -> Iterator:
+    result = probe_national_intel(national_intel_dsn)
+    admit_or_raise(result)
     try:
         from scripts.national_intel.db import connect
     except Exception as exc:  # pragma: no cover
         pytest.skip(f"db helper unavailable: {exc}")
     try:
-        with connect(national_intel_dsn) as conn:
-            # Autocommit-friendly: ensure clean transaction per test
+        with connect(national_intel_dsn, connect_timeout=2) as conn:
             if hasattr(conn, "rollback"):
                 conn.rollback()
             yield conn
             if hasattr(conn, "rollback"):
                 conn.rollback()
     except Exception as exc:
-        pytest.skip(f"isolated Postgres unavailable: {exc}")
+        pytest.skip(f"isolated Postgres unavailable after preflight: {exc}")

--- a/tests/test_golden_path_concorrentes_report.py
+++ b/tests/test_golden_path_concorrentes_report.py
@@ -34,7 +34,11 @@ def test_write_concorrentes_report_domain_file(tmp_path: Path) -> None:
     try:
         import psycopg2
 
-        psycopg2.connect(dsn, connect_timeout=3).close()
+        from scripts.testing.connection_policy import refuse_silent_mock
+
+        probe = psycopg2.connect(dsn, connect_timeout=3)
+        refuse_silent_mock(probe, required=True, context="golden_path_concorrentes")
+        probe.close()
     except Exception:
         pytest.skip("no test-db")
 

--- a/tests/test_golden_path_idempotency.py
+++ b/tests/test_golden_path_idempotency.py
@@ -16,6 +16,9 @@ def test_dual_seed_and_bid_table_no_duplicate_keys() -> None:
         pytest.skip("no psycopg2")
 
     conn = psycopg2.connect(dsn, connect_timeout=5)
+    from scripts.testing.connection_policy import refuse_silent_mock
+
+    refuse_silent_mock(conn, required=True, context="golden_path_idempotency")
     try:
         with conn.cursor() as cur:
             cur.execute("SELECT count(*), count(distinct cnpj_8) FROM sc_public_entities")

--- a/tests/test_golden_path_valores_report.py
+++ b/tests/test_golden_path_valores_report.py
@@ -34,7 +34,11 @@ def test_write_valores_report_domain_file(tmp_path: Path) -> None:
     try:
         import psycopg2
 
-        psycopg2.connect(dsn, connect_timeout=3).close()
+        from scripts.testing.connection_policy import refuse_silent_mock
+
+        probe = psycopg2.connect(dsn, connect_timeout=3)
+        refuse_silent_mock(probe, required=True, context="golden_path_valores")
+        probe.close()
     except Exception:
         pytest.skip("no test-db")
 

--- a/tests/test_issue_276_crawler_sandbox.py
+++ b/tests/test_issue_276_crawler_sandbox.py
@@ -1,0 +1,133 @@
+"""Refs #276 — crawler sandbox, archive limits, BLOCKED, redaction, units.
+
+Drives scripts.crawl.sandbox. Live systemd-analyze on the VPS remains residual.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.crawl.sandbox import (
+    blocked_access_reason,
+    classify_fetch_outcome,
+    environment_file_mode_ok,
+    guard_crawler_url,
+    redact_crawler_evidence,
+    running_as_non_root,
+    validate_archive_limits,
+    validate_crawler_unit_contract,
+    validate_pdf_limits,
+)
+from scripts.process_documents import storage
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "https://localhost/admin",
+        "https://127.0.0.1/secret",
+        "https://10.0.0.8/internal",
+        "https://192.168.1.20/x",
+        "https://169.254.169.254/latest/meta-data",
+        "https://public.example/a/%2e%2e/etc/passwd",
+    ],
+)
+def test_issue_276_blocks_file_localhost_rfc1918_and_traversal(url: str) -> None:
+    with pytest.raises(ValueError):
+        guard_crawler_url(url, resolve_dns=False)
+
+
+def test_issue_276_public_https_is_allowed() -> None:
+    assert guard_crawler_url("https://pncp.gov.br/api/consulta", resolve_dns=False).startswith("https://")
+
+
+def test_issue_276_captcha_and_login_are_blocked_never_success() -> None:
+    assert blocked_access_reason(status=403, body="ok") == "http_forbidden"
+    assert blocked_access_reason(status=200, body="<div class='g-recaptcha'></div>") == "captcha"
+    assert blocked_access_reason(status=200, body="Login senha entrar") == "login_wall"
+    assert (
+        classify_fetch_outcome(
+            status=200,
+            body="resolva o captcha",
+            records=0,
+            scope_complete=True,
+            pagination_reconciled=True,
+        )
+        == "BLOCKED"
+    )
+    assert (
+        classify_fetch_outcome(
+            status=200,
+            body="ok",
+            records=0,
+            scope_complete=True,
+            pagination_reconciled=True,
+        )
+        == "ZERO"
+    )
+    assert (
+        classify_fetch_outcome(
+            status=200,
+            body="ok",
+            records=0,
+            scope_complete=False,
+            pagination_reconciled=False,
+        )
+        == "partial"
+    )
+
+
+def test_issue_276_redacts_dsn_tokens_and_cookies() -> None:
+    leaked = (
+        "dsn=postgresql://user:supersecret@127.0.0.1:5433/extra_test "
+        "Authorization: Bearer abc.def.ghi "
+        "Cookie: session=abc123 "
+        "token=super-token"
+    )
+    redacted = redact_crawler_evidence(leaked)
+    assert "supersecret" not in redacted
+    assert "abc123" not in redacted
+    assert "super-token" not in redacted
+    assert "postgresql://user:supersecret" not in redacted
+
+
+def test_issue_276_pdf_and_zip_limits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(storage, "MAX_PDF_BYTES", 32)
+    with pytest.raises(ValueError, match="MAX_PDF_BYTES"):
+        validate_pdf_limits(b"%PDF" + b"x" * 40)
+
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as zf:
+        zf.writestr("../etc/passwd", "nope")
+    archive = tmp_path / "evil.zip"
+    archive.write_bytes(payload.getvalue())
+    with pytest.raises(ValueError, match="traversal"):
+        validate_archive_limits(archive, tmp_path / "out")
+
+
+def test_issue_276_units_require_non_root_and_environmentfile_0600(tmp_path: Path) -> None:
+    scheduler = Path("deploy/systemd/extra-crawl-scheduler.service").read_text(encoding="utf-8")
+    worker = Path("deploy/systemd/extra-crawl-worker@.service").read_text(encoding="utf-8")
+    for text in (scheduler, worker):
+        result = validate_crawler_unit_contract(text)
+        assert result["passed"] is True
+        assert result["user"] == "extra-consultoria"
+        assert result["environment_file_mode_required"] == "0600"
+
+    rootish = validate_crawler_unit_contract("[Service]\nUser=root\n")
+    assert rootish["passed"] is False
+    assert "non_root_user_required" in rootish["errors"]
+
+    env = tmp_path / "crawler.env"
+    env.write_text("LOCAL_DATALAKE_DSN=postgresql://x\n", encoding="utf-8")
+    env.chmod(0o640)
+    assert environment_file_mode_ok(env) is False
+    env.chmod(0o600)
+    assert environment_file_mode_ok(env) is True
+    assert running_as_non_root(euid=1000) is True
+    assert running_as_non_root(euid=0) is False

--- a/tests/test_issue_341_national_intel_preflight.py
+++ b/tests/test_issue_341_national_intel_preflight.py
@@ -1,0 +1,145 @@
+"""Refs #341 — national_intel preflight before product SQL.
+
+Drives scripts.national_intel.preflight.probe_national_intel. Missing DB
+must not hang; reachable DB without schema must not raise UndefinedTable
+in the test body; a fully migrated DSN is admitted as ready.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from scripts.national_intel.preflight import (
+    CONNECT_TIMEOUT_SECONDS,
+    REQUIRED_TABLES,
+    PreflightResult,
+    inspect_schema,
+    probe_national_intel,
+    resolve_probe_dsn,
+)
+
+
+class _Cursor:
+    def __init__(self, tables: set[str]) -> None:
+        self.tables = tables
+        self.last: tuple[Any, ...] | None = None
+
+    def __enter__(self) -> _Cursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.last = params
+        self._sql = sql
+
+    def fetchone(self) -> tuple[str, ...] | None:
+        if not self.last:
+            return None
+        _table_type, name = self.last
+        if name in self.tables:
+            return (name,)
+        return None
+
+
+class _Conn:
+    def __init__(self, tables: set[str]) -> None:
+        self.tables = tables
+        self.closed = False
+
+    def cursor(self) -> _Cursor:
+        return _Cursor(self.tables)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_issue_341_missing_db_does_not_hang() -> None:
+    def refuse(_dsn: str, timeout: int = 2) -> None:
+        assert timeout <= CONNECT_TIMEOUT_SECONDS
+        raise ConnectionRefusedError("connection refused")
+
+    started = time.monotonic()
+    result = probe_national_intel(
+        "postgresql://test:test@127.0.0.1:1/does_not_exist",
+        require_real=False,
+        timeout=CONNECT_TIMEOUT_SECONDS,
+        opener=refuse,
+    )
+    elapsed = time.monotonic() - started
+    assert result.outcome == "skip"
+    assert "unreachable" in result.reason
+    assert "ConnectionRefusedError" in result.reason
+    assert elapsed < 8
+    assert CONNECT_TIMEOUT_SECONDS <= 2
+
+
+def test_issue_341_reachable_without_schema_is_preflight_not_undefined_table() -> None:
+    def opener(_dsn: str, timeout: int = 2) -> _Conn:
+        del timeout
+        return _Conn(tables=set())
+
+    result = probe_national_intel(
+        "postgresql://test:test@127.0.0.1:5436/empty",
+        require_real=False,
+        opener=opener,
+    )
+    assert result.outcome == "skip"
+    assert "pncp_supplier_contracts" in result.missing_tables
+    assert "UndefinedTable" not in result.reason
+    assert "preflight" in result.reason
+
+
+def test_issue_341_require_real_and_explicit_dsn_fail_closed_on_missing_schema() -> None:
+    def opener(_dsn: str, timeout: int = 2) -> _Conn:
+        del timeout
+        return _Conn(tables=set())
+
+    result = probe_national_intel(
+        "postgresql://test:test@127.0.0.1:5436/empty",
+        require_real=True,
+        opener=opener,
+    )
+    assert result.outcome == "fail"
+    assert result.missing_tables == REQUIRED_TABLES
+
+
+def test_issue_341_fully_migrated_db_is_ready() -> None:
+    required = set(REQUIRED_TABLES)
+
+    def opener(_dsn: str, timeout: int = 2) -> _Conn:
+        del timeout
+        return _Conn(tables=required)
+
+    result = probe_national_intel(
+        "postgresql://test:test@127.0.0.1:5433/extra_test",
+        require_real=True,
+        opener=opener,
+    )
+    assert result.ready is True
+    assert result.outcome == "ready"
+    assert result.missing_tables == ()
+
+
+def test_issue_341_inspect_schema_never_runs_product_sql() -> None:
+    conn = _Conn(tables={"pncp_supplier_contracts"})
+    missing_tables, missing_views = inspect_schema(conn)
+    assert missing_tables == ()
+    assert "v_intel_contracts_raw_national" in missing_views
+
+
+def test_issue_341_resolve_probe_dsn_prefers_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NATIONAL_INTEL_DSN", raising=False)
+    monkeypatch.delenv("CAMPAIGN_TEST_DSN", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@127.0.0.1:5433/extra_test")
+    assert resolve_probe_dsn() == "postgresql://test:test@127.0.0.1:5433/extra_test"
+
+
+def test_issue_341_preflight_result_carries_host_without_secrets() -> None:
+    result = PreflightResult("skip", "national_intel preflight: database unreachable at 127.0.0.1:1/x", "127.0.0.1:1/x")
+    assert "password" not in result.reason
+    assert "test:test" not in result.dsn_host

--- a/tests/test_issue_343_connection_policy.py
+++ b/tests/test_issue_343_connection_policy.py
@@ -1,0 +1,143 @@
+"""Refs #343 — required real DSN is never silently replaced by MagicMock.
+
+Drives scripts.testing.connection_policy. The four canonical suites
+(concorrentes, valores, idempotency, opportunity integration) share one
+admission policy.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.testing.connection_policy import (
+    CANONICAL_REAL_SUITES,
+    GOLDEN_PATH_TABLES,
+    OPPORTUNITY_TABLES,
+    connection_kind,
+    decide_suite_strategy,
+    preflight_tables,
+    refuse_silent_mock,
+)
+
+
+class _RealishConn:
+    """Minimal stand-in with a psycopg2-like module name."""
+
+    def __init__(self, existing: set[str]) -> None:
+        self.existing = existing
+
+    def cursor(self) -> _RealishCursor:
+        return _RealishCursor(self.existing)
+
+
+class _RealishCursor:
+    def __init__(self, existing: set[str]) -> None:
+        self.existing = existing
+        self._name = ""
+
+    def __enter__(self) -> _RealishCursor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def execute(self, _sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self._name = str(params[0]) if params else ""
+
+    def fetchone(self) -> tuple[bool]:
+        return (self._name in self.existing,)
+
+
+def test_issue_343_connection_kind_names_magicmock() -> None:
+    assert connection_kind(MagicMock()) == "MagicMock"
+    assert connection_kind(None) == "none"
+
+
+def test_issue_343_refuse_silent_mock_when_required() -> None:
+    with pytest.raises(RuntimeError, match="silently replaced by MagicMock"):
+        refuse_silent_mock(MagicMock(), required=True, context="concorrentes")
+
+
+def test_issue_343_refuse_silent_mock_allows_named_real_connection() -> None:
+    conn = _RealishConn({"sc_public_entities"})
+    # Force module path so connection_kind does not call it MagicMock
+    _RealishConn.__module__ = "psycopg2.extensions"
+    kind = refuse_silent_mock(conn, required=True, context="valores")
+    assert kind == "psycopg2"
+
+
+def test_issue_343_canonical_suites_never_choose_mock() -> None:
+    expected = {
+        "test_golden_path_concorrentes_report.py",
+        "test_golden_path_valores_report.py",
+        "test_golden_path_idempotency.py",
+        "test_opportunity_integration.py",
+    }
+    assert CANONICAL_REAL_SUITES == expected
+    for name in expected:
+        assert decide_suite_strategy(
+            filename=name,
+            real_db_marker=False,
+            integration_marker=True,
+            require_real=True,
+            db_available=True,
+        ) == "real"
+        assert decide_suite_strategy(
+            filename=name,
+            real_db_marker=False,
+            integration_marker=True,
+            require_real=False,
+            db_available=True,
+        ) == "skip"
+        assert decide_suite_strategy(
+            filename=name,
+            real_db_marker=True,
+            integration_marker=False,
+            require_real=True,
+            db_available=False,
+        ) == "fail"
+        assert decide_suite_strategy(
+            filename=name,
+            real_db_marker=False,
+            integration_marker=False,
+            require_real=False,
+            db_available=False,
+        ) != "mock"
+
+
+def test_issue_343_unmarked_unit_still_may_mock() -> None:
+    assert (
+        decide_suite_strategy(
+            filename="test_unrelated_unit.py",
+            real_db_marker=False,
+            integration_marker=False,
+            require_real=False,
+            db_available=False,
+        )
+        == "mock"
+    )
+
+
+def test_issue_343_preflight_tables_on_magicmock_is_not_missing_schema() -> None:
+    result = preflight_tables(MagicMock(), GOLDEN_PATH_TABLES, context="idempotency")
+    assert result.ok is False
+    assert result.kind == "MagicMock"
+    assert "MagicMock" in result.reason
+    assert "missing schema" not in result.reason
+
+
+def test_issue_343_preflight_tables_reports_missing_and_ready() -> None:
+    _RealishConn.__module__ = "psycopg2.extensions"
+    missing = preflight_tables(_RealishConn(set()), OPPORTUNITY_TABLES, context="opportunity")
+    assert missing.ok is False
+    assert set(missing.missing) == set(OPPORTUNITY_TABLES)
+    ready = preflight_tables(
+        _RealishConn(set(OPPORTUNITY_TABLES)),
+        OPPORTUNITY_TABLES,
+        context="opportunity",
+    )
+    assert ready.ok is True
+    assert ready.kind == "psycopg2"

--- a/tests/test_opportunity_integration.py
+++ b/tests/test_opportunity_integration.py
@@ -15,8 +15,8 @@ import psycopg2
 import psycopg2.extras
 import pytest
 
-# Skip unless explicit
-pytestmark = pytest.mark.integration
+# Skip unless explicit. Refs #343: never receive a silent MagicMock.
+pytestmark = [pytest.mark.integration, pytest.mark.real_db]
 
 DEFAULT_DSN = (
     os.getenv("DATABASE_URL")
@@ -26,13 +26,16 @@ DEFAULT_DSN = (
 
 
 def _get_conn():
-    """Connect to PostgreSQL or skip."""
+    """Connect to PostgreSQL or skip. Refs #343: name the connection used."""
+    from scripts.testing.connection_policy import refuse_silent_mock
+
     try:
         conn = psycopg2.connect(DEFAULT_DSN)
         conn.autocommit = True
-        return conn
     except psycopg2.Error as e:
         pytest.skip(f"No database connection: {e}")
+    refuse_silent_mock(conn, required=True, context="opportunity_integration")
+    return conn
 
 
 def _table_exists(conn, table_name: str) -> bool:


### PR DESCRIPTION
## Outcome

Fail-closed test harness and crawler sandbox contracts for the never-worked P2s in this slice.

## Issues

Refs #341 #343 #276

Does **not** auto-close: live national_intel on a fully migrated isolated DSN, systemd-analyze on the VPS, and 24h host soak remain residual.

## What shipped

- #341 national_intel preflight: missing DB does not hang (2s connect timeout); reachable DB without `pncp_supplier_contracts` is an explicit preflight skip/fail, not `UndefinedTable` in the test body; fully migrated DSN is admitted as ready. Prefers `DATABASE_URL` / `LOCAL_DATALAKE_DSN` over implicit port 5436.
- #343 mock/real policy is explicit for concorrentes, valores, idempotency and opportunity-integration. A required real DSN is never silently replaced by `MagicMock`; missing DB/schema skips or fails with a named preflight reason.
- #276 `file://`, localhost/RFC1918 and path traversal are blocked; ZIP/PDF size/expansion limits exist; units require non-root `User=` and `EnvironmentFile` mode 0600; CAPTCHA/login/403 -> `BLOCKED`; DSN/tokens/cookies are redacted. Host systemd-analyze stays residual.

## Verification

```bash
python3 -m pytest tests/test_issue_341_national_intel_preflight.py tests/test_issue_343_connection_policy.py tests/test_issue_276_crawler_sandbox.py -o addopts='' -q
```

Local generated-artifacts and reviewability commands completed with zero violations (14 files).

## Honesty

No LOCAL_READY, VPS_OPERATIONAL, or 95 percent coverage claim. Required GitHub checks on this HEAD are the authority for merge.
