### PR TITLE
docs(ops): PNCP freshness recovery campaign verdict

### DIFF
--- a/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/REPORT.md
+++ b/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/REPORT.md
@@ -14,7 +14,7 @@
 |---|---|
 | #443 | **merged** squash `43579c84` 2026-08-20T15:55:19Z CI verde |
 | #444 | rebased em main+#443; cadence 4h landed na mesma linha; **merged** squash `7ca6a870` 2026-08-20T16:09:24Z CI verde |
-| Terceiro PR | **não aberto** |
+| #445 | docs-only do veredito desta campanha — **não** reimplementa #443/#444 |
 
 ## Cadence
 

--- a/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/REPORT.md
+++ b/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/REPORT.md
@@ -1,0 +1,60 @@
+# CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01
+
+**Verdict:** `PNCP_FRESHNESS_STILL_DEGRADED_UNCLOSED_CURRENT_WINDOW_UPSERT_OOM`  
+**as_of:** 2026-08-20T21:21:20Z  
+**Contrato:** `PNCP_CONTRACT_FRESHNESS/1.0`  
+**Host:** `ec-prod` / `159.195.18.88` / `v2202607385716487230`  
+**Deployed SHA:** `7ca6a8709e8e7dbf021b2f7aa12fbf4b88684428` (`origin/main`, squash #444 após #443)
+
+`VPS_OPERATIONAL` **não** foi declarado. Soak #248 **não** iniciou.
+
+## Disposition PRs
+
+| PR | Resultado |
+|---|---|
+| #443 | **merged** squash `43579c84` 2026-08-20T15:55:19Z CI verde |
+| #444 | rebased em main+#443; cadence 4h landed na mesma linha; **merged** squash `7ca6a870` 2026-08-20T16:09:24Z CI verde |
+| Terceiro PR | **não aberto** |
+
+## Cadence
+
+Capacidade 2026-08-19: sucesso ~21 min, 92/92 páginas, 45703 transformed, 44M RSS, load 0.15 / 8 cores.
+
+Escolha: **every 4h** `OnCalendar=*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo` (explícito).  
+`systemd-analyze calendar` aceita; max inter-run 4h. `--days 7` mantido (overlap late arrivals; 21 min não é custo material vs 4h).
+
+`LOCK_BUSY`/exit 75: `SuccessExitStatus=75` permanece no unit (não dispara OnFailure em contenção); freshness classifica `LOCK_BUSY_NO_CLOSE` e **nunca FRESH**. Retry = próximo slot 4h + `Persistent=true`.
+
+## Live canary (timer-triggered)
+
+Não foi `systemctl start pncp-contracts.service`.
+
+| Trigger | Quando (local −03) | Resultado |
+|---|---|---|
+| Persistent catch-up do slot 12:00 após `daemon-reload` | 13:09:53 | FAIL API timeout page 1; janela **não** fechada |
+| OnCalendar 16:00 + RandomizedDelay | 16:03:46–16:19:51 | FAIL `out of shared memory` / `max_locks_per_transaction` no upsert page~61/109; transformed=30500 ins=0; janela **não** fechada |
+| Próximo | 20:01:34 −03 | agendado |
+
+Checkpoint v2 `/var/lib` `ok=true`, completed ainda `20260807_20260814` + `20260812_20260819`. Failed attempts rebound (`previous_run_ids` inclui 16:09Z e 19:03Z) sem pular janelas concluídas.
+
+Canário SQL: IDs 19/08 presentes; `95782793000154-2-000833/2026` (20/08) **ausente** (`UNCLOSED_CURRENT_WINDOW`).
+
+Live CLI ×2: `status=STALE` `reason_codes=[UNCLOSED_CURRENT_WINDOW, WINDOW_INCOMPLETE]` `health_exit=2`. SLO shipped: `sustainable_hard_guardrail=true`, `sustainable_operational_target=true`, **sem** `CADENCE_CANNOT_MEET_24H`. `check-alerts` emite CRIT freshness com status, closed window, lag, next run, last_error, checkpoint_health.
+
+`max_locks_per_transaction` exige restart do PostgreSQL — **não** executado (fail-closed; sem restore isolado corrente).
+
+## Issues
+
+| Issue | Disposition |
+|---|---|
+| #241 | **OPEN**. FOUND live `pages_expected==pages_fetched` + requery IDs completa + 19/08 na base. Residual: empty scope devolve HTTP 204/422 → `SCOPE_INCOMPLETE`, não `ZERO_CONFIRMED`. Sem nova arquitetura. |
+| #319 | **CLOSE**. Autoridade `/var/lib/.../contracts_full.json`; leftover `/opt/.../incremental/` inventariado (sha256 `d93bff71…`, 14/08) e arquivado em `/var/lib/extra-consultoria/archives/contracts-checkpoints-opt-leftover/20260820T155500Z` (source intacto, sem delete). Resume SIGTERM 16/08 em `previous_run_ids` + rebind dos attempts 20/08 sem skip das completed. |
+| #277 / backup | Local dump diário fresco (2026-08-20 sha256 `397d8570…` 3.1G). Off-host Storage Box PostgreSQL daily **stale 2026-07-23**. `extra-joint-offsite-backup` **não instalado**. `extra_restore_proof` (4.48M vs prod 4.59M, created 2026-08-01) ≠ restore corrente. |
+| #248 | **SOAK_BLOCKED_BY_OFFSITE_BACKUP_STALE_AND_UNCLOSED_WINDOW**. Sem `SOAK_STARTED_AT`. |
+| #249 | permanece closed; não reexecutado |
+
+## Veredito
+
+`PNCP_FRESHNESS_STILL_DEGRADED_UNCLOSED_CURRENT_WINDOW_UPSERT_OOM`
+
+Cadence 4h está no host e o timer dispara. A janela corrente não fecha: persistência morre em `fn_capture_contract_snapshot` / `max_locks_per_transaction`. HARD ≤24h de **janela fechada** não foi reestabelecido.

--- a/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/RUNBOOK.md
+++ b/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/RUNBOOK.md
@@ -35,6 +35,10 @@ Próximo elapse tem de ser ≤4h (mais RandomizedDelay 300s). Timezone do spec �
 Esperar `LastTriggerUSec` avançar pelo timer. Journal `WINDOW_*` / `incremental done`.
 Checkpoint: `/var/lib/extra-consultoria/checkpoints/contracts/`.
 
+Deploy controlado 2026-08-20: SHA `7ca6a870`. Timer 4h disparou às 16:03 −03. Janela `20260813_20260820` **não** fechou: upsert `out of shared memory` (`max_locks_per_transaction` / trigger `fn_capture_contract_snapshot`). Corrigir GUC exige restart do PostgreSQL — fora deste runbook até haver restore isolado corrente.
+
 ## 4. Alertas
 
 `extra-check-alerts.timer` → `scripts/check-alerts.py`. Details JSON: status, last closed window, lag, unresolved, next run, last error, backup freshness, checkpoint health.
+
+Live 2026-08-20T21:21Z: CRIT `PNCP contracts freshness STALE` (`UNCLOSED_CURRENT_WINDOW`, `WINDOW_INCOMPLETE`).

--- a/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/freshness.json
+++ b/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/freshness.json
@@ -1,0 +1,98 @@
+{
+  "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+  "status": "STALE",
+  "reason_codes": [
+    "UNCLOSED_CURRENT_WINDOW",
+    "WINDOW_INCOMPLETE"
+  ],
+  "as_of": "2026-08-20T21:21:20.945295Z",
+  "deployed_sha": "7ca6a8709e8e7dbf021b2f7aa12fbf4b88684428",
+  "policy_version": "pncp-contracts.timer/*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo",
+  "slo": {
+    "desired_operational_target_hours": 6.0,
+    "desired_operational_percentile": 95,
+    "desired_hard_guardrail_hours": 24.0,
+    "timer_unit": "pncp-contracts.timer",
+    "timer_on_calendar": "*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo",
+    "timer_timezone_note": "explicit America/Sao_Paulo",
+    "timer_max_inter_run_hours": 4.0,
+    "timer_persistent": true,
+    "sustainable_operational_target": true,
+    "sustainable_hard_guardrail": true,
+    "honest_note": "pncp-contracts.timer OnCalendar=*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo (max inter-run 4.0h). HARD <=24h and 95% <=6h are sustainable on this calendar if a run finishes inside the remaining slack (measured incremental ~21min vs 4h slot)."
+  },
+  "source_publication_or_update_at": "2026-08-19T00:00:00Z",
+  "first_observed_at": "2026-08-19T09:21:09.265463Z",
+  "persisted_at": "2026-08-19T09:21:09.265463Z",
+  "run_id": "contracts-90d-20260820T190346Z-3b2e6f48ba",
+  "attempt_id": "contracts-90d-20260820T190346Z-3b2e6f48ba",
+  "source_window": "20260812_20260819",
+  "expected": null,
+  "fetched": null,
+  "persisted": null,
+  "deduplicated": null,
+  "failed": 0,
+  "pages_expected": null,
+  "pages_fetched": null,
+  "checkpoint_before": {
+    "completed_windows": [
+      "20260807_20260814",
+      "20260812_20260819"
+    ],
+    "attempt_run_id": "contracts-90d-20260820T190346Z-3b2e6f48ba"
+  },
+  "checkpoint_after": {
+    "completed_windows": [
+      "20260807_20260814",
+      "20260812_20260819"
+    ],
+    "attempt_run_id": "contracts-90d-20260820T190346Z-3b2e6f48ba"
+  },
+  "latest_successful_closed_window": "20260812_20260819",
+  "oldest_unresolved_gap": null,
+  "unresolved_window_count": 0,
+  "current_lag_hours": 2.024984804166667,
+  "lag_p50_hours": null,
+  "lag_p95_hours": null,
+  "lag_p99_hours": null,
+  "lag_sample_n": 0,
+  "last_run_at": "2026-08-20T19:03:46Z",
+  "next_run_at": "2026-08-20T23:01:34Z",
+  "last_error": "upsert failed window=20260813_20260820 page~61: out of shared memory\nHINT:  You might need to increase \"max_locks_per_transaction\".\nCONTEXT:  SQL statement \"INSERT INTO public.contract_version_history (\n        contrato_id, version, changed_by, change_type, snapshot\n    ) VALUES (\n        COALESCE(NEW.contrato_id, OLD.contrato_id),\n        max_version,\n        current_user,\n        CASE\n            WHEN TG_OP = 'DELETE' THEN 'deletion'\n            WHEN TG_OP = 'UPDATE' THEN 'snapshot'\n            ELSE 'snapshot'\n        END,\n        row_to_json(COALESCE(NEW, OLD))::JSONB\n    )\"\nPL/pgSQL function fn_capture_contract_snapshot() line 10 at SQL statement\n; source_population_drift:source_population_drift:persistence_failed,growth_above_budget:totalRegistros 53625 -> 54005; source_population_drift:totalRegistros 53625 -> 54005",
+  "timer": {
+    "unit": "pncp-contracts.timer",
+    "active": true,
+    "enabled": true,
+    "last_run_at": "2026-08-20T19:03:46Z",
+    "next_run_at": "2026-08-20T23:01:34Z",
+    "last_result": "exit-code",
+    "last_exec_status": 1,
+    "on_calendar": "*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo",
+    "timezone": "America/Sao_Paulo",
+    "persistent": true,
+    "lock_busy": false,
+    "raw_last_run_at": "Thu 2026-08-20 16:03:46 -03",
+    "raw_next_run_at": "Thu 2026-08-20 20:01:34 -03"
+  },
+  "spot_checks": [],
+  "checkpoint_health": {
+    "path": "/var/lib/extra-consultoria/checkpoints/contracts/contracts_full.json",
+    "sha256": "db73d171c1600f68a268c77218155e19f3fbbbc4ba72decaaf694e120a0d3a32",
+    "ok": true,
+    "in_worktree": false,
+    "conflict": false,
+    "inconsistent": false,
+    "uid": 1000,
+    "gid": 1000,
+    "logical_job_id": "pncp-contracts-incremental",
+    "updated_at": "2026-08-20T19:19:51Z"
+  },
+  "backup_freshness": {
+    "available": null,
+    "latest_age_hours": null,
+    "restore_hash_identical": null,
+    "reason_code": null
+  },
+  "health_exit": 2,
+  "campaign_verdict_hint": "FRESHNESS_DEGRADED"
+}

--- a/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/soak-prep.json
+++ b/docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/soak-prep.json
@@ -1,0 +1,29 @@
+{
+  "issue": 248,
+  "campaign": "CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01",
+  "STATUS": "SOAK_BLOCKED_BY_OFFSITE_BACKUP_STALE_AND_UNCLOSED_WINDOW",
+  "SOAK_STARTED_AT": "NOT_STARTED",
+  "SOAK_ENDS_AT": "NOT_STARTED",
+  "exact_sha": "7ca6a8709e8e7dbf021b2f7aa12fbf4b88684428",
+  "deployed_sha_observed": "7ca6a8709e8e7dbf021b2f7aa12fbf4b88684428",
+  "host_of_record": "ec-prod / 159.195.18.88 / v2202607385716487230",
+  "workload_policy_version": "pncp-contracts.timer/*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo",
+  "failure_criteria": [
+    "deploy SHA mismatch",
+    "non-recoverable reboot",
+    "failed restore",
+    "freshness/worker failure",
+    "truth gate violation"
+  ],
+  "restart_conditions": "any invalidating deploy/config/policy change or failure resets the full approved window",
+  "evidence_path": "docs/ops/campaigns/CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01/",
+  "current_elapsed_duration": 0,
+  "final_human_verdict": "PENDING",
+  "vps_operational_declared": false,
+  "blockers": [
+    "off-host postgresql daily dump on storage-box dated 2026-07-23",
+    "extra-joint-offsite-backup unit not installed",
+    "isolated restore DB extra_restore_proof is 2026-08-01 and row-count mismatched vs live",
+    "live incremental window 20260813_20260820 unclosed (upsert out of shared memory)"
+  ]
+}

--- a/docs/stories/story-pncp-freshness-recovery-and-soak-01.md
+++ b/docs/stories/story-pncp-freshness-recovery-and-soak-01.md
@@ -1,6 +1,6 @@
 # Story: Recover PNCP contracts freshness cadence and dispose live residuals
 
-Status: InProgress
+Status: Done
 Risk: HIGH-RISK (produção, timer, backup/restore)
 Campaign: CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01
 Issues: #241 #248 #319 #277 (disposition); reuse PR #443 / #444


### PR DESCRIPTION
## Summary

Campaign report for `CONFENGE-PNCP-FRESHNESS-RECOVERY-AND-SOAK-01`. Does not reimplement #443/#444.

Verdict: `PNCP_FRESHNESS_STILL_DEGRADED_UNCLOSED_CURRENT_WINDOW_UPSERT_OOM`

## Test plan
- [x] docs-only; generated-artifacts-policy; no executable code