### PR TITLE
test(coverage): add hermetic real-Postgres live proof

### DIFF
--- a/.github/workflows/coverage-live-proof.yml
+++ b/.github/workflows/coverage-live-proof.yml
@@ -1,0 +1,126 @@
+# Hermetic real-PostgreSQL live proof of #350 source-wide vs entity-scoped identity.
+# Manual by default. Optional PR trigger only when this campaign's files change.
+# No external secrets. No production environment. contents: read only.
+
+name: Coverage live proof
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/ops/coverage_live_proof/**"
+      - "tests/coverage_live_proof/**"
+      - "docs/ops/coverage-live-proof.md"
+      - ".github/workflows/coverage-live-proof.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-live-proof-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+  LOCAL_DATALAKE_DSN: postgresql://proof:proof@127.0.0.1:5432/coverage_live_proof
+  REQUIRE_REAL_DB: "1"
+
+jobs:
+  live-proof:
+    name: Real PostgreSQL live proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: proof
+          POSTGRES_PASSWORD: proof
+          POSTGRES_DB: coverage_live_proof
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U proof -d coverage_live_proof"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install existing dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Orchestrator unit tests
+        run: python3 -m pytest tests/coverage_live_proof -o addopts='' -m 'not real_db' --tb=short
+
+      - name: Existing #350 identity suite
+        run: python3 -m pytest tests/test_coverage_formula_and_identity.py -o addopts='' --tb=short
+
+      - name: Real-db acceptance
+        run: python3 -m pytest tests/coverage_live_proof -o addopts='' -m real_db --tb=short
+
+      - name: Live-proof runner
+        run: |
+          mkdir -p "${RUNNER_TEMP}/coverage-proof"
+          python3 -m scripts.ops.coverage_live_proof run --output "${RUNNER_TEMP}/coverage-proof"
+          python3 -m scripts.ops.coverage_live_proof run --output "${RUNNER_TEMP}/coverage-proof-2"
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          tmp = Path(os.environ["RUNNER_TEMP"])
+          first = (tmp / "coverage-proof" / "evidence.normalized.json").read_bytes()
+          second = (tmp / "coverage-proof-2" / "evidence.normalized.json").read_bytes()
+          raise SystemExit(0 if first == second else 1)
+          PY
+
+      - name: Upload evidence pack
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-live-proof
+          if-no-files-found: warn
+          path: |
+            ${{ runner.temp }}/coverage-proof/evidence.json
+            ${{ runner.temp }}/coverage-proof/evidence.normalized.json
+            ${{ runner.temp }}/coverage-proof/SHA256SUMS
+            ${{ runner.temp }}/coverage-proof/coverage-live-proof.log
+            ${{ runner.temp }}/coverage-proof/golden_path_ledger.json
+
+      - name: Teardown leftover campaign databases
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import os
+
+          from scripts.ops.coverage_live_proof.runner import (
+              is_campaign_database,
+              teardown_ephemeral,
+          )
+          import psycopg2
+
+          dsn = os.environ["LOCAL_DATALAKE_DSN"]
+          conn = psycopg2.connect(dsn)
+          conn.autocommit = True
+          cur = conn.cursor()
+          cur.execute(
+              "SELECT datname FROM pg_database WHERE datname LIKE 'coverage_live_proof_%'"
+          )
+          names = [row[0] for row in cur.fetchall() or []]
+          cur.close()
+          conn.close()
+          for name in names:
+              if is_campaign_database(name):
+                  teardown_ephemeral(dsn, name)
+                  print("dropped", name)
+          PY

--- a/docs/ops/coverage-live-proof.md
+++ b/docs/ops/coverage-live-proof.md
@@ -1,0 +1,111 @@
+# Coverage live proof (issue #350)
+
+Hermetic, reproducible proof that **source-wide aggregated evidence is not
+entity coverage**. The dual-coverage identity rules already live in
+`scripts/coverage/covered_entity.py`. This campaign does **not** change
+engines, thresholds, or schema. It proves those rules on a real PostgreSQL
+that this runner provisions, migrates, seeds, measures, hashes, and tears down.
+
+## Single local command
+
+PostgreSQL must already be reachable (local compose `test-db` on 5433, CI
+service, or any ephemeral cluster). The runner **creates a sibling database**
+`coverage_live_proof_<12-hex>` and drops only that database.
+
+```bash
+LOCAL_DATALAKE_DSN='postgresql://test:test@127.0.0.1:5433/extra_test' \
+  python3 -m scripts.ops.coverage_live_proof run \
+  --output /tmp/coverage-proof
+```
+
+`--dsn` may replace the environment variable. A missing DSN is refused. Known
+production markers (`ec-prod`, `/opt/extra-consultoria`, `extra_prod`, …) are
+refused. SQLite and MagicMock connections are refused.
+
+## Flow
+
+```
+provision ephemeral database
+        ↓
+apply canonical migrations
+  python3 -m scripts.ops.apply_migrations
+        ↓
+load deterministic seed (A / B / C)
+        ↓
+run shipped dual_coverage_evidence_gate
+        ↓
+run shipped golden path
+  python3 -m scripts.golden_path --dsn … --execute-dual-coverage-only
+        ↓
+query + serialize evidence.json
+        ↓
+strip volatiles → evidence.normalized.json
+        ↓
+SHA-256 (semantic + files)
+        ↓
+DROP only coverage_live_proof_*
+```
+
+## Seed expectations
+
+| Scenario | Seed | Expected |
+|----------|------|----------|
+| A source-wide only | aggregate row, NULL identity | `MISSING_EVIDENCE` / `source_wide_aggregate_without_identity`; entity numerator stays 0 |
+| B mixed | same aggregate + one `ent-10` row | only the identified row enters the numerator; no double count |
+| C incompatible | `identity_status=unmappable` | fail-closed `unmappable_evidence_cannot_drop` |
+| D replay | apply the same seed twice | no extra rows; identical `normalized_semantic_hash` |
+
+`GATE_THRESHOLD` is **read** from `scripts/coverage/dual_capability_coverage.py`
+(currently 0.95). It is not redefined here.
+
+## Evidence pack
+
+`--output` receives:
+
+- `evidence.json` — full run (includes `run_id`, duration, ephemeral name)
+- `evidence.normalized.json` — volatiles stripped; byte-stable across replays
+- `SHA256SUMS` — hashes of the two JSON files
+- `coverage-live-proof.log` — sanitized (password/DSN redacted)
+- `golden_path_ledger.json` — ledger from the shipped golden-path entry
+
+## Tests
+
+```bash
+# orchestrator (no database)
+python3 -m pytest tests/coverage_live_proof -o addopts='' -m 'not real_db'
+
+# acceptance (real PostgreSQL)
+REQUIRE_REAL_DB=1 LOCAL_DATALAKE_DSN='postgresql://test:test@127.0.0.1:5433/extra_test' \
+  python3 -m pytest tests/coverage_live_proof -o addopts='' -m real_db
+
+# existing #350 identity suite (unchanged)
+python3 -m pytest tests/test_coverage_formula_and_identity.py -o addopts=''
+```
+
+## CI
+
+Workflow: [`.github/workflows/coverage-live-proof.yml`](../../.github/workflows/coverage-live-proof.yml)
+
+- required `workflow_dispatch`
+- optional pull_request when this campaign’s files change
+- `pgvector/pgvector:pg16` service, no external secrets
+- `permissions: contents: read`
+- uploads the evidence pack and sanitized logs
+- teardown `if: always()`
+
+Dispatch:
+
+```bash
+gh workflow run coverage-live-proof.yml --repo tjsasakifln/extra-cli
+```
+
+A green Actions run may be linked from the PR. Local real-PostgreSQL proof
+alone is **not** `CI_PROVEN`.
+
+## What this does not do
+
+- Does not change `GATE_THRESHOLD` or any coverage formula
+- Does not edit `scripts/golden_path.py`, `tests/conftest.py`, or `scripts/testing/**`
+- Does not touch source registries, adapters, or PR #413
+- Does not connect to `ec-prod` or `/opt/extra-consultoria`
+- Does not treat leftover `extra_test` data as operational proof

--- a/scripts/ops/coverage_live_proof/__init__.py
+++ b/scripts/ops/coverage_live_proof/__init__.py
@@ -1,0 +1,15 @@
+"""Hermetic real-PostgreSQL live proof of #350 dual-coverage identity."""
+
+from __future__ import annotations
+
+EVIDENCE_SCHEMA_VERSION = "coverage-live-proof/1.0"
+EPHEMERAL_DB_PREFIX = "coverage_live_proof_"
+SEED_RUN_ID = "coverage-live-proof-seed"
+SEED_COMPLETED_AT = "2026-08-01T00:00:00+00:00"
+
+__all__ = [
+    "EPHEMERAL_DB_PREFIX",
+    "EVIDENCE_SCHEMA_VERSION",
+    "SEED_COMPLETED_AT",
+    "SEED_RUN_ID",
+]

--- a/scripts/ops/coverage_live_proof/__main__.py
+++ b/scripts/ops/coverage_live_proof/__main__.py
@@ -1,0 +1,95 @@
+"""CLI: python3 -m scripts.ops.coverage_live_proof run --output DIR"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from scripts.ops.coverage_live_proof.admission import sanitize_text
+from scripts.ops.coverage_live_proof.errors import CoverageLiveProofError
+from scripts.ops.coverage_live_proof.runner import (
+    resolve_cli_dsn,
+    run_live_proof,
+    teardown_ephemeral,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.ops.coverage_live_proof",
+        description=(
+            "Hermetic real-PostgreSQL live proof of source-wide vs entity-scoped "
+            "coverage identity (issue #350). Does not change coverage engines."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_p = sub.add_parser("run", help="provision, migrate, seed, evaluate, hash, teardown")
+    run_p.add_argument(
+        "--dsn",
+        default=None,
+        help="PostgreSQL DSN (default: LOCAL_DATALAKE_DSN). Required; no implicit default.",
+    )
+    run_p.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Directory for evidence.json, evidence.normalized.json, SHA256SUMS",
+    )
+    run_p.add_argument(
+        "--skip-golden-path",
+        action="store_true",
+        help="Skip the shipped golden-path subprocess (tests only)",
+    )
+    run_p.add_argument(
+        "--keep-database",
+        action="store_true",
+        help="Do not DROP the ephemeral database (debug only)",
+    )
+
+    td = sub.add_parser("teardown", help="DROP a campaign ephemeral database by name")
+    td.add_argument("--dsn", default=None, help="Admin DSN (default: LOCAL_DATALAKE_DSN)")
+    td.add_argument(
+        "--database",
+        required=True,
+        help="Must match coverage_live_proof_[12 hex chars]",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    dsn = resolve_cli_dsn(getattr(args, "dsn", None))
+    try:
+        if args.command == "run":
+            pack = run_live_proof(
+                dsn=dsn,
+                output_dir=args.output,
+                execute_golden=not args.skip_golden_path,
+                skip_teardown=bool(args.keep_database),
+            )
+            digest = pack["normalized_semantic_hash"]
+            print(f"coverage_live_proof_ok hash={digest}")
+            print(f"evidence={args.output / 'evidence.json'}")
+            return 0
+        if args.command == "teardown":
+            if not dsn:
+                print("explicit DSN required (--dsn or LOCAL_DATALAKE_DSN)", file=sys.stderr)
+                return 2
+            teardown_ephemeral(dsn, args.database)
+            print(f"dropped {args.database}")
+            return 0
+    except CoverageLiveProofError as exc:
+        print(sanitize_text(str(exc), dsn), file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(sanitize_text(f"{type(exc).__name__}: {exc}", dsn), file=sys.stderr)
+        return 1
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/coverage_live_proof/admission.py
+++ b/scripts/ops/coverage_live_proof/admission.py
@@ -1,0 +1,133 @@
+"""DSN admission, production refusal, sanitization, and threshold read.
+
+These helpers are pure (except ``read_gate_threshold``, which imports the
+shipped ``GATE_THRESHOLD``). They do not reimplement coverage math.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse, urlunparse
+
+from scripts.ops.coverage_live_proof.errors import MissingDsnError, ProductionDsnError
+
+PRODUCTION_HOST_MARKERS: tuple[str, ...] = (
+    "ec-prod",
+    "prod.",
+    ".prod",
+    "vps.",
+    "netcup",
+)
+PRODUCTION_PATH_MARKERS: tuple[str, ...] = (
+    "/opt/extra-consultoria",
+    "/opt/extra/",
+)
+PRODUCTION_DB_NAMES: frozenset[str] = frozenset(
+    {
+        "extra_prod",
+        "production",
+        "prod",
+        "prod_datalake",
+    }
+)
+_PASSWORD_IN_URL = re.compile(r"(://[^:/?#]+):([^@/?#]*)@", re.IGNORECASE)
+_POSTGRES_SCHEMES = frozenset({"postgres", "postgresql", "postgresql+psycopg2"})
+
+
+def require_explicit_dsn(dsn: str | None) -> str:
+    """Return a stripped DSN or raise if missing/blank."""
+    if dsn is None or not str(dsn).strip():
+        raise MissingDsnError("explicit DSN required (--dsn or LOCAL_DATALAKE_DSN)")
+    return str(dsn).strip()
+
+
+def refuse_non_postgres_scheme(dsn: str) -> None:
+    """Refuse sqlite and other non-PostgreSQL URL schemes before connect."""
+    parsed = urlparse(dsn)
+    scheme = (parsed.scheme or "").split("+", 1)[0].lower()
+    if scheme in {"sqlite", "sqlite3", "file"}:
+        from scripts.ops.coverage_live_proof.errors import NotPostgresError
+
+        raise NotPostgresError("SQLite DSN refused as live proof")
+    if scheme and scheme not in _POSTGRES_SCHEMES and "://" in dsn:
+        from scripts.ops.coverage_live_proof.errors import NotPostgresError
+
+        raise NotPostgresError(f"non-PostgreSQL DSN scheme refused: {scheme}")
+
+
+def production_hits(dsn: str) -> list[str]:
+    """Return production markers found in host, path, or database name."""
+    lowered = dsn.lower()
+    parsed = urlparse(dsn if "://" in dsn else f"postgresql://{dsn}")
+    host = (parsed.hostname or "").lower()
+    dbname = (parsed.path or "").lstrip("/").split("?")[0].lower()
+    hits: list[str] = []
+    if "ec-prod" in lowered:
+        hits.append("ec-prod")
+    for marker in PRODUCTION_PATH_MARKERS:
+        if marker in lowered:
+            hits.append(marker.rstrip("/"))
+    if "/opt/extra" in lowered and "ec-prod" not in hits:
+        # recall_capture_window uses this substring; keep the same refuse class.
+        hits.append("/opt/extra")
+    if host in {"prod", "production"} or any(m in host for m in PRODUCTION_HOST_MARKERS):
+        if f"host:{host}" not in hits:
+            hits.append(f"host:{host}")
+    if dbname in PRODUCTION_DB_NAMES:
+        hits.append(f"db:{dbname}")
+    return hits
+
+
+def refuse_production_dsn(dsn: str) -> None:
+    """Refuse known production host/base markers used in-repo."""
+    hits = production_hits(dsn)
+    if hits:
+        raise ProductionDsnError(
+            "production DSN refused: " + ", ".join(hits)
+        )
+
+
+def sanitize_dsn(dsn: str) -> str:
+    """Redact the password in a DSN. Never returns the raw secret."""
+    parsed = urlparse(dsn)
+    if parsed.password is not None:
+        user = parsed.username or ""
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        auth = f"{user}:***" if user or parsed.password else ""
+        netloc = f"{auth}@{host}{port}" if auth else f"{host}{port}"
+        return urlunparse(parsed._replace(netloc=netloc))
+    return _PASSWORD_IN_URL.sub(r"\1:***@", dsn)
+
+
+def sanitize_text(text: str, dsn: str | None = None) -> str:
+    """Redact passwords and raw DSN material from logs or exception text."""
+    redacted = text
+    if dsn:
+        password = urlparse(dsn).password
+        if password:
+            redacted = redacted.replace(password, "***")
+        raw = dsn
+        safe = sanitize_dsn(dsn)
+        if raw != safe:
+            redacted = redacted.replace(raw, safe)
+    redacted = _PASSWORD_IN_URL.sub(r"\1:***@", redacted)
+    return redacted
+
+
+def read_gate_threshold() -> float:
+    """Read GATE_THRESHOLD from the shipped dual-coverage implementation."""
+    from scripts.coverage.dual_capability_coverage import GATE_THRESHOLD
+
+    return float(GATE_THRESHOLD)
+
+
+def replace_database_name(dsn: str, dbname: str) -> str:
+    """Return a DSN pointing at ``dbname`` on the same host/user."""
+    parsed = urlparse(dsn)
+    return urlunparse(parsed._replace(path=f"/{dbname}"))
+
+
+def database_name_from_dsn(dsn: str) -> str:
+    parsed = urlparse(dsn)
+    return (parsed.path or "").lstrip("/").split("?")[0]

--- a/scripts/ops/coverage_live_proof/errors.py
+++ b/scripts/ops/coverage_live_proof/errors.py
@@ -1,0 +1,43 @@
+"""Typed failures for the coverage live-proof orchestrator."""
+
+from __future__ import annotations
+
+
+class CoverageLiveProofError(Exception):
+    """Base error for the live-proof runner."""
+
+
+class MissingDsnError(CoverageLiveProofError):
+    """No explicit DSN was provided."""
+
+
+class ProductionDsnError(CoverageLiveProofError):
+    """DSN points at a known production host or database."""
+
+
+class NotPostgresError(CoverageLiveProofError):
+    """Connection is not a real PostgreSQL server."""
+
+
+class FakeConnectionError(CoverageLiveProofError):
+    """MagicMock, unittest mock, or other fake proxy was supplied."""
+
+
+class MigrationApplyError(CoverageLiveProofError):
+    """Canonical apply_migrations failed."""
+
+
+class TeardownSafetyError(CoverageLiveProofError):
+    """Refusing to drop a database that this campaign did not create."""
+
+
+class EphemeralProvisionError(CoverageLiveProofError):
+    """Could not create an ephemeral proof database."""
+
+
+class SeedError(CoverageLiveProofError):
+    """Deterministic seed could not be applied."""
+
+
+class ScenarioExpectationError(CoverageLiveProofError):
+    """A seeded scenario did not match the shipped identity rules."""

--- a/scripts/ops/coverage_live_proof/evidence.py
+++ b/scripts/ops/coverage_live_proof/evidence.py
@@ -1,0 +1,125 @@
+"""Evidence pack serialization, volatile stripping, and SHA-256 sums."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.ops.coverage_live_proof import EVIDENCE_SCHEMA_VERSION
+
+VOLATILE_KEYS: frozenset[str] = frozenset(
+    {
+        "workflow_run_id",
+        "run_id",
+        "duration_seconds",
+        "duration_ms",
+        "started_at",
+        "finished_at",
+        "generated_at",
+        "timestamp",
+        "ephemeral_database",
+        "proof_dsn_sanitized",
+        "admin_dsn_sanitized",
+    }
+)
+
+
+def strip_volatiles(value: Any) -> Any:
+    """Remove timestamps, run IDs, and ephemeral names before the semantic hash."""
+    if isinstance(value, dict):
+        return {
+            key: strip_volatiles(item)
+            for key, item in value.items()
+            if key not in VOLATILE_KEYS
+        }
+    if isinstance(value, list):
+        return [strip_volatiles(item) for item in value]
+    return value
+
+
+def canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+
+
+def normalize_evidence(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = strip_volatiles(payload)
+    if not isinstance(normalized, dict):
+        raise TypeError("normalized evidence must be an object")
+    return normalized
+
+
+def semantic_hash(normalized: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(normalized)).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_evidence_pack(output_dir: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    """Write evidence.json, evidence.normalized.json, SHA256SUMS.
+
+    ``normalized_semantic_hash`` is computed from the stripped payload and
+    then stored on both the full and normalized documents.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    working = dict(payload)
+    working.setdefault("evidence_schema_version", EVIDENCE_SCHEMA_VERSION)
+    normalized = normalize_evidence(working)
+    digest = semantic_hash(normalized)
+    working["normalized_semantic_hash"] = digest
+    normalized["normalized_semantic_hash"] = digest
+
+    evidence_path = output_dir / "evidence.json"
+    normalized_path = output_dir / "evidence.normalized.json"
+    sums_path = output_dir / "SHA256SUMS"
+
+    evidence_path.write_text(
+        json.dumps(working, indent=2, sort_keys=True, ensure_ascii=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    normalized_path.write_bytes(canonical_json_bytes(normalized) + b"\n")
+
+    artifacts = {
+        "evidence.json": sha256_file(evidence_path),
+        "evidence.normalized.json": sha256_file(normalized_path),
+    }
+    sums_lines = [f"{digest}  {name}" for name, digest in artifacts.items()]
+    sums_path.write_text("\n".join(sums_lines) + "\n", encoding="utf-8")
+    artifacts["SHA256SUMS"] = sha256_file(sums_path)
+    working["artifacts"] = artifacts
+    # Rewrite evidence.json so the artifact hashes are part of the durable pack.
+    evidence_path.write_text(
+        json.dumps(working, indent=2, sort_keys=True, ensure_ascii=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    artifacts["evidence.json"] = sha256_file(evidence_path)
+    sums_lines = [
+        f"{artifacts['evidence.json']}  evidence.json",
+        f"{artifacts['evidence.normalized.json']}  evidence.normalized.json",
+    ]
+    sums_path.write_text("\n".join(sums_lines) + "\n", encoding="utf-8")
+    artifacts["SHA256SUMS"] = sha256_file(sums_path)
+    return {
+        "payload": working,
+        "normalized": normalized,
+        "normalized_semantic_hash": digest,
+        "artifacts": artifacts,
+        "paths": {
+            "evidence.json": str(evidence_path),
+            "evidence.normalized.json": str(normalized_path),
+            "SHA256SUMS": str(sums_path),
+        },
+    }

--- a/scripts/ops/coverage_live_proof/probe.py
+++ b/scripts/ops/coverage_live_proof/probe.py
@@ -1,0 +1,91 @@
+"""Prove the connection is real PostgreSQL — never MagicMock, SQLite, or a proxy."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, Mock
+
+from scripts.ops.coverage_live_proof.errors import FakeConnectionError, NotPostgresError
+
+
+def is_fake_connection(conn: object) -> bool:
+    """True for MagicMock, unittest.mock.Mock, or types whose name/module is a mock."""
+    if isinstance(conn, (MagicMock, Mock)):
+        return True
+    module = type(conn).__module__.lower()
+    name = type(conn).__name__.lower()
+    if "unittest.mock" in module or module == "mock":
+        return True
+    if "magicmock" in name or name.endswith("mock") or "fake" in name:
+        return True
+    return False
+
+
+def is_sqlite_connection(conn: object) -> bool:
+    module = type(conn).__module__.lower()
+    name = type(conn).__name__.lower()
+    return "sqlite" in module or "sqlite" in name
+
+
+def is_postgres_version(version_text: str) -> bool:
+    return "postgresql" in (version_text or "").lower()
+
+
+def connection_driver_name(conn: object) -> str:
+    typ = type(conn)
+    return f"{typ.__module__}.{typ.__name__}"
+
+
+def assert_real_postgres(conn: object) -> dict[str, str]:
+    """Query the server and refuse fakes / non-PostgreSQL.
+
+    Returns postgres_version and driver type. Does not log the DSN.
+    """
+    if is_fake_connection(conn):
+        raise FakeConnectionError("MagicMock/proxy refused as live proof")
+    if is_sqlite_connection(conn):
+        raise NotPostgresError("SQLite refused as live proof")
+
+    execute = getattr(conn, "cursor", None)
+    if not callable(execute):
+        raise NotPostgresError("connection has no cursor(); not PostgreSQL")
+
+    cur = conn.cursor()
+    try:
+        try:
+            cur.execute("SELECT version(), current_setting('server_version')")
+            row = cur.fetchone()
+        except Exception as exc:
+            raise NotPostgresError(f"version query failed: {exc}") from exc
+        if not row:
+            raise NotPostgresError("version query returned no row")
+        version_text = str(row[0] or "")
+        server_version = str(row[1] or "")
+        if not is_postgres_version(version_text) and not is_postgres_version(server_version):
+            raise NotPostgresError(
+                f"server is not PostgreSQL: {version_text[:80] or type(conn).__name__}"
+            )
+        return {
+            "postgres_version": version_text,
+            "server_version": server_version,
+            "driver": connection_driver_name(conn),
+        }
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()
+
+
+def connect_real(dsn: str, *, connect_timeout: int = 8) -> Any:
+    """Open a real psycopg2 connection and refuse a mocked driver."""
+    import psycopg2
+
+    if is_fake_connection(psycopg2.connect):
+        raise FakeConnectionError("psycopg2.connect is mocked; refusing live proof")
+    conn = psycopg2.connect(dsn, connect_timeout=connect_timeout)
+    if is_fake_connection(conn):
+        closer = getattr(conn, "close", None)
+        if callable(closer):
+            closer()
+        raise FakeConnectionError("psycopg2.connect returned MagicMock/proxy")
+    return conn

--- a/scripts/ops/coverage_live_proof/runner.py
+++ b/scripts/ops/coverage_live_proof/runner.py
@@ -1,0 +1,581 @@
+"""Orchestrator: admit DSN → ephemeral PG → migrate → seed → gate → pack → teardown."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from scripts.coverage.covered_entity import (
+    MISSING_EVIDENCE,
+    dual_coverage_evidence_gate,
+)
+from scripts.ops.coverage_live_proof import (
+    EPHEMERAL_DB_PREFIX,
+    EVIDENCE_SCHEMA_VERSION,
+)
+from scripts.ops.coverage_live_proof.admission import (
+    read_gate_threshold,
+    refuse_non_postgres_scheme,
+    refuse_production_dsn,
+    replace_database_name,
+    require_explicit_dsn,
+    sanitize_text,
+)
+from scripts.ops.coverage_live_proof.errors import (
+    EphemeralProvisionError,
+    MigrationApplyError,
+    ScenarioExpectationError,
+    TeardownSafetyError,
+)
+from scripts.ops.coverage_live_proof.evidence import write_evidence_pack
+from scripts.ops.coverage_live_proof.probe import assert_real_postgres, connect_real
+from scripts.ops.coverage_live_proof.seed import (
+    CANONICAL_ENTITY_KEY,
+    apply_seed,
+    count_seed_rows,
+    load_seed_rows,
+    seed_fixture_sha256,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EPHEMERAL_NAME = re.compile(r"^coverage_live_proof_[0-9a-f]{12}$")
+_SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def repository_sha(repo_root: Path | None = None) -> str:
+    env_sha = (os.environ.get("GITHUB_SHA") or os.environ.get("CONFENGE_PR_HEAD_SHA") or "").strip()
+    if env_sha:
+        return env_sha
+    root = repo_root or _REPO_ROOT
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S603,S607
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return "unknown"
+    if completed.returncode != 0:
+        return "unknown"
+    return (completed.stdout or "").strip() or "unknown"
+
+
+def local_run_id() -> str:
+    workflow = (os.environ.get("GITHUB_RUN_ID") or "").strip()
+    if workflow:
+        return workflow
+    return f"local-{secrets.token_hex(6)}"
+
+
+def quote_ident(name: str) -> str:
+    if not _SAFE_IDENT.match(name):
+        raise TeardownSafetyError(f"refusing unsafe identifier: {name!r}")
+    return '"' + name.replace('"', "") + '"'
+
+
+def is_campaign_database(name: str) -> bool:
+    return bool(_EPHEMERAL_NAME.match(name))
+
+
+def apply_canonical_migrations(dsn: str, *, root: Path | None = None) -> dict[str, list[str]]:
+    """Call the shipped apply_range. Does not reimplement migrations."""
+    from scripts.ops.apply_migrations import apply_range
+
+    migrations_root = root or (_REPO_ROOT / "db" / "migrations")
+    try:
+        return apply_range(dsn, migrations_root, mode="upgrade")
+    except Exception as exc:
+        message = sanitize_text(str(exc), dsn)
+        raise MigrationApplyError(f"canonical migration apply failed: {message}") from exc
+
+
+def load_applied_migration_ids(conn: Any) -> list[str]:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT version FROM public._migrations ORDER BY version"
+        )
+        return [str(row[0]) for row in (cur.fetchall() or [])]
+    except Exception:
+        rollback = getattr(conn, "rollback", None)
+        if callable(rollback):
+            rollback()
+        return []
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()
+
+
+def create_ephemeral_database(admin_dsn: str) -> tuple[str, str]:
+    """CREATE DATABASE coverage_live_proof_<hex> on the same cluster."""
+    token = secrets.token_hex(6)
+    dbname = f"{EPHEMERAL_DB_PREFIX}{token}"
+    if not is_campaign_database(dbname):
+        raise EphemeralProvisionError(f"generated name rejected: {dbname}")
+    admin = connect_real(admin_dsn)
+    try:
+        admin.autocommit = True
+        assert_real_postgres(admin)
+        cur = admin.cursor()
+        try:
+            cur.execute(f"CREATE DATABASE {quote_ident(dbname)}")
+        except Exception as exc:
+            raise EphemeralProvisionError(
+                sanitize_text(f"CREATE DATABASE failed: {exc}", admin_dsn)
+            ) from exc
+        finally:
+            cur.close()
+    finally:
+        admin.close()
+    return replace_database_name(admin_dsn, dbname), dbname
+
+
+def database_exists(admin_dsn: str, dbname: str) -> bool:
+    if not _SAFE_IDENT.match(dbname):
+        return False
+    conn = connect_real(admin_dsn)
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (dbname,))
+            return cur.fetchone() is not None
+        finally:
+            cur.close()
+    finally:
+        conn.close()
+
+
+def teardown_ephemeral(admin_dsn: str, dbname: str) -> None:
+    """DROP only a campaign-created database. Never extra_test / postgres / prod."""
+    if not is_campaign_database(dbname):
+        raise TeardownSafetyError(
+            f"refusing to drop non-campaign database {dbname!r}"
+        )
+    forbidden = {"extra_test", "postgres", "template0", "template1", "extra_prod"}
+    if dbname in forbidden:
+        raise TeardownSafetyError(f"refusing to drop reserved name {dbname!r}")
+    admin = connect_real(admin_dsn)
+    try:
+        admin.autocommit = True
+        cur = admin.cursor()
+        try:
+            cur.execute(
+                """
+                SELECT pg_terminate_backend(pid)
+                  FROM pg_stat_activity
+                 WHERE datname = %s AND pid <> pg_backend_pid()
+                """,
+                (dbname,),
+            )
+            cur.execute(f"DROP DATABASE IF EXISTS {quote_ident(dbname)}")
+        finally:
+            cur.close()
+    finally:
+        admin.close()
+
+
+def _scenario_rows(rows: list[dict[str, Any]], *tags: str) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for row in rows:
+        meta = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
+        if str(meta.get("live_proof_scenario") or "") in tags:
+            selected.append(row)
+    return selected
+
+
+def evaluate_identity_scenarios(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Run the shipped dual_coverage_evidence_gate on each scenario slice."""
+    from scripts.coverage.covered_entity import compute_coverage_kpis
+
+    slice_a = _scenario_rows(rows, "A")
+    slice_b = _scenario_rows(rows, "A", "B")
+    slice_c = _scenario_rows(rows, "C")
+
+    gate_a = dual_coverage_evidence_gate(slice_a)
+    gate_b = dual_coverage_evidence_gate(slice_b)
+    gate_c = dual_coverage_evidence_gate(slice_c)
+    kpis_a = compute_coverage_kpis(slice_a, universe_entity_ids=[CANONICAL_ENTITY_KEY])
+    kpis_b = compute_coverage_kpis(slice_b, universe_entity_ids=[CANONICAL_ENTITY_KEY])
+
+    scenario_a = {
+        "id": "A",
+        "name": "source_wide_only",
+        "classification": gate_a["classification"],
+        "reason": gate_a["reason"],
+        "measurement_success": gate_a["measurement_success"],
+        "source_wide_count": gate_a["source_wide_count"],
+        "identified_count": gate_a["identified_count"],
+        "unmapped_count": gate_a["unmapped_count"],
+        "entity_scoped_numerator": len(gate_a["numerator_rows"]),
+        "entity_denominator": 1,
+        "evaluated_entities": [CANONICAL_ENTITY_KEY],
+        "entity_status": MISSING_EVIDENCE,
+        "covered_count": kpis_a.covered_count,
+    }
+    scenario_b = {
+        "id": "B",
+        "name": "source_wide_plus_entity_scoped",
+        "classification": gate_b["classification"],
+        "reason": gate_b["reason"],
+        "measurement_success": gate_b["measurement_success"],
+        "source_wide_count": gate_b["source_wide_count"],
+        "identified_count": gate_b["identified_count"],
+        "unmapped_count": gate_b["unmapped_count"],
+        "entity_scoped_numerator": len(gate_b["numerator_rows"]),
+        "entity_denominator": 1,
+        "evaluated_entities": [CANONICAL_ENTITY_KEY],
+        "covered_count": kpis_b.covered_count,
+    }
+    scenario_c = {
+        "id": "C",
+        "name": "null_or_incompatible_identity",
+        "classification": gate_c["classification"],
+        "reason": gate_c["reason"],
+        "measurement_success": gate_c["measurement_success"],
+        "source_wide_count": gate_c["source_wide_count"],
+        "identified_count": gate_c["identified_count"],
+        "unmapped_count": gate_c["unmapped_count"],
+        "entity_scoped_numerator": len(gate_c["numerator_rows"]),
+        "entity_denominator": 1,
+        "evaluated_entities": ["ghost-unmappable"],
+    }
+
+    expectations = []
+    if scenario_a["reason"] != "source_wide_aggregate_without_identity":
+        expectations.append("A reason != source_wide_aggregate_without_identity")
+    if scenario_a["entity_scoped_numerator"] != 0:
+        expectations.append("A entity-scoped numerator increased")
+    if scenario_a["classification"] != MISSING_EVIDENCE:
+        expectations.append("A classification != MISSING_EVIDENCE")
+    if scenario_a["covered_count"] != 0:
+        expectations.append("A covered_count != 0")
+    if scenario_b["identified_count"] != 1 or scenario_b["entity_scoped_numerator"] != 1:
+        expectations.append("B did not count exactly one entity-scoped row")
+    if scenario_b["source_wide_count"] != 1:
+        expectations.append("B lost the source-wide aggregate")
+    if scenario_b["measurement_success"] is not True:
+        expectations.append("B measurement_success is not true")
+    if scenario_c["reason"] != "unmappable_evidence_cannot_drop":
+        expectations.append("C reason != unmappable_evidence_cannot_drop")
+    if scenario_c["measurement_success"] is not False:
+        expectations.append("C did not fail-close")
+    if scenario_c["entity_scoped_numerator"] != 0:
+        expectations.append("C entity-scoped numerator is not empty")
+
+    return {
+        "A": scenario_a,
+        "B": scenario_b,
+        "C": scenario_c,
+        "source_wide_count": gate_a["source_wide_count"],
+        "entity_scoped_count": gate_b["identified_count"],
+        "evaluated_entities": [CANONICAL_ENTITY_KEY, "ghost-unmappable"],
+        "expectation_errors": expectations,
+    }
+
+
+def execute_golden_path(proof_dsn: str, output_dir: Path, repo_root: Path) -> dict[str, Any]:
+    """Invoke the shipped golden-path entry on the ephemeral DSN."""
+    ledger = output_dir / "golden_path_ledger.json"
+    argv = [
+        sys.executable,
+        "-m",
+        "scripts.golden_path",
+        "--dsn",
+        proof_dsn,
+        "--execute-dual-coverage-only",
+        "--capability",
+        "both",
+        "--ledger-output",
+        str(ledger),
+    ]
+    env = os.environ.copy()
+    env["LOCAL_DATALAKE_DSN"] = proof_dsn
+    completed = subprocess.run(  # noqa: S603
+        argv,
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    ledger_payload: dict[str, Any] | None = None
+    if ledger.is_file():
+        try:
+            loaded = json.loads(ledger.read_text(encoding="utf-8"))
+            ledger_payload = loaded if isinstance(loaded, dict) else {"raw": loaded}
+        except json.JSONDecodeError:
+            ledger_payload = None
+    recorded_argv = [
+        sys.executable,
+        "-m",
+        "scripts.golden_path",
+        "--dsn",
+        "<redacted>",
+        "--execute-dual-coverage-only",
+        "--capability",
+        "both",
+        "--ledger-output",
+        "golden_path_ledger.json",
+    ]
+    details: dict[str, Any] = {}
+    if ledger_payload:
+        steps = ledger_payload.get("steps") or []
+        for step in steps:
+            if isinstance(step, dict) and step.get("step") in {
+                "dual_capability_coverage",
+                "coverage",
+                "calculate_coverage",
+            }:
+                details = step.get("details") or {}
+                break
+        if not details:
+            details = {
+                "measurement_success": ledger_payload.get("measurement_success"),
+                "overall": ledger_payload.get("overall") or ledger_payload.get("status"),
+            }
+    return {
+        "returncode": completed.returncode,
+        "argv": recorded_argv,
+        "stdout_sanitized": sanitize_text(completed.stdout or "", proof_dsn),
+        "stderr_sanitized": sanitize_text(completed.stderr or "", proof_dsn),
+        "ledger_present": ledger_payload is not None,
+        "measurement_success": bool((details or {}).get("measurement_success")),
+        "missing_evidence_reason": (details or {}).get("missing_evidence_reason"),
+        "source_wide_evidence_count": (details or {}).get("source_wide_evidence_count"),
+        "details": {
+            key: details[key]
+            for key in (
+                "measurement_success",
+                "coverage_gate_pass",
+                "missing_evidence_reason",
+                "source_wide_evidence_count",
+                "unmapped_evidence_count",
+                "method",
+                "dual_gate_status",
+            )
+            if key in details
+        },
+    }
+
+
+def _write_sanitized_log(path: Path, lines: list[str], dsn: str) -> None:
+    path.write_text(
+        "\n".join(sanitize_text(line, dsn) for line in lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_live_proof(
+    *,
+    dsn: str | None,
+    output_dir: Path,
+    repo_root: Path | None = None,
+    migrations_root: Path | None = None,
+    execute_golden: bool = True,
+    skip_teardown: bool = False,
+    inject_failure: str | None = None,
+) -> dict[str, Any]:
+    """Run the hermetic proof. Always tears down the ephemeral DB unless skipped."""
+    started = time.monotonic()
+    root = repo_root or _REPO_ROOT
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_lines: list[str] = []
+    errors: list[str] = []
+    commands: list[dict[str, Any]] = []
+    ephemeral_name: str | None = None
+    admin_dsn = require_explicit_dsn(dsn)
+    refuse_non_postgres_scheme(admin_dsn)
+    refuse_production_dsn(admin_dsn)
+    run_id = local_run_id()
+    threshold = read_gate_threshold()
+    proof_dsn: str | None = None
+    pack: dict[str, Any] | None = None
+
+    def log(message: str) -> None:
+        log_lines.append(sanitize_text(message, admin_dsn))
+
+    try:
+        admin_conn = connect_real(admin_dsn)
+        try:
+            probe = assert_real_postgres(admin_conn)
+        finally:
+            admin_conn.close()
+        log(f"admin_probe driver={probe['driver']}")
+
+        if inject_failure == "before_create":
+            raise RuntimeError("injected failure before_create")
+
+        proof_dsn, ephemeral_name = create_ephemeral_database(admin_dsn)
+        log(f"created {ephemeral_name}")
+        commands.append(
+            {
+                "step": "create_ephemeral_database",
+                "argv": ["CREATE DATABASE", "<ephemeral>"],
+            }
+        )
+
+        if inject_failure == "after_create":
+            raise RuntimeError("injected failure after_create")
+
+        proof_conn = connect_real(proof_dsn)
+        try:
+            probe = assert_real_postgres(proof_conn)
+        finally:
+            proof_conn.close()
+
+        migrate_cmd = [
+            sys.executable,
+            "-m",
+            "scripts.ops.apply_migrations",
+            "--dsn",
+            "<redacted>",
+        ]
+        commands.append({"step": "apply_migrations", "argv": migrate_cmd})
+        migration_summary = apply_canonical_migrations(proof_dsn, root=migrations_root)
+        log(
+            "migrations applied={a} skipped={s} repaired={r}".format(
+                a=len(migration_summary.get("applied", [])),
+                s=len(migration_summary.get("skipped", [])),
+                r=len(migration_summary.get("repaired", [])),
+            )
+        )
+
+        if inject_failure == "after_migrate":
+            raise RuntimeError("injected failure after_migrate")
+
+        proof_conn = connect_real(proof_dsn)
+        try:
+            first_seed = apply_seed(proof_conn)
+            rows = load_seed_rows(proof_conn)
+            first_count = count_seed_rows(proof_conn)
+            scenarios = evaluate_identity_scenarios(rows)
+            second_seed = apply_seed(proof_conn)
+            second_count = count_seed_rows(proof_conn)
+            replay_rows = load_seed_rows(proof_conn)
+            replay_scenarios = evaluate_identity_scenarios(replay_rows)
+            migration_ids = load_applied_migration_ids(proof_conn)
+        finally:
+            proof_conn.close()
+
+        if scenarios["expectation_errors"]:
+            raise ScenarioExpectationError(
+                "; ".join(scenarios["expectation_errors"])
+            )
+        if first_count != second_count:
+            raise ScenarioExpectationError(
+                f"replay duplicated rows: first={first_count} second={second_count}"
+            )
+        if second_seed["inserted"] != 0:
+            raise ScenarioExpectationError(
+                f"replay inserted {second_seed['inserted']} extra rows"
+            )
+
+        golden: dict[str, Any] = {"executed": False}
+        if execute_golden:
+            golden = execute_golden_path(proof_dsn, output_dir, root)
+            golden["executed"] = True
+            commands.append({"step": "golden_path", "argv": golden.get("argv", [])})
+            log(f"golden_path returncode={golden.get('returncode')}")
+
+        duration_ms = int((time.monotonic() - started) * 1000)
+        payload = {
+            "evidence_schema_version": EVIDENCE_SCHEMA_VERSION,
+            "repository_sha": repository_sha(root),
+            "run_id": run_id,
+            "workflow_run_id": os.environ.get("GITHUB_RUN_ID") or run_id,
+            "postgres_version": probe["postgres_version"],
+            "connection": {
+                "driver": probe["driver"],
+                "type": probe["driver"].rsplit(".", 1)[-1],
+            },
+            "migrations": {
+                "applied": list(migration_summary.get("applied") or []),
+                "skipped": list(migration_summary.get("skipped") or []),
+                "repaired": list(migration_summary.get("repaired") or []),
+                "identifiers": migration_ids,
+            },
+            "seed_fixture_sha256": seed_fixture_sha256(),
+            "source_wide_count": scenarios["source_wide_count"],
+            "entity_scoped_count": scenarios["entity_scoped_count"],
+            "evaluated_entities": scenarios["evaluated_entities"],
+            "scenarios": {
+                "A": scenarios["A"],
+                "B": scenarios["B"],
+                "C": scenarios["C"],
+                "D": {
+                    "id": "D",
+                    "name": "replay_idempotent",
+                    "row_count_first": first_count,
+                    "row_count_second": second_count,
+                    "inserted_first": first_seed["inserted"],
+                    "inserted_second": second_seed["inserted"],
+                    "skipped_second": second_seed["skipped"],
+                    "row_counts_stable": first_count == second_count,
+                    "scenarios_equal": scenarios["A"] == replay_scenarios["A"]
+                    and scenarios["B"] == replay_scenarios["B"]
+                    and scenarios["C"] == replay_scenarios["C"],
+                },
+            },
+            "measurement_success": bool(scenarios["B"]["measurement_success"]),
+            "threshold": threshold,
+            "commands": commands,
+            "duration_ms": duration_ms,
+            "errors": errors,
+            "golden_path": {
+                "executed": golden.get("executed"),
+                "returncode": golden.get("returncode"),
+                "measurement_success": golden.get("measurement_success"),
+                "missing_evidence_reason": golden.get("missing_evidence_reason"),
+                "source_wide_evidence_count": golden.get("source_wide_evidence_count"),
+                "details": golden.get("details") or {},
+            },
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "ephemeral_database": ephemeral_name,
+        }
+        pack = write_evidence_pack(output_dir, payload)
+        log(f"normalized_semantic_hash={pack['normalized_semantic_hash']}")
+        _write_sanitized_log(output_dir / "coverage-live-proof.log", log_lines, admin_dsn)
+        if inject_failure == "after_pack":
+            raise RuntimeError("injected failure after_pack")
+        return pack
+    except Exception as exc:
+        errors.append(sanitize_text(f"{type(exc).__name__}: {exc}", admin_dsn))
+        log(f"ERROR {type(exc).__name__}: {exc}")
+        _write_sanitized_log(output_dir / "coverage-live-proof.log", log_lines, admin_dsn)
+        raise
+    finally:
+        if ephemeral_name and not skip_teardown:
+            try:
+                teardown_ephemeral(admin_dsn, ephemeral_name)
+                log(f"dropped {ephemeral_name}")
+            except Exception as teardown_exc:
+                # Teardown errors must not hide the original failure.
+                _write_sanitized_log(
+                    output_dir / "coverage-live-proof.log",
+                    [*log_lines, f"teardown_error: {teardown_exc}"],
+                    admin_dsn,
+                )
+                if pack is not None:
+                    raise
+                # If the run already failed, keep the original exception.
+                if not errors:
+                    raise
+
+
+def resolve_cli_dsn(cli_dsn: str | None) -> str | None:
+    """CLI DSN wins; otherwise LOCAL_DATALAKE_DSN. Never invent a default."""
+    if cli_dsn and cli_dsn.strip():
+        return cli_dsn.strip()
+    env = os.environ.get("LOCAL_DATALAKE_DSN")
+    return env.strip() if env and env.strip() else None

--- a/scripts/ops/coverage_live_proof/seed.py
+++ b/scripts/ops/coverage_live_proof/seed.py
@@ -1,0 +1,257 @@
+"""Deterministic coverage_evidence seed for scenarios A–C (replay-safe)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import date
+from typing import Any
+
+from scripts.ops.coverage_live_proof import SEED_COMPLETED_AT, SEED_RUN_ID
+from scripts.ops.coverage_live_proof.errors import SeedError
+
+# Fixed identity used by scenario B. Not a planilha member; identity proof
+# goes through dual_coverage_evidence_gate, not universe membership.
+ENTITY_ID = 10
+CANONICAL_ENTITY_KEY = "ent-10"
+SOURCE = "pncp"
+DATA_TYPE = "bids"
+CAPABILITY = "open_tenders"
+
+
+@dataclass(frozen=True)
+class SeedRow:
+    scenario: str
+    entity_id: int | None
+    canonical_entity_key: str | None
+    source: str
+    data_type: str
+    capability: str
+    run_id: str
+    state: str
+    count_obtained: int
+    count_persisted: int
+    metadata: dict[str, Any]
+
+
+def seed_rows() -> tuple[SeedRow, ...]:
+    """Minimal fixture: source-wide (A), entity-scoped (B), unmappable (C)."""
+    source_wide_meta = {
+        "pipeline": "resilient_cycle",
+        "live_proof_scenario": "A",
+        "grain": "source_wide",
+    }
+    return (
+        SeedRow(
+            scenario="A",
+            entity_id=None,
+            canonical_entity_key=None,
+            source=SOURCE,
+            data_type=DATA_TYPE,
+            capability=CAPABILITY,
+            run_id=SEED_RUN_ID,
+            state="success_with_data",
+            count_obtained=800,
+            count_persisted=800,
+            metadata=source_wide_meta,
+        ),
+        SeedRow(
+            scenario="B",
+            entity_id=ENTITY_ID,
+            canonical_entity_key=CANONICAL_ENTITY_KEY,
+            source=SOURCE,
+            data_type=DATA_TYPE,
+            capability=CAPABILITY,
+            run_id=SEED_RUN_ID,
+            state="success_with_data",
+            count_obtained=3,
+            count_persisted=3,
+            metadata={"live_proof_scenario": "B", "grain": "entity"},
+        ),
+        SeedRow(
+            scenario="C",
+            entity_id=99,
+            canonical_entity_key="ghost-unmappable",
+            source=SOURCE,
+            data_type=DATA_TYPE,
+            capability=CAPABILITY,
+            run_id=SEED_RUN_ID,
+            state="success_with_data",
+            count_obtained=1,
+            count_persisted=1,
+            metadata={
+                "identity_status": "unmappable",
+                "live_proof_scenario": "C",
+                "grain": "incompatible",
+            },
+        ),
+    )
+
+
+def seed_fixture_payload() -> dict[str, Any]:
+    return {
+        "run_id": SEED_RUN_ID,
+        "completed_at": SEED_COMPLETED_AT,
+        "rows": [asdict(row) for row in seed_rows()],
+    }
+
+
+def seed_fixture_sha256() -> str:
+    payload = json.dumps(seed_fixture_payload(), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _row_exists(cur: Any, row: SeedRow) -> bool:
+    if row.entity_id is None and row.canonical_entity_key is None:
+        cur.execute(
+            """
+            SELECT 1 FROM coverage_evidence
+             WHERE source = %s AND data_type = %s AND run_id = %s
+               AND entity_id IS NULL AND canonical_entity_key IS NULL
+             LIMIT 1
+            """,
+            (row.source, row.data_type, row.run_id),
+        )
+    elif row.canonical_entity_key:
+        cur.execute(
+            """
+            SELECT 1 FROM coverage_evidence
+             WHERE canonical_entity_key = %s AND source = %s
+               AND data_type = %s AND run_id = %s
+             LIMIT 1
+            """,
+            (row.canonical_entity_key, row.source, row.data_type, row.run_id),
+        )
+    else:
+        cur.execute(
+            """
+            SELECT 1 FROM coverage_evidence
+             WHERE entity_id = %s AND source = %s AND data_type = %s AND run_id = %s
+               AND canonical_entity_key IS NULL
+             LIMIT 1
+            """,
+            (row.entity_id, row.source, row.data_type, row.run_id),
+        )
+    return cur.fetchone() is not None
+
+
+def apply_seed(conn: Any) -> dict[str, int]:
+    """Insert the fixture idempotently. Returns inserted/skipped counts."""
+    from psycopg2.extras import Json
+
+    cur = conn.cursor()
+    inserted = 0
+    skipped = 0
+    try:
+        for row in seed_rows():
+            if _row_exists(cur, row):
+                skipped += 1
+                continue
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO coverage_evidence (
+                        entity_id, canonical_entity_key, source, data_type,
+                        capability, run_id, state, count_obtained, count_transformed,
+                        count_persisted, metadata, queried_start, queried_end,
+                        completed_at, checked_at, applicability, freshness_status
+                    ) VALUES (
+                        %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s,
+                        %s::timestamptz, %s::timestamptz, %s, %s
+                    )
+                    """,
+                    (
+                        row.entity_id,
+                        row.canonical_entity_key,
+                        row.source,
+                        row.data_type,
+                        row.capability,
+                        row.run_id,
+                        row.state,
+                        row.count_obtained,
+                        row.count_persisted,
+                        row.count_persisted,
+                        Json(row.metadata),
+                        date(2026, 7, 1),
+                        date(2026, 7, 31),
+                        SEED_COMPLETED_AT,
+                        SEED_COMPLETED_AT,
+                        "applicable",
+                        "unknown",
+                    ),
+                )
+            except Exception as exc:
+                raise SeedError(f"seed insert failed for scenario {row.scenario}: {exc}") from exc
+            inserted += 1
+        commit = getattr(conn, "commit", None)
+        if callable(commit):
+            commit()
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()
+    return {"inserted": inserted, "skipped": skipped, "fixture_rows": len(seed_rows())}
+
+
+def load_seed_rows(conn: Any) -> list[dict[str, Any]]:
+    """Load seeded coverage_evidence rows as mappings for the shipped gate."""
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT entity_id, canonical_entity_key, source, data_type, state::text,
+                   run_id, count_obtained, count_persisted, metadata, capability, id
+              FROM coverage_evidence
+             WHERE run_id = %s
+             ORDER BY id
+            """,
+            (SEED_RUN_ID,),
+        )
+        fetched = cur.fetchall() or []
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()
+
+    rows: list[dict[str, Any]] = []
+    for item in fetched:
+        metadata = item[8] if isinstance(item[8], dict) else {}
+        if not isinstance(metadata, dict):
+            try:
+                metadata = json.loads(str(item[8] or "{}"))
+            except json.JSONDecodeError:
+                metadata = {}
+        rows.append(
+            {
+                "entity_id": item[0],
+                "canonical_entity_key": item[1],
+                "source": item[2],
+                "data_type": item[3],
+                "state": item[4],
+                "run_id": item[5],
+                "count_obtained": item[6],
+                "count_persisted": item[7],
+                "metadata": metadata,
+                "capability": item[9],
+                "evidence_id": item[10],
+            }
+        )
+    return rows
+
+
+def count_seed_rows(conn: Any) -> int:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT count(*) FROM coverage_evidence WHERE run_id = %s",
+            (SEED_RUN_ID,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()

--- a/tests/coverage_live_proof/__init__.py
+++ b/tests/coverage_live_proof/__init__.py
@@ -1,0 +1,1 @@
+"""Live-proof tests for #350 real-PostgreSQL identity evidence."""

--- a/tests/coverage_live_proof/test_admission.py
+++ b/tests/coverage_live_proof/test_admission.py
@@ -1,0 +1,159 @@
+"""Unit tests for DSN admission, fake-connection refusal, sanitize, threshold."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.coverage.dual_capability_coverage import GATE_THRESHOLD
+from scripts.ops.coverage_live_proof import EVIDENCE_SCHEMA_VERSION
+from scripts.ops.coverage_live_proof.admission import (
+    production_hits,
+    read_gate_threshold,
+    refuse_non_postgres_scheme,
+    refuse_production_dsn,
+    require_explicit_dsn,
+    sanitize_dsn,
+    sanitize_text,
+)
+from scripts.ops.coverage_live_proof.errors import (
+    FakeConnectionError,
+    MissingDsnError,
+    NotPostgresError,
+    ProductionDsnError,
+)
+from scripts.ops.coverage_live_proof.evidence import (
+    normalize_evidence,
+    semantic_hash,
+    write_evidence_pack,
+)
+from scripts.ops.coverage_live_proof.probe import (
+    assert_real_postgres,
+    connect_real,
+    is_postgres_version,
+)
+from scripts.ops.coverage_live_proof.runner import resolve_cli_dsn
+
+
+def test_refuses_missing_dsn() -> None:
+    with pytest.raises(MissingDsnError, match="explicit DSN"):
+        require_explicit_dsn(None)
+    with pytest.raises(MissingDsnError, match="explicit DSN"):
+        require_explicit_dsn("   ")
+    assert require_explicit_dsn("postgresql://test:test@127.0.0.1:5433/extra_test")
+
+
+def test_refuses_production_host_and_base() -> None:
+    cases = (
+        "postgresql://u:secret@ec-prod:5432/extra",
+        "postgresql://u:p@ec-prod.example:5432/extra",
+        "postgresql://u:p@127.0.0.1:5432/extra_prod",
+        "postgresql://u:p@host/x?app=/opt/extra-consultoria/app",
+        "postgresql://u:p@vps.example/production",
+    )
+    for dsn in cases:
+        with pytest.raises(ProductionDsnError, match="production DSN refused"):
+            refuse_production_dsn(dsn)
+    assert production_hits("postgresql://test:test@127.0.0.1:5433/extra_test") == []
+    refuse_production_dsn("postgresql://test:test@127.0.0.1:5433/extra_test")
+
+
+def test_refuses_sqlite_and_non_postgres_scheme() -> None:
+    with pytest.raises(NotPostgresError, match="SQLite"):
+        refuse_non_postgres_scheme("sqlite:///tmp/proof.db")
+    with pytest.raises(NotPostgresError):
+        refuse_non_postgres_scheme("sqlite3://foo")
+    refuse_non_postgres_scheme("postgresql://test:test@127.0.0.1:5433/extra_test")
+    assert is_postgres_version("PostgreSQL 16.4 on x86_64") is True
+    assert is_postgres_version("SQLite 3.45.0") is False
+
+
+def test_assert_real_postgres_refuses_magicmock() -> None:
+    fake = MagicMock(name="psycopg2.extensions.connection")
+    fake.cursor.return_value.fetchone.return_value = ("PostgreSQL 16.0", "16.0")
+    with pytest.raises(FakeConnectionError, match="MagicMock"):
+        assert_real_postgres(fake)
+
+
+def test_assert_real_postgres_refuses_sqlite_version() -> None:
+    class _Cursor:
+        def execute(self, _sql: str) -> None:
+            return None
+
+        def fetchone(self) -> tuple[str, str]:
+            return ("SQLite 3.45.1", "3.45.1")
+
+        def close(self) -> None:
+            return None
+
+    class _ForeignConn:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+    with pytest.raises(NotPostgresError, match="not PostgreSQL"):
+        assert_real_postgres(_ForeignConn())
+
+
+def test_connect_real_refuses_mocked_psycopg2() -> None:
+    """Autouse fixture mocks psycopg2.connect — the shipped probe must refuse it."""
+    with pytest.raises(FakeConnectionError):
+        connect_real("postgresql://test:test@127.0.0.1:5433/extra_test")
+
+
+def test_sanitize_dsn_and_logs_hide_password() -> None:
+    dsn = "postgresql://proof:super-secret@127.0.0.1:5432/coverage_live_proof"
+    safe = sanitize_dsn(dsn)
+    assert "super-secret" not in safe
+    assert "***" in safe
+    assert "127.0.0.1" in safe
+    leaked = f"failed to connect {dsn} password=super-secret"
+    cleaned = sanitize_text(leaked, dsn)
+    assert "super-secret" not in cleaned
+    assert dsn not in cleaned
+
+
+def test_threshold_is_read_not_rewritten() -> None:
+    assert read_gate_threshold() == GATE_THRESHOLD
+    assert GATE_THRESHOLD == 0.95
+    package = Path(__file__).resolve().parents[2] / "scripts" / "ops" / "coverage_live_proof"
+    for path in package.glob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        assert "GATE_THRESHOLD =" not in text
+        assert "threshold = 0.95" not in text.lower()
+
+
+def test_normalized_hash_stable_across_volatile_fields(tmp_path: Path) -> None:
+    base = {
+        "evidence_schema_version": EVIDENCE_SCHEMA_VERSION,
+        "source_wide_count": 1,
+        "entity_scoped_count": 1,
+        "threshold": read_gate_threshold(),
+        "scenarios": {"A": {"reason": "source_wide_aggregate_without_identity"}},
+    }
+    first = {**base, "run_id": "local-aaa", "duration_ms": 12, "generated_at": "2026-01-01T00:00:00Z"}
+    second = {**base, "run_id": "local-bbb", "duration_ms": 99, "generated_at": "2026-12-31T23:59:59Z"}
+    assert semantic_hash(normalize_evidence(first)) == semantic_hash(normalize_evidence(second))
+    pack_a = write_evidence_pack(tmp_path / "a", first)
+    pack_b = write_evidence_pack(tmp_path / "b", second)
+    assert pack_a["normalized_semantic_hash"] == pack_b["normalized_semantic_hash"]
+    bytes_a = (tmp_path / "a" / "evidence.normalized.json").read_bytes()
+    bytes_b = (tmp_path / "b" / "evidence.normalized.json").read_bytes()
+    assert bytes_a == bytes_b
+
+
+def test_resolve_cli_dsn_does_not_invent_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOCAL_DATALAKE_DSN", raising=False)
+    assert resolve_cli_dsn(None) is None
+    monkeypatch.setenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
+    assert resolve_cli_dsn(None) == "postgresql://test:test@127.0.0.1:5433/extra_test"
+    assert resolve_cli_dsn("postgresql://x:y@127.0.0.1/db") == "postgresql://x:y@127.0.0.1/db"
+
+
+def test_cli_run_without_dsn_exits_nonzero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("LOCAL_DATALAKE_DSN", raising=False)
+    from scripts.ops.coverage_live_proof.__main__ import main
+
+    code = main(["run", "--output", str(tmp_path)])
+    assert code != 0

--- a/tests/coverage_live_proof/test_orchestrator.py
+++ b/tests/coverage_live_proof/test_orchestrator.py
@@ -1,0 +1,63 @@
+"""Orchestrator unit tests that drive shipped helpers without a live database."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ops.coverage_live_proof.admission import sanitize_text
+from scripts.ops.coverage_live_proof.errors import MigrationApplyError, TeardownSafetyError
+from scripts.ops.coverage_live_proof.runner import is_campaign_database, quote_ident
+from scripts.ops.coverage_live_proof.seed import seed_fixture_sha256, seed_rows
+
+
+def test_campaign_database_name_is_strict() -> None:
+    assert is_campaign_database("coverage_live_proof_aabbccddeeff") is True
+    assert is_campaign_database("extra_test") is False
+    assert is_campaign_database("postgres") is False
+    assert is_campaign_database("coverage_live_proof_extra_test") is False
+    assert is_campaign_database("coverage_live_proof_") is False
+
+
+def test_quote_ident_rejects_unsafe_names() -> None:
+    assert quote_ident("coverage_live_proof_aabbccddeeff") == '"coverage_live_proof_aabbccddeeff"'
+    with pytest.raises(TeardownSafetyError):
+        quote_ident('extra"; DROP DATABASE extra_test; --')
+
+
+def test_seed_fixture_is_deterministic() -> None:
+    first = seed_fixture_sha256()
+    second = seed_fixture_sha256()
+    assert first == second
+    assert len(first) == 64
+    rows = seed_rows()
+    assert {row.scenario for row in rows} == {"A", "B", "C"}
+    assert rows[0].entity_id is None
+    assert rows[0].canonical_entity_key is None
+    assert rows[1].canonical_entity_key == "ent-10"
+    assert rows[2].metadata.get("identity_status") == "unmappable"
+
+
+def test_migration_error_message_hides_password() -> None:
+    dsn = "postgresql://proof:hunter2@127.0.0.1:1/nope"
+    wrapped = MigrationApplyError(
+        sanitize_text("canonical migration apply failed: could not connect " + dsn, dsn)
+    )
+    text = str(wrapped)
+    assert "hunter2" not in text
+    assert "canonical migration apply failed" in text
+
+
+def test_package_does_not_redefine_coverage_logic() -> None:
+    root = Path(__file__).resolve().parents[2] / "scripts" / "ops" / "coverage_live_proof"
+    forbidden = (
+        "GATE_THRESHOLD =",
+        "def classify_evidence_identity",
+        "def dual_coverage_evidence_gate",
+        "def compute_dual_coverage",
+    )
+    for path in root.glob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for token in forbidden:
+            assert token not in text, f"{path.name} must not contain {token}"

--- a/tests/coverage_live_proof/test_real_acceptance.py
+++ b/tests/coverage_live_proof/test_real_acceptance.py
@@ -211,7 +211,8 @@ def test_golden_path_entry_runs_on_ephemeral(migrated_proof_dsn: str, tmp_path: 
     assert "super-secret" not in combined
     password = urlparse(migrated_proof_dsn).password or ""
     if password:
-        assert password not in combined
+        assert f":{password}@" not in combined
+        assert migrated_proof_dsn not in combined
     assert result["ledger_present"] is True or result["returncode"] in {0, 1, 2}
 
 
@@ -235,7 +236,11 @@ def test_runner_writes_evidence_pack(tmp_path: Path) -> None:
     assert payload["scenarios"]["D"]["row_counts_stable"] is True
     assert "psycopg2" in payload["connection"]["driver"]
     log_text = (tmp_path / "coverage-live-proof.log").read_text(encoding="utf-8")
+    evidence_text = (tmp_path / "evidence.json").read_text(encoding="utf-8")
     password = urlparse(admin).password or ""
     if password:
-        assert password not in log_text
-        assert password not in (tmp_path / "evidence.json").read_text(encoding="utf-8")
+        leaked = f":{password}@"
+        assert leaked not in log_text
+        assert leaked not in evidence_text
+        assert admin not in log_text
+        assert admin not in evidence_text

--- a/tests/coverage_live_proof/test_real_acceptance.py
+++ b/tests/coverage_live_proof/test_real_acceptance.py
@@ -1,0 +1,241 @@
+"""Acceptance tests on real PostgreSQL. Never MagicMock. Marked real_db."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+from scripts.coverage.covered_entity import MISSING_EVIDENCE
+from scripts.coverage.dual_capability_coverage import GATE_THRESHOLD
+from scripts.ops.coverage_live_proof.admission import read_gate_threshold, require_explicit_dsn
+from scripts.ops.coverage_live_proof.errors import MigrationApplyError
+from scripts.ops.coverage_live_proof.evidence import write_evidence_pack
+from scripts.ops.coverage_live_proof.probe import assert_real_postgres, connect_real
+from scripts.ops.coverage_live_proof.runner import (
+    apply_canonical_migrations,
+    create_ephemeral_database,
+    database_exists,
+    evaluate_identity_scenarios,
+    execute_golden_path,
+    is_campaign_database,
+    run_live_proof,
+    teardown_ephemeral,
+)
+from scripts.ops.coverage_live_proof.seed import apply_seed, count_seed_rows, load_seed_rows
+
+pytestmark = pytest.mark.real_db
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+def _admin_dsn() -> str:
+    return require_explicit_dsn(os.environ.get("LOCAL_DATALAKE_DSN"))
+
+
+@pytest.fixture(scope="module")
+def migrated_proof_dsn() -> str:
+    admin = _admin_dsn()
+    proof_dsn, dbname = create_ephemeral_database(admin)
+    try:
+        apply_canonical_migrations(proof_dsn)
+        yield proof_dsn
+    finally:
+        teardown_ephemeral(admin, dbname)
+
+
+def test_probe_records_real_postgres_driver(migrated_proof_dsn: str) -> None:
+    conn = connect_real(migrated_proof_dsn)
+    try:
+        info = assert_real_postgres(conn)
+    finally:
+        conn.close()
+    assert "PostgreSQL" in info["postgres_version"]
+    assert "psycopg2" in info["driver"]
+    assert "MagicMock" not in info["driver"]
+
+
+def test_migrations_are_idempotent(migrated_proof_dsn: str) -> None:
+    second = apply_canonical_migrations(migrated_proof_dsn)
+    assert second["applied"] == []
+    assert len(second["skipped"]) >= 1
+
+
+def test_scenario_source_wide_only_does_not_count_entity(migrated_proof_dsn: str) -> None:
+    conn = connect_real(migrated_proof_dsn)
+    try:
+        apply_seed(conn)
+        rows = load_seed_rows(conn)
+        result = evaluate_identity_scenarios(rows)
+    finally:
+        conn.close()
+    scenario_a = result["A"]
+    assert scenario_a["classification"] == MISSING_EVIDENCE
+    assert scenario_a["reason"] == "source_wide_aggregate_without_identity"
+    assert scenario_a["entity_scoped_numerator"] == 0
+    assert scenario_a["covered_count"] == 0
+    assert scenario_a["measurement_success"] is False
+
+
+def test_scenario_mixed_counts_only_entity_scoped(migrated_proof_dsn: str) -> None:
+    conn = connect_real(migrated_proof_dsn)
+    try:
+        apply_seed(conn)
+        result = evaluate_identity_scenarios(load_seed_rows(conn))
+    finally:
+        conn.close()
+    scenario_b = result["B"]
+    assert scenario_b["identified_count"] == 1
+    assert scenario_b["entity_scoped_numerator"] == 1
+    assert scenario_b["source_wide_count"] == 1
+    assert scenario_b["measurement_success"] is True
+    assert scenario_b["covered_count"] == 1
+
+
+def test_scenario_unmappable_fail_closed(migrated_proof_dsn: str) -> None:
+    conn = connect_real(migrated_proof_dsn)
+    try:
+        apply_seed(conn)
+        result = evaluate_identity_scenarios(load_seed_rows(conn))
+    finally:
+        conn.close()
+    scenario_c = result["C"]
+    assert scenario_c["reason"] == "unmappable_evidence_cannot_drop"
+    assert scenario_c["measurement_success"] is False
+    assert scenario_c["entity_scoped_numerator"] == 0
+    assert scenario_c["classification"] == MISSING_EVIDENCE
+
+
+def test_replay_does_not_duplicate_and_hash_is_stable(
+    migrated_proof_dsn: str, tmp_path: Path
+) -> None:
+    conn = connect_real(migrated_proof_dsn)
+    try:
+        apply_seed(conn)
+        first_count = count_seed_rows(conn)
+        second = apply_seed(conn)
+        second_count = count_seed_rows(conn)
+        rows = load_seed_rows(conn)
+    finally:
+        conn.close()
+    assert first_count == second_count == 3
+    assert second["inserted"] == 0
+    scenarios = evaluate_identity_scenarios(rows)
+    payload = {
+        "source_wide_count": scenarios["source_wide_count"],
+        "entity_scoped_count": scenarios["entity_scoped_count"],
+        "scenarios": {"A": scenarios["A"], "B": scenarios["B"], "C": scenarios["C"]},
+        "threshold": read_gate_threshold(),
+    }
+    pack_a = write_evidence_pack(
+        tmp_path / "r1", {**payload, "run_id": "one", "duration_ms": 1}
+    )
+    pack_b = write_evidence_pack(
+        tmp_path / "r2", {**payload, "run_id": "two", "duration_ms": 9}
+    )
+    assert pack_a["normalized_semantic_hash"] == pack_b["normalized_semantic_hash"]
+    assert (tmp_path / "r1" / "evidence.normalized.json").read_bytes() == (
+        tmp_path / "r2" / "evidence.normalized.json"
+    ).read_bytes()
+
+
+def test_teardown_on_success() -> None:
+    admin = _admin_dsn()
+    _proof, dbname = create_ephemeral_database(admin)
+    assert is_campaign_database(dbname)
+    assert database_exists(admin, dbname) is True
+    teardown_ephemeral(admin, dbname)
+    assert database_exists(admin, dbname) is False
+
+
+def _campaign_databases(admin_dsn: str) -> set[str]:
+    conn = connect_real(admin_dsn)
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT datname FROM pg_database WHERE datname LIKE 'coverage_live_proof_%'")
+        names = {str(row[0]) for row in (cur.fetchall() or [])}
+        cur.close()
+        return names
+    finally:
+        conn.close()
+
+
+def test_teardown_on_failure_leaves_no_campaign_db(tmp_path: Path) -> None:
+    admin = _admin_dsn()
+    before = _campaign_databases(admin)
+    with pytest.raises(RuntimeError, match="injected failure after_create"):
+        run_live_proof(
+            dsn=admin,
+            output_dir=tmp_path,
+            execute_golden=False,
+            inject_failure="after_create",
+        )
+    after = _campaign_databases(admin)
+    assert after == before
+
+
+def test_clear_migration_failure(tmp_path: Path) -> None:
+    admin = _admin_dsn()
+    proof_dsn, dbname = create_ephemeral_database(admin)
+    try:
+        bad_root = tmp_path / "migrations"
+        bad_root.mkdir()
+        (bad_root / "001_fail.sql").write_text(
+            "DO $$ BEGIN RAISE EXCEPTION 'coverage_live_proof_injected_failure'; END $$;\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(MigrationApplyError, match="canonical migration apply failed"):
+            apply_canonical_migrations(proof_dsn, root=bad_root)
+    finally:
+        teardown_ephemeral(admin, dbname)
+
+
+def test_threshold_unchanged_on_real_path(migrated_proof_dsn: str) -> None:
+    conn = connect_real(migrated_proof_dsn)
+    try:
+        apply_seed(conn)
+        result = evaluate_identity_scenarios(load_seed_rows(conn))
+    finally:
+        conn.close()
+    assert read_gate_threshold() == GATE_THRESHOLD == 0.95
+    assert result["expectation_errors"] == []
+
+
+def test_golden_path_entry_runs_on_ephemeral(migrated_proof_dsn: str, tmp_path: Path) -> None:
+    result = execute_golden_path(migrated_proof_dsn, tmp_path, _REPO)
+    assert result["argv"][1:4] == ["-m", "scripts.golden_path", "--dsn"]
+    assert "--execute-dual-coverage-only" in result["argv"]
+    combined = (result.get("stdout_sanitized") or "") + (result.get("stderr_sanitized") or "")
+    assert "super-secret" not in combined
+    password = urlparse(migrated_proof_dsn).password or ""
+    if password:
+        assert password not in combined
+    assert result["ledger_present"] is True or result["returncode"] in {0, 1, 2}
+
+
+def test_runner_writes_evidence_pack(tmp_path: Path) -> None:
+    admin = _admin_dsn()
+    before = _campaign_databases(admin)
+    pack = run_live_proof(
+        dsn=admin,
+        output_dir=tmp_path,
+        execute_golden=True,
+    )
+    after = _campaign_databases(admin)
+    assert after == before
+    assert (tmp_path / "evidence.json").is_file()
+    assert (tmp_path / "evidence.normalized.json").is_file()
+    assert (tmp_path / "SHA256SUMS").is_file()
+    payload = pack["payload"]
+    assert payload["threshold"] == GATE_THRESHOLD
+    assert payload["scenarios"]["A"]["reason"] == "source_wide_aggregate_without_identity"
+    assert payload["scenarios"]["B"]["entity_scoped_numerator"] == 1
+    assert payload["scenarios"]["D"]["row_counts_stable"] is True
+    assert "psycopg2" in payload["connection"]["driver"]
+    log_text = (tmp_path / "coverage-live-proof.log").read_text(encoding="utf-8")
+    password = urlparse(admin).password or ""
+    if password:
+        assert password not in log_text
+        assert password not in (tmp_path / "evidence.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Hermetic real-PostgreSQL live proof of the already-shipped #350 identity rules: source-wide aggregates never enter an entity numerator.

**Refs #350**

| Field | SHA |
|-------|-----|
| BASE (main) | `a752919b307315e77c3210181e93123b7e50dc5e` |
| HEAD | `b3be3d84e8bbc5fd7ea0932e7062231a82f60e1d` |

Update-against-main at final gate: already 0 commits behind `origin/main` (strict). No new HEAD created.

`ALTERAÇÃO_DE_POLÍTICA=NÃO` — no coverage logic, `GATE_THRESHOLD` (still 0.95, read from shipped `scripts.coverage.dual_capability_coverage`), or promote/defer change. 14-file allowlist only. No mock / SQLite / production DSN.

## Flow

```
provision ephemeral database (coverage_live_proof_<12-hex>)
        ↓
migrate  (python3 -m scripts.ops.apply_migrations)
        ↓
seed     (A source-wide / B entity-scoped / C unmappable)
        ↓
run      dual_coverage_evidence_gate + golden_path --execute-dual-coverage-only
        ↓
query    coverage_evidence on the real cluster
        ↓
normalize (strip run_id / timestamps / ephemeral name)
        ↓
hash     evidence.normalized.json + SHA256SUMS
        ↓
teardown DROP only coverage_live_proof_*
```

## Green live-proof run (CI_PROVEN)

https://github.com/tjsasakifln/extra-cli/actions/runs/32070431220

Job `Real PostgreSQL live proof` id `95512187025` — success (~64s wall).
Artifact `coverage-live-proof` id `9301534113`.

- Image: `pgvector/pgvector:pg16`
- Server: `PostgreSQL 16.15 (Debian 16.15-1.pgdg12+2)`
- Driver: `psycopg2.extensions.connection`
- Migrations applied: 98 canonical `db/migrations` files (`001`…`096`, skipped=0)
- `normalized_semantic_hash=f266ba29cda43f3dd64c298a04bd76de8f1c815d7b569b4116a1e0aceaefb690`
- Same-job replay: two runner invocations, byte-identical `evidence.normalized.json` (step exit 0)
- Scenario A: `MISSING_EVIDENCE` / `source_wide_aggregate_without_identity` / entity numerator 0
- Scenario B: entity numerator 1, source-wide count 1 (no double count), `measurement_success=true`
- Scenario C: fail-closed `unmappable_evidence_cannot_drop`
- Scenario D: replay inserted 0 extra rows; row counts 3=3
- `threshold=0.95` read from shipped `GATE_THRESHOLD`
- Logs/JSON contain no `:password@` / raw DSN

Golden-path subprocess on the empty ephemeral universe returned 1 (expected; identity verdict is the shipped gate on SQL-loaded rows, not the default-universe KPI).

Local vs CI hashes differ because `repository_sha` is HEAD locally and `GITHUB_SHA` (merge ref `246ea02d…`) on `pull_request`.

## Local unit bar (this campaign)

- `tests/coverage_live_proof -m 'not real_db'`: 16 passed, exit 0
- `tests/test_coverage_formula_and_identity.py`: 10 passed, exit 0
- Local `127.0.0.1:5433` refused (docker unavailable) — real-db bar is the CI job above, not a fabricated local green run

## Workflow

`.github/workflows/coverage-live-proof.yml`

- `workflow_dispatch` + optional PR trigger only when this campaign’s files change
- `pgvector/pgvector:pg16` service + healthcheck
- no external secrets; `permissions: contents: read`
- timeout 30m; teardown `if: always()`

Issue #350 stays **OPEN**. This PR is hermetic proof only. Closing #350 still requires a **human-reviewed** green real run plus EXTRA-005 live census. An agent review is not a human review.

## Out of scope

PR #413 / #428 / #430 untouched. No engines, adapters, registries, manifests, `national_claims` migration edits, web-cfg/warmbly/SmartLic, or existing workflows were modified.