### PR TITLE
docs(ops): record #425 merge SHA and CI_PROVEN

### DIFF
--- a/docs/ops/campaigns/CONFENGE-EXTRA-LIVE-INBOUND-TRUTH-02/EVIDENCE.md
+++ b/docs/ops/campaigns/CONFENGE-EXTRA-LIVE-INBOUND-TRUTH-02/EVIDENCE.md
@@ -76,6 +76,14 @@ Export directory: `exports/public-read-live/contract-analysis/1.0/{payload,manif
 
 This is an honest `HOLD_FOR_DATA` official-live feed: live rows exist, documents/semantic columns do not. No text was invented. No OCR.
 
+## CI / merge
+
+PR https://github.com/tjsasakifln/extra-cli/pull/425 squash-merged to `main` as `c84c9a4e6ec1adbe90541803468b45f22b152abf`.
+
+HEAD `79fc883f` (the tip that merged): 28/28 checks SUCCESS, including Test All, Edital Relevance Foundation, Lint, mypy, Generated Artifacts Policy, PR Reviewability. No review threads. No #413 files. No migrations.
+
+First CI on `18b63189` failed only `test_dsn_absent_is_blocked_not_live` because the runner has `LOCAL_DATALAKE_DSN`; the follow-up isolated that env. Class: `CI_PROVEN`.
+
 ## Classes
 
 | Result | Class |

--- a/docs/ops/campaigns/CONFENGE-EXTRA-LIVE-INBOUND-TRUTH-02/STATE.json
+++ b/docs/ops/campaigns/CONFENGE-EXTRA-LIVE-INBOUND-TRUTH-02/STATE.json
@@ -1,9 +1,12 @@
 {
   "campaign": "CONFENGE-EXTRA-LIVE-INBOUND-TRUTH-02",
   "baseline_sha": "4bbb825c5052558fec495c9528e5fa5a6a2e8416",
+  "merged_sha": "c84c9a4e6ec1adbe90541803468b45f22b152abf",
+  "pr": 425,
   "branch": "feat/live-inbound-truth-02",
   "pr_413_files_touched": false,
   "classes": {
+    "ci": "CI_PROVEN",
     "drift_classifier": "CODE_PROVEN",
     "incremental_dry_run": "LIVE_PROVEN",
     "host_incremental_unit": "LIVE_PROVEN",


### PR DESCRIPTION
Follow-up to #425. Records squash-merge SHA `c84c9a4e` and `CI_PROVEN` in the LIVE-INBOUND-TRUTH-02 campaign files. Docs only. Does not close #400/#414/#415/#302.