### PR TITLE
feat(authority): emit official-live contract analysis handoff

### DIFF
--- a/docs/ops/official-live-authority-handoff-01.md
+++ b/docs/ops/official-live-authority-handoff-01.md
@@ -1,0 +1,62 @@
+# Official-live authority handoff 01
+
+Sanitized campaign report. No secrets, no raw documents, no production write.
+
+## Baseline revalidated
+
+- `origin/main` at start: `54b9b509eddf982a7fa7dae2f6ced713c2c3e34f`
+- Landed: `scripts/official_contract_semantics/**` (#428) and `scripts/historical_contract_authority/**` (#430)
+- Open PR #413 left untouched
+- Issues: #414 closed; #400 closed; #415 remains open (peer-group DoD is larger than this slice)
+- `LOCAL_DATALAKE_DSN` / `DATABASE_URL` absent in this environment
+- Consumer: web-cfg #83 / PR #118
+
+## What shipped
+
+Additive 1.1 clocks: `event_effective_at`, `source_published_at`, `retrieved_at`, `verified_at`, `source_as_of`.
+Operational freshness uses only `verified_at`/`retrieved_at`. An old contractual event re-verified now is not `stale_evidence` and is not rewritten as recent.
+
+`analysis_mode`: `DOCUMENT_CHAIN` | `TIMELINE` | `COMPARATIVE`.
+`NOT_APPLICABLE` is allowed only without comparative language and with a document-backed singular insight.
+Comparative language reactivates the peer gate. Generic value+term is not a singular insight.
+
+Live window is current and configurable (default last 30 days). PNCP 429 retries and is not cached.
+
+Entry:
+
+```bash
+python3 -m scripts.historical_contract_authority --mode official-live \
+  --limit 12 --start-date 2026-07-18 --end-date 2026-08-17 \
+  --as-of 2026-08-17T12:00:00Z --output <handoff-dir>
+```
+
+## Live result
+
+Status: **BLOCKED** (not READY).
+
+- Sources tried: `pncp_consulta_api` (DSN unavailable, recorded as unavailability)
+- Window: 2026-07-18 .. 2026-08-17, UF SC, limit 12
+- Documents considered: 1; obtained: 2 (listing + page)
+- Partial dossier: `242dc2e35e5523e01f64a57cb3058b35` `DATA_HOLD`
+- Contract observed: PNCP `08184785000101-2-000459/2026` (GLP / registro de preços, Joinville)
+- Reason codes: `HOLD_FOR_DATA`, `missing_singular_insight`
+- `publication_authorization=false`, `index_authorization=false`, `production_write=false`, `backfill=false`
+- Two canaries: same `BLOCKED` status, same dossier content hash `8054ea40c0b84ca40f51021793f29ff4ae42b48851a8a7e7625177eb72b2ba13`
+
+Rendezvous (atomic, outside git):
+
+`$HOME/.local/share/confenge/handoffs/contract-analysis/official-live-01/`
+
+Contains `BLOCKED.json`, `manifest.json`, `dossiers/<id>.json` (DATA_HOLD), `SHA256SUMS.txt`, `replay.txt`, `README.md`. No `READY.json`.
+
+## Tests
+
+- Focused: 94 passed (`tests/official_contract_semantics/`, `tests/historical_contract_authority/`)
+- Broader slice: 135 passed, 1 skipped
+- Adversarial: old event + current verify is not stale; old event is not recent; comparative language reactivates peers; missing locator blocks READY; 1.0 still loads; hashes exclude verification clocks
+
+## Residual
+
+The bounded official window verified one SC contract. It has official identity, value and term, but no documentary singularity (aditivo, reajuste, reequilíbrio, prazo material, BDI, medição/glosa). That is not HANDOFF_READY.
+
+Smallest next verifiable step: rerun the same official-live entry on a window that actually contains those documentary families, or with DSN already present. Do not fabricate READY.

--- a/scripts/historical_contract_authority/acquire.py
+++ b/scripts/historical_contract_authority/acquire.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -22,6 +23,10 @@ from scripts.historical_contract_authority.schema import (
 )
 from scripts.process_documents.inventory_pipeline import detect_mime, extract_text
 from scripts.process_documents.inventory_pipeline import sha256_bytes as inventory_sha256
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def locator_from(raw: dict[str, Any]) -> Locator:
@@ -74,6 +79,9 @@ def document_from_mapping(raw: dict[str, Any]) -> DocumentRecord:
         superseded_by=raw.get("superseded_by"),
         http_status=raw.get("http_status"),
         redirect_chain=tuple(raw.get("redirect_chain") or ()),
+        retrieved_at=raw.get("retrieved_at"),
+        verified_at=raw.get("verified_at"),
+        source_as_of=raw.get("source_as_of"),
         text=text,
     )
 
@@ -113,6 +121,7 @@ def bounded_fetch(
                     data, response.headers.get_content_type() if response.headers else "application/octet-stream"
                 )
                 text, usable = extract_native(data, mime, locator=url)
