### PR TITLE
fix(authority): bind official-live claims to retrieved listing bytes

### DIFF
--- a/docs/ops/official-live-authority-handoff-01.md
+++ b/docs/ops/official-live-authority-handoff-01.md
@@ -38,10 +38,10 @@ Status: **BLOCKED** (not READY).
 - Window: 2026-07-18 .. 2026-08-17, UF SC, limit 12
 - Documents considered: 1; obtained: 2 (listing + page)
 - Partial dossier: `242dc2e35e5523e01f64a57cb3058b35` `DATA_HOLD`
-- Contract observed: PNCP `08184785000101-2-000459/2026` (GLP / registro de preços, Joinville)
+- Contract actually written: PNCP `15537199000169-2-000008/2026` (locação de veículos, Itajaí). An earlier canary saw GLP Joinville `08184785000101-2-000459/2026`; that is **not** the rendezvous dossier.
 - Reason codes: `HOLD_FOR_DATA`, `missing_singular_insight`
 - `publication_authorization=false`, `index_authorization=false`, `production_write=false`, `backfill=false`
-- Two canaries: same `BLOCKED` status, same dossier content hash `8054ea40c0b84ca40f51021793f29ff4ae42b48851a8a7e7625177eb72b2ba13`
+- Two canaries after the insight tighten: same `BLOCKED` status and the same dossier id `242dc2e35e5523e01f64a57cb3058b35`
 
 Rendezvous (atomic, outside git):
 
