### PR TITLE
fix(publication): reject CNPJ/municipio swap and value/date conflicts

### DIFF
--- a/scripts/contract_publication/detectors.py
+++ b/scripts/contract_publication/detectors.py
@@ -21,6 +21,7 @@ from scripts.contract_publication.facts import (
     freshness_hours,
     nominal_amount,
     parse_as_of,
+    parse_optional_datetime,
     text,
 )
 from scripts.contract_publication.models import DetectorResult
@@ -697,18 +698,138 @@ def detect_peer_difference(projected: ProjectedRecord, *, as_of: str) -> Detecto
     )
 
 
+def _digits_only(value: Any) -> str:
+    return "".join(char for char in str(value or "") if char.isdigit())
+
+
+def _looks_like_cnpj(value: Any) -> bool:
+    return len(_digits_only(value)) == 14
+
+
+def _looks_like_place_name(value: Any) -> bool:
+    found = text(value)
+    if not found:
+        return False
+    return not _looks_like_cnpj(found) and any(char.isalpha() for char in found)
+
+
 def detect_identity_swap_is_not_insight(projected: ProjectedRecord, *, as_of: str) -> DetectorResult:
+    """CNPJ in a place field (or a place name in a CNPJ field) is never insight."""
+    record = projected.record
+    municipio = record.get("municipio") or record.get("city")
+    orgao = record.get("orgao_cnpj")
+    supplier = record.get("fornecedor_cnpj") or record.get("contractor_id")
+    previous_orgao = record.get("previous_orgao_cnpj")
+    previous_supplier = record.get("previous_fornecedor_cnpj")
+    previous_city = record.get("previous_municipio")
+    swapped = False
+    kinds: list[str] = []
+    if _looks_like_cnpj(municipio):
+        swapped = True
+        kinds.append("municipio_holds_cnpj")
+    if _looks_like_place_name(orgao):
+        swapped = True
+        kinds.append("orgao_cnpj_holds_place")
+    if _looks_like_place_name(supplier):
+        swapped = True
+        kinds.append("fornecedor_cnpj_holds_place")
+    if (
+        previous_orgao
+        and previous_supplier
+        and text(orgao) == text(previous_supplier)
+        and text(supplier) == text(previous_orgao)
+    ):
+        swapped = True
+        kinds.append("party_cnpj_swapped")
+    if previous_city and _looks_like_cnpj(municipio) and text(municipio) == text(previous_orgao):
+        swapped = True
+        kinds.append("municipio_took_prior_cnpj")
+    freshness = _freshness_payload(projected, as_of)
+    if not swapped:
+        return _known(
+            "identity_swap_is_not_insight",
+            fired=False,
+            strength=0.0,
+            reason="municipality_or_party_swap_is_not_insight",
+            evidence=(),
+            epistemic="INFERENCE",
+            method=_method("identity_swap_is_not_insight/1.0", "explicit non-event"),
+            freshness=freshness,
+            result={"insight": False, "swap": False},
+            limitations=("identity_swap_never_promotes",),
+        )
     return _known(
         "identity_swap_is_not_insight",
-        fired=False,
+        fired=True,
         strength=0.0,
-        reason="municipality_or_party_swap_is_not_insight",
-        evidence=(),
-        epistemic="INFERENCE",
-        method=_method("identity_swap_is_not_insight/1.0", "explicit non-event"),
-        freshness=_freshness_payload(projected, as_of),
-        result={"insight": False},
+        reason="identity_swap_not_insight",
+        evidence=explicit_evidence_refs(record),
+        epistemic="FACT",
+        method=_method("identity_swap_is_not_insight/1.0", "CNPJ/municipio inversion is never novelty"),
+        freshness=freshness,
+        result={"insight": False, "swap": True, "kinds": kinds},
         limitations=("identity_swap_never_promotes",),
+    )
+
+
+def detect_value_or_date_conflict(projected: ProjectedRecord, *, as_of: str) -> DetectorResult:
+    """Conflicting official amounts or inverted dates fail closed."""
+    record = projected.record
+    freshness = _freshness_payload(projected, as_of)
+    start = parse_optional_datetime(record.get("data_inicio") or record.get("start_at"))
+    end = parse_optional_datetime(record.get("data_fim") or record.get("end_at"))
+    signed = parse_optional_datetime(record.get("data_assinatura") or record.get("signed_at"))
+    conflicts: list[str] = []
+    if start is not None and end is not None and start > end:
+        conflicts.append("start_after_end")
+    if signed is not None and end is not None and signed > end:
+        conflicts.append("signed_after_end")
+    if signed is not None and start is not None and signed > start:
+        # assinatura after início is unusual but not always a conflict; only flag inversion vs end above
+        pass
+
+    def _amount(key: str) -> Decimal | None:
+        raw = record.get(key)
+        if raw in (None, ""):
+            return None
+        try:
+            return Decimal(str(raw))
+        except ArithmeticError:
+            return None
+
+    total = _amount("valor_total")
+    updated = _amount("valor_atualizado")
+    initial = _amount("valor_inicial")
+    stated_delta = _delta_amount(record.get("value_changes"))
+    if total is not None and updated is not None and total != updated:
+        accounted = stated_delta is not None and abs(updated - total) == stated_delta
+        if not accounted:
+            conflicts.append("conflicting_values")
+    if initial is not None and total is not None and initial != total:
+        if stated_delta is None or abs(initial + stated_delta - total) > Decimal("0.01"):
+            conflicts.append("conflicting_values")
+    if not conflicts:
+        return _known(
+            "value_or_date_conflict",
+            fired=False,
+            strength=0.0,
+            reason="no_value_or_date_conflict",
+            evidence=explicit_evidence_refs(record),
+            epistemic="CALCULATION",
+            method=_method("value_or_date_conflict/1.0", "inverted dates or disagreeing official amounts"),
+            freshness=freshness,
+            result={"conflicts": []},
+        )
+    return _known(
+        "value_or_date_conflict",
+        fired=True,
+        strength=0.0,
+        reason="value_or_date_conflict",
+        evidence=explicit_evidence_refs(record),
+        epistemic="FACT",
+        method=_method("value_or_date_conflict/1.0", "inverted dates or disagreeing official amounts"),
+        freshness=freshness,
+        result={"conflicts": conflicts},
     )
 
 