+                stamp = _now()
                 record = {
                     "ok": True,
                     "url": url,
@@ -124,6 +133,8 @@ def bounded_fetch(
                     "extract_status": "ok" if usable else "no_native_text",
                     "ocr_used": False,
                     "redirect_chain": tuple(getattr(response, "url", url) for _ in (0,)),
+                    "retrieved_at": stamp,
+                    "verified_at": stamp,
                 }
                 cache[url] = record
                 if not url.startswith("file:"):

--- a/scripts/historical_contract_authority/analysis.py
+++ b/scripts/historical_contract_authority/analysis.py
@@ -1,0 +1,149 @@
+"""analysis_mode and comparability policy. Comparative language reactivates the peer gate."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+AnalysisMode = Literal["DOCUMENT_CHAIN", "TIMELINE", "COMPARATIVE"]
+
+ANALYSIS_MODES: tuple[str, ...] = ("DOCUMENT_CHAIN", "TIMELINE", "COMPARATIVE")
+
+COMPARATIVE_PATTERNS = (
+    re.compile(r"\boutlier\b", re.I),
+    re.compile(r"\branking\b", re.I),
+    re.compile(r"\bbenchmark\b", re.I),
+    re.compile(r"\bpercentil\b", re.I),
+    re.compile(r"\bpeers?\b", re.I),
+    re.compile(r"grupo compar", re.I),
+    re.compile(r"compar[aá]ve", re.I),
+    re.compile(r"acima da mediana", re.I),
+    re.compile(r"abaixo da mediana", re.I),
+    re.compile(r"fora da distribui", re.I),
+    re.compile(r"delta de peer", re.I),
+    re.compile(r"frente (aos|a os|aos seus) pares", re.I),
+    re.compile(r"at[ií]pico frente", re.I),
+)
+
+COMMERCIAL_ADJACENCY = {
+    "aditivo": ("aditiv", "apostila"),
+    "reequilibrio": ("reequilibr", "recomposi"),
+    "reajuste": ("reajuste", "repactu"),
+    "prazo": ("aditivo de prazo", "prorrog", "amplia[cç][aã]o de prazo"),
+    "medicao_glosa": ("medi[cç][aã]o", "glosa"),
+    "bdi": (r"\bbdi\b",),
+    "defesa_margem": ("defesa de margem", "margem de contribui"),
+}
+
+
+_NEGATION = re.compile(
+    r"(n[aã]o\s+(um|uma|é|e|ha|há|se)?\s*|sem\s+|aus[eê]ncia de\s+|nunca\s+)",
+    re.I,
+)
+
+
+def detect_comparative_language(*texts: str | None) -> tuple[str, ...]:
+    hits: list[str] = []
+    for text in texts:
+        if not text:
+            continue
+        for pattern in COMPARATIVE_PATTERNS:
+            match = pattern.search(text)
+            if not match:
+                continue
+            prefix = text[max(0, match.start() - 24) : match.start()]
+            if _NEGATION.search(prefix):
+                continue
+            hits.append(pattern.pattern)
+    return tuple(dict.fromkeys(hits))
+
+
+def commercial_adjacency(*texts: str | None) -> tuple[str, ...]:
+    blob = " ".join(item for item in texts if item).casefold()
+    found: list[str] = []
+    for name, tokens in COMMERCIAL_ADJACENCY.items():
+        if any(re.search(token, blob, re.I) for token in tokens):
+            found.append(name)
+    return tuple(found)
+
+
+def resolve_analysis_mode(
+    *,
+    requested: str | None,
+    claims: tuple[str, ...],
+    insight: str | None,
+    limitations: tuple[str, ...],
+    comparative_engine_used: bool,
+) -> tuple[str, tuple[str, ...]]:
+    requested_mode = (requested or "").strip().upper() or None
+    comparative_hits = detect_comparative_language(insight, *claims, *limitations)
+    if comparative_engine_used or requested_mode == "COMPARATIVE" or comparative_hits:
+        return "COMPARATIVE", comparative_hits
+    if requested_mode in ANALYSIS_MODES:
+        return requested_mode, ()
+    return "DOCUMENT_CHAIN", ()
+
+
+def resolve_comparability(
+    *,
+    analysis_mode: str,
+    comparative_hits: tuple[str, ...],
+    singular_insight: str | None,
+    limitations_declare_no_comparison: bool,
+    engine_status: str | None,
+    engine_reason_codes: tuple[str, ...],
+    unit_compatible: bool,
+    regime_compatible: bool,
+    scope_compatible: bool,
+    period_compatible: bool,
+) -> dict[str, Any]:
+    if analysis_mode == "COMPARATIVE" or comparative_hits:
+        if not (unit_compatible and regime_compatible and scope_compatible and period_compatible):
+            return {
+                "status": "NOT_COMPARABLE",
+                "reason_codes": (
+                    "comparative_language_requires_peer_gate",
+                    *engine_reason_codes,
+                    *(("incompatible_unit",) if not unit_compatible else ()),
+                    *(("incompatible_regime",) if not regime_compatible else ()),
+                    *(("incompatible_scope",) if not scope_compatible else ()),
+                    *(("incompatible_period",) if not period_compatible else ()),
+                ),
+                "justification": (
+                    "Comparative language or COMPARATIVE mode reactivates the peer gate; "
+                    "compatible unit/regime/scope/period were not demonstrated."
+                ),
+                "peer_gate": "active",
+            }
+        status = (
+            engine_status if engine_status in {"COMPARABLE", "HOLD_FOR_DATA", "NOT_COMPARABLE"} else "NOT_COMPARABLE"
+        )
+        return {
+            "status": status,
+            "reason_codes": engine_reason_codes or ("peer_engine",),
+            "justification": "COMPARATIVE mode uses the fail-closed peer gate.",
+            "peer_gate": "active",
+        }
+    if analysis_mode in {"DOCUMENT_CHAIN", "TIMELINE"}:
+        if not singular_insight or not limitations_declare_no_comparison:
+            return {
+                "status": "HOLD_FOR_DATA",
+                "reason_codes": ("missing_singular_insight_or_comparison_limitation",),
+                "justification": "Non-comparative mode still needs a document-backed insight and an explicit no-comparison limitation.",
+                "peer_gate": "not_applicable",
+            }
+        return {
+            "status": "NOT_APPLICABLE",
+            "reason_codes": ("no_comparative_claim", "singular_document_insight"),
+            "justification": (
+                "DOCUMENT_CHAIN/TIMELINE emits no ranking, outlier, benchmark or peer delta; "
+                "absence of comparison is an explicit limitation."
+            ),
+            "peer_gate": "not_applicable",
+        }
+    return {
+        "status": "NOT_COMPARABLE",
+        "reason_codes": ("unknown_analysis_mode",),
+        "justification": "Unknown analysis_mode cannot authorize comparison.",
+        "peer_gate": "active",
+    }

--- a/scripts/historical_contract_authority/cli.py
+++ b/scripts/historical_contract_authority/cli.py
@@ -13,6 +13,7 @@ from scripts.historical_contract_authority.adapters import rank_via_414
 from scripts.historical_contract_authority.cases import CASE_BUILDERS, fixture_corpus
 from scripts.historical_contract_authority.engine import build_dossier, dossier_dict, process_cases
 from scripts.historical_contract_authority.handoff import write_handoff
+from scripts.historical_contract_authority.official_live import run_official_live_handoff
 from scripts.historical_contract_authority.schema import (
     HANDOFF_DIR,
     MAX_CONTRACTS,
@@ -175,11 +176,15 @@ def run_live(*, output: Path, dsn: str | None, limit: int, as_of: str | None = N
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="historical-contract-authority")
-    parser.add_argument("--mode", choices=("fixture", "live"), default="fixture")
+    parser.add_argument("--mode", choices=("fixture", "live", "official-live"), default="fixture")
     parser.add_argument("--output", type=Path, default=HANDOFF_DIR)
     parser.add_argument("--dsn", default=None)
     parser.add_argument("--limit", type=int, default=40)
     parser.add_argument("--as-of", dest="as_of", default=None)
+    parser.add_argument("--start-date", dest="start_date", default=None)
+    parser.add_argument("--end-date", dest="end_date", default=None)
+    parser.add_argument("--cache-dir", dest="cache_dir", default=None)
+    parser.add_argument("--skip-pages", action="store_true")
     parser.add_argument("--case", choices=sorted(CASE_BUILDERS), default=None)
     return parser
 
@@ -192,6 +197,29 @@ def main(argv: list[str] | None = None) -> int:
         dossier = dossier_dict(build_dossier(case, as_of=stamp))
         sys.stdout.write(canonical_dumps(dossier) + "\n")
         return 0
+    if args.mode == "official-live":
+        result = run_official_live_handoff(
+            output=args.output,
+            dsn=args.dsn,
+            limit=args.limit,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            cache_dir=Path(args.cache_dir) if args.cache_dir else None,
+            fetch_pages=not args.skip_pages,
+            as_of=args.as_of,
+        )
+        summary = {
+            "as_of": result["as_of"],
+            "status": result["status"],
+            "output": result["output"],
+            "ready": len(result["ready"]),
+            "ids": [item["analysis_id"] for item in result["ready"]],
+            "replay_command": result["replay_command"],
+            "live": result["live"],
+            "producer": result["producer"],
+        }
+        sys.stdout.write(canonical_dumps(summary) + "\n")
+        return 0 if result["status"] in {"READY", "BLOCKED"} else 1
     if args.mode == "live":
         try:
             result = run_live(output=args.output, dsn=args.dsn, limit=args.limit, as_of=args.as_of)

--- a/scripts/historical_contract_authority/consumer.py
+++ b/scripts/historical_contract_authority/consumer.py
@@ -1,0 +1,251 @@
+"""Consumer-bound official-live dossier. Producer of facts, never of INDEX."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.historical_contract_authority.analysis import (
+    commercial_adjacency,
+    detect_comparative_language,
+    resolve_analysis_mode,
+    resolve_comparability,
+)
+from scripts.historical_contract_authority.freshness import dossier_freshness, strip_temporal_for_hash
+from scripts.historical_contract_authority.schema import (
+    CONSUMER_ID,
+    FORBIDDEN_CONCLUSION,
+    FORBIDDEN_PUBLIC_STATES,
+    content_hash,
+    is_sha256,
+)
+
+OFFICIAL_LIVE_SCHEMA = "official-live-authority-dossier/1.1"
+OFFICIAL_LIVE_SCHEMA_V10 = "official-live-authority-dossier/1.0"
+ACCEPTED_OFFICIAL_LIVE_SCHEMAS = frozenset({OFFICIAL_LIVE_SCHEMA, OFFICIAL_LIVE_SCHEMA_V10})
+HANDOFF_STATUSES = frozenset({"HANDOFF_READY", "DATA_HOLD", "DATA_REJECT", "UNKNOWN"})
+
+
+def _blob(*parts: Any) -> str:
+    return " ".join(str(item) for item in parts if item).casefold()
+
+
+def claim_is_located(claim: dict[str, Any]) -> bool:
+    locator = claim.get("locator") or claim.get("locators")
+    if isinstance(locator, (list, tuple)):
+        locator = next((item for item in locator if item), None)
+    if isinstance(locator, dict):
+        locator = "|".join(str(value) for value in locator.values() if value)
+    evidence_id = claim.get("evidence_id") or (claim.get("source_refs") or [None])[0]
+    url = claim.get("url") or claim.get("official_url")
+    digest = claim.get("sha256") or claim.get("hash") or claim.get("source_document_sha256")
+    return bool(evidence_id and url and is_sha256(str(digest or "")) and locator and str(locator) != "UNSPECIFIED")
+
+
+def validate_consumer_dossier(payload: dict[str, Any]) -> tuple[bool, tuple[str, ...]]:
+    reasons: list[str] = []
+    schema = payload.get("schema")
+    if schema not in ACCEPTED_OFFICIAL_LIVE_SCHEMAS and schema not in {
+        "historical-contract-authority-dossier/1.0",
+        "historical-contract-authority-dossier/1.1",
+        "public-read-contract-analysis/1.0",
+        "official-contract-observation/1.0",
+        "official-contract-observation/1.1",
+    }:
+        if schema:
+            reasons.append("unsupported_schema")
+    if payload.get("schema") == OFFICIAL_LIVE_SCHEMA:
+        for required in (
+            "analysis_id",
+            "identity",
+            "provenance",
+            "factual_matrix",
+            "analysis",
+            "gates",
+        ):
+            if not payload.get(required):
+                reasons.append(f"missing_{required}")
+    gates = payload.get("gates") or {}
+    if gates.get("official_live") is True:
+        provenance = payload.get("provenance") or {}
+        if not provenance.get("verified_at") or not provenance.get("retrieved_at"):
+            reasons.append("official_live_without_verification_clock")
+        if not (payload.get("artifacts") or provenance.get("artifact_hashes")):
+            reasons.append("official_live_without_verified_bytes")
+    if gates.get("publication_authorization") is True:
+        reasons.append("publication_authorization_must_be_false")
+    if gates.get("index_authorization") is True:
+        reasons.append("index_authorization_must_be_false")
+    if gates.get("commercial_relationship_claim") is True:
+        reasons.append("commercial_relationship_claim_must_be_false")
+    if gates.get("handoff_status") == "HANDOFF_READY":
+        claims = (payload.get("factual_matrix") or {}).get("claims") or payload.get("claims") or []
+        facts = [item for item in claims if item.get("class") == "FACT" or item.get("klass") == "FACT"]
+        if not facts or any(not claim_is_located(item) for item in facts):
+            reasons.append("missing_locator_blocks_handoff_ready")
+        analysis = payload.get("analysis") or {}
+        if not analysis.get("singular_insight"):
+            reasons.append("missing_singular_insight")
+        if analysis.get("comparability_status") == "NOT_APPLICABLE":
+            hits = detect_comparative_language(
+                analysis.get("singular_insight"),
+                *(item.get("text") for item in claims),
+            )
+            if hits:
+                reasons.append("comparative_language_with_not_applicable")
+        if analysis.get("analysis_mode") == "COMPARATIVE" and analysis.get("comparability_status") != "COMPARABLE":
+            reasons.append("comparative_not_handoff_ready")
+        if gates.get("official_live") is not True:
+            reasons.append("handoff_ready_requires_official_live")
+    blob = _blob(
+        payload.get("analysis", {}).get("singular_insight"),
+        *(item.get("text") for item in (payload.get("factual_matrix") or {}).get("claims") or ()),
+    )
+    if any(term in blob for term in FORBIDDEN_CONCLUSION):
+        reasons.append("forbidden_conclusion")
+    dumped = str(payload)
+    if any(token in dumped for token in FORBIDDEN_PUBLIC_STATES):
+        reasons.append("forbidden_public_state")
+    return (not reasons), tuple(dict.fromkeys(reasons))
+
+
+def assemble_consumer_dossier(
+    *,
+    analysis_id: str,
+    identity: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+    claims: list[dict[str, Any]],
+    calculations: list[dict[str, Any]],
+    inferences: list[dict[str, Any]],
+    unknowns: list[dict[str, Any]],
+    insight: str,
+    limitations: list[str],
+    method: str,
+    producer_repo: str,
+    producer_commit: str,
+    replay_command: str,
+    query_window: dict[str, Any],
+    retrieved_at: str | None,
+    verified_at: str | None,
+    source_as_of: str | None,
+    event_effective_at: str | None,
+    source_published_at: str | None,
+    as_of: str,
+    bytes_obtained: bool,
+    requested_mode: str | None = None,
+    engine_status: str | None = None,
+    engine_reason_codes: tuple[str, ...] = (),
+    unit_compatible: bool = False,
+    regime_compatible: bool = False,
+    scope_compatible: bool = False,
+    period_compatible: bool = False,
+    catalog_mode: str = "official_live",
+    candidate_disposition: str = "entered",
+    candidate_reason: str = "",
+) -> dict[str, Any]:
+    claim_texts = tuple(str(item.get("text") or "") for item in (*claims, *inferences))
+    analysis_mode, comparative_hits = resolve_analysis_mode(
+        requested=requested_mode,
+        claims=claim_texts,
+        insight=insight,
+        limitations=tuple(limitations),
+        comparative_engine_used=engine_status == "COMPARABLE",
+    )
+    no_comparison = any("sem compara" in item.casefold() or "no comparison" in item.casefold() for item in limitations)
+    comparability = resolve_comparability(
+        analysis_mode=analysis_mode,
+        comparative_hits=comparative_hits,
+        singular_insight=insight,
+        limitations_declare_no_comparison=no_comparison and bool(insight),
+        engine_status=engine_status,
+        engine_reason_codes=engine_reason_codes,
+        unit_compatible=unit_compatible,
+        regime_compatible=regime_compatible,
+        scope_compatible=scope_compatible,
+        period_compatible=period_compatible,
+    )
+    adjacency = commercial_adjacency(insight, identity.get("objeto"), identity.get("object_text"), *claim_texts)
+    freshness = dossier_freshness(
+        as_of=as_of,
+        event_effective_at=event_effective_at,
+        source_published_at=source_published_at,
+        retrieved_at=retrieved_at,
+        verified_at=verified_at,
+        source_as_of=source_as_of,
+        bytes_obtained=bytes_obtained,
+    )
+    official_live = bool(bytes_obtained and retrieved_at and verified_at and artifacts)
+    artifact_hashes = {
+        str(item.get("evidence_id") or item.get("url")): item.get("sha256") for item in artifacts if item.get("sha256")
+    }
+    matrix = {
+        "facts": [item for item in claims if (item.get("class") or item.get("klass")) == "FACT"],
+        "calculations": calculations,
+        "inferences": inferences,
+        "unknowns": unknowns,
+        "claims": claims,
+    }
+    gates = {
+        "official_live": official_live,
+        "handoff_status": "DATA_HOLD",
+        "publication_authorization": False,
+        "index_authorization": False,
+        "commercial_relationship_claim": False,
+    }
+    provenance = {
+        "schema": OFFICIAL_LIVE_SCHEMA,
+        "version": "1.1",
+        "producer_repo": producer_repo,
+        "producer_commit": producer_commit,
+        "query_window": query_window,
+        "replay_command": replay_command,
+        "retrieved_at": retrieved_at,
+        "verified_at": verified_at,
+        "source_as_of": source_as_of,
+        "event_effective_at": event_effective_at,
+        "source_published_at": source_published_at,
+        "artifact_hashes": artifact_hashes,
+        "consumer": CONSUMER_ID,
+    }
+    analysis = {
+        "analysis_mode": analysis_mode,
+        "singular_insight": insight,
+        "commercial_adjacency": list(adjacency),
+        "method": method,
+        "limitations": limitations,
+        "comparability_status": comparability["status"],
+        "comparability_justification": comparability["justification"],
+        "comparability": comparability,
+        "reputational_safety": "atipico_nao_e_irregular",
+    }
+    payload: dict[str, Any] = {
+        "schema": OFFICIAL_LIVE_SCHEMA,
+        "analysis_id": analysis_id,
+        "identity": identity,
+        "provenance": provenance,
+        "factual_matrix": matrix,
+        "analysis": analysis,
+        "gates": gates,
+        "artifacts": artifacts,
+        "freshness": freshness,
+        "catalog_mode": catalog_mode,
+        "candidate_disposition": candidate_disposition,
+        "candidate_reason": candidate_reason,
+        "handoff_status": "DATA_HOLD",
+    }
+    ok, reasons = validate_consumer_dossier({**payload, "gates": {**gates, "handoff_status": "HANDOFF_READY"}})
+    if official_live and ok and comparability["status"] in {"NOT_APPLICABLE", "COMPARABLE"}:
+        gates["handoff_status"] = "HANDOFF_READY"
+        payload["handoff_status"] = "HANDOFF_READY"
+        payload["reason_codes"] = ["quality_gates_passed"]
+    else:
+        extra = [] if ok else list(reasons)
+        if not official_live:
+            extra.append("official_sources_not_verified_this_run")
+        if comparability["status"] not in {"NOT_APPLICABLE", "COMPARABLE"}:
+            extra.append(str(comparability["status"]))
+        payload["reason_codes"] = list(dict.fromkeys(extra or ["DATA_HOLD"]))
+        payload["handoff_status"] = "DATA_HOLD"
+        gates["handoff_status"] = "DATA_HOLD"
+    payload["gates"] = gates
+    payload["content_hash"] = content_hash(strip_temporal_for_hash(payload))
+    return payload

--- a/scripts/historical_contract_authority/engine.py
+++ b/scripts/historical_contract_authority/engine.py
@@ -9,6 +9,7 @@ from typing import Any
 from scripts.historical_contract_authority.acquire import attach_portal_locators, collect_documents
 from scripts.historical_contract_authority.adapters import compare_via_415
 from scripts.historical_contract_authority.extract import assemble_from_documents