@@ -57,6 +57,8 @@ Contains `BLOCKED.json`, `manifest.json`, `dossiers/<id>.json` (DATA_HOLD), `SHA
 
 ## Residual
 
-The bounded official window verified one SC contract. It has official identity, value and term, but no documentary singularity (aditivo, reajuste, reequilíbrio, prazo material, BDI, medição/glosa). That is not HANDOFF_READY.
+The bounded official window verified one SC contract (`15537199000169-2-000008/2026`, locação de veículos em Itajaí). It has official identity, value and term, but no documentary singularity (aditivo, reajuste, reequilíbrio, prazo material, BDI, medição/glosa). That is not HANDOFF_READY.
+
+FACT claims must cite the consulta listing URL whose bytes produced the sha256, never the `/app/contratos` HTML shell.
 
 Smallest next verifiable step: rerun the same official-live entry on a window that actually contains those documentary families, or with DSN already present. Do not fabricate READY.

--- a/scripts/historical_contract_authority/official_live.py
+++ b/scripts/historical_contract_authority/official_live.py
@@ -20,6 +20,8 @@ from scripts.historical_contract_authority.schema import (
     sha256_text,
 )
 from scripts.official_contract_semantics.export_publication import observation_to_snapshot_record
+from scripts.official_contract_semantics.http_client import fetch_official
+from scripts.official_contract_semantics.identity import raw_record_hash_for
 from scripts.official_contract_semantics.live import (
     default_live_window,
     resolve_dsn,
@@ -159,10 +161,14 @@ def _claims_from_observations(
     unknowns: list[dict[str, Any]] = []
     inferences: list[dict[str, Any]] = []
     for item in items:
+        if item.source_kind == "official_page":
+            continue
         artifact = artifact_by_doc.get(str(item.source_document_id or item.observation_id)) or {}
         url = item.official_url or artifact.get("url")
         digest = item.source_document_sha256 or artifact.get("sha256")
-        locator = _locator_for(item)
+        listing_index = (item.extra or {}).get("listing_index")
+        prefix = f"$.data[{listing_index}]" if listing_index is not None else "$"
+        locator = item.locator.as_dict() or {"json_path": f"{prefix}.objetoContrato"}
         evidence_id = str(item.source_document_id or item.contract_identifier or item.observation_id)
         stable = str(item.contract_identifier or evidence_id).replace("/", "-")
         base = {
@@ -179,7 +185,7 @@ def _claims_from_observations(
                     "claim_id": f"fact-object-{stable}",
                     "class": "FACT",
                     "text": f"Objeto oficial: {item.object_text[:240]}",
-                    "locator": {"json_path": "$.objetoContrato"},
+                    "locator": {"json_path": f"{prefix}.objetoContrato"},
                 }
             )
         if item.value_amount is not None and item.value_semantic:
@@ -189,7 +195,7 @@ def _claims_from_observations(
                     "claim_id": f"fact-value-{stable}",
                     "class": "FACT",
                     "text": f"Valor {item.value_semantic} publicado: {format(item.value_amount, 'f')} {item.currency or 'BRL'}.",
-                    "locator": {"json_path": "$.valorGlobal"},
+                    "locator": {"json_path": f"{prefix}.valorGlobal"},
                 }
             )
         if item.period_start or item.period_end:
@@ -199,7 +205,7 @@ def _claims_from_observations(
                     "claim_id": f"fact-period-{stable}",
                     "class": "FACT",
                     "text": f"Vigência oficial {item.period_start or 'UNKNOWN'} a {item.period_end or 'UNKNOWN'}.",
-                    "locator": {"json_path": "$.dataVigenciaInicio"},
+                    "locator": {"json_path": f"{prefix}.dataVigenciaInicio"},
                 }
             )
         if item.amendment_type:
@@ -275,6 +281,22 @@ def _insight_for(items: list[OfficialContractObservation], facts: list[dict[str,
     return ""
 
 
+def claim_bound_to_retrieved_bytes(claim: dict[str, Any], body: bytes) -> bool:
+    """True only when claim.sha256 is the hash of the bytes retrieved from claim.url."""
+    digest = str(claim.get("sha256") or "")
+    return bool(digest) and digest == raw_record_hash_for(body)
+
+
+def verify_claim_url_hash(*, claim: dict[str, Any], cache_dir: Path | None = None) -> bool:
+    url = claim.get("url")
+    if not url:
+        return False
+    fetched = fetch_official(str(url), cache_dir=cache_dir, retries=0, rate_limit_s=0)
+    if not fetched.ok or not fetched.sha256:
+        return False
+    return fetched.sha256 == str(claim.get("sha256") or "")
+
+
 def _artifact(
     obs: OfficialContractObservation, *, retrieved_at: str | None, verified_at: str | None
 ) -> dict[str, Any] | None:
@@ -308,7 +330,7 @@ def dossier_from_group(
     disposition: str,
     disposition_reason: str,
 ) -> dict[str, Any]:
-    first = items[0]
+    first = next((item for item in items if item.source_kind != "official_page"), items[0])
     artifacts = [
         item for item in (_artifact(obs, retrieved_at=retrieved_at, verified_at=verified_at) for obs in items) if item
     ]
@@ -330,7 +352,15 @@ def dossier_from_group(
         "uf": (first.extra or {}).get("uf"),
         "municipio": (first.extra or {}).get("municipio"),
         "source_system": first.source_system,
-        "official_urls": sorted({item.official_url for item in items if item.official_url}),
+        "official_urls": sorted(
+            {
+                *(item.official_url for item in items if item.official_url),
+                *((item.extra or {}).get("portal_url") for item in items if (item.extra or {}).get("portal_url")),
+            }
+        ),
+        "evidence_urls": sorted(
+            {item.official_url for item in items if item.official_url and item.source_kind != "official_page"}
+        ),
         "event_effective_at": first.effective_at,
         "source_published_at": first.observed_at,
     }

--- a/scripts/official_contract_semantics/live.py
+++ b/scripts/official_contract_semantics/live.py
@@ -124,6 +124,81 @@ def _select_rows(dsn: str, limit: int) -> tuple[list[dict[str, Any]] | None, Sou
         )
 
 
+def records_from_consulta_listing(
+    *,
+    listing_url: str,
+    listing_body: str,
+    listing_sha256: str,
+    retrieved_at: str,
+    limit: int,
+) -> tuple[list[dict[str, Any]], list[SourceUnavailability], bool]:
+    """Bind each record to the listing URL whose bytes produced listing_sha256.
+
+    The HTML portal (/app/contratos/...) is kept as portal_url only. It must never
+    inherit the consulta listing hash. The bool is True when the listing page had items.
+    """
+    try:
+        payload = __import__("json").loads(listing_body)
+    except ValueError as exc:
+        return [], [SourceUnavailability(official_url=listing_url, error_kind="parser_error", message=str(exc))], False
+    data = payload.get("data") if isinstance(payload, dict) else payload
+    if not isinstance(data, list):
+        return (
+            [],
+            [SourceUnavailability(official_url=listing_url, error_kind="unexpected_shape", message="data_not_list")],
+            False,
+        )
+    records: list[dict[str, Any]] = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            continue
+        contrato_id = str(
+            item.get("numeroControlePncp") or item.get("numeroControlePNCP") or item.get("numeroContratoEmpenho") or ""
+        )
+        unidade = item.get("unidadeOrgao") if isinstance(item.get("unidadeOrgao"), dict) else {}
+        uf = str(item.get("uf") or item.get("siglaUf") or unidade.get("ufSigla") or unidade.get("uf") or "")
+        if uf.upper() not in {"SC", "SANTA CATARINA"}:
+            continue
+        portal_url = PNCP_CONTRACT_URL.format(contrato_id=contrato_id) if contrato_id else None
+        records.append(
+            {
+                "source_system": "pncp",
+                "source_kind": "contract",
+                "official_url": listing_url,
+                "source_document_id": contrato_id or None,
+                "contract_identifier": contrato_id or None,
+                "contracting_entity_identifier": (
+                    item.get("cnpjOrgao") or (item.get("orgaoEntidade") or {}).get("cnpj")
+                    if isinstance(item.get("orgaoEntidade"), dict)
+                    else item.get("cnpjOrgao")
+                ),
+                "supplier_identifier": item.get("niFornecedor")
+                or ((item.get("fornecedor") or {}).get("ni") if isinstance(item.get("fornecedor"), dict) else None),
+                "object_text": item.get("objetoContrato") or item.get("objeto"),
+                "valor_global": item.get("valorGlobal") or item.get("valorInicial"),
+                "period_start": item.get("dataVigenciaInicio"),
+                "period_end": item.get("dataVigenciaFim"),
+                "effective_at": item.get("dataAssinatura"),
+                "observed_at": item.get("dataPublicacaoPncp"),
+                "event_effective_at": item.get("dataAssinatura"),
+                "source_published_at": item.get("dataPublicacaoPncp"),
+                "retrieved_at": retrieved_at,
+                "verified_at": retrieved_at,
+                "source_document_sha256": listing_sha256,
+                "locator": {"json_path": f"$.data[{index}].objetoContrato"},
+                "extra": {
+                    "uf": "SC",
+                    "municipio": item.get("nomeUnidade") or unidade.get("municipioNome") or item.get("municipio"),
+                    "portal_url": portal_url,
+                    "listing_index": index,
+                },
+            }
+        )
+        if len(records) >= limit:
+            break
+    return records, [], bool(data)
+
+
 def _api_records(
     limit: int,
     cache_dir: Path | None,
@@ -143,72 +218,25 @@ def _api_records(
             f"&pagina={page}&tamanhoPagina=10"
         )
         fetched = fetch_official(url, cache_dir=cache_dir)
-        if not fetched.ok or not fetched.body:
+        if not fetched.ok or not fetched.body or not fetched.sha256:
             errors.append(
                 fetched.unavailability
                 or SourceUnavailability(official_url=url, error_kind="unavailable", message="empty_body")
             )
             break
-        try:
-            payload = __import__("json").loads(fetched.body)
-        except ValueError as exc:
-            errors.append(SourceUnavailability(official_url=url, error_kind="parser_error", message=str(exc)))
+        page_rows, page_errors, saw_items = records_from_consulta_listing(
+            listing_url=url,
+            listing_body=fetched.body,
+            listing_sha256=fetched.sha256,
+            retrieved_at=retrieved_at,
+            limit=limit - len(records),
+        )
+        errors.extend(page_errors)
+        if page_errors and not page_rows:
             break
-        data = payload.get("data") if isinstance(payload, dict) else payload
-        if not isinstance(data, list):
-            errors.append(
-                SourceUnavailability(official_url=url, error_kind="unexpected_shape", message="data_not_list")
-            )
+        records.extend(page_rows)
+        if not saw_items or len(records) >= limit:
             break
-        if not data:
-            break
-        for item in data:
-            if not isinstance(item, dict):
-                continue
-            contrato_id = str(
-                item.get("numeroControlePncp")
-                or item.get("numeroControlePNCP")
-                or item.get("numeroContratoEmpenho")
-                or ""
-            )
-            unidade = item.get("unidadeOrgao") if isinstance(item.get("unidadeOrgao"), dict) else {}
-            uf = str(item.get("uf") or item.get("siglaUf") or unidade.get("ufSigla") or unidade.get("uf") or "")
-            if uf.upper() not in {"SC", "SANTA CATARINA"}:
-                continue
-            records.append(
-                {
-                    "source_system": "pncp",
-                    "source_kind": "contract",
-                    "official_url": PNCP_CONTRACT_URL.format(contrato_id=contrato_id) if contrato_id else url,
-                    "source_document_id": contrato_id or None,
-                    "contract_identifier": contrato_id or None,
-                    "contracting_entity_identifier": (
-                        item.get("cnpjOrgao") or (item.get("orgaoEntidade") or {}).get("cnpj")
-                        if isinstance(item.get("orgaoEntidade"), dict)
-                        else item.get("cnpjOrgao")
-                    ),
-                    "supplier_identifier": item.get("niFornecedor")
-                    or ((item.get("fornecedor") or {}).get("ni") if isinstance(item.get("fornecedor"), dict) else None),
-                    "object_text": item.get("objetoContrato") or item.get("objeto"),
-                    "valor_global": item.get("valorGlobal") or item.get("valorInicial"),
-                    "period_start": item.get("dataVigenciaInicio"),
-                    "period_end": item.get("dataVigenciaFim"),
-                    "effective_at": item.get("dataAssinatura"),
-                    "observed_at": item.get("dataPublicacaoPncp"),
-                    "event_effective_at": item.get("dataAssinatura"),
-                    "source_published_at": item.get("dataPublicacaoPncp"),
-                    "retrieved_at": retrieved_at,
-                    "verified_at": retrieved_at,
-                    "source_document_sha256": fetched.sha256,
-                    "locator": {"json_path": "$.objetoContrato"},
-                    "extra": {
-                        "uf": "SC",
-                        "municipio": item.get("nomeUnidade") or unidade.get("municipioNome") or item.get("municipio"),
-                    },
-                }
-            )
-            if len(records) >= limit:
-                break
         page += 1
     return records, errors
 
@@ -299,20 +327,27 @@ def run_live_readonly(
             record["extra"] = {"uf": row.get("uf"), "municipio": row.get("municipio")}
         record.setdefault("event_effective_at", record.get("effective_at"))
         record.setdefault("source_published_at", record.get("observed_at"))
-        extract_inputs.append({**record, **(record.get("extra") or {})})
-        url = record.get("official_url")
-        if fetch_pages and url:
-            fetched = fetch_official(str(url), cache_dir=cache)
+        extra = dict(record.get("extra") or {})
+        extract_inputs.append({**record, **extra})
+        portal_url = extra.get("portal_url")
+        if fetch_pages and portal_url:
+            fetched = fetch_official(str(portal_url), cache_dir=cache)
             if fetched.ok and fetched.body:
                 obtained += 1
                 page_identity = {
-                    **record,
+                    "source_system": record.get("source_system"),
                     "source_kind": "official_page",
+                    "official_url": portal_url,
                     "source_document_id": f"{record.get('source_document_id')}:page",
                     "source_document_sha256": fetched.sha256,
+                    "contract_identifier": record.get("contract_identifier"),
+                    "contracting_entity_identifier": record.get("contracting_entity_identifier"),
+                    "supplier_identifier": record.get("supplier_identifier"),
                     "retrieved_at": started,
                     "verified_at": started,
+                    "locator": {"section": "official-page"},
                     "html": fetched.body,
+                    "extra": extra,
                 }
                 page_result = extract_record(page_identity)
                 observations.extend(page_result.observations)
@@ -320,11 +355,13 @@ def run_live_readonly(
             else:
                 failed.append(
                     (
-                        fetched.unavailability or SourceUnavailability(official_url=str(url), error_kind="unavailable")
+                        fetched.unavailability
+                        or SourceUnavailability(official_url=str(portal_url), error_kind="unavailable")
                     ).as_dict()
                 )
                 unavailabilities.append(
-                    fetched.unavailability or SourceUnavailability(official_url=str(url), error_kind="unavailable")
+                    fetched.unavailability
+                    or SourceUnavailability(official_url=str(portal_url), error_kind="unavailable")
                 )
 
     row_result = extract_payload(extract_inputs)

--- a/tests/historical_contract_authority/test_official_live_handoff.py
+++ b/tests/historical_contract_authority/test_official_live_handoff.py
@@ -312,3 +312,96 @@ def test_no_production_write_and_no_backfill_flags() -> None:
     assert manifest["backfill"] is False
     assert manifest["publication_authorization"] is False
     assert manifest["index_authorization"] is False
+
+
+def test_claim_sha256_equals_hash_of_bytes_fetched_from_claim_url() -> None:
+    """Drive the shipped listing assembler. Fail if claim.hash is not the cited URL body."""
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from threading import Thread
+
+    from scripts.historical_contract_authority.official_live import (
+        dossier_from_group,
+        verify_claim_url_hash,
+    )
+    from scripts.official_contract_semantics.extract import extract_payload
+    from scripts.official_contract_semantics.identity import raw_record_hash_for
+    from scripts.official_contract_semantics.live import records_from_consulta_listing
+
+    listing = {
+        "data": [
+            {
+                "numeroControlePncp": "15537199000169-2-000008/2026",
+                "objetoContrato": "Locacao de veiculos automotores sem motorista.",
+                "valorGlobal": 36792.0,
+                "dataVigenciaInicio": "2026-07-20",
+                "dataVigenciaFim": "2026-12-31",
+                "dataAssinatura": "2026-07-18",
+                "dataPublicacaoPncp": "2026-07-19T10:00:00",
+                "cnpjOrgao": "15537199000169",
+                "niFornecedor": "12345678000199",
+                "unidadeOrgao": {"ufSigla": "SC", "municipioNome": "Itajai"},
+            }
+        ]
+    }
+    listing_bytes = json.dumps(listing, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    spa_bytes = b"<!doctype html><html><body>angular-shell</body></html>"
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path.startswith("/consulta"):
+                payload, mime = listing_bytes, "application/json"
+            else:
+                payload, mime = spa_bytes, "text/html"
+            self.send_response(200)
+            self.send_header("Content-Type", mime)
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        listing_url = f"http://127.0.0.1:{server.server_address[1]}/consulta"
+        portal_url = f"http://127.0.0.1:{server.server_address[1]}/app/contratos/15537199000169-2-000008/2026"
+        listing_sha = raw_record_hash_for(listing_bytes)
+        records, errors, saw_items = records_from_consulta_listing(
+            listing_url=listing_url,
+            listing_body=listing_bytes.decode("utf-8"),
+            listing_sha256=listing_sha,
+            retrieved_at="2026-08-17T12:00:00Z",
+            limit=3,
+        )
+        assert errors == []
+        assert saw_items is True
+        assert records
+        assert records[0]["official_url"] == listing_url
+        assert records[0]["source_document_sha256"] == listing_sha
+        assert records[0]["official_url"] != portal_url
+        extracted = extract_payload(records)
+        dossier = dossier_from_group(
+            str(records[0]["contract_identifier"]),
+            list(extracted.observations),
+            retrieved_at="2026-08-17T12:00:00Z",
+            verified_at="2026-08-17T12:00:00Z",
+            source_as_of=None,
+            as_of="2026-08-17T12:00:00Z",
+            producer={"repo": "tjsasakifln/extra-cli", "branch": "fix", "commit": "abc"},
+            replay_command="replay",
+            query_window={"start": "2026-07-18", "end": "2026-08-17", "uf": "SC"},
+            bytes_obtained=True,
+            disposition="entered",
+            disposition_reason="test",
+        )
+        facts = [item for item in dossier["factual_matrix"]["claims"] if item.get("class") == "FACT"]
+        assert facts
+        for claim in facts:
+            assert claim["url"] == listing_url
+            assert claim["sha256"] == listing_sha
+            assert verify_claim_url_hash(claim=claim) is True
+            assert claim["sha256"] != raw_record_hash_for(spa_bytes)
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
## Summary

Follow-up to #431. FACT claims were citing `https://pncp.gov.br/app/contratos/...` (Angular shell) with the sha256 of the consulta listing. That triple is not verifiable.

