### PR TITLE
feat(coverage): promote-or-defer remaining VALIDATE sources (#252 #254 #255 #260 #334 #335)

### DIFF
--- a/.aiox/state/stories/story-never-worked-validate-measure-6.json
+++ b/.aiox/state/stories/story-never-worked-validate-measure-6.json
@@ -1,7 +1,7 @@
 {
   "story_id": "story-never-worked-validate-measure-6",
   "risk_level": "STANDARD",
-  "status": "InProgress",
+  "status": "InReview",
   "po_validated": true,
   "qa_verdict": "PENDING",
   "po_closed": false,

--- a/.aiox/state/stories/story-never-worked-validate-measure-6.json
+++ b/.aiox/state/stories/story-never-worked-validate-measure-6.json
@@ -1,0 +1,24 @@
+{
+  "story_id": "story-never-worked-validate-measure-6",
+  "risk_level": "STANDARD",
+  "status": "InProgress",
+  "po_validated": true,
+  "qa_verdict": "PENDING",
+  "po_closed": false,
+  "scope_files": [
+    "scripts/coverage/promote_or_defer.py",
+    "tests/test_issue_252_254_255_260_334_335_promote_or_defer.py",
+    "docs/stories/story-never-worked-validate-measure-6.md"
+  ],
+  "reviewed_commit": null,
+  "gates": {
+    "lint": "PENDING",
+    "typecheck": "PENDING",
+    "tests": "PENDING",
+    "build": "NA"
+  },
+  "rollback_plan": "revert the branch; no schema or production change",
+  "snapshot_evidence": null,
+  "publication_authorized": false,
+  "maintenance_mode": false
+}

--- a/docs/stories/story-never-worked-validate-measure-6.md
+++ b/docs/stories/story-never-worked-validate-measure-6.md
@@ -1,6 +1,6 @@
 # Story: Never-worked VALIDATE promote-or-defer (#252 #254 #255 #260 #334 #335)
 
-**Status:** InProgress
+**Status:** Ready for Review
 **Branch:** `feat/never-worked-validate-measure`
 **Base:** `origin/main` (includes #411 promote-or-defer consumer)
 **Capability:** in-repo promote-or-defer measurement only
@@ -38,3 +38,13 @@ VALIDATE issues, consumed from the existing #346 ranking. No adapters.
 
 Rewriting the issue to a measured residual or closing it still needs the
 ranking evidence plus a human promotion decision.
+
+## Evidence boundary
+
+- The versioned corpus contains 11 rows, not the unavailable real 197-row XLS.
+- Joinville (#334) and e-Publica (#335) each have one measured ranked miss and
+  remain below the material threshold.
+- Compras.gov OCDS (#252), DOE-SC (#254), TCE-SC (#255), and PCP (#260) have no
+  ranked row in this corpus. Their metrics are serialized as `null`, never as a
+  measured zero; `DEFER` means insufficient promotion evidence.
+- No issue is closed and no operational or coverage claim is promoted here.

--- a/docs/stories/story-never-worked-validate-measure-6.md
+++ b/docs/stories/story-never-worked-validate-measure-6.md
@@ -1,0 +1,40 @@
+# Story: Never-worked VALIDATE promote-or-defer (#252 #254 #255 #260 #334 #335)
+
+**Status:** InProgress
+**Branch:** `feat/never-worked-validate-measure`
+**Base:** `origin/main` (includes #411 promote-or-defer consumer)
+**Capability:** in-repo promote-or-defer measurement only
+
+## Goal
+
+Record promote-or-defer decisions for the six remaining never-worked
+VALIDATE issues, consumed from the existing #346 ranking. No adapters.
+
+## Locked issues
+
+1. #252 Compras.gov OCDS
+2. #254 DOE-SC
+3. #255 TCE-SC
+4. #260 PCP
+5. #334 Joinville
+6. #335 e-Publica
+
+## Scope
+
+### IN
+
+- Extend `scripts/coverage/promote_or_defer.py` ISSUE_SOURCES
+- Tests that drive `load_ranking` / `decide_all` / CLI `main`
+- Preserve seed evidence; record ranking hash
+
+### OUT
+
+- New crawler/adapter modules
+- Coverage engineering or live ops
+- Storage/backup (#271 #277) — other PR
+- Auto-close of GitHub issues
+
+## Residual
+
+Rewriting the issue to a measured residual or closing it still needs the
+ranking evidence plus a human promotion decision.

--- a/scripts/coverage/promote_or_defer.py
+++ b/scripts/coverage/promote_or_defer.py
@@ -103,10 +103,11 @@ class SourceDecision:
     decision: Decision
     reason: str
     adapter_key: str | None
-    unique_recall: float
-    implementation_effort: float
-    score: float
-    n_misses: int
+    # Missing ranking rows are unknown, not measured zeroes.
+    unique_recall: float | None
+    implementation_effort: float | None
+    score: float | None
+    n_misses: int | None
     seed_identity: str
     seed_evidence: str
     snapshot_ref: str | None
@@ -179,10 +180,10 @@ def decide_promotion(
             decision="DEFER",
             reason="no commercially ranked row for this source on the #346 snapshot",
             adapter_key=None,
-            unique_recall=0.0,
-            implementation_effort=0.0,
-            score=0.0,
-            n_misses=0,
+            unique_recall=None,
+            implementation_effort=None,
+            score=None,
+            n_misses=None,
             seed_identity=str(meta["seed_identity"]),
             seed_evidence=seed_evidence,
             snapshot_ref=None,

--- a/scripts/coverage/promote_or_defer.py
+++ b/scripts/coverage/promote_or_defer.py
@@ -1,7 +1,10 @@
-"""#261 #331 #332 #333 — consume #346 ranking; promote or defer, no adapters.
+"""Consume #346 ranking; promote or defer VALIDATE sources; no adapters.
 
 Reads the existing AlertaLicitação ranking snapshot and records one
 decision per VALIDATE source. Does not start adapter, coverage or live ops.
+
+Wave 1 (#411): #261 #331 #332 #333
+Wave 2: #252 #254 #255 #260 #334 #335
 """
 
 from __future__ import annotations
@@ -35,7 +38,58 @@ ISSUE_SOURCES: dict[int, dict[str, Any]] = {
         "label": "portais_municipais",
         "seed_identity": "MUN-333",
     },
+    252: {
+        "adapter_keys": ("ocds", "compras_gov", "compras.gov", "comprasgov"),
+        "label": "Compras.gov OCDS",
+        "seed_identity": "OCDS-252",
+        "seed_evidence": "official release-package collector absent from #346 snapshot",
+    },
+    254: {
+        "adapter_keys": ("doe_sc", "doe-sc", "doe"),
+        "label": "DOE-SC",
+        "seed_identity": "DOE-254",
+        "seed_evidence": "public editions path exists; no publication in measured snapshot",
+    },
+    255: {
+        "adapter_keys": ("tce_sc", "tce-sc", "tce"),
+        "label": "TCE-SC",
+        "seed_identity": "TCE-255",
+        "seed_evidence": "partial code; no live evidence in the compared window",
+    },
+    260: {
+        "adapter_keys": ("pcp", "portal_compras_publicas"),
+        "label": "PCP",
+        "seed_identity": "PCP-260",
+        "seed_evidence": "crawler exists; live manifest recorded sem_dados_no_lake",
+    },
+    334: {
+        "adapter_keys": ("joinville",),
+        "label": "Joinville",
+        "seed_identity": "JOI-334",
+        "seed_evidence": "3 seed occurrences; not unique commercially relevant recall",
+    },
+    335: {
+        "adapter_keys": ("e-publica",),
+        "label": "e-Publica",
+        "seed_identity": "EPUB-335",
+        "seed_evidence": "2 seed occurrences; not unique commercially relevant recall",
+    },
 }
+
+WAVE1_ISSUES: tuple[int, ...] = (261, 331, 332, 333)
+WAVE2_ISSUES: tuple[int, ...] = (252, 254, 255, 260, 334, 335)
+# Filenames that would start adapter work for these VALIDATE issues.
+# Pre-existing DOE/TCE/PCP/Compras.gov crawlers are not in this list.
+FORBIDDEN_ADAPTER_MODULES: tuple[str, ...] = (
+    "bll_crawler.py",
+    "bnc_crawler.py",
+    "dou_crawler.py",
+    "portais_municipais_crawler.py",
+    "ocds_crawler.py",
+    "compras_gov_ocds_crawler.py",
+    "joinville_crawler.py",
+    "e_publica_crawler.py",
+)
 
 DEFAULT_WINDOW_START = "2026-08-01"
 DEFAULT_WINDOW_END = "2026-08-12"
@@ -98,7 +152,13 @@ def _seed_record(report: ReconciliationReport, issue: int) -> dict[str, Any]:
     for seed in HISTORICAL_SEEDS:
         if int(seed["issue"]) == issue:
             return {**seed, "evidence": "seed preserved; not present in this ranking window"}
-    raise KeyError(issue)
+    meta = ISSUE_SOURCES[issue]
+    return {
+        "identity": identity,
+        "issue": issue,
+        "label": meta["label"],
+        "evidence": str(meta.get("seed_evidence") or "seed preserved; not present in this ranking window"),
+    }
 
 
 def decide_promotion(
@@ -181,7 +241,7 @@ def decide_promotion(
     )
 
 
-def decide_all(report: ReconciliationReport, issues: tuple[int, ...] = (261, 331, 332, 333)) -> tuple[SourceDecision, ...]:
+def decide_all(report: ReconciliationReport, issues: tuple[int, ...] = WAVE1_ISSUES) -> tuple[SourceDecision, ...]:
     top = report.ranking[0] if report.ranking else None
     out: list[SourceDecision] = []
     for issue in issues:

--- a/tests/test_issue_252_254_255_260_334_335_promote_or_defer.py
+++ b/tests/test_issue_252_254_255_260_334_335_promote_or_defer.py
@@ -1,0 +1,141 @@
+"""Refs #252 #254 #255 #260 #334 #335 — consume #346 ranking; promote or defer.
+
+Drives scripts.coverage.promote_or_defer. No adapter modules are created.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.coverage.alerta_miss_ranking import AdapterRank
+from scripts.coverage.promote_or_defer import (
+    FORBIDDEN_ADAPTER_MODULES,
+    ISSUE_SOURCES,
+    MATERIAL_UNIQUE_RECALL,
+    WAVE2_ISSUES,
+    decide_all,
+    decide_promotion,
+    decisions_payload,
+    load_ranking,
+    main,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "alerta_miss"
+SNAPSHOT = FIXTURES / "snapshot-197.jsonl"
+EXTRA = FIXTURES / "extra-window.jsonl"
+
+
+def test_wave2_consume_346_snapshot_and_defer() -> None:
+    report = load_ranking(SNAPSHOT, EXTRA)
+    decisions = decide_all(report, WAVE2_ISSUES)
+    by_issue = {item.issue: item for item in decisions}
+    assert set(by_issue) == set(WAVE2_ISSUES)
+    for issue, item in by_issue.items():
+        assert item.decision == "DEFER"
+        assert item.seed_identity == ISSUE_SOURCES[issue]["seed_identity"]
+        assert item.seed_evidence
+        assert item.ranking_hash == report.report_hash
+        assert item.unique_recall < MATERIAL_UNIQUE_RECALL
+    payload = decisions_payload(report, decisions)
+    assert payload["consumes"] == "#346"
+    assert payload["adapter_code_started"] is False
+    assert payload["coverage_engineering_started"] is False
+    assert payload["live_ops_started"] is False
+    assert payload["ranking_hash"] == report.report_hash
+    assert [row["issue"] for row in payload["decisions"]] == list(WAVE2_ISSUES)
+
+
+def test_wave2_promote_only_when_material_and_top() -> None:
+    rank = AdapterRank(
+        adapter_key="joinville",
+        n_misses=5,
+        expected_unique_recall_gain=5.0,
+        business_relevance=1.0,
+        reuse_factor=0.7,
+        implementation_effort=5.0,
+        score=0.7,
+        uncertainty="measured",
+        snapshot_ref="fixture:top",
+        components={},
+    )
+    lower = AdapterRank(
+        adapter_key="e-publica",
+        n_misses=4,
+        expected_unique_recall_gain=4.0,
+        business_relevance=1.0,
+        reuse_factor=0.7,
+        implementation_effort=5.0,
+        score=0.56,
+        uncertainty="measured",
+        snapshot_ref="fixture:lower",
+        components={},
+    )
+    seed = {"identity": "JOI-334", "evidence": "https://joinville.sc.gov.br/edital/334", "issue": 334}
+    promoted = decide_promotion(issue=334, rank=rank, top=rank, seed=seed, ranking_hash="abc")
+    assert promoted.decision == "PROMOTE"
+    assert promoted.unique_recall == 5.0
+    deferred = decide_promotion(issue=335, rank=lower, top=rank, seed=seed, ranking_hash="abc")
+    assert deferred.decision == "DEFER"
+    assert "not the highest" in deferred.reason
+    below = AdapterRank(
+        adapter_key="ocds",
+        n_misses=1,
+        expected_unique_recall_gain=1.0,
+        business_relevance=1.0,
+        reuse_factor=0.7,
+        implementation_effort=5.0,
+        score=0.14,
+        uncertainty="measured",
+        snapshot_ref="fixture:below",
+        components={},
+    )
+    ocds = decide_promotion(
+        issue=252,
+        rank=below,
+        top=below,
+        seed={"identity": "OCDS-252", "evidence": "no collector", "issue": 252},
+        ranking_hash="abc",
+    )
+    assert ocds.decision == "DEFER"
+    assert "material threshold" in ocds.reason
+
+
+def test_wave2_cli_records_decisions_and_ranking_hash(tmp_path: Path) -> None:
+    out = tmp_path / "decisions.json"
+    rc = main(
+        [
+            "--alerta",
+            str(SNAPSHOT),
+            "--extra",
+            str(EXTRA),
+            "--issues",
+            "252,254,255,260,334,335",
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert [row["issue"] for row in payload["decisions"]] == [252, 254, 255, 260, 334, 335]
+    assert all(row["decision"] == "DEFER" for row in payload["decisions"])
+    assert payload["adapter_code_started"] is False
+    assert payload["ranking_hash"]
+    by_issue = {row["issue"]: row for row in payload["decisions"]}
+    assert by_issue[334]["seed_identity"] == "JOI-334"
+    assert by_issue[335]["seed_identity"] == "EPUB-335"
+    assert by_issue[252]["source"] == "Compras.gov OCDS"
+    assert by_issue[254]["source"] == "DOE-SC"
+    assert by_issue[255]["source"] == "TCE-SC"
+    assert by_issue[260]["source"] == "PCP"
+
+
+def test_wave2_do_not_add_adapter_modules() -> None:
+    root = Path(__file__).resolve().parents[1] / "scripts" / "crawl"
+    for name in FORBIDDEN_ADAPTER_MODULES:
+        assert not (root / name).exists()
+    # Existing PCP/TCE/DOE crawlers must not be rewritten as a promote.
+    # Measurement-only: the new adapter filenames above stay absent.
+    assert not (root / "joinville_crawler.py").exists()
+    assert not (root / "e_publica_crawler.py").exists()
+    assert not (root / "ocds_crawler.py").exists()

--- a/tests/test_issue_252_254_255_260_334_335_promote_or_defer.py
+++ b/tests/test_issue_252_254_255_260_334_335_promote_or_defer.py
@@ -36,7 +36,20 @@ def test_wave2_consume_346_snapshot_and_defer() -> None:
         assert item.seed_identity == ISSUE_SOURCES[issue]["seed_identity"]
         assert item.seed_evidence
         assert item.ranking_hash == report.report_hash
+    for issue in (252, 254, 255, 260):
+        item = by_issue[issue]
+        assert item.unique_recall is None
+        assert item.implementation_effort is None
+        assert item.score is None
+        assert item.n_misses is None
+        assert item.snapshot_ref is None
+        assert "no commercially ranked row" in item.reason
+    for issue in (334, 335):
+        item = by_issue[issue]
+        assert item.unique_recall is not None
         assert item.unique_recall < MATERIAL_UNIQUE_RECALL
+        assert item.n_misses == 1
+        assert item.snapshot_ref
     payload = decisions_payload(report, decisions)
     assert payload["consumes"] == "#346"
     assert payload["adapter_code_started"] is False
@@ -124,6 +137,13 @@ def test_wave2_cli_records_decisions_and_ranking_hash(tmp_path: Path) -> None:
     by_issue = {row["issue"]: row for row in payload["decisions"]}
     assert by_issue[334]["seed_identity"] == "JOI-334"
     assert by_issue[335]["seed_identity"] == "EPUB-335"
+    assert by_issue[334]["unique_recall"] == 1.0
+    assert by_issue[335]["unique_recall"] == 1.0
+    for issue in (252, 254, 255, 260):
+        assert by_issue[issue]["unique_recall"] is None
+        assert by_issue[issue]["implementation_effort"] is None
+        assert by_issue[issue]["score"] is None
+        assert by_issue[issue]["n_misses"] is None
     assert by_issue[252]["source"] == "Compras.gov OCDS"
     assert by_issue[254]["source"] == "DOE-SC"
     assert by_issue[255]["source"] == "TCE-SC"


### PR DESCRIPTION
## Outcome

Records promote-or-defer decisions for the six remaining never-worked VALIDATE issues without starting adapter work.

## Issues

Refs #252 #254 #255 #260 #334 #335. This PR does not auto-close them.

## What ships

- Extends `scripts.coverage.promote_or_defer` for OCDS, DOE-SC, TCE-SC, PCP, Joinville and e-Publica.
- Preserves seed evidence and the ranking hash.
- Joinville and e-Publica each have one measured ranked miss on the versioned corpus and remain below the material threshold.
- OCDS, DOE-SC, TCE-SC and PCP have no ranked row in that corpus. Their metrics serialize as `null`; DEFER means insufficient promotion evidence, never measured zero.
- No new crawler modules, live operation or coverage claim.

## Evidence boundary

The versioned fixture has 11 rows. The real 197-row XLS remains unavailable, so this PR cannot prove the full #346 ranking or promote any source.

## Verification

- 22 focused ranking/promote-or-defer tests passed.
- Ruff passed.
- Exact mypy scopes from CI passed.
- Source contracts: 17/17 passed.
- Generated-artifacts policy: PASS (4 files).
- PR reviewability policy: PASS (4 files).
- Canonical real-PostgreSQL suite reached 5,858 passed / 139 skipped; one environment-only failure because local `psql` is not installed. Required GitHub CI on exact HEAD is the merge authority.

## Honesty

No adapter, no coverage engineering, no live proof, no issue closure and no 197-row XLS claim.