+from scripts.historical_contract_authority.freshness import dossier_freshness
 from scripts.historical_contract_authority.gates import (
     admit,
     build_score,
@@ -373,17 +374,27 @@ def build_dossier(
         maintenance=maintenance,
         score=score,
         as_of=stamp,
-        freshness={
-            "as_of": stamp,
-            "max_age_hours": 48,
-            "policy": "authority-freshness/1.0",
-            "source_as_of": (working.get("dates") or {}).get("reference"),
-        },
+        freshness=dossier_freshness(
+            as_of=stamp,
+            event_effective_at=(working.get("dates") or {}).get("reference")
+            or (working.get("dates") or {}).get("assinatura"),
+            source_published_at=(working.get("dates") or {}).get("published_at")
+            or (working.get("dates") or {}).get("observed_at"),
+            retrieved_at=next((item.retrieved_at for item in documents if item.retrieved_at), None),
+            verified_at=next((item.verified_at for item in documents if item.verified_at), None),
+            source_as_of=(working.get("dates") or {}).get("source_as_of"),
+            bytes_obtained=any(item.bytes_len > 0 or item.text.strip() for item in documents),
+        ),
         source_snapshot_hash=snap,
         producer_sha=producer_sha(),
         catalog_mode=str(working.get("catalog_mode") or "fixture"),
         limitations=limitations,
         content_hash="",
+        analysis_mode=str(working.get("analysis_mode") or "DOCUMENT_CHAIN"),
+        official_live=False,
+        publication_authorization=False,
+        index_authorization=False,
+        commercial_relationship_claim=False,
     )
     return dossier
 

--- a/scripts/historical_contract_authority/freshness.py
+++ b/scripts/historical_contract_authority/freshness.py
@@ -1,0 +1,54 @@
+"""Authority freshness: re-verified history is not stale_evidence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.official_contract_semantics.freshness import (
+    FRESHNESS_POLICY,
+    TEMPORAL_HASH_EXCLUSIONS,
+    TemporalFields,
+    event_is_recent,
+    freshness_block,
+    is_stale_evidence,
+    operational_clock,
+    resolve_temporal_fields,
+    strip_temporal_for_hash,
+)
+
+AUTHORITY_FRESHNESS_POLICY = FRESHNESS_POLICY
+
+
+def dossier_freshness(
+    *,
+    as_of: str,
+    event_effective_at: str | None,
+    source_published_at: str | None,
+    retrieved_at: str | None,
+    verified_at: str | None,
+    source_as_of: str | None,
+    bytes_obtained: bool,
+    max_age_hours: int = 48,
+) -> dict[str, Any]:
+    temporal = resolve_temporal_fields(
+        event_effective_at=event_effective_at,
+        source_published_at=source_published_at,
+        retrieved_at=retrieved_at,
+        verified_at=verified_at,
+        source_as_of=source_as_of,
+        bytes_obtained=bytes_obtained,
+    )
+    return freshness_block(temporal, as_of=as_of, bytes_obtained=bytes_obtained, max_age_hours=max_age_hours)
+
+
+__all__ = [
+    "AUTHORITY_FRESHNESS_POLICY",
+    "TEMPORAL_HASH_EXCLUSIONS",
+    "TemporalFields",
+    "dossier_freshness",
+    "event_is_recent",
+    "is_stale_evidence",
+    "operational_clock",
+    "resolve_temporal_fields",
+    "strip_temporal_for_hash",
+]

--- a/scripts/historical_contract_authority/models.py
+++ b/scripts/historical_contract_authority/models.py
@@ -64,6 +64,9 @@ class DocumentRecord:
     superseded_by: str | None = None
     http_status: int | None = None
     redirect_chain: tuple[str, ...] = ()
+    retrieved_at: str | None = None
+    verified_at: str | None = None
+    source_as_of: str | None = None
     text: str = ""
 
     def as_dict(self) -> dict[str, Any]:
@@ -226,6 +229,11 @@ class Dossier:
     catalog_mode: str
     limitations: tuple[str, ...]
     content_hash: str
+    analysis_mode: str = "DOCUMENT_CHAIN"
+    official_live: bool = False
+    publication_authorization: bool = False
+    index_authorization: bool = False
+    commercial_relationship_claim: bool = False
 
     def as_dict(self) -> dict[str, Any]:
         payload = {
@@ -249,6 +257,11 @@ class Dossier:
             "producer_sha": self.producer_sha,
             "catalog_mode": self.catalog_mode,
             "limitations": list(self.limitations),
+            "analysis_mode": self.analysis_mode,
+            "official_live": self.official_live,
+            "publication_authorization": self.publication_authorization,
+            "index_authorization": self.index_authorization,
+            "commercial_relationship_claim": self.commercial_relationship_claim,
         }
         payload["content_hash"] = content_hash(payload)
         return jsonable(payload)

--- a/scripts/historical_contract_authority/official_live.py
+++ b/scripts/historical_contract_authority/official_live.py
@@ -1,0 +1,625 @@
+"""Bounded official-live acquisition and atomic consumer handoff."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.historical_contract_authority.analysis import commercial_adjacency
+from scripts.historical_contract_authority.consumer import assemble_consumer_dossier
+from scripts.historical_contract_authority.freshness import strip_temporal_for_hash
+from scripts.historical_contract_authority.schema import (
+    CONSUMER_ID,
+    content_hash,
+    producer_sha,
+    sha256_bytes,
+    sha256_text,
+)
+from scripts.official_contract_semantics.export_publication import observation_to_snapshot_record
+from scripts.official_contract_semantics.live import (
+    default_live_window,
+    resolve_dsn,
+    run_live_readonly,
+)
+from scripts.official_contract_semantics.models import OfficialContractObservation, observation_from_mapping
+
+OFFICIAL_LIVE_HANDOFF_SCHEMA = "official-live-authority-handoff/1.1"
+MAX_LIVE_CANDIDATES = 12
+MAX_LIVE_READY = 3
+DEFAULT_RENDEZVOUS = (
+    Path.home() / ".local" / "share" / "confenge" / "handoffs" / "contract-analysis" / "official-live-01"
+)
+PRODUCER_REPO = "tjsasakifln/extra-cli"
+
+
+def rendezvous_dir() -> Path:
+    root = os.environ.get("CONFENGE_HANDOFF_DIR")
+    if root:
+        return Path(root) / "contract-analysis" / "official-live-01"
+    return DEFAULT_RENDEZVOUS
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def git_identity(repo_root: Path | None = None) -> dict[str, str]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    identity = {"repo": PRODUCER_REPO, "branch": "unknown", "commit": producer_sha()[:40]}
+    git_dir = root / ".git"
+    if git_dir.is_file():
+        text = git_dir.read_text(encoding="utf-8").strip()
+        if text.startswith("gitdir:"):
+            git_dir = Path(text.split(":", 1)[1].strip())
+            if not git_dir.is_absolute():
+                git_dir = (root / git_dir).resolve()
+    if not git_dir.is_dir():
+        return identity
+    common = git_dir
+    commondir = git_dir / "commondir"
+    if commondir.is_file():
+        common_text = commondir.read_text(encoding="utf-8").strip()
+        candidate = Path(common_text)
+        common = candidate if candidate.is_absolute() else (git_dir / candidate).resolve()
+    head = git_dir / "HEAD"
+    if not head.is_file():
+        return identity
+    ref = head.read_text(encoding="utf-8").strip()
+    if ref.startswith("ref:"):
+        ref_name = ref.split(":", 1)[1].strip()
+        identity["branch"] = ref_name.split("refs/heads/", 1)[-1]
+        for base in (git_dir, common):
+            ref_path = base / ref_name
+            if ref_path.is_file():
+                identity["commit"] = ref_path.read_text(encoding="utf-8").strip()
+                break
+    elif len(ref) >= 40:
+        identity["commit"] = ref
+    return identity
+
+
+def _object_text(obs: OfficialContractObservation | dict[str, Any]) -> str:
+    if isinstance(obs, OfficialContractObservation):
+        return str(obs.object_text or "")
+    return str(obs.get("object_text") or obs.get("objeto_contrato") or "")
+
+
+def _contract_id(obs: OfficialContractObservation | dict[str, Any]) -> str:
+    if isinstance(obs, OfficialContractObservation):
+        return str(obs.contract_identifier or obs.observation_id)
+    return str(obs.get("contract_identifier") or obs.get("canonical_contract_id") or obs.get("observation_id") or "")
+
+
+def group_observations(observations: list[OfficialContractObservation]) -> dict[str, list[OfficialContractObservation]]:
+    grouped: dict[str, list[OfficialContractObservation]] = {}
+    for item in observations:
+        grouped.setdefault(_contract_id(item), []).append(item)
+    return grouped
+
+
+def select_candidates(
+    grouped: dict[str, list[OfficialContractObservation]],
+    *,
+    limit: int = MAX_LIVE_CANDIDATES,
+) -> tuple[list[str], list[dict[str, str]]]:
+    scored: list[tuple[int, str, str]] = []
+    log: list[dict[str, str]] = []
+    for contract_id, items in grouped.items():
+        blob = " ".join(_object_text(item) for item in items)
+        adjacency = commercial_adjacency(blob)
+        page_bonus = (
+            2 if any(item.source_kind == "official_page" and item.source_document_sha256 for item in items) else 0
+        )
+        fact_bonus = 1 if any(item.value_amount is not None or item.object_text for item in items) else 0
+        if not contract_id:
+            log.append({"contract_id": "", "disposition": "UNKNOWN", "reason": "missing_contract_identifier"})
+            continue
+        score = len(adjacency) * 3 + page_bonus + fact_bonus
+        if not adjacency and not page_bonus:
+            scored.append((score, contract_id, "entered_identity_only"))
+        else:
+            scored.append((score + 1, contract_id, "entered_adjacency_or_page"))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    chosen = [item[1] for item in scored[:limit]]
+    chosen_set = set(chosen)
+    for score, contract_id, reason in scored:
+        if contract_id in chosen_set:
+            log.append({"contract_id": contract_id, "disposition": "entered", "reason": reason, "score": str(score)})
+        else:
+            log.append(
+                {
+                    "contract_id": contract_id,
+                    "disposition": "exited",
+                    "reason": "beyond_candidate_cap",
+                    "score": str(score),
+                }
+            )
+    return chosen, log
+
+
+def _locator_for(obs: OfficialContractObservation) -> dict[str, Any]:
+    loc = obs.locator.as_dict()
+    if loc:
+        return loc
+    if obs.source_kind == "official_page":
+        return {"section": "official-page"}
+    return {"json_path": "$.objetoContrato"} if obs.object_text else {}
+
+
+def _claims_from_observations(
+    items: list[OfficialContractObservation],
+    *,
+    artifact_by_doc: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    facts: list[dict[str, Any]] = []
+    unknowns: list[dict[str, Any]] = []
+    inferences: list[dict[str, Any]] = []
+    for item in items:
+        artifact = artifact_by_doc.get(str(item.source_document_id or item.observation_id)) or {}
+        url = item.official_url or artifact.get("url")
+        digest = item.source_document_sha256 or artifact.get("sha256")
+        locator = _locator_for(item)
+        evidence_id = str(item.source_document_id or item.contract_identifier or item.observation_id)
+        stable = str(item.contract_identifier or evidence_id).replace("/", "-")
+        base = {
+            "evidence_id": evidence_id,
+            "url": url,
+            "sha256": digest,
+            "locator": locator,
+            "source_refs": [evidence_id],
+        }
+        if item.object_text and url and digest and locator:
+            facts.append(
+                {
+                    **base,
+                    "claim_id": f"fact-object-{stable}",
+                    "class": "FACT",
+                    "text": f"Objeto oficial: {item.object_text[:240]}",
+                    "locator": {"json_path": "$.objetoContrato"},
+                }
+            )
+        if item.value_amount is not None and item.value_semantic:
+            facts.append(
+                {
+                    **base,
+                    "claim_id": f"fact-value-{stable}",
+                    "class": "FACT",
+                    "text": f"Valor {item.value_semantic} publicado: {format(item.value_amount, 'f')} {item.currency or 'BRL'}.",
+                    "locator": {"json_path": "$.valorGlobal"},
+                }
+            )
+        if item.period_start or item.period_end:
+            facts.append(
+                {
+                    **base,
+                    "claim_id": f"fact-period-{stable}",
+                    "class": "FACT",
+                    "text": f"Vigência oficial {item.period_start or 'UNKNOWN'} a {item.period_end or 'UNKNOWN'}.",
+                    "locator": {"json_path": "$.dataVigenciaInicio"},
+                }
+            )
+        if item.amendment_type:
+            facts.append(
+                {
+                    **base,
+                    "claim_id": f"fact-amendment-{stable}",
+                    "class": "FACT",
+                    "text": f"Fonte oficial registra tipo de aditivo: {item.amendment_type}.",
+                }
+            )
+        if item.unit is None:
+            unknowns.append(
+                {
+                    **base,
+                    "claim_id": f"unk-unit-{stable}",
+                    "class": "UNKNOWN",
+                    "text": "Unidade física não demonstrada na fonte oficial desta execução.",
+                }
+            )
+        if item.execution_regime is None:
+            unknowns.append(
+                {
+                    **base,
+                    "claim_id": f"unk-regime-{stable}",
+                    "class": "UNKNOWN",
+                    "text": "Regime de execução não demonstrado na fonte oficial desta execução.",
+                }
+            )
+        if item.procurement_modality is None:
+            unknowns.append(
+                {
+                    **base,
+                    "claim_id": f"unk-mod-{stable}",
+                    "class": "UNKNOWN",
+                    "text": "Modalidade não demonstrada na fonte oficial desta execução.",
+                }
+            )
+    return facts, inferences, unknowns
+
+
+def _insight_for(items: list[OfficialContractObservation], facts: list[dict[str, Any]]) -> str:
+    objects = [item.object_text for item in items if item.object_text]
+    adjacency = commercial_adjacency(*objects, *(item.get("text") for item in facts))
+    if not objects:
+        return ""
+    primary = objects[0]
+    if "aditivo" in adjacency:
+        return (
+            f"A cadeia documental oficial descreve o contrato «{primary[:180]}» "
+            "com menção a aditivo; o insight é a sequência documental, sem comparação."
+        )
+    if "reajuste" in adjacency or "reequilibrio" in adjacency:
+        return (
+            f"A fonte oficial descreve «{primary[:180]}» com adjacência de reajuste/reequilíbrio; "
+            "não se afirma direito, desequilíbrio ou irregularidade."
+        )
+    if "prazo" in adjacency:
+        return (
+            f"A fonte oficial descreve «{primary[:180]}» com componente de prazo; "
+            "a leitura é cronológica e não comparativa."
+        )
+    if "bdi" in adjacency or "defesa_margem" in adjacency:
+        return (
+            f"A fonte oficial descreve «{primary[:180]}» com adjacência de BDI/margem; "
+            "não se infere sobrepreço nem irregularidade."
+        )
+    if "medicao_glosa" in adjacency:
+        return (
+            f"A fonte oficial descreve «{primary[:180]}» com adjacência de medição/glosa; "
+            "não se afirma inadimplemento nem irregularidade."
+        )
+    return ""
+
+
+def _artifact(
+    obs: OfficialContractObservation, *, retrieved_at: str | None, verified_at: str | None
+) -> dict[str, Any] | None:
+    if not obs.official_url or not obs.source_document_sha256:
+        return None
+    return {
+        "evidence_id": obs.source_document_id or obs.observation_id,
+        "url": obs.official_url,
+        "sha256": obs.source_document_sha256,
+        "mime": "application/json" if obs.source_kind == "contract" else "text/html",
+        "locator": _locator_for(obs),
+        "retrieved_at": retrieved_at,
+        "verified_at": verified_at,
+        "source_kind": obs.source_kind,
+        "bytes_obtained": True,
+    }
+
+
+def dossier_from_group(
+    contract_id: str,
+    items: list[OfficialContractObservation],
+    *,
+    retrieved_at: str | None,
+    verified_at: str | None,
+    source_as_of: str | None,
+    as_of: str,
+    producer: dict[str, str],
+    replay_command: str,
+    query_window: dict[str, Any],
+    bytes_obtained: bool,
+    disposition: str,
+    disposition_reason: str,
+) -> dict[str, Any]:
+    first = items[0]
+    artifacts = [
+        item for item in (_artifact(obs, retrieved_at=retrieved_at, verified_at=verified_at) for obs in items) if item
+    ]
+    by_doc = {str(item["evidence_id"]): item for item in artifacts}
+    facts, inferences, unknowns = _claims_from_observations(items, artifact_by_doc=by_doc)
+    insight = _insight_for(items, facts)
+    limitations = [
+        "Sem comparação de pares: unidade, regime, escopo e período compatíveis não foram demonstrados.",
+        "atípico nunca significa irregular.",
+        "Campos sem evidência oficial permanecem UNKNOWN.",
+    ]
+    identity = {
+        "analysis_id": contract_id,
+        "contract_id": contract_id,
+        "process_id": first.process_identifier,
+        "orgao_cnpj": first.contracting_entity_identifier,
+        "fornecedor_cnpj": first.supplier_identifier,
+        "objeto": first.object_text,
+        "uf": (first.extra or {}).get("uf"),
+        "municipio": (first.extra or {}).get("municipio"),
+        "source_system": first.source_system,
+        "official_urls": sorted({item.official_url for item in items if item.official_url}),
+        "event_effective_at": first.effective_at,
+        "source_published_at": first.observed_at,
+    }
+    analysis_id = content_hash(
+        {"schema": "official-live-authority-dossier/1.1", "contract_id": contract_id, "window": query_window}
+    )[:32]
+    return assemble_consumer_dossier(
+        analysis_id=analysis_id,
+        identity=identity,
+        artifacts=artifacts,
+        claims=facts,
+        calculations=[],
+        inferences=inferences,
+        unknowns=unknowns,
+        insight=insight,
+        limitations=limitations,
+        method="official-live-document-chain/1.1",
+        producer_repo=producer["repo"],
+        producer_commit=producer["commit"],
+        replay_command=replay_command,
+        query_window=query_window,
+        retrieved_at=retrieved_at,
+        verified_at=verified_at,
+        source_as_of=source_as_of,
+        event_effective_at=first.effective_at,
+        source_published_at=first.observed_at,
+        as_of=as_of,
+        bytes_obtained=bytes_obtained and bool(artifacts),
+        requested_mode="DOCUMENT_CHAIN",
+        candidate_disposition=disposition,
+        candidate_reason=disposition_reason,
+    )
+
+
+def _write_tree(root: Path, files: dict[str, str]) -> None:
+    if root.exists():
+        shutil.rmtree(root)
+    root.mkdir(parents=True)
+    for rel, text in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = text if text.endswith("\n") else text + "\n"
+        path.write_text(payload, encoding="utf-8")
+
+
+def write_atomic_rendezvous(dest: Path, files: dict[str, str]) -> Path:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.parent / f".{dest.name}.tmp.{os.getpid()}"
+    backup = dest.parent / f".{dest.name}.bak.{os.getpid()}"
+    try:
+        _write_tree(tmp, files)
+        if dest.exists():
+            if backup.exists():
+                shutil.rmtree(backup)
+            dest.rename(backup)
+        tmp.rename(dest)
+        if backup.exists():
+            shutil.rmtree(backup)
+    except Exception:
+        if tmp.exists():
+            shutil.rmtree(tmp)
+        raise
+    return dest
+
+
+def _dumps(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def build_rendezvous_files(
+    dossiers: list[dict[str, Any]],
+    *,
+    producer: dict[str, str],
+    generated_at: str,
+    replay_command: str,
+    query_window: dict[str, Any],
+    live_meta: dict[str, Any],
+    candidate_log: list[dict[str, str]],
+    tests: list[str],
+) -> dict[str, str]:
+    ready = [item for item in dossiers if item.get("handoff_status") == "HANDOFF_READY"][:MAX_LIVE_READY]
+    hold = [item for item in dossiers if item.get("handoff_status") != "HANDOFF_READY"]
+    files: dict[str, str] = {}
+    for item in (*ready, *hold):
+        files[f"dossiers/{item['analysis_id']}.json"] = _dumps(item)
+    manifest = {
+        "schema": OFFICIAL_LIVE_HANDOFF_SCHEMA,
+        "version": "1.1",
+        "producer_repo": producer["repo"],
+        "producer_branch": producer["branch"],
+        "producer_commit": producer["commit"],
+        "generated_at": generated_at,
+        "query_window": query_window,
+        "replay_command": replay_command,
+        "consumer": CONSUMER_ID,
+        "dossier_count": len(ready),
+        "ids": [item["analysis_id"] for item in ready],
+        "hold_ids": [item["analysis_id"] for item in hold],
+        "candidate_log": candidate_log,
+        "publication_authorization": False,
+        "index_authorization": False,
+        "commercial_relationship_claim": False,
+        "production_write": False,
+        "backfill": False,
+        "live": live_meta,
+        "content_hashes": {item["analysis_id"]: item.get("content_hash") for item in (*ready, *hold)},
+    }
+    manifest["content_hash"] = content_hash(strip_temporal_for_hash(manifest))
+    files["manifest.json"] = _dumps(manifest)
+    files["replay.txt"] = replay_command + "\n"
+    if ready:
+        ready_doc = {
+            "schema": OFFICIAL_LIVE_HANDOFF_SCHEMA,
+            "version": "1.1",
+            "producer_repo": producer["repo"],
+            "producer_branch": producer["branch"],
+            "producer_commit": producer["commit"],
+            "generated_at": generated_at,
+            "dossier_count": len(ready),
+            "ids": [item["analysis_id"] for item in ready],
+            "manifest_sha256": sha256_text(files["manifest.json"]),
+            "root_content_hash": content_hash(
+                strip_temporal_for_hash(
+                    {"ids": [item["analysis_id"] for item in ready], "hashes": manifest["content_hashes"]}
+                )
+            ),
+            "status": "READY",
+        }
+        files["READY.json"] = _dumps(ready_doc)
+        files["README.md"] = (
+            "# official-live-01\n\n"
+            f"status: READY\n"
+            f"dossier_count: {len(ready)}\n"
+            f"consumer: {CONSUMER_ID} / web-cfg#83\n"
+            "publication_authorization: false\n"
+            "index_authorization: false\n"
+        )
+    else:
+        blocked = {
+            "schema": OFFICIAL_LIVE_HANDOFF_SCHEMA,
+            "version": "1.1",
+            "status": "BLOCKED",
+            "producer_repo": producer["repo"],
+            "producer_commit": producer["commit"],
+            "generated_at": generated_at,
+            "reason_codes": sorted(
+                {code for item in dossiers for code in item.get("reason_codes") or []}
+                or list(live_meta.get("reason_codes") or ["no_handoff_ready_dossier"])
+            ),
+            "sources_tried": live_meta.get("sources") or [],
+            "availability": live_meta.get("unavailabilities") or live_meta.get("failures") or [],
+            "tests": tests,
+            "replay_command": replay_command,
+            "smallest_next_verifiable_step": (
+                "Reverificar a mesma janela PNCP com documentos oficiais que tragam "
+                "locator+hash e um insight singular sem linguagem comparativa."
+            ),
+            "dossier_count": 0,
+        }
+        files["BLOCKED.json"] = _dumps(blocked)
+        files["README.md"] = (
+            "# official-live-01\n\n"
+            "status: BLOCKED\n"
+            "READY.json was not written.\n"
+            f"reason_codes: {', '.join(blocked['reason_codes'])}\n"
+        )
+    sums = []
+    for rel in sorted(name for name in files if name != "SHA256SUMS.txt"):
+        sums.append(f"{sha256_bytes(files[rel].encode('utf-8'))}  {rel}")
+    files["SHA256SUMS.txt"] = "\n".join(sums) + "\n"
+    return files
+
+
+def run_official_live_handoff(
+    *,
+    output: Path | None = None,
+    dsn: str | None = None,
+    limit: int = MAX_LIVE_CANDIDATES,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    cache_dir: Path | None = None,
+    fetch_pages: bool = True,
+    as_of: str | None = None,
+    write_rendezvous: bool = True,
+) -> dict[str, Any]:
+    started = utc_now()
+    stamp = as_of or started
+    window_start, window_end = default_live_window(start=start_date, end=end_date, as_of=stamp)
+    bounded = max(1, min(int(limit), MAX_LIVE_CANDIDATES))
+    dest = output or rendezvous_dir()
+    producer = git_identity()
+    live = run_live_readonly(
+        dsn=dsn,
+        limit=bounded,
+        out_dir=None,
+        cache_dir=cache_dir,
+        fetch_pages=fetch_pages,
+        as_of=stamp,
+        start_date=window_start,
+        end_date=window_end,
+    )
+    observations = [observation_from_mapping(row) for row in live.get("observations") or []]
+    grouped = group_observations(observations)
+    chosen, candidate_log = select_candidates(grouped, limit=bounded)
+    retrieved_at = live.get("finished_at") if live.get("documents_obtained") else None
+    verified_at = retrieved_at
+    bytes_obtained = int(live.get("documents_obtained") or 0) > 0
+    query_window = {"start": window_start, "end": window_end, "uf": "SC", "limit": bounded}
+    replay = (
+        "python3 -m scripts.historical_contract_authority --mode official-live "
+        f"--limit {bounded} --start-date {window_start} --end-date {window_end} "
+        "--as-of {as_of} --output <handoff-dir>".format(as_of=stamp)
+    )
+    dossiers: list[dict[str, Any]] = []
+    for contract_id in chosen:
+        disposition = next(
+            (item for item in candidate_log if item.get("contract_id") == contract_id),
+            {"disposition": "entered", "reason": "selected"},
+        )
+        dossiers.append(
+            dossier_from_group(
+                contract_id,
+                grouped[contract_id],
+                retrieved_at=retrieved_at if bytes_obtained else None,
+                verified_at=verified_at if bytes_obtained else None,
+                source_as_of=None,
+                as_of=stamp,
+                producer=producer,
+                replay_command=replay,
+                query_window=query_window,
+                bytes_obtained=bytes_obtained,
+                disposition=str(disposition.get("disposition") or "entered"),
+                disposition_reason=str(disposition.get("reason") or ""),
+            )
+        )
+    live_meta = {
+        "sources": live.get("sources") or [],
+        "documents_considered": live.get("documents_considered"),
+        "documents_obtained": live.get("documents_obtained"),
+        "documents_failed": live.get("documents_failed"),
+        "unavailabilities": live.get("unavailabilities") or [],
+        "failures": live.get("failures") or [],
+        "reason_codes": [
+            item.get("error_kind") for item in (live.get("unavailabilities") or []) if item.get("error_kind")
+        ],
+        "production_write": False,
+        "backfill": False,
+        "official_live": bool(bytes_obtained and fetch_pages),
+        "dsn_present": bool(resolve_dsn(dsn)),
+        "period": live.get("period"),
+    }
+    files = build_rendezvous_files(
+        dossiers,
+        producer=producer,
+        generated_at=started,
+        replay_command=replay,
+        query_window=query_window,
+        live_meta=live_meta,
+        candidate_log=candidate_log,
+        tests=["tests/historical_contract_authority/test_official_live_handoff.py"],
+    )
+    written = None
+    if write_rendezvous:
+        written = str(write_atomic_rendezvous(dest, files))
+    ready = [item for item in dossiers if item.get("handoff_status") == "HANDOFF_READY"]
+    return {
+        "as_of": stamp,
+        "output": written or str(dest),
+        "files": files,
+        "dossiers": dossiers,
+        "ready": ready,
+        "live": live_meta,
+        "producer": producer,
+        "replay_command": replay,
+        "query_window": query_window,
+        "status": "READY" if ready else "BLOCKED",
+        "snapshot_records": [observation_to_snapshot_record(item) for item in observations],
+        "live_manifest": {key: value for key, value in live.items() if key != "observations"},
+    }
+
+
+def same_consumer_shape(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    keys = (
+        "schema",
+        "analysis_id",
+        "identity",
+        "provenance",
+        "factual_matrix",
+        "analysis",
+        "gates",
+    )
+    return all(key in left and key in right for key in keys)

--- a/scripts/historical_contract_authority/schema.py
+++ b/scripts/historical_contract_authority/schema.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 SCHEMA = "historical-contract-authority-dossier/1.0"
+SCHEMA_V11 = "historical-contract-authority-dossier/1.1"
 METHOD_VERSION = "historical-contract-authority-method/1.0"
 EXTRACTOR_VERSION = "historical-contract-authority-extract/1.0"
 SCORE_VERSION = "dossier-authority-score/1.0"
@@ -16,16 +17,18 @@ CONTRACT_VERSION = "v1.0.0"
 CONSUMER_SCHEMA = "public-read-contract-analysis/1.0"
 CONSUMER_ID = "web-cfg#83"
 HANDOFF_SCHEMA = "authority-handoff-contract-analysis/1.0"
+HANDOFF_SCHEMA_V11 = "official-live-authority-handoff/1.1"
 
 DossierState = Literal["REJECT", "HOLD_FOR_DATA", "HANDOFF_READY"]
 ClaimClass = Literal["FACT", "CALCULATION", "INFERENCE", "UNKNOWN"]
 DataState = Literal["DATA_READY", "DATA_HOLD", "DATA_REJECT"]
-ComparabilityState = Literal["COMPARABLE", "HOLD_FOR_DATA", "NOT_COMPARABLE"]
+ComparabilityState = Literal["COMPARABLE", "HOLD_FOR_DATA", "NOT_COMPARABLE", "NOT_APPLICABLE"]
 
 DOSSIER_STATES: tuple[str, ...] = ("REJECT", "HOLD_FOR_DATA", "HANDOFF_READY")
 CLAIM_CLASSES: tuple[str, ...] = ("FACT", "CALCULATION", "INFERENCE", "UNKNOWN")
 DATA_STATES: tuple[str, ...] = ("DATA_READY", "DATA_HOLD", "DATA_REJECT")
-COMPARABILITY_STATES: tuple[str, ...] = ("COMPARABLE", "HOLD_FOR_DATA", "NOT_COMPARABLE")
+COMPARABILITY_STATES: tuple[str, ...] = ("COMPARABLE", "HOLD_FOR_DATA", "NOT_COMPARABLE", "NOT_APPLICABLE")
+ANALYSIS_MODES: tuple[str, ...] = ("DOCUMENT_CHAIN", "TIMELINE", "COMPARATIVE")
 
 FORBIDDEN_PUBLIC_STATES = frozenset(
     {"INDEX", "PUBLISHABLE_INDEX", "PUBLISHABLE_NOINDEX", "PUBLISHABLE", "REVIEW_CANDIDATE"}
@@ -64,6 +67,8 @@ HANDOFF_MIN_DIMENSION = 75
 MIN_MATERIAL_CLAIMS = 5
 MIN_EVIDENCE_FAMILIES = 3
 MAX_HANDOFF_READY = 5
+MAX_OFFICIAL_LIVE_READY = 3
+MAX_OFFICIAL_LIVE_CANDIDATES = 12
 
 USER_AGENT = (
     "Extra-CLI-historical-contract-authority/1.0 "

--- a/scripts/official_contract_semantics/cli.py
+++ b/scripts/official_contract_semantics/cli.py
@@ -13,7 +13,7 @@ from scripts.official_contract_semantics.coverage import coverage_matrix
 from scripts.official_contract_semantics.export_comparables import export_comparables_corpus
 from scripts.official_contract_semantics.export_publication import export_publication_evidence
 from scripts.official_contract_semantics.extract import extract_many_paths, extract_path
-from scripts.official_contract_semantics.live import run_live_readonly
+from scripts.official_contract_semantics.live import default_live_window, run_live_readonly
 from scripts.official_contract_semantics.models import OfficialContractObservation, observation_from_mapping
 from scripts.official_contract_semantics.persist import append_observations
 from scripts.official_contract_semantics.reconcile import reconcile
@@ -116,6 +116,32 @@ def cmd_export_publication(args: argparse.Namespace) -> int:
     return _print(document)
 
 
+def cmd_official_live_handoff(args: argparse.Namespace) -> int:
+    from pathlib import Path as PathType
+
+    from scripts.historical_contract_authority.official_live import run_official_live_handoff
+
+    result = run_official_live_handoff(
+        output=PathType(args.output) if args.output else None,
+        dsn=args.dsn,
+        limit=args.limit,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        cache_dir=PathType(args.cache_dir) if args.cache_dir else None,
+        fetch_pages=not args.skip_pages,
+        as_of=args.as_of,
+    )
+    printable = {
+        "status": result["status"],
+        "output": result["output"],
+        "ready": [item["analysis_id"] for item in result["ready"]],
+        "replay_command": result["replay_command"],
+        "live": result["live"],
+        "window": default_live_window(start=args.start_date, end=args.end_date, as_of=args.as_of),
+    }
+    return _print(printable)
+
+
 def cmd_live(args: argparse.Namespace) -> int:
     manifest = run_live_readonly(
         dsn=args.dsn,
@@ -124,6 +150,8 @@ def cmd_live(args: argparse.Namespace) -> int:
         cache_dir=args.cache_dir,
         fetch_pages=not args.skip_pages,
         as_of=args.as_of,
+        start_date=args.start_date,
+        end_date=args.end_date,
     )
     printable = {key: value for key, value in manifest.items() if key != "observations"}
     printable["observation_ids"] = [item["observation_id"] for item in manifest.get("observations") or []]
@@ -203,8 +231,21 @@ def build_parser() -> argparse.ArgumentParser:
     live.add_argument("--out")
     live.add_argument("--cache-dir", dest="cache_dir")
     live.add_argument("--as-of", dest="as_of")
+    live.add_argument("--start-date", dest="start_date")
+    live.add_argument("--end-date", dest="end_date")
     live.add_argument("--skip-pages", action="store_true")
     live.set_defaults(func=cmd_live)
+
+    handoff = sub.add_parser("official-live-handoff")
+    handoff.add_argument("--dsn")
+    handoff.add_argument("--limit", type=int, default=DEFAULT_LIVE_LIMIT)
+    handoff.add_argument("--output")
+    handoff.add_argument("--cache-dir", dest="cache_dir")
+    handoff.add_argument("--as-of", dest="as_of")
+    handoff.add_argument("--start-date", dest="start_date")
+    handoff.add_argument("--end-date", dest="end_date")
+    handoff.add_argument("--skip-pages", action="store_true")
+    handoff.set_defaults(func=cmd_official_live_handoff)
 
     pipeline = sub.add_parser("pipeline")
     pipeline.add_argument("--input", nargs="+", required=True)

--- a/scripts/official_contract_semantics/constants.py
+++ b/scripts/official_contract_semantics/constants.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+SCHEMA_VERSION_V10 = "official-contract-observation/1.0"
 SCHEMA_VERSION = "official-contract-observation/1.1"
+ACCEPTED_SCHEMA_VERSIONS = frozenset({SCHEMA_VERSION_V10, SCHEMA_VERSION})
 EXTRACTOR_VERSION = "official-contract-semantics-extract/1.1"
 RECONCILE_VERSION = "official-contract-semantics-reconcile/1.0"
 EXPORT_COMPARABLES_VERSION = "official-contract-semantics-export-comparables/1.1"
 EXPORT_PUBLICATION_VERSION = "official-contract-semantics-export-publication/1.1"
-LIVE_VERSION = "official-contract-semantics-live-readonly/1.0"
+LIVE_VERSION = "official-contract-semantics-live-readonly/1.1"
 POLICY_VERSION = "official-contract-semantics-policy/1.1"
 
 PACKAGE_NAME = "official_contract_semantics"
@@ -106,9 +108,7 @@ NOT_APPLICABLE_TOKENS = frozenset(
     }
 )
 
-DERIVATION_COMPARABLES_CANONICAL = (
-    "export_comparables/valor_global_or_contratado_to_valor_integral_nominal/1.1"
-)
+DERIVATION_COMPARABLES_CANONICAL = "export_comparables/valor_global_or_contratado_to_valor_integral_nominal/1.1"
 
 AMENDMENT_TYPES = (
     "prazo",
@@ -119,7 +119,7 @@ AMENDMENT_TYPES = (
 )
 
 # Execution timestamps never enter the semantic hash or observation_id.
-EXECUTION_TIMESTAMP_FIELDS = frozenset({"extracted_at"})
+EXECUTION_TIMESTAMP_FIELDS = frozenset({"extracted_at", "retrieved_at", "verified_at"})
 
 SEMANTIC_FIELDS = (
     "object_text",

--- a/scripts/official_contract_semantics/extract.py
+++ b/scripts/official_contract_semantics/extract.py
@@ -39,6 +39,7 @@ from scripts.official_contract_semantics.models import (
     OfficialContractObservation,
     SourceUnavailability,
 )
+from scripts.official_contract_semantics.serialize import semantic_payload
 from scripts.official_contract_semantics.validate import ObservationValidationError, validate_mapping
 
 VALUE_FIELD_TO_SEMANTIC = {
@@ -204,7 +205,9 @@ def draft_from_record(raw: dict[str, Any], *, default_source: str = "fixture") -
     document_sha = _text(raw.get("source_document_sha256") or raw.get("sha256"))
     if document_sha is None:
         document_sha = raw_record_hash_for(document_text)
-    raw_hash = _text(raw.get("raw_record_hash")) or raw_record_hash_for(raw)
+    raw_hash = _text(raw.get("raw_record_hash")) or raw_record_hash_for(
+        semantic_payload(raw) if isinstance(raw, dict) else raw
+    )
     amendment_type = _text(raw.get("amendment_type"))
     if not amendment_type:
         if raw.get("amendment_value_delta") not in {None, ""} and raw.get("amendment_term_delta") not in {None, ""}:
@@ -218,8 +221,12 @@ def draft_from_record(raw: dict[str, Any], *, default_source: str = "fixture") -
         **dict(raw.get("extra") or {}),
         **{key: raw[key] for key in ("uf", "municipio") if raw.get(key)},
     }
-    orgao_raw = _raw_identifier(raw.get("contracting_entity_identifier") or raw.get("orgao_cnpj") or raw.get("orgao_id"))
-    supplier_raw = _raw_identifier(raw.get("supplier_identifier") or raw.get("fornecedor_cnpj") or raw.get("fornecedor_id"))
+    orgao_raw = _raw_identifier(
+        raw.get("contracting_entity_identifier") or raw.get("orgao_cnpj") or raw.get("orgao_id")
+    )
+    supplier_raw = _raw_identifier(
+        raw.get("supplier_identifier") or raw.get("fornecedor_cnpj") or raw.get("fornecedor_id")
+    )
     if identifier_is_masked(orgao_raw):
         extra["contracting_entity_identifier_raw"] = orgao_raw
         extra["contracting_entity_identifier_masked"] = True
@@ -275,6 +282,11 @@ def draft_from_record(raw: dict[str, Any], *, default_source: str = "fixture") -
         ),
         "observed_at": observed_at,
         "effective_at": effective_at,
+        "event_effective_at": _text(raw.get("event_effective_at")) or effective_at,
+        "source_published_at": _text(raw.get("source_published_at")) or observed_at,
+        "retrieved_at": _text(raw.get("retrieved_at")),
+        "verified_at": _text(raw.get("verified_at")),
+        "source_as_of": _text(raw.get("source_as_of")),
         "extractor_version": EXTRACTOR_VERSION,
         "locator": locator,
         "evidence_excerpt": clip_excerpt(excerpt_source),
@@ -404,14 +416,18 @@ def extract_record(raw: dict[str, Any], *, default_source: str = "fixture") -> E
         except ValueError as exc:
             rejections.append(
                 ExtractionRejection(
-                    code=REASON_CONFLICTING_VALUE_FIELDS if str(exc) == REASON_CONFLICTING_VALUE_FIELDS else REASON_PARSER_ERROR,
+                    code=REASON_CONFLICTING_VALUE_FIELDS
+                    if str(exc) == REASON_CONFLICTING_VALUE_FIELDS
+                    else REASON_PARSER_ERROR,
                     message=str(exc),
                     source_document_id=_text(raw.get("source_document_id") or raw.get("document_id")),
                     official_url=_text(raw.get("official_url") or raw.get("url")),
                 )
             )
     return ExtractResult(
-        observations=tuple(sorted({item.observation_id: item for item in observations}.values(), key=lambda item: item.observation_id)),
+        observations=tuple(
+            sorted({item.observation_id: item for item in observations}.values(), key=lambda item: item.observation_id)
+        ),
         rejections=tuple(rejections),
         document_errors=(),
     )

--- a/scripts/official_contract_semantics/freshness.py
+++ b/scripts/official_contract_semantics/freshness.py
@@ -1,0 +1,174 @@
+"""Operational freshness uses verification clocks, never contractual event age."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+FRESHNESS_POLICY = "official-authority-freshness/1.1"
+STALE_REASON_UNVERIFIED = "unverified_source"
+STALE_REASON_NO_BYTES = "url_without_retrieved_bytes"
+STALE_REASON_CLOCK = "verification_clock_stale"
+NOT_STALE = "not_stale"
+
+# Wall-clock fields that must never enter a semantic/content hash.
+TEMPORAL_HASH_EXCLUSIONS = frozenset(
+    {
+        "retrieved_at",
+        "verified_at",
+        "extracted_at",
+        "generated_at",
+        "started_at",
+        "finished_at",
+        "content_hash",
+    }
+)
+
+
+def parse_instant(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        if len(text) == 10:
+            try:
+                parsed = datetime.fromisoformat(text + "T00:00:00+00:00")
+            except ValueError:
+                return None
+        else:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def event_is_recent(*, event_effective_at: str | None, now: str, recent_hours: int = 48) -> bool:
+    """An old contractual event stays historically old even if re-verified now."""
+    event = parse_instant(event_effective_at)
+    clock = parse_instant(now)
+    if event is None or clock is None:
+        return False
+    return (clock - event) <= timedelta(hours=recent_hours)
+
+
+@dataclass(frozen=True)
+class TemporalFields:
+    event_effective_at: str | None
+    source_published_at: str | None
+    retrieved_at: str | None
+    verified_at: str | None
+    source_as_of: str | None
+
+    def as_dict(self) -> dict[str, str | None]:
+        return {
+            "event_effective_at": self.event_effective_at,
+            "source_published_at": self.source_published_at,
+            "retrieved_at": self.retrieved_at,
+            "verified_at": self.verified_at,
+            "source_as_of": self.source_as_of,
+        }
+
+
+def resolve_temporal_fields(
+    *,
+    event_effective_at: str | None = None,
+    source_published_at: str | None = None,
+    retrieved_at: str | None = None,
+    verified_at: str | None = None,
+    source_as_of: str | None = None,
+    effective_at: str | None = None,
+    observed_at: str | None = None,
+    bytes_obtained: bool = False,
+) -> TemporalFields:
+    retrieved = retrieved_at if bytes_obtained else None
+    verified = verified_at if bytes_obtained else None
+    return TemporalFields(
+        event_effective_at=event_effective_at or effective_at,
+        source_published_at=source_published_at or observed_at,
+        retrieved_at=retrieved,
+        verified_at=verified,
+        source_as_of=source_as_of,
+    )
+
+
+def operational_clock(*, verified_at: str | None, retrieved_at: str | None) -> str | None:
+    return verified_at or retrieved_at
+
+
+def is_stale_evidence(
+    *,
+    event_effective_at: str | None,
+    source_published_at: str | None,
+    retrieved_at: str | None,
+    verified_at: str | None,
+    as_of: str,
+    bytes_obtained: bool,
+    max_age_hours: int = 48,
+) -> tuple[bool, str]:
+    """Freshness is operational. Event age never makes a just-verified source stale."""
+    del event_effective_at, source_published_at
+    if not bytes_obtained:
+        return True, STALE_REASON_NO_BYTES
+    clock = operational_clock(verified_at=verified_at, retrieved_at=retrieved_at)
+    if clock is None:
+        return True, STALE_REASON_UNVERIFIED
+    verified = parse_instant(clock)
+    as_of_dt = parse_instant(as_of)
+    if verified is None or as_of_dt is None:
+        return True, STALE_REASON_UNVERIFIED
+    if as_of_dt - verified > timedelta(hours=max_age_hours):
+        return True, STALE_REASON_CLOCK
+    return False, NOT_STALE
+
+
+def freshness_block(
+    temporal: TemporalFields,
+    *,
+    as_of: str,
+    bytes_obtained: bool,
+    max_age_hours: int = 48,
+) -> dict[str, Any]:
+    stale, reason = is_stale_evidence(
+        event_effective_at=temporal.event_effective_at,
+        source_published_at=temporal.source_published_at,
+        retrieved_at=temporal.retrieved_at,
+        verified_at=temporal.verified_at,
+        as_of=as_of,
+        bytes_obtained=bytes_obtained,
+        max_age_hours=max_age_hours,
+    )
+    return {
+        "policy": FRESHNESS_POLICY,
+        "as_of": as_of,
+        "operational_clock": "verified_at|retrieved_at",
+        "max_age_hours": max_age_hours,
+        "stale": stale,
+        "reason": reason,
+        "event_is_recent": event_is_recent(
+            event_effective_at=temporal.event_effective_at,
+            now=as_of,
+            recent_hours=max_age_hours,
+        ),
+        **temporal.as_dict(),
+    }
+
+
+def strip_temporal_for_hash(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        return {
+            str(key): strip_temporal_for_hash(value)
+            for key, value in payload.items()
+            if key not in TEMPORAL_HASH_EXCLUSIONS
+        }
+    if isinstance(payload, list):
+        return [strip_temporal_for_hash(item) for item in payload]
+    if isinstance(payload, tuple):
+        return [strip_temporal_for_hash(item) for item in payload]
+    return payload

--- a/scripts/official_contract_semantics/http_client.py
+++ b/scripts/official_contract_semantics/http_client.py
@@ -142,6 +142,9 @@ def fetch_official(
                 http_status=int(exc.code),
                 message=str(exc.reason),
             )
+            if int(exc.code) == 429:
+                _sleep(rate_limit_s * (attempt + 2), sleeper)
+                continue
             if int(exc.code) < 500:
                 break
         except urllib.error.URLError as exc:
@@ -162,5 +165,7 @@ def fetch_official(
         sha256=None,
         unavailability=last_error,
     )
-    _store_cache(cache_dir, failure)
+    transient = last_error is not None and last_error.http_status in {429, 500, 502, 503, 504}
+    if not transient:
+        _store_cache(cache_dir, failure)
     return failure

--- a/scripts/official_contract_semantics/live.py
+++ b/scripts/official_contract_semantics/live.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +45,36 @@ SC_TOKENS = ("%paviment%", "%recapeamento%", "%cbuq%", "%asfalt%", "%microrevest
 
 def _now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_live_window(
+    *,
+    start: str | None = None,
+    end: str | None = None,
+    as_of: str | None = None,
+    days: int = 30,
+) -> tuple[str, str]:
+    """Current configurable window. Never depends on a hardcoded campaign date."""
+    if start and end:
+        return start[:10], end[:10]
+    if as_of:
+        try:
+            end_dt = datetime.fromisoformat(as_of.replace("Z", "+00:00")).date()
+        except ValueError:
+            end_dt = datetime.now(UTC).date()
+    else:
+        end_dt = datetime.now(UTC).date()
+    start_dt = end_dt - timedelta(days=max(1, days))
+    if start:
+        return start[:10], end_dt.isoformat()
+    if end:
+        end_dt = datetime.fromisoformat(end[:10]).date()
+        start_dt = end_dt - timedelta(days=max(1, days))
+    return start_dt.isoformat(), end_dt.isoformat()
+
+
+def pncp_ymd(iso_date: str) -> str:
+    return iso_date.replace("-", "")[:8]
 
 
 def resolve_dsn(explicit: str | None = None) -> str | None:
@@ -94,60 +124,93 @@ def _select_rows(dsn: str, limit: int) -> tuple[list[dict[str, Any]] | None, Sou
         )
 
 
-def _api_records(limit: int, cache_dir: Path | None) -> tuple[list[dict[str, Any]], list[SourceUnavailability]]:
-    url = PNCP_API_URL.format(start="20260701", end="20260707")
-    fetched = fetch_official(url, cache_dir=cache_dir)
-    if not fetched.ok or not fetched.body:
-        return [], [fetched.unavailability] if fetched.unavailability else [
-            SourceUnavailability(official_url=url, error_kind="unavailable", message="empty_body")
-        ]
-    try:
-        payload = __import__("json").loads(fetched.body)
-    except ValueError as exc:
-        return [], [SourceUnavailability(official_url=url, error_kind="parser_error", message=str(exc))]
-    data = payload.get("data") if isinstance(payload, dict) else payload
-    if not isinstance(data, list):
-        return [], [SourceUnavailability(official_url=url, error_kind="unexpected_shape", message="data_not_list")]
+def _api_records(
+    limit: int,
+    cache_dir: Path | None,
+    *,
+    start: str,
+    end: str,
+    retrieved_at: str,
+) -> tuple[list[dict[str, Any]], list[SourceUnavailability]]:
     records: list[dict[str, Any]] = []
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        contrato_id = str(
-            item.get("numeroControlePncp") or item.get("numeroControlePNCP") or item.get("numeroContratoEmpenho") or ""
+    errors: list[SourceUnavailability] = []
+    page = 1
+    max_pages = 3
+    while len(records) < limit and page <= max_pages:
+        url = (
+            "https://pncp.gov.br/api/consulta/v1/contratos"
+            f"?dataInicial={pncp_ymd(start)}&dataFinal={pncp_ymd(end)}"
+            f"&pagina={page}&tamanhoPagina=10"
         )
-        unidade = item.get("unidadeOrgao") if isinstance(item.get("unidadeOrgao"), dict) else {}
-        uf = str(item.get("uf") or item.get("siglaUf") or unidade.get("ufSigla") or unidade.get("uf") or "")
-        if uf.upper() not in {"SC", "SANTA CATARINA"}:
-            continue
-        records.append(
-            {
-                "source_system": "pncp",
-                "source_kind": "contract",
-                "official_url": PNCP_CONTRACT_URL.format(contrato_id=contrato_id) if contrato_id else url,
-                "source_document_id": contrato_id or None,
-                "contract_identifier": contrato_id or None,
-                "contracting_entity_identifier": (
-                    item.get("cnpjOrgao") or (item.get("orgaoEntidade") or {}).get("cnpj")
-                    if isinstance(item.get("orgaoEntidade"), dict)
-                    else item.get("cnpjOrgao")
-                ),
-                "supplier_identifier": item.get("niFornecedor")
-                or ((item.get("fornecedor") or {}).get("ni") if isinstance(item.get("fornecedor"), dict) else None),
-                "object_text": item.get("objetoContrato") or item.get("objeto"),
-                "valor_global": item.get("valorGlobal") or item.get("valorInicial"),
-                "period_start": item.get("dataVigenciaInicio"),
-                "period_end": item.get("dataVigenciaFim"),
-                "effective_at": item.get("dataAssinatura"),
-                "observed_at": item.get("dataPublicacaoPncp"),
-                "extra": {
-                    "uf": "SC",
-                    "municipio": item.get("nomeUnidade") or unidade.get("municipioNome") or item.get("municipio"),
-                },
-            }
-        )
-        if len(records) >= limit:
+        fetched = fetch_official(url, cache_dir=cache_dir)
+        if not fetched.ok or not fetched.body:
+            errors.append(
+                fetched.unavailability
+                or SourceUnavailability(official_url=url, error_kind="unavailable", message="empty_body")
+            )
             break
-    return records, []
+        try:
+            payload = __import__("json").loads(fetched.body)
+        except ValueError as exc:
+            errors.append(SourceUnavailability(official_url=url, error_kind="parser_error", message=str(exc)))
+            break
+        data = payload.get("data") if isinstance(payload, dict) else payload
+        if not isinstance(data, list):
+            errors.append(
+                SourceUnavailability(official_url=url, error_kind="unexpected_shape", message="data_not_list")
+            )
+            break
+        if not data:
+            break
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            contrato_id = str(
+                item.get("numeroControlePncp")
+                or item.get("numeroControlePNCP")
+                or item.get("numeroContratoEmpenho")
+                or ""
+            )
+            unidade = item.get("unidadeOrgao") if isinstance(item.get("unidadeOrgao"), dict) else {}
+            uf = str(item.get("uf") or item.get("siglaUf") or unidade.get("ufSigla") or unidade.get("uf") or "")
+            if uf.upper() not in {"SC", "SANTA CATARINA"}:
+                continue
+            records.append(
+                {
+                    "source_system": "pncp",
+                    "source_kind": "contract",
+                    "official_url": PNCP_CONTRACT_URL.format(contrato_id=contrato_id) if contrato_id else url,
+                    "source_document_id": contrato_id or None,
+                    "contract_identifier": contrato_id or None,
+                    "contracting_entity_identifier": (
+                        item.get("cnpjOrgao") or (item.get("orgaoEntidade") or {}).get("cnpj")
+                        if isinstance(item.get("orgaoEntidade"), dict)
+                        else item.get("cnpjOrgao")
+                    ),
+                    "supplier_identifier": item.get("niFornecedor")
+                    or ((item.get("fornecedor") or {}).get("ni") if isinstance(item.get("fornecedor"), dict) else None),
+                    "object_text": item.get("objetoContrato") or item.get("objeto"),
+                    "valor_global": item.get("valorGlobal") or item.get("valorInicial"),
+                    "period_start": item.get("dataVigenciaInicio"),
+                    "period_end": item.get("dataVigenciaFim"),
+                    "effective_at": item.get("dataAssinatura"),
+                    "observed_at": item.get("dataPublicacaoPncp"),
+                    "event_effective_at": item.get("dataAssinatura"),
+                    "source_published_at": item.get("dataPublicacaoPncp"),
+                    "retrieved_at": retrieved_at,
+                    "verified_at": retrieved_at,
+                    "source_document_sha256": fetched.sha256,
+                    "locator": {"json_path": "$.objetoContrato"},
+                    "extra": {
+                        "uf": "SC",
+                        "municipio": item.get("nomeUnidade") or unidade.get("municipioNome") or item.get("municipio"),
+                    },
+                }
+            )
+            if len(records) >= limit:
+                break
+        page += 1
+    return records, errors
 
 
 def build_replay_command(
@@ -157,12 +220,18 @@ def build_replay_command(
     out_dir: str | Path | None = None,
     cache_dir: str | Path | None = None,
     fetch_pages: bool = True,
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> str:
     parts = [
         "python3 -m scripts.official_contract_semantics live-readonly",
         f"--limit {int(limit)}",
         f"--as-of {as_of}",
     ]
+    if start_date:
+        parts.append(f"--start-date {start_date}")
+    if end_date:
+        parts.append(f"--end-date {end_date}")
     if not fetch_pages:
         parts.append("--skip-pages")
     if cache_dir is not None:
@@ -180,10 +249,13 @@ def run_live_readonly(
     cache_dir: str | Path | None = None,
     fetch_pages: bool = True,
     as_of: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
 ) -> dict[str, Any]:
     bounded = max(1, min(int(limit), MAX_LIVE_LIMIT))
     started = _now()
     stamp = as_of or started
+    window_start, window_end = default_live_window(start=start_date, end=end_date, as_of=stamp)
     cache = Path(cache_dir) if cache_dir else None
     considered = 0
     obtained = 0
@@ -213,10 +285,11 @@ def run_live_readonly(
 
     if not rows:
         sources_used.append("pncp_consulta_api")
-        api_rows, api_errors = _api_records(bounded, cache)
+        api_rows, api_errors = _api_records(bounded, cache, start=window_start, end=window_end, retrieved_at=started)
         unavailabilities.extend(api_errors)
         failed.extend(item.as_dict() for item in api_errors)
         rows = api_rows
+        obtained += sum(1 for item in api_rows if item.get("source_document_sha256"))
 
     considered = len(rows)
     extract_inputs: list[dict[str, Any]] = []
@@ -224,6 +297,8 @@ def run_live_readonly(
         record = _row_to_record(row) if "contrato_id" in row else row
         if record.get("extra") is None and row.get("uf"):
             record["extra"] = {"uf": row.get("uf"), "municipio": row.get("municipio")}
+        record.setdefault("event_effective_at", record.get("effective_at"))
+        record.setdefault("source_published_at", record.get("observed_at"))
         extract_inputs.append({**record, **(record.get("extra") or {})})
         url = record.get("official_url")
         if fetch_pages and url:
@@ -235,6 +310,8 @@ def run_live_readonly(
                     "source_kind": "official_page",
                     "source_document_id": f"{record.get('source_document_id')}:page",
                     "source_document_sha256": fetched.sha256,
+                    "retrieved_at": started,
+                    "verified_at": started,
                     "html": fetched.body,
                 }
                 page_result = extract_record(page_identity)
@@ -249,8 +326,6 @@ def run_live_readonly(
                 unavailabilities.append(
                     fetched.unavailability or SourceUnavailability(official_url=str(url), error_kind="unavailable")
                 )
-        else:
-            obtained += 1
 
     row_result = extract_payload(extract_inputs)
     observations.extend(row_result.observations)
@@ -263,6 +338,8 @@ def run_live_readonly(
         out_dir=out_dir,
         cache_dir=cache_dir,
         fetch_pages=fetch_pages,
+        start_date=window_start,
+        end_date=window_end,
     )
     artifact_sha256: dict[str, str] = {}
     if out_dir is not None:
@@ -271,13 +348,13 @@ def run_live_readonly(
             out / "live-observations.jsonl", [item.as_dict() for item in reconciled]
         )
     manifest: dict[str, Any] = {
-        "schema": "official-contract-semantics-live-manifest/1.0",
+        "schema": "official-contract-semantics-live-manifest/1.1",
         "live_version": LIVE_VERSION,
         "user_agent": USER_AGENT,
         "started_at": started,
         "finished_at": _now(),
         "as_of": stamp,
-        "period": {"start": "2026-07-01", "end": "2026-07-07", "uf": "SC"},
+        "period": {"start": window_start, "end": window_end, "uf": "SC"},
         "limit": bounded,
         "sources": sources_used,
         "commands": [replay],
@@ -291,6 +368,7 @@ def run_live_readonly(
         "production_write": False,
         "backfill": False,
         "inferred_from_absence": False,
+        "official_live": obtained > 0,
         "note": "unavailability is recorded as unavailability, never as absence of a fact",
         "artifact_sha256": artifact_sha256,
     }

--- a/scripts/official_contract_semantics/models.py
+++ b/scripts/official_contract_semantics/models.py
@@ -90,6 +90,11 @@ class OfficialContractObservation:
     field_epistemics: dict[str, str] = field(default_factory=dict)
     derivation_method: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
+    event_effective_at: str | None = None
+    source_published_at: str | None = None
+    retrieved_at: str | None = None
+    verified_at: str | None = None
+    source_as_of: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {}
@@ -107,6 +112,8 @@ class OfficialContractObservation:
     def semantic_dict(self) -> dict[str, Any]:
         payload = self.as_dict()
         payload.pop("extracted_at", None)
+        payload.pop("retrieved_at", None)
+        payload.pop("verified_at", None)
         return payload
 
 
@@ -231,7 +238,9 @@ def observation_from_mapping(raw: dict[str, Any]) -> OfficialContractObservation
         _check_enum(epistemic, EPISTEMIC_CLASSES, "epistemic_class")
     field_epistemics = dict(raw.get("field_epistemics") or {})
     for field_name, field_class in field_epistemics.items():
-        _check_enum(str(field_class), (*FIELD_EPISTEMIC_CLASSES, *SEARCH_EPISTEMIC_CLASSES), f"field_epistemic:{field_name}")
+        _check_enum(
+            str(field_class), (*FIELD_EPISTEMIC_CLASSES, *SEARCH_EPISTEMIC_CLASSES), f"field_epistemic:{field_name}"
+        )
     from scripts.official_contract_semantics.identity import parse_optional_decimal
 
     return OfficialContractObservation(
@@ -279,4 +288,9 @@ def observation_from_mapping(raw: dict[str, Any]) -> OfficialContractObservation
         field_epistemics=field_epistemics,
         derivation_method=raw.get("derivation_method"),
         extra=dict(raw.get("extra") or {}),
+        event_effective_at=raw.get("event_effective_at") or raw.get("effective_at"),
+        source_published_at=raw.get("source_published_at") or raw.get("observed_at"),
+        retrieved_at=raw.get("retrieved_at"),
+        verified_at=raw.get("verified_at"),
+        source_as_of=raw.get("source_as_of"),
     )

--- a/scripts/official_contract_semantics/validate.py
+++ b/scripts/official_contract_semantics/validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from scripts.official_contract_semantics.constants import (
+    ACCEPTED_SCHEMA_VERSIONS,
     AMENDMENT_TYPES,
     CONFIDENCE_CLASSES,
     EPISTEMIC_CLASSES,
@@ -54,7 +55,7 @@ def _fail(code: str, message: str) -> None:
 
 
 def validate_mapping(raw: dict[str, Any]) -> OfficialContractObservation:
-    if raw.get("schema_version") not in {None, SCHEMA_VERSION} and raw.get("schema_version") != SCHEMA_VERSION:
+    if raw.get("schema_version") not in {None, *ACCEPTED_SCHEMA_VERSIONS}:
         _fail(REASON_INVALID_SCHEMA, str(raw.get("schema_version")))
     if raw.get("infer_from_absence") or raw.get("assume_missing_if_unpublished"):
         _fail(REASON_INFERRED_FROM_ABSENCE, "absence_is_not_a_fact")

--- a/tests/historical_contract_authority/test_official_live_handoff.py
+++ b/tests/historical_contract_authority/test_official_live_handoff.py
@@ -1,0 +1,314 @@
+"""Official-live consumer handoff: freshness, analysis_mode, gates, rendezvous."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.historical_contract_authority.analysis import resolve_analysis_mode, resolve_comparability
+from scripts.historical_contract_authority.consumer import (
+    assemble_consumer_dossier,
+    claim_is_located,
+    validate_consumer_dossier,
+)
+from scripts.historical_contract_authority.freshness import dossier_freshness, strip_temporal_for_hash
+from scripts.historical_contract_authority.official_live import (
+    build_rendezvous_files,
+    same_consumer_shape,
+    write_atomic_rendezvous,
+)
+from scripts.historical_contract_authority.schema import content_hash, is_sha256
+
+DIGEST = "a" * 64
+
+
+def _claim(text: str = "Objeto oficial de pavimentacao asfaltica em Brusque.") -> dict:
+    return {
+        "claim_id": "fact-1",
+        "class": "FACT",
+        "text": text,
+        "evidence_id": "doc-1",
+        "url": "https://pncp.gov.br/app/contratos/x",
+        "sha256": DIGEST,
+        "locator": {"json_path": "$.objetoContrato"},
+        "source_refs": ["doc-1"],
+    }
+
+
+def _artifact() -> dict:
+    return {
+        "evidence_id": "doc-1",
+        "url": "https://pncp.gov.br/app/contratos/x",
+        "sha256": DIGEST,
+        "locator": {"json_path": "$.objetoContrato"},
+        "retrieved_at": "2026-08-17T12:00:00Z",
+        "verified_at": "2026-08-17T12:00:00Z",
+    }
+
+
+def _identity() -> dict:
+    return {
+        "contract_id": "1536471100010442024001",
+        "orgao_cnpj": "82940433000194",
+        "fornecedor_cnpj": "07894512000133",
+        "objeto": "Pavimentacao asfaltica com aditivo de prazo",
+        "uf": "SC",
+        "municipio": "Brusque",
+        "source_system": "pncp",
+        "official_urls": ["https://pncp.gov.br/app/contratos/x"],
+    }
+
+
+def _assemble(**overrides):
+    kwargs = {
+        "analysis_id": "analysis-demo-01",
+        "identity": _identity(),
+        "artifacts": [_artifact()],
+        "claims": [_claim()],
+        "calculations": [],
+        "inferences": [],
+        "unknowns": [
+            {
+                "claim_id": "unk-unit",
+                "class": "UNKNOWN",
+                "text": "Unidade física não demonstrada na fonte oficial desta execução.",
+                "evidence_id": "doc-1",
+                "url": "https://pncp.gov.br/app/contratos/x",
+                "sha256": DIGEST,
+                "locator": {"json_path": "$.unidade"},
+            }
+        ],
+        "insight": (
+            "A cadeia documental oficial descreve pavimentação com aditivo de prazo; "
+            "o insight é a sequência documental, não um ranking de pares."
+        ),
+        "limitations": [
+            "Sem comparação de pares: unidade, regime, escopo e período compatíveis não foram demonstrados.",
+            "atípico nunca significa irregular.",
+        ],
+        "method": "official-live-document-chain/1.1",
+        "producer_repo": "tjsasakifln/extra-cli",
+        "producer_commit": "abc123",
+        "replay_command": "python3 -m scripts.historical_contract_authority --mode official-live --limit 2",
+        "query_window": {"start": "2026-08-03", "end": "2026-08-17", "uf": "SC"},
+        "retrieved_at": "2026-08-17T12:00:00Z",
+        "verified_at": "2026-08-17T12:00:00Z",
+        "source_as_of": None,
+        "event_effective_at": "2024-03-01",
+        "source_published_at": "2024-03-02",
+        "as_of": "2026-08-17T12:00:00Z",
+        "bytes_obtained": True,
+        "requested_mode": "DOCUMENT_CHAIN",
+    }
+    kwargs.update(overrides)
+    return assemble_consumer_dossier(**kwargs)
+
+
+def test_old_event_current_verify_not_stale_and_not_recent() -> None:
+    block = dossier_freshness(
+        as_of="2026-08-17T12:00:00Z",
+        event_effective_at="2024-03-01",
+        source_published_at="2024-03-02",
+        retrieved_at="2026-08-17T12:00:00Z",
+        verified_at="2026-08-17T12:00:00Z",
+        source_as_of=None,
+        bytes_obtained=True,
+    )
+    assert block["stale"] is False
+    assert block["event_is_recent"] is False
+    assert block["event_effective_at"] == "2024-03-01"
+
+
+def test_generic_value_and_term_is_not_singular_insight() -> None:
+    from scripts.historical_contract_authority.official_live import _insight_for
+    from scripts.official_contract_semantics.models import observation_from_mapping
+
+    raw = {
+        "schema_version": "official-contract-observation/1.1",
+        "observation_id": "obs-generic",
+        "source_system": "pncp",
+        "source_kind": "contract",
+        "official_url": "https://pncp.gov.br/app/contratos/x",
+        "source_document_id": "x",
+        "source_document_sha256": DIGEST,
+        "contract_identifier": "x",
+        "object_text": "Aquisição de botijão de gás por registro de preços.",
+        "value_amount": "1289.00",
+        "value_semantic": "valor_global",
+        "period_start": "2026-07-31",
+        "period_end": "2026-12-31",
+        "raw_record_hash": DIGEST,
+        "status": "observed",
+        "confidence_class": "explicit_structured_field",
+        "locator": {"json_path": "$.objetoContrato"},
+        "extractor_version": "official-contract-semantics-extract/1.1",
+    }
+    obs = observation_from_mapping(raw)
+    assert _insight_for([obs], []) == ""
+
+
+def test_document_chain_without_comparative_language_accepts_not_applicable() -> None:
+    dossier = _assemble()
+    assert dossier["analysis"]["analysis_mode"] == "DOCUMENT_CHAIN"
+    assert dossier["analysis"]["comparability_status"] == "NOT_APPLICABLE"
+    assert dossier["handoff_status"] == "HANDOFF_READY"
+    assert dossier["gates"]["publication_authorization"] is False
+    assert dossier["gates"]["index_authorization"] is False
+    assert dossier["gates"]["commercial_relationship_claim"] is False
+    assert dossier["gates"]["official_live"] is True
+
+
+def test_comparative_phrase_reactivates_peer_gate() -> None:
+    mode, hits = resolve_analysis_mode(
+        requested="DOCUMENT_CHAIN",
+        claims=("Valor acima da mediana dos peers de pavimentação.",),
+        insight="Contrato outlier frente aos pares.",
+        limitations=("sem comparação",),
+        comparative_engine_used=False,
+    )
+    assert mode == "COMPARATIVE"
+    assert hits
+    result = resolve_comparability(
+        analysis_mode=mode,
+        comparative_hits=hits,
+        singular_insight="Contrato outlier frente aos pares.",
+        limitations_declare_no_comparison=True,
+        engine_status="NOT_COMPARABLE",
+        engine_reason_codes=("incompatible_unit",),
+        unit_compatible=False,
+        regime_compatible=False,
+        scope_compatible=False,
+        period_compatible=False,
+    )
+    assert result["status"] == "NOT_COMPARABLE"
+    dossier = _assemble(insight="Este contrato é outlier frente aos pares de pavimentação.")
+    assert dossier["analysis"]["analysis_mode"] == "COMPARATIVE"
+    assert dossier["analysis"]["comparability_status"] == "NOT_COMPARABLE"
+    assert dossier["handoff_status"] != "HANDOFF_READY"
+
+
+def test_comparative_without_compatible_peers_cannot_be_ready() -> None:
+    dossier = _assemble(requested_mode="COMPARATIVE", insight="Comparação de valor integral nominal.")
+    assert dossier["analysis"]["analysis_mode"] == "COMPARATIVE"
+    assert dossier["handoff_status"] != "HANDOFF_READY"
+
+
+def test_missing_locator_blocks_handoff_ready() -> None:
+    bare = {"claim_id": "fact-bare", "class": "FACT", "text": "Valor publicado.", "evidence_id": "doc-1"}
+    assert claim_is_located(bare) is False
+    dossier = _assemble(claims=[bare])
+    assert dossier["handoff_status"] != "HANDOFF_READY"
+    assert "missing_locator_blocks_handoff_ready" in dossier["reason_codes"]
+
+
+def test_official_live_false_without_verification_clock() -> None:
+    dossier = _assemble(retrieved_at=None, verified_at=None, bytes_obtained=False)
+    assert dossier["gates"]["official_live"] is False
+    assert dossier["handoff_status"] != "HANDOFF_READY"
+
+
+def test_dsn_and_api_paths_share_consumer_shape() -> None:
+    api = _assemble(analysis_id="from-api")
+    dsn = _assemble(analysis_id="from-dsn")
+    assert same_consumer_shape(api, dsn)
+    for payload in (api, dsn):
+        assert payload["schema"] == "official-live-authority-dossier/1.1"
+        assert payload["gates"]["publication_authorization"] is False
+        assert payload["provenance"]["replay_command"]
+
+
+def test_schema_1_0_consumer_payload_still_validates() -> None:
+    payload = {
+        "schema": "official-live-authority-dossier/1.0",
+        "analysis_id": "legacy",
+        "identity": _identity(),
+        "gates": {
+            "official_live": False,
+            "handoff_status": "DATA_HOLD",
+            "publication_authorization": False,
+            "index_authorization": False,
+            "commercial_relationship_claim": False,
+        },
+    }
+    ok, reasons = validate_consumer_dossier(payload)
+    assert ok is True
+    assert reasons == ()
+
+
+def test_hashes_are_deterministic_excluding_clocks() -> None:
+    first = _assemble(retrieved_at="2026-08-17T12:00:00Z", verified_at="2026-08-17T12:00:00Z")
+    second = _assemble(retrieved_at="2026-08-17T18:00:00Z", verified_at="2026-08-17T18:00:00Z")
+    assert first["content_hash"] == second["content_hash"]
+    assert first["content_hash"] == content_hash(
+        strip_temporal_for_hash({k: v for k, v in first.items() if k != "content_hash"})
+    )
+    assert is_sha256(first["content_hash"])
+
+
+def test_publication_index_authorization_stay_false() -> None:
+    dossier = _assemble()
+    ok, reasons = validate_consumer_dossier(
+        {
+            **dossier,
+            "gates": {**dossier["gates"], "publication_authorization": True, "index_authorization": True},
+        }
+    )
+    assert ok is False
+    assert "publication_authorization_must_be_false" in reasons
+    assert "index_authorization_must_be_false" in reasons
+
+
+def test_atomic_rendezvous_ready_xor_blocked(tmp_path: Path) -> None:
+    ready = _assemble()
+    dest = tmp_path / "official-live-01"
+    files = build_rendezvous_files(
+        [ready],
+        producer={"repo": "tjsasakifln/extra-cli", "branch": "goal/x", "commit": "abc"},
+        generated_at="2026-08-17T12:00:00Z",
+        replay_command="python3 -m scripts.historical_contract_authority --mode official-live --limit 2",
+        query_window={"start": "2026-08-03", "end": "2026-08-17"},
+        live_meta={"sources": ["pncp_consulta_api"], "production_write": False, "backfill": False},
+        candidate_log=[{"contract_id": "x", "disposition": "entered", "reason": "adjacency"}],
+        tests=["tests/historical_contract_authority/test_official_live_handoff.py"],
+    )
+    write_atomic_rendezvous(dest, files)
+    assert (dest / "READY.json").is_file()
+    assert not (dest / "BLOCKED.json").exists()
+    ready_doc = json.loads((dest / "READY.json").read_text(encoding="utf-8"))
+    assert ready_doc["status"] == "READY"
+    assert ready_doc["dossier_count"] == 1
+    hold = _assemble(insight="", claims=[_claim()], bytes_obtained=False, retrieved_at=None, verified_at=None)
+    blocked_dest = tmp_path / "blocked"
+    blocked_files = build_rendezvous_files(
+        [hold],
+        producer={"repo": "tjsasakifln/extra-cli", "branch": "goal/x", "commit": "abc"},
+        generated_at="2026-08-17T12:00:00Z",
+        replay_command="replay",
+        query_window={"start": "2026-08-03", "end": "2026-08-17"},
+        live_meta={"sources": ["pncp_consulta_api"], "reason_codes": ["no_handoff_ready_dossier"]},
+        candidate_log=[],
+        tests=[],
+    )
+    write_atomic_rendezvous(blocked_dest, blocked_files)
+    assert (blocked_dest / "BLOCKED.json").is_file()
+    assert not (blocked_dest / "READY.json").exists()
+    assert json.loads((blocked_dest / "BLOCKED.json").read_text(encoding="utf-8"))["status"] == "BLOCKED"
+
+
+def test_no_production_write_and_no_backfill_flags() -> None:
+    dossier = _assemble()
+    files = build_rendezvous_files(
+        [dossier],
+        producer={"repo": "tjsasakifln/extra-cli", "branch": "goal/x", "commit": "abc"},
+        generated_at="2026-08-17T12:00:00Z",
+        replay_command="replay",
+        query_window={"start": "2026-08-03", "end": "2026-08-17"},
+        live_meta={"production_write": False, "backfill": False, "sources": ["pncp_consulta_api"]},
+        candidate_log=[],
+        tests=[],
+    )
+    manifest = json.loads(files["manifest.json"])
+    assert manifest["production_write"] is False
+    assert manifest["backfill"] is False
+    assert manifest["publication_authorization"] is False
+    assert manifest["index_authorization"] is False

--- a/tests/official_contract_semantics/test_cli_and_live.py
+++ b/tests/official_contract_semantics/test_cli_and_live.py
@@ -34,6 +34,38 @@ def test_cli_extract_validate_reconcile(tmp_path: Path) -> None:
     assert reconciled["observations"][0]["status"] == "observed"
 
 
+def test_http_429_retries_and_is_not_cached(tmp_path: Path) -> None:
+    hits = {"n": 0}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            hits["n"] += 1
+            if hits["n"] == 1:
+                self.send_response(429)
+                self.end_headers()
+                self.wfile.write(b"slow down")
+                return
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"data":[]}')
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = f"http://127.0.0.1:{server.server_address[1]}/contratos"
+        result = fetch_official(url, retries=2, rate_limit_s=0, cache_dir=tmp_path / "cache", sleeper=lambda _s: None)
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert result.ok is True
+    assert hits["n"] == 2
+    assert result.body is not None
+
+
 def test_http_404_is_unavailability_not_absence() -> None:
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
@@ -113,9 +145,12 @@ def test_live_manifest_hash_matches_final_bytes_and_replay_argv(tmp_path: Path, 
     )
     assert "live-manifest.json" not in on_disk["artifact_sha256"]
     assert returned["manifest_file_sha256"] == hashlib.sha256(final).hexdigest()
+    from scripts.official_contract_semantics.live import default_live_window
+
+    window_start, window_end = default_live_window(as_of="2026-08-17")
     assert on_disk["replay_command"] == (
         "python3 -m scripts.official_contract_semantics live-readonly "
-        "--limit 2 --as-of 2026-08-17 "
+        f"--limit 2 --as-of 2026-08-17 --start-date {window_start} --end-date {window_end} "
         f"--skip-pages --cache-dir {cache} --out {out}"
     )
     assert on_disk["commands"] == [on_disk["replay_command"]]

--- a/tests/official_contract_semantics/test_freshness_and_schema.py
+++ b/tests/official_contract_semantics/test_freshness_and_schema.py
@@ -1,0 +1,117 @@
+"""Temporal freshness and 1.0→1.1 contract tests. Drive shipped functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.official_contract_semantics.constants import ACCEPTED_SCHEMA_VERSIONS, SCHEMA_VERSION, SCHEMA_VERSION_V10
+from scripts.official_contract_semantics.freshness import (
+    STALE_REASON_NO_BYTES,
+    event_is_recent,
+    is_stale_evidence,
+    resolve_temporal_fields,
+    strip_temporal_for_hash,
+)
+from scripts.official_contract_semantics.live import default_live_window
+from scripts.official_contract_semantics.models import observation_from_mapping
+from scripts.official_contract_semantics.serialize import content_hash
+from scripts.official_contract_semantics.validate import ObservationValidationError, validate_mapping
+from tests.official_contract_semantics.conftest import FIXTURE_DIR
+from tests.official_contract_semantics.test_schema_and_validate import _valid_base
+
+
+def test_old_event_with_current_verification_is_not_stale() -> None:
+    stale, reason = is_stale_evidence(
+        event_effective_at="2022-03-01T00:00:00Z",
+        source_published_at="2022-03-02T00:00:00Z",
+        retrieved_at="2026-08-17T12:00:00Z",
+        verified_at="2026-08-17T12:00:00Z",
+        as_of="2026-08-17T12:00:00Z",
+        bytes_obtained=True,
+    )
+    assert stale is False
+    assert reason == "not_stale"
+    assert event_is_recent(event_effective_at="2022-03-01T00:00:00Z", now="2026-08-17T12:00:00Z") is False
+
+
+def test_old_event_is_not_treated_as_recent() -> None:
+    temporal = resolve_temporal_fields(
+        event_effective_at="2020-01-15T00:00:00Z",
+        retrieved_at="2026-08-17T12:00:00Z",
+        verified_at="2026-08-17T12:00:00Z",
+        bytes_obtained=True,
+    )
+    assert temporal.event_effective_at == "2020-01-15T00:00:00Z"
+    assert temporal.retrieved_at == "2026-08-17T12:00:00Z"
+    assert event_is_recent(event_effective_at=temporal.event_effective_at, now="2026-08-17T12:00:00Z") is False
+
+
+def test_url_without_bytes_does_not_receive_freshness() -> None:
+    temporal = resolve_temporal_fields(
+        event_effective_at="2022-03-01T00:00:00Z",
+        retrieved_at="2026-08-17T12:00:00Z",
+        verified_at="2026-08-17T12:00:00Z",
+        bytes_obtained=False,
+    )
+    assert temporal.retrieved_at is None
+    assert temporal.verified_at is None
+    stale, reason = is_stale_evidence(
+        event_effective_at="2022-03-01T00:00:00Z",
+        source_published_at="2022-03-01T00:00:00Z",
+        retrieved_at="2026-08-17T12:00:00Z",
+        verified_at="2026-08-17T12:00:00Z",
+        as_of="2026-08-17T12:00:00Z",
+        bytes_obtained=False,
+    )
+    assert stale is True
+    assert reason == STALE_REASON_NO_BYTES
+
+
+def test_schema_1_0_payload_still_loads() -> None:
+    raw = _valid_base()
+    raw["schema_version"] = SCHEMA_VERSION_V10
+    raw.pop("event_effective_at", None)
+    raw.pop("retrieved_at", None)
+    raw.pop("verified_at", None)
+    raw.pop("source_published_at", None)
+    raw.pop("source_as_of", None)
+    observation = validate_mapping(raw)
+    assert observation.schema_version == SCHEMA_VERSION_V10
+    assert SCHEMA_VERSION_V10 in ACCEPTED_SCHEMA_VERSIONS
+    assert SCHEMA_VERSION in ACCEPTED_SCHEMA_VERSIONS
+
+
+def test_incomplete_schema_fails_closed() -> None:
+    raw = _valid_base()
+    raw["schema_version"] = "official-contract-observation/0.9"
+    with pytest.raises(ObservationValidationError) as exc:
+        validate_mapping(raw)
+    assert exc.value.code == "invalid_schema_version"
+
+
+def test_1_1_fields_are_optional_and_hash_excludes_clocks() -> None:
+    left = {
+        "object": "contrato",
+        "retrieved_at": "2026-08-17T12:00:00Z",
+        "verified_at": "2026-08-17T12:00:00Z",
+        "event_effective_at": "2022-01-01",
+    }
+    right = {
+        "object": "contrato",
+        "retrieved_at": "2026-08-17T18:00:00Z",
+        "verified_at": "2026-08-17T18:00:00Z",
+        "event_effective_at": "2022-01-01",
+    }
+    assert content_hash(strip_temporal_for_hash(left)) == content_hash(strip_temporal_for_hash(right))
+    mapped = observation_from_mapping(_valid_base())
+    assert mapped.event_effective_at or mapped.effective_at
+
+
+def test_live_window_is_current_not_hardcoded_july() -> None:
+    start, end = default_live_window(as_of="2026-08-17T12:00:00Z")
+    assert start == "2026-07-18"
+    assert end == "2026-08-17"
+    custom_start, custom_end = default_live_window(start="2026-08-01", end="2026-08-10")
+    assert (custom_start, custom_end) == ("2026-08-01", "2026-08-10")
+    fixture = FIXTURE_DIR / "01_global_unknown_unit.json"
+    assert fixture.is_file()


### PR DESCRIPTION
## Summary

Consumer-bound official-live authority handoff for web-cfg #83.

This does **not** close #400 or #415. #414 is already closed.

Refs #400 #414 #415

## What changed

- Additive temporal fields: `event_effective_at`, `source_published_at`, `retrieved_at`, `verified_at`, `source_as_of`.
- Operational freshness uses only verification/retrieval clocks. An old contractual event re-verified now is not `stale_evidence` and is not rewritten as a recent event.
- `analysis_mode` (`DOCUMENT_CHAIN` / `TIMELINE` / `COMPARATIVE`). `NOT_APPLICABLE` only when there is no comparative language and a document-backed singular insight. Comparative language reactivates the peer gate.
- Bounded official-live entry (`--mode official-live`, max 12 candidates, max 3 READY). Current configurable window. DSN if already present, else public PNCP. 429 retries, no cache of transient errors.
- Atomic rendezvous: `READY.json` xor `BLOCKED.json`.

## Live proof (this execution)

**BLOCKED** — not READY. Honest outcome.

- Window: 2026-07-18 .. 2026-08-17, UF SC, limit 12
- Sources: public PNCP API (DSN absent, recorded as unavailability)
- 1 contract considered, 2 documents obtained
- Partial dossier `242dc2e35e5523e01f64a57cb3058b35` remains `DATA_HOLD` (`missing_singular_insight`)
- Observed contract is a GLP / registro-de-preços instrument without documentary singularity (no aditivo/reajuste/BDI/glosa)
- Two canaries: same BLOCKED status and same dossier content hash `8054ea40c0b84ca40f51021793f29ff4ae42b48851a8a7e7625177eb72b2ba13`
- `publication_authorization=false`, `index_authorization=false`, `production_write=false`, `backfill=false`
- Rendezvous: `$HOME/.local/share/confenge/handoffs/contract-analysis/official-live-01/`

Report: `docs/ops/official-live-authority-handoff-01.md`

## Tests

- Focused: 94 passed (`tests/official_contract_semantics/`, `tests/historical_contract_authority/`)
- Broader slice: 135 passed, 1 skipped
- PR gates: generated-artifacts-policy PASS, pr-reviewability PASS

## Allowlist

Only `scripts/official_contract_semantics/**`, `scripts/historical_contract_authority/**`, their tests, and the campaign ops report. PR #413 paths were not touched.

## Consumer instruction (web-cfg)

Do not INDEX. Do not treat this batch as HANDOFF_READY. Read `BLOCKED.json` at the rendezvous path above. Replay:

```bash
python3 -m scripts.historical_contract_authority --mode official-live --limit 12 --start-date 2026-07-18 --end-date 2026-08-17 --as-of 2026-08-17T12:00:00Z --output <handoff-dir>
```