This binds each claim `url` + `sha256` + `locator` to the listing artifact actually retrieved.

Refs #400 #414 #415

## Fix

- `records_from_consulta_listing` is the shipped assembler: `official_url` is the consulta URL, `source_document_sha256` is the hash of those bytes, locator is `$.data[i].campo`.
- `/app/contratos/{id}` stays `portal_url` only and is fetched separately as `official_page`.
- `verify_claim_url_hash` re-fetches `claim.url` and requires `fetched.sha256 == claim.sha256`.
- Report now names the dossier actually written: Itajaí `15537199000169-2-000008/2026` (not the earlier GLP Joinville canary).

## Test

`test_claim_sha256_equals_hash_of_bytes_fetched_from_claim_url` drives `records_from_consulta_listing` → extract → `dossier_from_group` against a local listing vs SPA pair. It fails if a claim cites the HTML URL or if `claim.sha256` is not the hash of the bytes at `claim.url`.

Focused suite: 95 passed.

## Live re-proof

Still **BLOCKED** (no `READY.json`). Rendezvous dossier `242dc2e35e5523e01f64a57cb3058b35` / contract `15537199000169-2-000008/2026` (Itajaí, locação de veículos). FACT claims now cite `https://pncp.gov.br/api/consulta/v1/contratos?...` with listing sha256 and `$.data[0].*` locators; `verify_claim_url_hash` is true. `publication_authorization` / `index_authorization` remain false.

Consumer web-cfg #83: do not INDEX.