### PR TITLE
fix(ops): freshness lag from last successful close; off-host backup

### DIFF
--- a/scripts/ops/pncp_contract_freshness.py
+++ b/scripts/ops/pncp_contract_freshness.py
@@ -252,6 +252,78 @@ def load_shipped_service_text(*, service_path: Path | None = None) -> str:
     return path.read_text(encoding="utf-8")
 
 
+BACKUP_MAX_AGE_HOURS = 28.0
+LOCAL_BACKUP_DIR = os.getenv("LOCAL_BACKUP_DIR", "/var/lib/extra-consultoria/backups/postgresql")
+OFFSITE_BACKUP_DIR = os.getenv(
+    "OFFSITE_BACKUP_DIR",
+    str(Path(os.getenv("BACKUP_MOUNT_POINT", "/mnt/storage-box")) / "backups" / "postgresql"),
+)
+BACKUP_LOG_FILE = os.getenv("BACKUP_LOG_FILE", "/var/log/backup-database.log")
+
+
+def _newest_dump(directory: Path) -> Path | None:
+    if not directory.is_dir():
+        return None
+    found: list[Path] = []
+    for pattern in ("*.dump", "*.dump.gz"):
+        found.extend(directory.glob(pattern))
+        found.extend(directory.glob(f"*/{pattern}"))
+    if not found:
+        return None
+    return max(found, key=lambda path: path.stat().st_mtime)
+
+
+def collect_backup_snapshot(
+    *,
+    as_of: datetime | None = None,
+    local_dir: str | Path | None = None,
+    offsite_dir: str | Path | None = None,
+    restore_hash_identical: bool | None = None,
+    restore_proof_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Observe local + off-host dumps. Stale/missing off-host is BACKUP_UNAVAILABLE."""
+    now = as_of or datetime.now(UTC)
+    local_root = Path(local_dir or LOCAL_BACKUP_DIR)
+    offsite_root = Path(offsite_dir or OFFSITE_BACKUP_DIR)
+    local_dump = _newest_dump(local_root)
+    offsite_dump = _newest_dump(offsite_root)
+    local_age = None
+    if local_dump is not None:
+        local_age = (now.timestamp() - local_dump.stat().st_mtime) / 3600.0
+    offsite_age = None
+    if offsite_dump is not None:
+        offsite_age = (now.timestamp() - offsite_dump.stat().st_mtime) / 3600.0
+    identical = restore_hash_identical
+    proof = Path(restore_proof_path) if restore_proof_path else None
+    if identical is None and proof is not None and proof.is_file():
+        try:
+            payload = json.loads(proof.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = {}
+        if "hash_identical" in payload:
+            identical = bool(payload.get("hash_identical"))
+    # Recoverability for soak is off-host. Local-only is not enough.
+    if offsite_age is not None:
+        latest_age = offsite_age
+        available = offsite_age <= BACKUP_MAX_AGE_HOURS
+    elif local_age is not None:
+        latest_age = local_age
+        available = False  # off-host missing
+    else:
+        latest_age = None
+        available = False
+    return {
+        "available": available,
+        "latest_age_hours": latest_age,
+        "local_age_hours": local_age,
+        "offsite_age_hours": offsite_age,
+        "local_path": str(local_dump) if local_dump else None,
+        "offsite_path": str(offsite_dump) if offsite_dump else None,
+        "restore_hash_identical": identical,
+        "max_age_hours": BACKUP_MAX_AGE_HOURS,
+    }
+
+
 def classify_backup(
     *,
     available: bool | None,
@@ -371,6 +443,28 @@ def parse_window_key(key: str) -> tuple[date, date] | None:
     except ValueError:
         return None
     return start, end
+
+
+def last_successful_close_at(
+    *,
+    latest_closed: Mapping[str, Any] | None,
+    snapshot: Mapping[str, Any],
+    completed_keys: Sequence[str],
+) -> datetime | None:
+    """Lag clock is the last *successful* close. Failed attempt updated_at is not a close."""
+    if latest_closed:
+        closed = parse_dt(latest_closed.get("closed_at"))
+        if closed is not None:
+            return closed
+    explicit = parse_dt(snapshot.get("last_successful_closed_at"))
+    if explicit is not None:
+        return explicit
+    if completed_keys:
+        span = parse_window_key(str(completed_keys[-1]))
+        if span is not None:
+            end = span[1]
+            return datetime(end.year, end.month, end.day, tzinfo=UTC)
+    return None
 
 
 def lag_percentiles(samples: Sequence[float]) -> dict[str, float | None]:
@@ -623,6 +717,10 @@ def classify_status(
         reasons.append(REASON_WINDOW_INCOMPLETE)
     if pagination_incomplete:
         reasons.append(REASON_PAGINATION_INCOMPLETE)
+    if current_lag_hours is not None and current_lag_hours > hard_guardrail_hours:
+        reasons.append(REASON_LAG_ABOVE_HARD_GUARDRAIL)
+    elif current_lag_hours is not None and current_lag_hours > operational_target_hours:
+        reasons.append(REASON_LAG_ABOVE_OPERATIONAL_TARGET)
 
     reasons = _unique(reasons)
     if untrustworthy:
@@ -769,10 +867,10 @@ def build_contract(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             pagination_incomplete = True
             extra_reasons.append(REASON_PAGINATION_INCOMPLETE)
 
-    closed_at = parse_dt(
-        (latest_closed or {}).get("closed_at")
-        or checkpoint.get("updated_at")
-        or snapshot.get("last_successful_closed_at")
+    closed_at = last_successful_close_at(
+        latest_closed=latest_closed,
+        snapshot=snapshot,
+        completed_keys=completed_keys,
     )
     current_lag_hours = None
     if closed_at is not None:
@@ -1193,6 +1291,10 @@ def collect_snapshot(
     connect: Callable[[str], Any] | None = None,
     timer: Mapping[str, Any] | None = None,
     as_of: datetime | None = None,
+    backup: Mapping[str, Any] | None = None,
+    backup_local_dir: str | Path | None = None,
+    backup_offsite_dir: str | Path | None = None,
+    restore_proof_path: str | Path | None = None,
 ) -> dict[str, Any]:
     if snapshot_path is not None:
         data = json.loads(Path(snapshot_path).read_text(encoding="utf-8"))
@@ -1238,7 +1340,7 @@ def collect_snapshot(
                     "failed": (result or {}).get("page_errors") or 0,
                     "pages_expected": pages,
                     "pages_fetched": pages,
-                    "closed_at": checkpoint.get("updated_at") if terminal == "COMPLETE" else None,
+                    "closed_at": ((result or {}).get("closed_at") if terminal == "COMPLETE" else None),
                 }
             )
     for window in windows:
@@ -1247,13 +1349,25 @@ def collect_snapshot(
         if window.get("pages_fetched") is None and window.get("pages") is not None:
             window["pages_fetched"] = window["pages"]
         if window.get("status") == "completed" and not window.get("closed_at"):
-            window["closed_at"] = evidence.get("completed_at") or checkpoint.get("updated_at")
+            evidence_ok = str(evidence.get("status") or "").lower() in {"success", "completed", "complete", ""}
+            if evidence_ok and not checkpoint.get("last_error"):
+                window["closed_at"] = evidence.get("completed_at")
         if window.get("window_key") and not window.get("source_window"):
             span = parse_window_key(str(window["window_key"]))
             if span:
                 window["source_window"] = {"start": span[0].isoformat(), "end": span[1].isoformat()}
 
     db = collect_db_snapshot(dsn=dsn, connect=connect)
+    backup_snap = (
+        dict(backup)
+        if backup is not None
+        else collect_backup_snapshot(
+            as_of=now,
+            local_dir=backup_local_dir,
+            offsite_dir=backup_offsite_dir,
+            restore_proof_path=restore_proof_path,
+        )
+    )
     snapshot = {
         "as_of": now.isoformat().replace("+00:00", "Z"),
         "live": live,
@@ -1266,6 +1380,7 @@ def collect_snapshot(
         "checkpoint": checkpoint,
         "windows": windows,
         "db": db,
+        "backup": backup_snap,
         "source_publication_or_update_at": db.get("latest_source_publication_or_update_at"),
         "first_observed_at": db.get("latest_first_seen_at"),
         "persisted_at": db.get("latest_ingested_at"),

--- a/scripts/ops/pncp_contract_freshness.py
+++ b/scripts/ops/pncp_contract_freshness.py
@@ -445,6 +445,20 @@ def parse_window_key(key: str) -> tuple[date, date] | None:
     return start, end
 
 
+def latest_completed_window_key(keys: Sequence[str]) -> str | None:
+    """Most recent completed window by end date, not list insertion order."""
+    best_key: str | None = None
+    best_end: date | None = None
+    for key in keys:
+        span = parse_window_key(str(key))
+        if span is None:
+            continue
+        if best_end is None or span[1] > best_end:
+            best_end = span[1]
+            best_key = str(key)
+    return best_key
+
+
 def last_successful_close_at(
     *,
     latest_closed: Mapping[str, Any] | None,
@@ -459,8 +473,9 @@ def last_successful_close_at(
     explicit = parse_dt(snapshot.get("last_successful_closed_at"))
     if explicit is not None:
         return explicit
-    if completed_keys:
-        span = parse_window_key(str(completed_keys[-1]))
+    latest_key = latest_completed_window_key(completed_keys)
+    if latest_key:
+        span = parse_window_key(latest_key)
         if span is not None:
             end = span[1]
             return datetime(end.year, end.month, end.day, tzinfo=UTC)
@@ -834,12 +849,23 @@ def build_contract(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         if isinstance(w, dict)
         and str(w.get("status") or "").lower() in {"failed", "blocked", "incomplete", "partial", "partial_or_failed"}
     ]
-    latest_closed = closed[-1] if closed else None
     completed_keys = [str(w.get("window_key")) for w in closed if w.get("window_key")]
     for key in checkpoint.get("completed_windows") or []:
         text = str(key)
         if text and text not in completed_keys:
             completed_keys.append(text)
+    latest_key = latest_completed_window_key(completed_keys)
+    latest_closed = None
+    if latest_key:
+        for window in reversed(closed):
+            if str(window.get("window_key") or "") == latest_key:
+                latest_closed = window
+                break
+    if latest_closed is None and closed:
+        latest_closed = max(
+            closed,
+            key=lambda window: parse_window_key(str(window.get("window_key") or "")) or (date.min, date.min),
+        )
     blocked = [str(k) for k in (checkpoint.get("blocked_windows") or [])]
     failed = [str(k) for k in (checkpoint.get("failed_windows") or [])]
     unresolved = [k for k in [*blocked, *failed] if k]
@@ -967,8 +993,8 @@ def build_contract(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     latest_window = None
     if latest_closed:
         latest_window = latest_closed.get("window_key") or latest_closed.get("source_window")
-    elif completed_keys:
-        latest_window = completed_keys[-1]
+    elif latest_key:
+        latest_window = latest_key
 
     counts = {
         "expected": (latest_closed or {}).get("expected"),

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -841,9 +841,10 @@ def test_failed_upsert_lag_is_last_successful_close_not_checkpoint_updated_at(tm
     close = last_successful_close_at(
         latest_closed=None,
         snapshot=snapshot,
-        completed_keys=["20260807_20260814", "20260812_20260819"],
+        completed_keys=["20260619_20260718", "20260807_20260814", "20260812_20260819"],
     )
     assert close == datetime(2026, 8, 19, tzinfo=UTC)
+    assert artifact["latest_successful_closed_window"] == "20260812_20260819"
 
 
 def test_collect_backup_snapshot_stale_offsite_is_unavailable(tmp_path: Path) -> None:

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -55,6 +56,7 @@ from scripts.ops.pncp_contract_freshness import (
     classify_retificacao,
     classify_schema,
     classify_status,
+    collect_backup_snapshot,
     collect_checkpoint_snapshot,
     collect_db_snapshot,
     collect_snapshot,
@@ -62,6 +64,7 @@ from scripts.ops.pncp_contract_freshness import (
     empty_window_reason,
     health_exit,
     lag_percentiles,
+    last_successful_close_at,
     legal_page_size,
     load_shipped_cadence,
     load_shipped_service_text,
@@ -714,6 +717,177 @@ def test_collect_snapshot_live_shaped_is_stale_from_lag_not_unknown(tmp_path: Pa
     assert artifact["last_run_at"] == "2026-08-19T09:00:20Z"
     assert artifact["next_run_at"] == "2026-08-21T09:00:31Z"
     assert artifact["pages_expected"] == artifact["pages_fetched"] == 92
+
+
+def test_failed_upsert_lag_is_last_successful_close_not_checkpoint_updated_at(tmp_path: Path) -> None:
+    """Live 2026-08-20 shape: completed 20260812_20260819, failed 20260813_20260820.
+
+    checkpoint.updated_at is the FAILED attempt. Lag must stay >24h vs as_of 21:21Z.
+    """
+    as_of = datetime(2026, 8, 20, 21, 21, tzinfo=UTC)
+    evidence = tmp_path / "incremental-latest.json"
+    evidence.write_text(
+        json.dumps(
+            {
+                "run_id": "contracts-90d-20260820T190346Z-3b2e6f48ba",
+                "git_sha": "7ca6a8709e8e7dbf021b2f7aa12fbf4b88684428",
+                "status": "failed",
+                "completed_at": "2026-08-20T19:19:51Z",
+                "windows": [
+                    {
+                        "window_key": "20260813_20260820",
+                        "status": "failed",
+                        "pages": 61,
+                        "expected": 54005,
+                        "fetched": 30500,
+                        "persisted": 0,
+                        "skipped": 30000,
+                        "page_errors": 3,
+                        "error": "upsert failed window=20260813_20260820 page~61: out of shared memory",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+    (ckpt_dir / "contracts_full.json").write_text(
+        json.dumps(
+            {
+                "source": "pncp_contracts",
+                "mode": "full",
+                "completed_windows": ["20260807_20260814", "20260812_20260819"],
+                "blocked_windows": [],
+                "failed_windows": ["20260813_20260820"],
+                "updated_at": "2026-08-20T19:19:51Z",
+                "last_error": "upsert failed window=20260813_20260820 page~61: out of shared memory",
+                "window_results": {
+                    "20260812_20260819": {
+                        "terminal": "COMPLETE",
+                        "expected": 45703,
+                        "fetched": 45703,
+                        "persisted": 18495,
+                        "skipped": 27208,
+                        "page_errors": 0,
+                    },
+                    "20260813_20260820": {
+                        "terminal": "FAILED",
+                        "expected": 54005,
+                        "fetched": 30500,
+                        "persisted": 0,
+                        "page_errors": 3,
+                    },
+                },
+                "meta": {
+                    "logical_job_id": "pncp-contracts-incremental",
+                    "attempt_run_id": "contracts-90d-20260820T190346Z-3b2e6f48ba",
+                    "checkpoint_version": 2,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    timer = collect_timer_snapshot(
+        show_timer={
+            "ActiveState": "active",
+            "UnitFileState": "enabled",
+            "LastTriggerUSec": "Thu 2026-08-20 16:03:46 -03",
+            "NextElapseUSecRealtime": "Thu 2026-08-20 20:01:34 -03",
+        },
+        show_service={
+            "ExecMainStartTimestamp": "Thu 2026-08-20 16:03:46 -03",
+            "ExecMainStatus": "1",
+            "Result": "exit-code",
+        },
+    )
+    local_dir = tmp_path / "local-backups"
+    offsite_dir = tmp_path / "offsite-backups"
+    local_dir.mkdir()
+    offsite_dir.mkdir()
+    (local_dir / "pncp.dump").write_bytes(b"dump")
+    old = offsite_dir / "daily"
+    old.mkdir()
+    stale = old / "pncp_datalake-2026-07-23.dump"
+    stale.write_bytes(b"old")
+    os.utime(stale, (as_of.timestamp() - 28 * 86400, as_of.timestamp() - 28 * 86400))
+    snapshot = collect_snapshot(
+        live=True,
+        evidence_path=evidence,
+        checkpoint_dir=ckpt_dir,
+        production=False,
+        repo_root=tmp_path,
+        state_root=tmp_path,
+        dsn="postgresql://test/pncp_datalake",
+        connect=_live_pg_connect,
+        timer=timer,
+        as_of=as_of,
+        backup_local_dir=local_dir,
+        backup_offsite_dir=offsite_dir,
+    )
+    artifact = build_contract(snapshot)
+    failed_stamp = parse_dt("2026-08-20T19:19:51Z")
+    assert failed_stamp is not None
+    fake_lag = (as_of - failed_stamp).total_seconds() / 3600.0
+    assert fake_lag < DESIRED_HARD_GUARDRAIL_HOURS
+    assert artifact["current_lag_hours"] is not None
+    assert artifact["current_lag_hours"] > DESIRED_HARD_GUARDRAIL_HOURS
+    assert artifact["current_lag_hours"] > fake_lag
+    assert artifact["status"] != "FRESH"
+    assert artifact["status"] == "STALE"
+    assert REASON_LAG_ABOVE_HARD_GUARDRAIL in artifact["reason_codes"]
+    assert artifact["latest_successful_closed_window"] == "20260812_20260819"
+    assert artifact["backup_freshness"]["reason_code"] == REASON_BACKUP_UNAVAILABLE
+    close = last_successful_close_at(
+        latest_closed=None,
+        snapshot=snapshot,
+        completed_keys=["20260807_20260814", "20260812_20260819"],
+    )
+    assert close == datetime(2026, 8, 19, tzinfo=UTC)
+
+
+def test_collect_backup_snapshot_stale_offsite_is_unavailable(tmp_path: Path) -> None:
+    as_of = datetime(2026, 8, 20, 21, 21, tzinfo=UTC)
+    local_dir = tmp_path / "local"
+    offsite_dir = tmp_path / "offsite" / "daily"
+    local_dir.mkdir()
+    offsite_dir.mkdir(parents=True)
+    recent = local_dir / "pncp_datalake-20260820.dump"
+    recent.write_bytes(b"local")
+    os.utime(recent, (as_of.timestamp() - 9 * 3600, as_of.timestamp() - 9 * 3600))
+    stale = offsite_dir / "pncp_datalake-2026-07-23.dump"
+    stale.write_bytes(b"offsite")
+    os.utime(stale, (as_of.timestamp() - 28 * 86400, as_of.timestamp() - 28 * 86400))
+    snap = collect_backup_snapshot(as_of=as_of, local_dir=local_dir, offsite_dir=offsite_dir.parent)
+    assert snap["offsite_age_hours"] is not None
+    assert snap["offsite_age_hours"] > 28
+    assert snap["available"] is False
+    assert (
+        classify_backup(
+            available=snap["available"],
+            latest_age_hours=snap["latest_age_hours"],
+            max_age_hours=float(snap["max_age_hours"]),
+        )
+        == REASON_BACKUP_UNAVAILABLE
+    )
+    missing_offsite = collect_backup_snapshot(as_of=as_of, local_dir=local_dir, offsite_dir=tmp_path / "no-offsite")
+    assert missing_offsite["available"] is False
+    proof = tmp_path / "restore.json"
+    proof.write_text(json.dumps({"hash_identical": False}), encoding="utf-8")
+    mismatch = collect_backup_snapshot(
+        as_of=as_of,
+        local_dir=local_dir,
+        offsite_dir=offsite_dir.parent,
+        restore_proof_path=proof,
+    )
+    assert mismatch["restore_hash_identical"] is False
+    assert (
+        classify_backup(
+            available=True,
+            restore_hash_identical=mismatch["restore_hash_identical"],
+        )
+        == REASON_RESTORE_MISMATCH
+    )
 
 
 def test_real_db_marker_not_mocked_in_this_module() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #444 live canary. Does not reimplement #443/#444.

- `current_lag_hours` is the last **successful** closed window, never `checkpoint.updated_at` of a failed upsert.
- `collect_snapshot` records local + off-host dump ages so stale Storage Box is `BACKUP_UNAVAILABLE`.

## Test plan

- [x] `test_failed_upsert_lag_is_last_successful_close_not_checkpoint_updated_at` drives `collect_snapshot`+`build_contract` with the 2026-08-20 failed-upsert shape; lag>24h; `LAG_ABOVE_HARD_GUARDRAIL`; not FRESH
- [x] `test_collect_backup_snapshot_stale_offsite_is_unavailable` drives the shipped collector
- [x] full `tests/test_pncp_contract_freshness.py` 33 passed