### PR TITLE
feat(coverage): promote-or-defer VALIDATE sources from #346 ranking

### DIFF
--- a/scripts/coverage/promote_or_defer.py
+++ b/scripts/coverage/promote_or_defer.py
@@ -1,0 +1,244 @@
+"""#261 #331 #332 #333 — consume #346 ranking; promote or defer, no adapters.
+
+Reads the existing AlertaLicitação ranking snapshot and records one
+decision per VALIDATE source. Does not start adapter, coverage or live ops.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from scripts.coverage.alerta_miss_ranking import (
+    HISTORICAL_SEEDS,
+    AdapterRank,
+    ReconciliationReport,
+    classify_historical_seeds,
+    run_measurement,
+)
+
+Decision = Literal["PROMOTE", "DEFER"]
+
+# P1 requires measured material unique recall. A single seed row is not enough.
+MATERIAL_UNIQUE_RECALL = 3.0
+
+ISSUE_SOURCES: dict[int, dict[str, Any]] = {
+    261: {"adapter_keys": ("bll",), "label": "BLL", "seed_identity": "BLL-261"},
+    331: {"adapter_keys": ("bnc",), "label": "BNC", "seed_identity": "BNC-331"},
+    332: {"adapter_keys": ("dou", "diario_oficial"), "label": "DOU", "seed_identity": "DOU-332"},
+    333: {
+        "adapter_keys": ("portal_proprio", "portais_municipais", "transparencia"),
+        "label": "portais_municipais",
+        "seed_identity": "MUN-333",
+    },
+}
+
+DEFAULT_WINDOW_START = "2026-08-01"
+DEFAULT_WINDOW_END = "2026-08-12"
+DEFAULT_REGISTERED = frozenset({"pncp", "ciga"})
+
+
+@dataclass(frozen=True)
+class SourceDecision:
+    issue: int
+    source: str
+    decision: Decision
+    reason: str
+    adapter_key: str | None
+    unique_recall: float
+    implementation_effort: float
+    score: float
+    n_misses: int
+    seed_identity: str
+    seed_evidence: str
+    snapshot_ref: str | None
+    ranking_hash: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_ranking(
+    alerta_path: Path,
+    extra_path: Path,
+    *,
+    window_start: str = DEFAULT_WINDOW_START,
+    window_end: str = DEFAULT_WINDOW_END,
+    registered_sources: frozenset[str] | None = None,
+) -> ReconciliationReport:
+    """Consume the shipped #346 measurement. Does not implement adapters."""
+    return run_measurement(
+        alerta_path.read_bytes(),
+        extra_path.read_bytes(),
+        alerta_filename=alerta_path.name,
+        extra_filename=extra_path.name,
+        window_start=window_start,
+        window_end=window_end,
+        registered_sources=registered_sources or DEFAULT_REGISTERED,
+    )
+
+
+def _rank_for_issue(report: ReconciliationReport, issue: int) -> AdapterRank | None:
+    keys = set(ISSUE_SOURCES[issue]["adapter_keys"])
+    matches = [rank for rank in report.ranking if rank.adapter_key in keys]
+    if not matches:
+        return None
+    return sorted(matches, key=lambda rank: (-rank.score, -rank.n_misses, rank.adapter_key))[0]
+
+
+def _seed_record(report: ReconciliationReport, issue: int) -> dict[str, Any]:
+    identity = str(ISSUE_SOURCES[issue]["seed_identity"])
+    for record in classify_historical_seeds(report):
+        if str(record.get("identity")) == identity or int(record.get("issue") or 0) == issue:
+            return record
+    for seed in HISTORICAL_SEEDS:
+        if int(seed["issue"]) == issue:
+            return {**seed, "evidence": "seed preserved; not present in this ranking window"}
+    raise KeyError(issue)
+
+
+def decide_promotion(
+    *,
+    issue: int,
+    rank: AdapterRank | None,
+    top: AdapterRank | None,
+    seed: dict[str, Any],
+    ranking_hash: str,
+) -> SourceDecision:
+    """Promote only the highest material recall-per-effort source."""
+    meta = ISSUE_SOURCES[issue]
+    seed_evidence = str(seed.get("evidence") or seed.get("identity") or "")
+    if rank is None:
+        return SourceDecision(
+            issue=issue,
+            source=str(meta["label"]),
+            decision="DEFER",
+            reason="no commercially ranked row for this source on the #346 snapshot",
+            adapter_key=None,
+            unique_recall=0.0,
+            implementation_effort=0.0,
+            score=0.0,
+            n_misses=0,
+            seed_identity=str(meta["seed_identity"]),
+            seed_evidence=seed_evidence,
+            snapshot_ref=None,
+            ranking_hash=ranking_hash,
+        )
+    if rank.expected_unique_recall_gain < MATERIAL_UNIQUE_RECALL:
+        return SourceDecision(
+            issue=issue,
+            source=str(meta["label"]),
+            decision="DEFER",
+            reason=(
+                "unique recall "
+                f"{rank.expected_unique_recall_gain} < material threshold "
+                f"{MATERIAL_UNIQUE_RECALL}; seed evidence preserved"
+            ),
+            adapter_key=rank.adapter_key,
+            unique_recall=rank.expected_unique_recall_gain,
+            implementation_effort=rank.implementation_effort,
+            score=rank.score,
+            n_misses=rank.n_misses,
+            seed_identity=str(meta["seed_identity"]),
+            seed_evidence=seed_evidence,
+            snapshot_ref=rank.snapshot_ref,
+            ranking_hash=ranking_hash,
+        )
+    if top is None or rank.adapter_key != top.adapter_key:
+        return SourceDecision(
+            issue=issue,
+            source=str(meta["label"]),
+            decision="DEFER",
+            reason="not the highest expected commercially relevant recall per unit of effort",
+            adapter_key=rank.adapter_key,
+            unique_recall=rank.expected_unique_recall_gain,
+            implementation_effort=rank.implementation_effort,
+            score=rank.score,
+            n_misses=rank.n_misses,
+            seed_identity=str(meta["seed_identity"]),
+            seed_evidence=seed_evidence,
+            snapshot_ref=rank.snapshot_ref,
+            ranking_hash=ranking_hash,
+        )
+    return SourceDecision(
+        issue=issue,
+        source=str(meta["label"]),
+        decision="PROMOTE",
+        reason="highest measured commercially relevant recall per unit of effort and material gain",
+        adapter_key=rank.adapter_key,
+        unique_recall=rank.expected_unique_recall_gain,
+        implementation_effort=rank.implementation_effort,
+        score=rank.score,
+        n_misses=rank.n_misses,
+        seed_identity=str(meta["seed_identity"]),
+        seed_evidence=seed_evidence,
+        snapshot_ref=rank.snapshot_ref,
+        ranking_hash=ranking_hash,
+    )
+
+
+def decide_all(report: ReconciliationReport, issues: tuple[int, ...] = (261, 331, 332, 333)) -> tuple[SourceDecision, ...]:
+    top = report.ranking[0] if report.ranking else None
+    out: list[SourceDecision] = []
+    for issue in issues:
+        out.append(
+            decide_promotion(
+                issue=issue,
+                rank=_rank_for_issue(report, issue),
+                top=top,
+                seed=_seed_record(report, issue),
+                ranking_hash=report.report_hash,
+            )
+        )
+    return tuple(out)
+
+
+def decisions_payload(report: ReconciliationReport, decisions: tuple[SourceDecision, ...]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "consumes": "#346",
+        "adapter_code_started": False,
+        "coverage_engineering_started": False,
+        "live_ops_started": False,
+        "ranking_hash": report.report_hash,
+        "import_id": report.import_id,
+        "snapshot_window": [report.window_start, report.window_end],
+        "decisions": [item.as_dict() for item in decisions],
+        "historical_seeds": classify_historical_seeds(report),
+        "ranking": [rank.as_dict() for rank in report.ranking],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Promote or defer VALIDATE sources from the #346 ranking")
+    parser.add_argument("--alerta", required=True)
+    parser.add_argument("--extra", required=True)
+    parser.add_argument("--window-start", default=DEFAULT_WINDOW_START)
+    parser.add_argument("--window-end", default=DEFAULT_WINDOW_END)
+    parser.add_argument("--issues", default="261,331,332,333")
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args(argv)
+    issues = tuple(int(part) for part in args.issues.split(",") if part.strip())
+    report = load_ranking(
+        Path(args.alerta),
+        Path(args.extra),
+        window_start=args.window_start,
+        window_end=args.window_end,
+    )
+    decisions = decide_all(report, issues)
+    payload = decisions_payload(report, decisions)
+    text = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+    sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_261_331_332_333_promote_or_defer.py
+++ b/tests/test_issue_261_331_332_333_promote_or_defer.py
@@ -1,0 +1,106 @@
+"""Refs #261 #331 #332 #333 — consume #346 ranking; promote or defer.
+
+Drives scripts.coverage.promote_or_defer. No adapter modules are created.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.coverage.alerta_miss_ranking import AdapterRank
+from scripts.coverage.promote_or_defer import (
+    ISSUE_SOURCES,
+    MATERIAL_UNIQUE_RECALL,
+    decide_all,
+    decide_promotion,
+    decisions_payload,
+    load_ranking,
+    main,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "alerta_miss"
+SNAPSHOT = FIXTURES / "snapshot-197.jsonl"
+EXTRA = FIXTURES / "extra-window.jsonl"
+
+
+def test_issue_261_331_332_333_consume_346_snapshot_and_defer() -> None:
+    report = load_ranking(SNAPSHOT, EXTRA)
+    decisions = decide_all(report)
+    by_issue = {item.issue: item for item in decisions}
+    assert set(by_issue) == {261, 331, 332, 333}
+    for issue, item in by_issue.items():
+        assert item.decision == "DEFER"
+        assert item.seed_identity == ISSUE_SOURCES[issue]["seed_identity"]
+        assert item.seed_evidence
+        assert item.ranking_hash == report.report_hash
+        assert item.unique_recall < MATERIAL_UNIQUE_RECALL
+    payload = decisions_payload(report, decisions)
+    assert payload["consumes"] == "#346"
+    assert payload["adapter_code_started"] is False
+    assert payload["coverage_engineering_started"] is False
+    assert payload["live_ops_started"] is False
+    seed_ids = {row["identity"] for row in payload["historical_seeds"]}
+    assert {"BLL-261", "BNC-331", "DOU-332", "MUN-333"} <= seed_ids
+
+
+def test_issue_261_promote_only_when_material_and_top() -> None:
+    rank = AdapterRank(
+        adapter_key="bll",
+        n_misses=5,
+        expected_unique_recall_gain=5.0,
+        business_relevance=1.0,
+        reuse_factor=0.7,
+        implementation_effort=5.0,
+        score=0.7,
+        uncertainty="measured",
+        snapshot_ref="fixture:top",
+        components={},
+    )
+    lower = AdapterRank(
+        adapter_key="bnc",
+        n_misses=4,
+        expected_unique_recall_gain=4.0,
+        business_relevance=1.0,
+        reuse_factor=0.7,
+        implementation_effort=5.0,
+        score=0.56,
+        uncertainty="measured",
+        snapshot_ref="fixture:lower",
+        components={},
+    )
+    seed = {"identity": "BLL-261", "evidence": "https://bll.org.br/edital/261", "issue": 261}
+    promoted = decide_promotion(issue=261, rank=rank, top=rank, seed=seed, ranking_hash="abc")
+    assert promoted.decision == "PROMOTE"
+    assert promoted.unique_recall == 5.0
+    assert promoted.implementation_effort == 5.0
+    deferred = decide_promotion(issue=331, rank=lower, top=rank, seed=seed, ranking_hash="abc")
+    assert deferred.decision == "DEFER"
+    assert "not the highest" in deferred.reason
+
+
+def test_issue_332_333_cli_records_decisions(tmp_path: Path) -> None:
+    out = tmp_path / "decisions.json"
+    rc = main(
+        [
+            "--alerta",
+            str(SNAPSHOT),
+            "--extra",
+            str(EXTRA),
+            "--issues",
+            "261,331,332,333",
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert [row["issue"] for row in payload["decisions"]] == [261, 331, 332, 333]
+    assert all(row["decision"] == "DEFER" for row in payload["decisions"])
+    assert payload["adapter_code_started"] is False
+
+
+def test_issue_261_331_332_333_do_not_add_adapter_modules() -> None:
+    root = Path(__file__).resolve().parents[1] / "scripts" / "crawl"
+    for name in ("bll_crawler.py", "bnc_crawler.py", "dou_crawler.py", "portais_municipais_crawler.py"):
+        assert not (root / name).exists()


### PR DESCRIPTION
## Outcome

Recorded promote-or-defer decisions for the four VALIDATE measure-before-adapter issues, consumed from the existing #346 ranking.

## Issues

Refs #261 #331 #332 #333

Does **not** auto-close: rewriting the issue to a measured residual or closing it still needs the ranking evidence plus a human promotion decision. No adapter work starts here.

## What shipped

- Consumer of `scripts.coverage.alerta_miss_ranking.run_measurement` (#346).
- One decision per source (`BLL`, `BNC`, `DOU`, `portais_municipais`) with unique-recall, effort, score, ranking hash and preserved seed evidence.
- Default snapshot defers all four: unique recall is below the material threshold. Promotion only when the source is the highest recall-per-effort **and** material.
- No `bll`/`bnc`/`dou`/`portais_municipais` crawler modules.

## Verification

```bash
python3 -m pytest tests/test_issue_261_331_332_333_promote_or_defer.py -o addopts='' -q
python3 -m scripts.coverage.promote_or_defer --alerta tests/fixtures/alerta_miss/snapshot-197.jsonl --extra tests/fixtures/alerta_miss/extra-window.jsonl --issues 261,331,332,333
```

Local generated-artifacts and reviewability commands completed with zero violations (2 files).

## Honesty

No adapter, no coverage engineering, no live ops. Seed URLs stay in the #346 snapshot.