@@ -766,6 +887,7 @@ def run_detectors(projected: ProjectedRecord, cohort: CohortIndex, *, as_of: str
         detect_peer_difference(projected, as_of=as_of),
         detect_demand_theme(projected, as_of=as_of),
         detect_identity_swap_is_not_insight(projected, as_of=as_of),
+        detect_value_or_date_conflict(projected, as_of=as_of),
     )
 
 

--- a/scripts/contract_publication/state.py
+++ b/scripts/contract_publication/state.py
@@ -101,6 +101,13 @@ def decide_state(
     unsourced = unsourced_insight_detectors(detectors)
     flags = sensitivity_flags(projected, detectors)
 
+    swap = next((item for item in detectors if item.detector_id == "identity_swap_is_not_insight"), None)
+    if swap is not None and swap.fired:
+        return "REJECT", ("identity_swap_not_insight",)
+    conflict = next((item for item in detectors if item.detector_id == "value_or_date_conflict"), None)
+    if conflict is not None and conflict.fired:
+        return "REJECT", ("value_or_date_conflict",)
+
     if unsourced and not sourced:
         return "HOLD_FOR_DATA", ("anomaly_without_source",)
 

--- a/tests/contract_publication/test_detectors.py
+++ b/tests/contract_publication/test_detectors.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from scripts.contract_publication.detectors import (
     build_cohort,
     detect_documented_resumption,
+    detect_identity_swap_is_not_insight,
+    detect_value_or_date_conflict,
     run_detectors,
 )
 from scripts.contract_publication.engine import load_snapshot, rank_candidates
@@ -146,6 +148,28 @@ def test_identity_swap_is_inference_not_fact() -> None:
     item = detectors["identity_swap_is_not_insight"]
     assert item.epistemic_class == "INFERENCE"
     assert not item.fired
+
+
+def test_identity_swap_fires_when_cnpj_and_municipio_are_inverted() -> None:
+    as_of, by_id, _mode = _by_id()
+    record = dict(by_id["CAND-VALUE-TERM-01"])
+    record["municipio"] = record["orgao_cnpj"]
+    record["orgao_cnpj"] = "Florianopolis"
+    projected = project_record(record, as_of=as_of)
+    result = detect_identity_swap_is_not_insight(projected, as_of=as_of)
+    assert result.fired is True
+    assert result.reason_code == "identity_swap_not_insight"
+
+
+def test_value_or_date_conflict_fires_on_inverted_dates() -> None:
+    as_of, by_id, _mode = _by_id()
+    record = dict(by_id["CAND-VALUE-TERM-01"])
+    record["data_inicio"] = "2026-12-01"
+    record["data_fim"] = "2025-02-01"
+    projected = project_record(record, as_of=as_of)
+    result = detect_value_or_date_conflict(projected, as_of=as_of)
+    assert result.fired is True
+    assert result.reason_code == "value_or_date_conflict"
 
 
 def test_ranking_states_are_only_allowed_public_states() -> None:

--- a/tests/public_read_consumers/test_live_refresh.py
+++ b/tests/public_read_consumers/test_live_refresh.py
@@ -236,25 +236,80 @@ def test_inference_is_not_serialized_as_fact() -> None:
                 assert node.get("class") != "FACT"
 
 
-def test_cnpj_or_city_swap_is_not_novelty() -> None:
+def _strong_editorial(records: list[dict]) -> dict:
+    return next(item for item in records if item.get("canonical_contract_id") == "CAND-VALUE-TERM-01")
+
+
+def test_cnpj_or_city_swap_is_not_novelty(tmp_path: Path) -> None:
     from scripts.contract_publication.engine import rank_candidates
 
     snap = _fixture_snapshot()
-    ranked = {
-        item.analysis_candidate_id: item
-        for item in rank_candidates(snap["records"], as_of=snap["as_of"], catalog_mode="fixture")
-    }
-    swapped = ranked.get("CAND-SWAP-01") or next(
-        (
-            item
-            for item in ranked.values()
-            if "swap" in item.analysis_candidate_id.lower() or "municipio" in ",".join(item.reason_codes)
-        ),
-        None,
+    strong = _strong_editorial(snap["records"])
+    baseline = rank_candidates([dict(strong)], as_of=snap["as_of"], catalog_mode="fixture")
+    assert baseline[0].candidate_state == "EDITORIAL_REVIEW"
+
+    swapped = dict(strong)
+    swapped["canonical_contract_id"] = "CAND-SWAP-01"
+    swapped["source_id"] = "CAND-SWAP-01"
+    swapped["numero_controle_pncp"] = "CAND-SWAP-01"
+    swapped["municipio"] = strong["orgao_cnpj"]
+    swapped["orgao_cnpj"] = strong["municipio"]
+    ranked = rank_candidates([swapped], as_of=snap["as_of"], catalog_mode="fixture")
+    item = ranked[0]
+    assert item.analysis_candidate_id == "CAND-SWAP-01"
+    assert item.candidate_state != "EDITORIAL_REVIEW"
+    assert item.candidate_state == "REJECT"
+    assert "identity_swap_not_insight" in item.reason_codes
+
+    dest = tmp_path / "swap"
+    payload_snap = _fixture_snapshot()
+    payload_snap["records"] = [swapped]
+    refresh(
+        consumer=CONSUMER_ID,
+        out=dest,
+        snapshot=payload_snap,
+        fixture=True,
+        generated_at="2026-08-17T00:00:00Z",
     )
-    if swapped is None:
-        pytest.skip("golden corpus has no swap record on this revision")
-    assert swapped.candidate_state != "EDITORIAL_REVIEW" or "swap" not in swapped.reason_codes
+    exported = json.loads((dest / "payload.json").read_text(encoding="utf-8"))
+    analysis = next(row for row in exported["analyses"] if row["analysis_candidate_id"] == "CAND-SWAP-01")
+    assert analysis["data_state"] == "DATA_REJECT"
+    assert "identity_swap_not_insight" in analysis["reason_codes"] or analysis["data_state"] == "DATA_REJECT"
+
+
+def test_value_or_date_conflict_is_not_editorial_review(tmp_path: Path) -> None:
+    from scripts.contract_publication.engine import rank_candidates
+
+    snap = _fixture_snapshot()
+    strong = _strong_editorial(snap["records"])
+    conflicting = dict(strong)
+    conflicting["canonical_contract_id"] = "CAND-CONFLICT-01"
+    conflicting["source_id"] = "CAND-CONFLICT-01"
+    conflicting["numero_controle_pncp"] = "CAND-CONFLICT-01"
+    conflicting["data_inicio"] = "2026-12-01"
+    conflicting["data_fim"] = "2025-02-01"
+    conflicting["valor_total"] = 12_000_000
+    conflicting["valor_atualizado"] = 18_000_000
+    ranked = rank_candidates([conflicting], as_of=snap["as_of"], catalog_mode="fixture")
+    item = ranked[0]
+    assert item.candidate_state != "EDITORIAL_REVIEW"
+    assert item.candidate_state == "REJECT"
+    assert "value_or_date_conflict" in item.reason_codes
+
+    dest = tmp_path / "conflict"
+    payload_snap = _fixture_snapshot()
+    payload_snap["records"] = [conflicting]
+    refresh(
+        consumer=CONSUMER_ID,
+        out=dest,
+        snapshot=payload_snap,
+        fixture=True,
+        generated_at="2026-08-17T00:00:00Z",
+    )
+    exported = json.loads((dest / "payload.json").read_text(encoding="utf-8"))
+    analysis = next(row for row in exported["analyses"] if row["analysis_candidate_id"] == "CAND-CONFLICT-01")
+    assert analysis["data_state"] == "DATA_REJECT"
+    assert "value_or_date_conflict" in analysis["reason_codes"] or analysis["data_state"] == "DATA_REJECT"
 
 
 def test_duplicate_or_rectification_collapses() -> None:


### PR DESCRIPTION
Follow-up to #425. Closes the two adversarial holes the skeptic flagged:

- CNPJ in `municipio` / place name in `orgao_cnpj` is `REJECT` (`identity_swap_not_insight`), never `EDITORIAL_REVIEW`.
- Inverted dates or disagreeing official amounts are `REJECT` (`value_or_date_conflict`).

Tests construct the records and drive `rank_candidates` + `refresh`. No `pytest.skip`.
Does not close #400/#414/#415/#302. Does not touch #413 files.