### PR TITLE
fix(outreach): production-ready controlled-email cohort producer

### DIFF
--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -205,6 +205,10 @@ def _published_target_fit_snapshot(
 
     Offline fixtures retain embedded decisions. With a production DSN, store
     misses stay omitted here so the exporter emits explicit missing tombstones.
+    A published row without a source watermark is not an authoritative decision
+    and is omitted the same way: the authoritative export fails closed on the
+    first incomplete lead, so admitting one would abort the whole run instead of
+    tombstoning one account.
     """
     if not dsn:
         return list(rows), "universe_embedded_snapshot", None
@@ -228,6 +232,8 @@ def _published_target_fit_snapshot(
             continue
         decision = published.get(canonical[:8]) or published.get(raw[:8])
         if not decision:
+            continue
+        if not str(decision.get("source_watermark") or decision.get("target_fit_source_watermark") or "").strip():
             continue
         snapshot.append(
             {

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -67,6 +67,7 @@ COMPANY_ASSOCIATION_SOURCES = frozenset(
         "company_registry",
         "site",
         "institutional_site",
+        "contact_page",
     }
 )
 
@@ -78,6 +79,23 @@ UNTRUSTWORTHY_SOURCE_URL_MARKERS = (
     "mail.google.com",
     "googleusercontent.com",
 )
+
+# Parser/template leftovers are not corporate domains.
+IMPLAUSIBLE_MAILBOX_TLDS = frozenset(
+    {
+        "replace",
+        "phone",
+        "js",
+        "ts",
+        "py",
+        "local",
+        "localhost",
+        "invalid",
+        "example",
+        "test",
+    }
+)
+HTML_ENTITY_LOCAL_MARKERS = ("u003e", "u003c", "u0026", "&gt;", "&lt;", "&amp;")
 
 EMAIL_CHANNEL_TYPES = frozenset(
     {
@@ -267,32 +285,69 @@ def _official_domain(route: ReachabilityRoute) -> str:
     return str(extra.get("official_domain") or extra.get("canonical_domain") or "").lower().removeprefix("www.").strip()
 
 
+def mailbox_host_plausible(domain: str | None) -> bool:
+    """Reject parser-minted hosts such as model.phone.replace."""
+    host = str(domain or "").lower().removeprefix("www.").strip()
+    if not host or "." not in host:
+        return False
+    if any(marker in host for marker in ("model.phone", ".phone.", "undefined", "null")):
+        return False
+    labels = [part for part in host.split(".") if part]
+    if len(labels) < 2:
+        return False
+    tld = labels[-1]
+    if tld in IMPLAUSIBLE_MAILBOX_TLDS or not tld.isalpha() or len(tld) < 2:
+        return False
+    if any(not label.replace("-", "").isalnum() for label in labels):
+        return False
+    return True
+
+
+def mailbox_local_implausible(mailbox: str | None) -> bool:
+    local = str(mailbox or "").split("@", 1)[0].lower()
+    if not local:
+        return True
+    if any(marker in local for marker in HTML_ENTITY_LOCAL_MARKERS):
+        return True
+    if local in {"undefined", "null", "none", "true", "false"}:
+        return True
+    return False
+
+
 def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     """True only when public provenance can bind the mailbox to this account."""
     if untrustworthy_source_url(route.source_url):
+        return False
+    if mailbox_local_implausible(route.channel_value):
         return False
     source = str(route.source_type or "").lower().strip()
     mailbox_dom = email_domain(route.channel_value)
     url_host = _url_host(route.source_url)
     official = _official_domain(route)
     freemail = is_freemail(route.channel_value)
+    if not freemail and not mailbox_host_plausible(mailbox_dom):
+        return False
     on_official_page = bool(official and url_host and _hosts_equivalent(url_host, official))
     mailbox_on_official = bool(official and mailbox_dom and not freemail and _hosts_equivalent(mailbox_dom, official))
     if official:
+        if not mailbox_host_plausible(official) and not freemail:
+            return False
         if source in COMPANY_ASSOCIATION_SOURCES:
             if freemail:
-                return on_official_page or not url_host
-            return mailbox_on_official or on_official_page
+                return on_official_page
+            return mailbox_on_official or (on_official_page and _hosts_equivalent(mailbox_dom, url_host))
         if on_official_page:
             return mailbox_on_official or freemail
         return False
-    if source in COMPANY_ASSOCIATION_SOURCES:
-        return True
-    if source in {"", "unknown"}:
-        if not url_host or not mailbox_dom or freemail:
-            return False
-        return _hosts_equivalent(mailbox_dom, url_host)
-    return False
+    # Empty official_domain is not proof of company association.
+    if freemail:
+        # Associated freemail must be published on a company page, not minted.
+        return source in COMPANY_ASSOCIATION_SOURCES and bool(url_host)
+    if not url_host or not mailbox_dom:
+        return False
+    if not _hosts_equivalent(mailbox_dom, url_host):
+        return False
+    return source in COMPANY_ASSOCIATION_SOURCES | {"", "unknown"}
 
 
 def mailbox_company_evidence(route: ReachabilityRoute) -> str:
@@ -633,6 +688,13 @@ def evaluate_controlled_email_eligible(
     if route.epistemic_class == EpistemicClass.INFERRED:
         eligible = False
         reasons.append("inferred_cannot_be_observed")
+    if mailbox_local_implausible(mailbox):
+        eligible = False
+        reasons.append("html_entity_or_template_local_part")
+    domain = email_domain(mailbox)
+    if domain and not is_freemail(mailbox) and not mailbox_host_plausible(domain):
+        eligible = False
+        reasons.append("implausible_mailbox_host")
     if company_ev != EVIDENCE_OBSERVED:
         eligible = False
         reasons.append("mailbox_company_evidence_unknown")
@@ -642,6 +704,9 @@ def evaluate_controlled_email_eligible(
             reasons.append("missing_provenance")
         if str(route.source_type or "").lower() == "web_search" and company_ev != EVIDENCE_OBSERVED:
             reasons.append("web_search_unassociated")
+        url_host = _url_host(route.source_url)
+        if domain and url_host and not _hosts_equivalent(domain, url_host):
+            reasons.append("mailbox_source_host_mismatch")
     if route_class == EmailRouteClass.DIRECT_PERSON and person_ev != EVIDENCE_OBSERVED:
         eligible = False
         reasons.append("direct_person_requires_named_person_evidence")
@@ -1030,3 +1095,38 @@ def stamp_and_rank_feed_contacts(
             merged["corroborated"] = True
         stamped.append(merged)
     return apply_preferred_recommended_alias(stamped)
+
+
+def apply_cross_account_preferred_mailbox_gate(leads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Exactly one account may keep a preferred mailbox. Later duplicates lose it."""
+    claimed: dict[str, str] = {}
+    out: list[dict[str, Any]] = []
+    for lead in leads:
+        if not isinstance(lead, dict):
+            out.append(lead)
+            continue
+        company = lead.get("company") if isinstance(lead.get("company"), dict) else {}
+        account = str(company.get("cnpj14") or lead.get("source_lead_id") or "")
+        updated_contacts: list[Any] = []
+        for contact in lead.get("contacts") or []:
+            if not isinstance(contact, dict):
+                updated_contacts.append(contact)
+                continue
+            item = dict(contact)
+            mailbox = canonicalize_mailbox(str(item.get("email") or ""))
+            if item.get("preferred_initial") and mailbox:
+                owner = claimed.get(mailbox)
+                if owner and owner != account:
+                    item["preferred_initial"] = False
+                    item["recommended"] = False
+                    item["controlled_email_eligible"] = False
+                    item["reason_codes"] = list(item.get("reason_codes") or []) + [
+                        "duplicate_preferred_mailbox_across_accounts"
+                    ]
+                else:
+                    claimed[mailbox] = account
+            updated_contacts.append(item)
+        refreshed = dict(lead)
+        refreshed["contacts"] = updated_contacts
+        out.append(refreshed)
+    return out

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -339,10 +339,10 @@ def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
         if on_official_page:
             return mailbox_on_official or freemail
         return False
-    # Empty official_domain is not proof of company association.
+    # Empty official_domain cannot prove a freemail belongs to this company
+    # (aggregators such as cnpja.com publish third-party addresses).
     if freemail:
-        # Associated freemail must be published on a company page, not minted.
-        return source in COMPANY_ASSOCIATION_SOURCES and bool(url_host)
+        return False
     if not url_host or not mailbox_dom:
         return False
     if not _hosts_equivalent(mailbox_dom, url_host):

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -10,6 +10,7 @@ This module never grants auto-send.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -96,6 +97,13 @@ IMPLAUSIBLE_MAILBOX_TLDS = frozenset(
     }
 )
 HTML_ENTITY_LOCAL_MARKERS = ("u003e", "u003c", "u0026", "&gt;", "&lt;", "&amp;")
+
+# Company-authored documents already bound to the CNPJ by the datalake prove the
+# association by authorship, not by where the file happens to be hosted. A PNCP
+# or transparency-portal host is never the company host, so the site host-match
+# rule cannot be applied to this evidence family.
+CNPJ_LINKED_DOCUMENT_SOURCES = frozenset({"official_documents", "official_document"})
+CNPJ_LINKED_DOCUMENT_EVIDENCE = frozenset({"company_authored_document", "official_cnpj_linked_document"})
 
 EMAIL_CHANNEL_TYPES = frozenset(
     {
@@ -314,6 +322,25 @@ def mailbox_local_implausible(mailbox: str | None) -> bool:
     return False
 
 
+def cnpj_linked_document_association(route: ReachabilityRoute) -> bool:
+    """True for a company-authored document the datalake already binds to this CNPJ.
+
+    Authorship is the association proof here, so the mailbox host is not required
+    to match the document host. The CNPJ on the document must match the account.
+    """
+    source = str(route.source_type or "").lower().strip()
+    if source not in CNPJ_LINKED_DOCUMENT_SOURCES:
+        return False
+    extra = route.extra if isinstance(route.extra, dict) else {}
+    if str(extra.get("evidence_strength") or "").lower().strip() not in CNPJ_LINKED_DOCUMENT_EVIDENCE:
+        return False
+    if extra.get("pattern_guessed_email") or extra.get("pattern_guessed"):
+        return False
+    account = re.sub(r"\D", "", str(route.company_entity_id or ""))[:14]
+    document = re.sub(r"\D", "", str(extra.get("document_cnpj14") or ""))[:14]
+    return len(account) == 14 and account == document
+
+
 def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     """True only when public provenance can bind the mailbox to this account."""
     if untrustworthy_source_url(route.source_url):
@@ -327,6 +354,8 @@ def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     freemail = is_freemail(route.channel_value)
     if not freemail and not mailbox_host_plausible(mailbox_dom):
         return False
+    if not freemail and cnpj_linked_document_association(route):
+        return True
     on_official_page = bool(official and url_host and _hosts_equivalent(url_host, official))
     mailbox_on_official = bool(official and mailbox_dom and not freemail and _hosts_equivalent(mailbox_dom, official))
     if official:
@@ -915,6 +944,18 @@ def route_from_feed_contact(
     observed_id = str(contact.get("person_id") or "").strip()
     if observed_id:
         extra.setdefault("observed_person_id", observed_id)
+    evidence_strength = str(contact.get("evidence_strength") or "").strip().lower()
+    if evidence_strength:
+        extra.setdefault("evidence_strength", evidence_strength)
+    document_cnpj = re.sub(
+        r"\D",
+        "",
+        str(contact.get("document_cnpj14") or contact.get("cnpj14") or contact.get("cnpj") or ""),
+    )[:14]
+    if len(document_cnpj) == 14:
+        extra.setdefault("document_cnpj14", document_cnpj)
+    if contact.get("pattern_guessed_email") or contact.get("pattern_guessed"):
+        extra.setdefault("pattern_guessed_email", True)
     discovery = contact.get("email_discovery_class") or contact.get("route_class")
     if discovery:
         extra.setdefault("email_discovery_class", str(discovery))

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -57,6 +57,22 @@ SAMPLE_PER_ROUTE_CLASS = 3
 ALLOWED_ROUTE_CLASSES = frozenset(rc.value for rc in DEFAULT_PILOT_ROUTE_CLASSES)
 BLOCKING_SUPPRESSION = frozenset({"OPT_OUT", "DNC", "HARD_BOUNCE", "SUPPRESSED"})
 
+# A zero is a finding, not an absence. Every funnel key ships even when unhit.
+FUNNEL_KEYS: tuple[str, ...] = (
+    "accounts_considered",
+    "official_domain",
+    "any_public_email",
+    *(rc.value for rc in EmailRouteClass if rc != EmailRouteClass.PROBABILISTIC_OR_RISKY),
+    "RISKY",
+    "controlled_eligible",
+    "preferred_initial",
+    "no_email",
+    "no_domain",
+    "blocked",
+    "suppressed",
+    "double_preferred",
+)
+
 
 def _utc_stamp() -> str:
     return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
@@ -160,8 +176,8 @@ def select_cohort(
     """Keep accounts with exactly one surviving preferred_initial mailbox."""
     gated = apply_cross_account_preferred_mailbox_gate(leads)
 
-    funnel: Counter[str] = Counter()
-    class_counts: Counter[str] = Counter()
+    funnel: Counter[str] = Counter(dict.fromkeys(FUNNEL_KEYS, 0))
+    class_counts: Counter[str] = Counter(dict.fromkeys((rc.value for rc in EmailRouteClass), 0))
     selected: list[dict[str, Any]] = []
     claimed: set[str] = set()
 

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -9,6 +9,11 @@ the controlled-email hard gates, caps the cohort, and writes:
   <private_root>/<run_stamp>/confenge.outreach.v1.json.sha256   (0600)
   <private_root>/<run_stamp>/manifest.redacted.json             (0600, no PII)
 
+Eligibility is re-derived here from the contact's own provenance rather than
+trusted from the exported stamp: a feed produced by an older classifier can carry
+routes the current policy rejects, and the cohort must reflect the policy that is
+shipped now.
+
 The private feed never belongs in Git. The redacted manifest carries the funnel,
 the route-class distribution and a stratified evidence sample with hosts only —
 never a mailbox, a person or a CNPJ.
@@ -39,6 +44,8 @@ from scripts.decision_unit_intelligence.controlled_email import (  # noqa: E402
     apply_cross_account_preferred_mailbox_gate,
     canonicalize_mailbox,
     email_domain,
+    evaluate_controlled_email_eligible,
+    route_from_feed_contact,
 )
 from scripts.warmbly_bridge import SCHEMA_OUTREACH  # noqa: E402
 
@@ -81,7 +88,23 @@ def load_feed_leads(feed_dir: Path) -> tuple[list[dict[str, Any]], dict[str, Any
     return leads, manifest
 
 
-def _contact_blocked(contact: dict[str, Any]) -> str | None:
+def recheck_contact(
+    contact: dict[str, Any],
+    *,
+    account_id: str,
+    official_domain: str | None,
+) -> Any:
+    """Re-derive eligibility under the shipped policy, ignoring the exported stamp."""
+    route = route_from_feed_contact(contact, account_id=account_id, official_domain=official_domain)
+    return evaluate_controlled_email_eligible(route)
+
+
+def _contact_blocked(
+    contact: dict[str, Any],
+    *,
+    account_id: str = "",
+    official_domain: str | None = None,
+) -> str | None:
     """Reason this mailbox cannot enter the bounded cohort, or None."""
     mailbox = canonicalize_mailbox(str(contact.get("email") or ""))
     if not mailbox or "@" not in mailbox:
@@ -103,6 +126,11 @@ def _contact_blocked(contact: dict[str, Any]) -> str | None:
         return "mailbox_purpose_blocked"
     if str(contact.get("mailbox_company_evidence") or "").upper() != "OBSERVED":
         return "mailbox_company_evidence_unknown"
+    verdict = recheck_contact(contact, account_id=account_id, official_domain=official_domain)
+    if not verdict.controlled_email_eligible:
+        return "stamp_disagrees_with_shipped_policy"
+    if verdict.route_class.value != route_class:
+        return "stamp_disagrees_with_shipped_policy"
     return None
 
 
@@ -153,7 +181,11 @@ def select_cohort(
             continue
 
         contact = preferred[0]
-        reason = _contact_blocked(contact)
+        reason = _contact_blocked(
+            contact,
+            account_id=str(company.get("cnpj14") or lead.get("source_lead_id") or ""),
+            official_domain=_host(str(company.get("website") or "")),
+        )
         if reason is not None:
             funnel[f"blocked_{reason}"] += 1
             funnel["blocked"] += 1

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Build the bounded controlled-email cohort feed from an exported outreach feed.
+
+Reads the canonical `confenge.outreach.v1` chunks produced by the outreach
+pipeline, keeps only accounts whose single `preferred_initial` mailbox survives
+the controlled-email hard gates, caps the cohort, and writes:
+
+  <private_root>/<run_stamp>/confenge.outreach.v1.json          (0600, holds PII)
+  <private_root>/<run_stamp>/confenge.outreach.v1.json.sha256   (0600)
+  <private_root>/<run_stamp>/manifest.redacted.json             (0600, no PII)
+
+The private feed never belongs in Git. The redacted manifest carries the funnel,
+the route-class distribution and a stratified evidence sample with hosts only —
+never a mailbox, a person or a CNPJ.
+
+This script never sends mail, never opens an SMTP connection and never enables
+auto_send. Warmbly owns delivery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from collections import Counter
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.decision_unit_intelligence.controlled_email import (  # noqa: E402
+    DEFAULT_PILOT_ROUTE_CLASSES,
+    EmailRouteClass,
+    apply_cross_account_preferred_mailbox_gate,
+    canonicalize_mailbox,
+    email_domain,
+)
+from scripts.warmbly_bridge import SCHEMA_OUTREACH  # noqa: E402
+
+MANIFEST_SCHEMA = "confenge.fresh-cohort.manifest.v1"
+DEFAULT_PRIVATE_ROOT = Path("/var/lib/extra-consultoria/private/outreach/cohorts")
+DEFAULT_COHORT_SIZE = 50
+SAMPLE_PER_ROUTE_CLASS = 3
+
+ALLOWED_ROUTE_CLASSES = frozenset(rc.value for rc in DEFAULT_PILOT_ROUTE_CLASSES)
+BLOCKING_SUPPRESSION = frozenset({"OPT_OUT", "DNC", "HARD_BOUNCE", "SUPPRESSED"})
+
+
+def _utc_stamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _host(url: str | None) -> str | None:
+    from urllib.parse import urlparse
+
+    raw = str(url or "").strip()
+    if not raw:
+        return None
+    host = (urlparse(raw).hostname or "").lower().removeprefix("www.")
+    return host or None
+
+
+def load_feed_leads(feed_dir: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Read every chunk of an exported outreach feed, in manifest order."""
+    manifest_path = feed_dir / "manifest.json"
+    manifest: dict[str, Any] = {}
+    if manifest_path.is_file():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    leads: list[dict[str, Any]] = []
+    for chunk in sorted(feed_dir.glob("chunk_*.json")):
+        payload = json.loads(chunk.read_text(encoding="utf-8"))
+        schema = str(payload.get("schema_version") or "")
+        if schema != SCHEMA_OUTREACH:
+            raise ValueError(f"{chunk}: expected {SCHEMA_OUTREACH}, found {schema!r}")
+        leads.extend(payload.get("leads") or [])
+    return leads, manifest
+
+
+def _contact_blocked(contact: dict[str, Any]) -> str | None:
+    """Reason this mailbox cannot enter the bounded cohort, or None."""
+    mailbox = canonicalize_mailbox(str(contact.get("email") or ""))
+    if not mailbox or "@" not in mailbox:
+        return "mailbox_missing"
+    route_class = str(contact.get("route_class") or "")
+    if route_class == EmailRouteClass.PROBABILISTIC_OR_RISKY.value:
+        return "risky_excluded_from_default_pilot"
+    if route_class not in ALLOWED_ROUTE_CLASSES:
+        return "route_class_outside_default_pilot"
+    if not contact.get("controlled_email_eligible"):
+        return "not_controlled_email_eligible"
+    if str(contact.get("route_suppression") or "NONE").upper() in BLOCKING_SUPPRESSION:
+        return "suppressed"
+    if contact.get("dnc") or contact.get("do_not_contact"):
+        return "dnc"
+    if contact.get("bounce") or contact.get("bounced"):
+        return "hard_bounce"
+    if contact.get("mailbox_purpose_send_blocked"):
+        return "mailbox_purpose_blocked"
+    if str(contact.get("mailbox_company_evidence") or "").upper() != "OBSERVED":
+        return "mailbox_company_evidence_unknown"
+    return None
+
+
+def select_cohort(
+    leads: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Keep accounts with exactly one surviving preferred_initial mailbox."""
+    gated = apply_cross_account_preferred_mailbox_gate(leads)
+
+    funnel: Counter[str] = Counter()
+    class_counts: Counter[str] = Counter()
+    selected: list[dict[str, Any]] = []
+    claimed: set[str] = set()
+
+    for lead in gated:
+        funnel["accounts_considered"] += 1
+        company = lead.get("company") if isinstance(lead.get("company"), dict) else {}
+        contacts = [c for c in (lead.get("contacts") or []) if isinstance(c, dict)]
+        emails = [c for c in contacts if canonicalize_mailbox(str(c.get("email") or ""))]
+
+        if company.get("website") or any(c.get("official_domain") for c in contacts):
+            funnel["official_domain"] += 1
+        else:
+            funnel["no_domain"] += 1
+        if emails:
+            funnel["any_public_email"] += 1
+        else:
+            funnel["no_email"] += 1
+
+        for contact in emails:
+            route_class = str(contact.get("route_class") or "")
+            if route_class == EmailRouteClass.PROBABILISTIC_OR_RISKY.value:
+                funnel["RISKY"] += 1
+            elif route_class in ALLOWED_ROUTE_CLASSES:
+                funnel[route_class] += 1
+            if contact.get("controlled_email_eligible"):
+                funnel["controlled_eligible"] += 1
+
+        preferred = [c for c in emails if c.get("preferred_initial")]
+        if len(preferred) > 1:
+            funnel["double_preferred"] += 1
+            funnel["blocked"] += 1
+            continue
+        if not preferred:
+            funnel["blocked"] += 1
+            continue
+
+        contact = preferred[0]
+        reason = _contact_blocked(contact)
+        if reason is not None:
+            funnel[f"blocked_{reason}"] += 1
+            funnel["blocked"] += 1
+            if reason in {"suppressed", "dnc", "hard_bounce"}:
+                funnel["suppressed"] += 1
+            continue
+
+        mailbox = canonicalize_mailbox(str(contact.get("email") or ""))
+        if mailbox in claimed:
+            funnel["double_preferred"] += 1
+            funnel["blocked"] += 1
+            continue
+
+        funnel["preferred_initial"] += 1
+        if len(selected) >= limit:
+            continue
+        claimed.add(mailbox)
+        class_counts[str(contact.get("route_class") or "")] += 1
+        member = dict(lead)
+        member["contacts"] = [contact]
+        selected.append(member)
+
+    stats = {
+        "funnel": dict(funnel),
+        "route_class_distribution": dict(class_counts),
+    }
+    return selected, stats
+
+
+def stratified_sample(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Small per-route-class evidence sample. Hosts only — never a mailbox."""
+    per_class: Counter[str] = Counter()
+    sample: list[dict[str, Any]] = []
+    for member in members:
+        contact = (member.get("contacts") or [{}])[0]
+        route_class = str(contact.get("route_class") or "")
+        if per_class[route_class] >= SAMPLE_PER_ROUTE_CLASS:
+            continue
+        per_class[route_class] += 1
+        company = member.get("company") if isinstance(member.get("company"), dict) else {}
+        official = _host(str(company.get("website") or "")) or None
+        mailbox_domain = email_domain(str(contact.get("email") or "")) or None
+        source_host = _host(contact.get("source_url"))
+        sample.append(
+            {
+                "route_class": route_class,
+                "source_type": str((contact.get("provenance") or {}).get("source_type") or "")
+                or str(contact.get("source_type") or ""),
+                "source_host": source_host,
+                "official_host": official,
+                "mailbox_domain": mailbox_domain,
+                "mailbox_domain_matches_official": bool(official and mailbox_domain == official),
+                "source_host_matches_official": bool(official and source_host == official),
+                "mailbox_company_evidence": contact.get("mailbox_company_evidence"),
+                "controlled_email_eligible": bool(contact.get("controlled_email_eligible")),
+                "preferred_initial": bool(contact.get("preferred_initial")),
+            }
+        )
+    return sample
+
+
+def write_private_feed(
+    members: list[dict[str, Any]],
+    *,
+    out_dir: Path,
+    source_manifest: dict[str, Any],
+    as_of: str,
+    run_id: str,
+) -> dict[str, Any]:
+    """Write the 0600 private feed plus its hash. Returns the feed metadata."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(out_dir, 0o700)
+    feed = {
+        "schema_version": SCHEMA_OUTREACH,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "as_of": as_of,
+        "auto_send": False,
+        "smtp": "none",
+        "source": {
+            **(source_manifest.get("source") or {}),
+            "cohort_run_id": run_id,
+            "cohort_policy": "controlled-email-policy.v1",
+        },
+        "pagination": {"has_more": False},
+        "leads": members,
+    }
+    body = json.dumps(feed, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    feed_path = out_dir / "confenge.outreach.v1.json"
+    feed_path.write_text(body, encoding="utf-8")
+    os.chmod(feed_path, 0o600)
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    sha_path = out_dir / "confenge.outreach.v1.json.sha256"
+    sha_path.write_text(digest + "\n", encoding="utf-8")
+    os.chmod(sha_path, 0o600)
+    return {"path": str(feed_path), "sha256": digest, "mode": "0600"}
+
+
+def build(
+    *,
+    feed_dir: Path,
+    private_root: Path,
+    limit: int,
+    as_of: str,
+    run_stamp: str,
+) -> dict[str, Any]:
+    leads, source_manifest = load_feed_leads(feed_dir)
+    members, stats = select_cohort(leads, limit=limit)
+    out_dir = private_root / run_stamp
+    run_id = f"fresh-cohort-{run_stamp}"
+    feed_meta = write_private_feed(
+        members,
+        out_dir=out_dir,
+        source_manifest=source_manifest,
+        as_of=as_of,
+        run_id=run_id,
+    )
+    funnel = dict(stats["funnel"])
+    considered = funnel.get("accounts_considered") or 0
+    funnel["yield"] = round(len(members) / considered, 4) if considered else 0.0
+    funnel["as_of"] = as_of
+    manifest = {
+        "schema": MANIFEST_SCHEMA,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "fresh_run_id": run_id,
+        "as_of": as_of,
+        "auto_send": False,
+        "REAL_EMAIL_SENT": False,
+        "smtp": "none",
+        "private_feed_path": feed_meta["path"],
+        "private_feed_mode": feed_meta["mode"],
+        "feed_sha256": feed_meta["sha256"],
+        "member_count": len(members),
+        "requested_limit": limit,
+        "route_class_distribution": stats["route_class_distribution"],
+        "funnel": funnel,
+        "sample_qa": stratified_sample(members),
+        "source_feed": {
+            "dir": str(feed_dir),
+            "lead_count": source_manifest.get("lead_count"),
+            "repo_sha": (source_manifest.get("source") or {}).get("repo_sha"),
+            "run_id": (source_manifest.get("source") or {}).get("run_id"),
+            "snapshot_hash": (source_manifest.get("source") or {}).get("snapshot_hash"),
+        },
+        "schema_versions": {
+            "outreach_schema": SCHEMA_OUTREACH,
+            "controlled_email_policy": "controlled-email-policy.v1",
+        },
+    }
+    manifest_path = out_dir / "manifest.redacted.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    os.chmod(manifest_path, 0o600)
+    manifest["manifest_path"] = str(manifest_path)
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--feed-dir", required=True, help="Exported 06_warmbly_feed directory")
+    ap.add_argument("--private-root", default=str(DEFAULT_PRIVATE_ROOT), help="Private cohort root")
+    ap.add_argument("--limit", type=int, default=DEFAULT_COHORT_SIZE, help="Cohort cap")
+    ap.add_argument("--as-of", default=date.today().isoformat())
+    ap.add_argument("--run-stamp", default=None, help="Defaults to the current UTC stamp")
+    args = ap.parse_args(argv)
+
+    manifest = build(
+        feed_dir=Path(args.feed_dir),
+        private_root=Path(args.private_root),
+        limit=int(args.limit),
+        as_of=str(args.as_of),
+        run_stamp=str(args.run_stamp or _utc_stamp()),
+    )
+    print(json.dumps(manifest, ensure_ascii=False, indent=2))
+    return 0 if manifest["member_count"] > 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -97,6 +97,7 @@ def resolve_official_domain(lead: dict[str, Any], contact: dict[str, Any]) -> st
         contact.get("official_domain"),
         extra.get("official_domain"),
         extra.get("canonical_domain"),
+        company.get("official_domain"),
         company.get("website"),
         company.get("site"),
     ):
@@ -187,7 +188,7 @@ def select_cohort(
         contacts = [c for c in (lead.get("contacts") or []) if isinstance(c, dict)]
         emails = [c for c in contacts if canonicalize_mailbox(str(c.get("email") or ""))]
 
-        if company.get("website") or any(c.get("official_domain") for c in contacts):
+        if company.get("official_domain") or company.get("website") or any(c.get("official_domain") for c in contacts):
             funnel["official_domain"] += 1
         else:
             funnel["no_domain"] += 1

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -68,8 +68,26 @@ def _host(url: str | None) -> str | None:
     raw = str(url or "").strip()
     if not raw:
         return None
-    host = (urlparse(raw).hostname or "").lower().removeprefix("www.")
+    parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (parsed.hostname or raw.split("/")[0]).lower().removeprefix("www.").strip()
     return host or None
+
+
+def resolve_official_domain(lead: dict[str, Any], contact: dict[str, Any]) -> str | None:
+    """Same official-domain ladder the exporter used, so the recheck is faithful."""
+    company = lead.get("company") if isinstance(lead.get("company"), dict) else {}
+    extra = contact.get("extra") if isinstance(contact.get("extra"), dict) else {}
+    for candidate in (
+        contact.get("official_domain"),
+        extra.get("official_domain"),
+        extra.get("canonical_domain"),
+        company.get("website"),
+        company.get("site"),
+    ):
+        host = _host(str(candidate or ""))
+        if host:
+            return host
+    return None
 
 
 def load_feed_leads(feed_dir: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
@@ -184,7 +202,7 @@ def select_cohort(
         reason = _contact_blocked(
             contact,
             account_id=str(company.get("cnpj14") or lead.get("source_lead_id") or ""),
-            official_domain=_host(str(company.get("website") or "")),
+            official_domain=resolve_official_domain(lead, contact),
         )
         if reason is not None:
             funnel[f"blocked_{reason}"] += 1
@@ -225,8 +243,7 @@ def stratified_sample(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if per_class[route_class] >= SAMPLE_PER_ROUTE_CLASS:
             continue
         per_class[route_class] += 1
-        company = member.get("company") if isinstance(member.get("company"), dict) else {}
-        official = _host(str(company.get("website") or "")) or None
+        official = resolve_official_domain(member, contact)
         mailbox_domain = email_domain(str(contact.get("email") or "")) or None
         source_host = _host(contact.get("source_url"))
         sample.append(

--- a/scripts/warmbly_bridge/mapping.py
+++ b/scripts/warmbly_bridge/mapping.py
@@ -661,6 +661,11 @@ def map_lead(
     stamped = stamp_and_rank_feed_contacts(contacts, account_id=cnpj, official_domain=official or None)
     contacts[:] = stamped
     lead["contacts"] = contacts
+    # Publish the domain the classifier actually judged against. The universe
+    # website field is usually empty, so without this the consumer sees an
+    # association verdict it cannot re-derive, and a re-check downstream would
+    # judge the same mailbox with less evidence than the classifier had.
+    lead["company"]["official_domain"] = official or None
 
     # Canonical principal is preferred_initial. `recommended` is a compatibility
     # alias of that same unique principal (including generic/role mailboxes that

--- a/scripts/warmbly_bridge/mapping.py
+++ b/scripts/warmbly_bridge/mapping.py
@@ -781,4 +781,6 @@ def build_leads(
             lead["source_lead_id"],
         )
     )
-    return leads
+    from scripts.decision_unit_intelligence.controlled_email import apply_cross_account_preferred_mailbox_gate
+
+    return apply_cross_account_preferred_mailbox_gate(leads)

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -116,6 +116,7 @@ def test_production_snapshot_uses_published_store_and_canonicalizes_prevencao(
                 "cnpj_raiz": "01489370",
                 "company_key": "cnpj_root:01489370",
                 "target_fit_class": "TARGET_OUT_OF_SCOPE",
+                "source_watermark": "2026-08-12T07:00:00Z",
             }
         },
     )
@@ -139,8 +140,47 @@ def test_production_snapshot_uses_published_store_and_canonicalizes_prevencao(
             "cnpj_raiz": "14893700",
             "company_key": "cnpj_root:14893700",
             "target_fit_class": "TARGET_OUT_OF_SCOPE",
+            "source_watermark": "2026-08-12T07:00:00Z",
         }
     ]
+
+
+def test_published_decision_without_a_watermark_is_tombstoned_not_exported(monkeypatch) -> None:
+    """One incomplete decision must cost one account, never the whole export."""
+    import scripts.confenge_outreach_pipeline.pipeline as pipeline
+    import scripts.confenge_target_fit.db as target_fit_db
+
+    class FakeConnection:
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(target_fit_db, "connect", lambda dsn, readonly: FakeConnection())
+    monkeypatch.setattr(
+        pipeline,
+        "load_published_index",
+        lambda connection, cnpj14s: {
+            "14893700": {
+                "cnpj_raiz": "14893700",
+                "company_key": "cnpj_root:14893700",
+                "target_fit_class": "TARGET_CONFIRMED",
+                "source_watermark": "",
+            },
+            "11222333": {
+                "cnpj_raiz": "11222333",
+                "company_key": "cnpj_root:11222333",
+                "target_fit_class": "TARGET_CONFIRMED",
+                "source_watermark": "2026-08-12T07:00:00Z",
+            },
+        },
+    )
+    monkeypatch.setattr(pipeline, "get_control", lambda connection, key: {"watermark": "2026-08-12T08:00:00Z"})
+
+    snapshot, _, _ = _published_target_fit_snapshot(
+        [{"cnpj14": "14893700000105"}, {"cnpj14": "11222333000181"}],
+        dsn="postgresql://unused",
+    )
+
+    assert [row["cnpj_raiz"] for row in snapshot] == ["11222333"]
 
 
 def test_production_activation_does_not_use_limit_downstream_as_capacity(tmp_path: Path) -> None:

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -171,3 +171,31 @@ def test_feed_hash_matches_the_bytes_on_disk(tmp_path):
     )
     body = Path(manifest["private_feed_path"]).read_bytes()
     assert hashlib.sha256(body).hexdigest() == manifest["feed_sha256"]
+
+
+def test_a_stale_stamp_cannot_smuggle_an_untrustworthy_route():
+    """An export from an older classifier is re-judged under the shipped policy."""
+    smuggled = _contact(
+        "contato@sustainconsulting.llc",
+        source_url="https://multisend-unsubscribe.gmail.com/x",
+        provenance={"source_type": "web_search"},
+    )
+    members, stats = select_cohort(
+        [_lead("11111111000191", [smuggled])],
+        limit=50,
+    )
+    assert members == []
+    assert stats["funnel"]["blocked_stamp_disagrees_with_shipped_policy"] == 1
+
+
+def test_a_route_the_shipped_policy_confirms_still_passes():
+    honest = _contact(
+        "contato@alpha.com.br",
+        source_url="https://alpha.com.br/contato",
+        provenance={"source_type": "contact_page"},
+    )
+    members, _ = select_cohort(
+        [_lead("11111111000191", [honest], website="https://alpha.com.br")],
+        limit=50,
+    )
+    assert len(members) == 1

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -239,3 +239,23 @@ def test_every_funnel_and_route_class_key_ships_even_at_zero():
         assert key in stats["funnel"], key
     assert stats["route_class_distribution"]["PROBABILISTIC_OR_RISKY"] == 0
     assert stats["route_class_distribution"]["DIRECT_PERSON"] == 0
+
+
+def test_the_published_official_domain_feeds_the_recheck():
+    """The exporter publishes the domain it judged against; the recheck reuses it."""
+    from scripts.ops.build_controlled_email_cohort import resolve_official_domain
+
+    lead = _lead("11111111000191", [])
+    lead["company"]["official_domain"] = "alpha.com.br"
+    assert resolve_official_domain(lead, {}) == "alpha.com.br"
+
+    contact = _contact(
+        "contato@alpha.com.br",
+        source_url="https://alpha.com.br/fale-conosco",
+    )
+    lead_with_contact = _lead("11111111000191", [contact])
+    lead_with_contact["company"]["official_domain"] = "alpha.com.br"
+    members, stats = select_cohort([lead_with_contact], limit=50)
+    assert len(members) == 1
+    assert stats["funnel"]["official_domain"] == 1
+    assert stats["funnel"]["no_domain"] == 0

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -199,3 +199,23 @@ def test_a_route_the_shipped_policy_confirms_still_passes():
         limit=50,
     )
     assert len(members) == 1
+
+
+def test_official_domain_ladder_matches_the_exporter():
+    from scripts.ops.build_controlled_email_cohort import resolve_official_domain
+
+    lead = _lead("11111111000191", [], website="https://www.Alpha.com.br/quem-somos")
+    assert resolve_official_domain(lead, {}) == "alpha.com.br"
+    assert resolve_official_domain(lead, {"official_domain": "beta.com.br"}) == "beta.com.br"
+    assert resolve_official_domain(_lead("11111111000191", []), {}) is None
+
+
+def test_a_route_on_its_own_official_domain_survives_the_recheck():
+    """The exporter's official domain must not be lost, or good routes die."""
+    contact = _contact(
+        "contato@alpha.com.br",
+        source_url="https://alpha.com.br/contato",
+        official_domain="alpha.com.br",
+    )
+    members, _ = select_cohort([_lead("11111111000191", [contact])], limit=50)
+    assert len(members) == 1

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -1,0 +1,173 @@
+"""Bounded controlled-email cohort producer keeps PII private and gates hard.
+
+Drives the shipped producer against a synthetic `confenge.outreach.v1` export.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+from scripts.ops.build_controlled_email_cohort import build, select_cohort
+from scripts.warmbly_bridge import SCHEMA_OUTREACH
+
+
+def _contact(
+    email: str,
+    *,
+    route_class: str = "GENERIC_COMPANY",
+    eligible: bool = True,
+    preferred: bool = True,
+    **overrides: Any,
+) -> dict[str, Any]:
+    contact = {
+        "email": email,
+        "route_class": route_class,
+        "controlled_email_eligible": eligible,
+        "preferred_initial": preferred,
+        "recommended": preferred,
+        "mailbox_company_evidence": "OBSERVED",
+        "route_suppression": "NONE",
+        "source_url": f"https://{email.split('@', 1)[1]}/contato",
+        "provenance": {"source_type": "contact_page"},
+    }
+    contact.update(overrides)
+    return contact
+
+
+def _lead(cnpj14: str, contacts: list[dict[str, Any]], *, website: str | None = None) -> dict[str, Any]:
+    return {
+        "source_lead_id": f"lead-{cnpj14}",
+        "company": {"cnpj14": cnpj14, "razao_social": f"EMPRESA {cnpj14}", "website": website},
+        "contacts": contacts,
+    }
+
+
+def _write_export(tmp_path: Path, leads: list[dict[str, Any]]) -> Path:
+    feed_dir = tmp_path / "06_warmbly_feed"
+    feed_dir.mkdir(parents=True)
+    (feed_dir / "chunk_0000.json").write_text(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_OUTREACH,
+                "generated_at": "2026-08-22T00:00:00Z",
+                "pagination": {"has_more": False},
+                "source": {"system": "extra-cli", "repo_sha": "0" * 40, "run_id": "run-test"},
+                "leads": leads,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (feed_dir / "manifest.json").write_text(
+        json.dumps({"lead_count": len(leads), "source": {"repo_sha": "0" * 40, "run_id": "run-test"}}),
+        encoding="utf-8",
+    )
+    return feed_dir
+
+
+def test_risky_and_suppressed_never_enter_the_cohort():
+    leads = [
+        _lead("11111111000191", [_contact("contato@alpha.com.br")]),
+        _lead(
+            "22222222000172",
+            [_contact("chute@beta.com.br", route_class="PROBABILISTIC_OR_RISKY", eligible=False)],
+        ),
+        _lead("33333333000153", [_contact("contato@gama.com.br", route_suppression="OPT_OUT")]),
+        _lead("44444444000134", [_contact("contato@delta.com.br", eligible=False)]),
+        _lead("55555555000115", [_contact("contato@epsilon.com.br", mailbox_purpose_send_blocked=True)]),
+    ]
+    members, stats = select_cohort(leads, limit=50)
+    assert [m["company"]["cnpj14"] for m in members] == ["11111111000191"]
+    assert stats["route_class_distribution"] == {"GENERIC_COMPANY": 1}
+    assert stats["funnel"]["RISKY"] == 1
+    assert stats["funnel"]["suppressed"] == 1
+
+
+def test_exactly_one_preferred_route_per_account():
+    leads = [
+        _lead(
+            "11111111000191",
+            [_contact("contato@alpha.com.br"), _contact("licitacoes@alpha.com.br", route_class="ROLE_OR_DEPARTMENT")],
+        ),
+        _lead("22222222000172", [_contact("contato@beta.com.br", preferred=False)]),
+    ]
+    members, stats = select_cohort(leads, limit=50)
+    assert members == []
+    assert stats["funnel"]["double_preferred"] == 1
+
+
+def test_the_same_mailbox_cannot_be_claimed_by_two_accounts():
+    shared = "contato@grupo.com.br"
+    leads = [
+        _lead("11111111000191", [_contact(shared)]),
+        _lead("22222222000172", [_contact(shared)]),
+    ]
+    members, _ = select_cohort(leads, limit=50)
+    assert len(members) == 1
+
+
+def test_cohort_is_capped_without_padding():
+    leads = [_lead(f"{n:011d}191"[:14], [_contact(f"contato@empresa{n}.com.br")]) for n in range(1, 8)]
+    members, stats = select_cohort(leads, limit=3)
+    assert len(members) == 3
+    assert stats["funnel"]["preferred_initial"] == 7
+
+
+def test_private_feed_is_0600_and_the_manifest_carries_no_pii(tmp_path):
+    feed_dir = _write_export(
+        tmp_path,
+        [
+            _lead("11111111000191", [_contact("contato@alpha.com.br")], website="https://alpha.com.br"),
+            _lead(
+                "22222222000172",
+                [_contact("licitacoes@beta.com.br", route_class="ROLE_OR_DEPARTMENT")],
+                website="https://beta.com.br",
+            ),
+        ],
+    )
+    private_root = tmp_path / "private"
+    manifest = build(
+        feed_dir=feed_dir,
+        private_root=private_root,
+        limit=50,
+        as_of="2026-08-22",
+        run_stamp="20260822T000000Z",
+    )
+
+    assert manifest["member_count"] == 2
+    assert manifest["auto_send"] is False
+    assert manifest["REAL_EMAIL_SENT"] is False
+    assert manifest["smtp"] == "none"
+    assert manifest["route_class_distribution"] == {"GENERIC_COMPANY": 1, "ROLE_OR_DEPARTMENT": 1}
+
+    feed_path = Path(manifest["private_feed_path"])
+    assert stat.S_IMODE(os.stat(feed_path).st_mode) == 0o600
+    assert stat.S_IMODE(os.stat(feed_path.parent).st_mode) == 0o700
+
+    feed = json.loads(feed_path.read_text(encoding="utf-8"))
+    assert feed["schema_version"] == SCHEMA_OUTREACH
+    assert feed["auto_send"] is False
+    assert all(len(lead["contacts"]) == 1 for lead in feed["leads"])
+
+    redacted = Path(manifest["manifest_path"]).read_text(encoding="utf-8")
+    assert "@" not in redacted
+    assert "11111111000191" not in redacted
+    assert "alpha.com.br" in redacted  # public host is evidence, not PII
+
+
+def test_feed_hash_matches_the_bytes_on_disk(tmp_path):
+    import hashlib
+
+    feed_dir = _write_export(tmp_path, [_lead("11111111000191", [_contact("contato@alpha.com.br")])])
+    manifest = build(
+        feed_dir=feed_dir,
+        private_root=tmp_path / "private",
+        limit=50,
+        as_of="2026-08-22",
+        run_stamp="20260822T000000Z",
+    )
+    body = Path(manifest["private_feed_path"]).read_bytes()
+    assert hashlib.sha256(body).hexdigest() == manifest["feed_sha256"]

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -81,7 +81,7 @@ def test_risky_and_suppressed_never_enter_the_cohort():
     ]
     members, stats = select_cohort(leads, limit=50)
     assert [m["company"]["cnpj14"] for m in members] == ["11111111000191"]
-    assert stats["route_class_distribution"] == {"GENERIC_COMPANY": 1}
+    assert stats["route_class_distribution"]["GENERIC_COMPANY"] == 1
     assert stats["funnel"]["RISKY"] == 1
     assert stats["funnel"]["suppressed"] == 1
 
@@ -141,7 +141,14 @@ def test_private_feed_is_0600_and_the_manifest_carries_no_pii(tmp_path):
     assert manifest["auto_send"] is False
     assert manifest["REAL_EMAIL_SENT"] is False
     assert manifest["smtp"] == "none"
-    assert manifest["route_class_distribution"] == {"GENERIC_COMPANY": 1, "ROLE_OR_DEPARTMENT": 1}
+    assert manifest["route_class_distribution"] == {
+        "DIRECT_PERSON": 0,
+        "ROLE_OR_DEPARTMENT": 1,
+        "GENERIC_COMPANY": 1,
+        "PUBLIC_COMPANY_FREEMAIL": 0,
+        "PROBABILISTIC_OR_RISKY": 0,
+    }
+    assert sum(manifest["route_class_distribution"].values()) == manifest["member_count"]
 
     feed_path = Path(manifest["private_feed_path"])
     assert stat.S_IMODE(os.stat(feed_path).st_mode) == 0o600
@@ -219,3 +226,16 @@ def test_a_route_on_its_own_official_domain_survives_the_recheck():
     )
     members, _ = select_cohort([_lead("11111111000191", [contact])], limit=50)
     assert len(members) == 1
+
+
+def test_every_funnel_and_route_class_key_ships_even_at_zero():
+    """A zero is a finding. Consumers must never have to guess an absent key."""
+    from scripts.ops.build_controlled_email_cohort import FUNNEL_KEYS
+
+    _, stats = select_cohort([], limit=50)
+    for key in FUNNEL_KEYS:
+        assert stats["funnel"][key] == 0, key
+    for key in ("DIRECT_PERSON", "ROLE_OR_DEPARTMENT", "GENERIC_COMPANY", "PUBLIC_COMPANY_FREEMAIL"):
+        assert key in stats["funnel"], key
+    assert stats["route_class_distribution"]["PROBABILISTIC_OR_RISKY"] == 0
+    assert stats["route_class_distribution"]["DIRECT_PERSON"] == 0

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -173,7 +173,11 @@ def test_contato_eligible_without_inventing_person() -> None:
 def test_associated_gmail_is_public_company_freemail() -> None:
     route = _route(
         "empresa@gmail.com",
-        extra={"company_associated": True, "mailbox_company_evidence": "OBSERVED"},
+        extra={
+            "company_associated": True,
+            "mailbox_company_evidence": "OBSERVED",
+            "official_domain": "empresaexemplo.com.br",
+        },
         source_type="company_website",
     )
     classified = evaluate_controlled_email_eligible(route, person=None)
@@ -264,7 +268,11 @@ def test_four_mailboxes_one_preferred_initial_route() -> None:
         _route("contato@empresaexemplo.com.br"),
         _route(
             "empresa@gmail.com",
-            extra={"company_associated": True, "mailbox_company_evidence": "OBSERVED"},
+            extra={
+                "company_associated": True,
+                "mailbox_company_evidence": "OBSERVED",
+                "official_domain": "empresaexemplo.com.br",
+            },
         ),
     ]
     ranking = classify_account_email_routes(_account(routes, [person]), named_person_safe=is_email_safe_for_warmbly)
@@ -327,7 +335,11 @@ def test_generic_mailbox_never_becomes_fake_person() -> None:
 def test_gmail_never_becomes_fake_corporate_domain() -> None:
     route = _route(
         "empresa@gmail.com",
-        extra={"company_associated": True, "mailbox_company_evidence": "OBSERVED"},
+        extra={
+            "company_associated": True,
+            "mailbox_company_evidence": "OBSERVED",
+            "official_domain": "empresaexemplo.com.br",
+        },
     )
     classified = evaluate_controlled_email_eligible(route, person=None)
     assert classified.route_class == EmailRouteClass.PUBLIC_COMPANY_FREEMAIL
@@ -594,6 +606,19 @@ def test_empty_official_site_source_rejects_mailbox_host_mismatch() -> None:
     assert lead["contacts"][0]["controlled_email_eligible"] is False
 
 
+def test_empty_official_freemail_from_aggregator_page_is_not_eligible() -> None:
+    classified = evaluate_controlled_email_eligible(
+        _route(
+            "empresa@terra.com.br",
+            source_type="contact_page",
+            source_url="https://cnpja.com/office/123",
+            extra={"company_associated": True, "mailbox_company_evidence": "OBSERVED"},
+        )
+    )
+    assert classified.controlled_email_eligible is False
+    assert classified.route_class == EmailRouteClass.PROBABILISTIC_OR_RISKY
+
+
 def test_parser_minted_mailbox_host_is_not_eligible() -> None:
     classified = evaluate_controlled_email_eligible(
         _route(
@@ -733,7 +758,11 @@ def test_five_class_synthetic_canary_snapshot() -> None:
         _route("contato@empresaexemplo.com.br"),
         _route(
             "empresa@gmail.com",
-            extra={"company_associated": True, "mailbox_company_evidence": "OBSERVED"},
+            extra={
+                "company_associated": True,
+                "mailbox_company_evidence": "OBSERVED",
+                "official_domain": "empresaexemplo.com.br",
+            },
             source_type="company_website",
         ),
         _route(
@@ -882,6 +911,7 @@ def _five_class_universe_intel_contacts() -> tuple[dict, dict, dict]:
                 "email": "empresa@gmail.com",
                 "ownership_status": "COMPANY_OWNED",
                 "source_url": "https://empresaexemplo.com.br/contato",
+                "source_type": "company_website",
                 "mailbox_company_evidence": "OBSERVED",
                 "source_contact_id": "c-gmail",
             },

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -1012,3 +1012,50 @@ def test_five_class_mapping_feed_written_for_warmbly_ingest() -> None:
     if sibling.parent.is_dir():
         sibling.write_text(dest.read_text(encoding="utf-8"), encoding="utf-8")
         assert json.loads(sibling.read_text(encoding="utf-8"))["leads"][0]["contacts"][0]["email"]
+
+
+def _cnpj_linked_doc_route(
+    mailbox: str = "licitacoes@alphaengenharia.com.br",
+    *,
+    document_cnpj14: str = ACCOUNT_ID,
+    evidence_strength: str = "company_authored_document",
+) -> ReachabilityRoute:
+    """Company-authored document hosted on a datalake/portal host, not the company host."""
+    return _route(
+        mailbox,
+        channel=ChannelType.ROLE_MAILBOX,
+        ownership=OwnershipStatus.UNKNOWN,
+        source_type="official_documents",
+        source_url="https://datalake.example/doc/1",
+        extra={
+            "evidence_strength": evidence_strength,
+            "document_cnpj14": document_cnpj14,
+        },
+    )
+
+
+def test_cnpj_linked_company_document_survives_host_match_gate():
+    """Authorship binds the mailbox; a PNCP/portal host is never the company host."""
+    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route())
+    assert verdict.mailbox_company_evidence == "OBSERVED"
+    assert verdict.controlled_email_eligible is True
+    assert verdict.route_class == EmailRouteClass.ROLE_OR_DEPARTMENT
+
+
+def test_document_for_a_different_cnpj_is_not_associated():
+    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route(document_cnpj14="99887766000155"))
+    assert verdict.mailbox_company_evidence == "UNKNOWN"
+    assert verdict.controlled_email_eligible is False
+    assert "mailbox_company_evidence_unknown" in verdict.reason_codes
+
+
+def test_weak_document_evidence_does_not_bypass_host_match():
+    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route(evidence_strength="snippet_mention"))
+    assert verdict.mailbox_company_evidence == "UNKNOWN"
+    assert verdict.controlled_email_eligible is False
+
+
+def test_freemail_on_a_cnpj_linked_document_still_needs_a_company_page():
+    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route("alphaengenharia@gmail.com"))
+    assert verdict.mailbox_company_evidence == "UNKNOWN"
+    assert verdict.controlled_email_eligible is False

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -15,6 +15,7 @@ from scripts.decision_unit_intelligence.controlled_email import (
     CONTROLLED_EMAIL_POLICY_VERSION,
     EmailRouteClass,
     alternative_after_preferred_bounce,
+    apply_cross_account_preferred_mailbox_gate,
     classify_account_email_routes,
     classify_email_route_class,
     evaluate_controlled_email_eligible,
@@ -42,7 +43,7 @@ from scripts.decision_unit_intelligence.projection import (
     project_warmbly_outreach,
 )
 from scripts.warmbly_bridge import SCHEMA_OUTREACH
-from scripts.warmbly_bridge.mapping import map_lead
+from scripts.warmbly_bridge.mapping import build_leads, map_lead
 
 ACCOUNT_ID = "12345678000190"
 
@@ -539,6 +540,121 @@ def test_map_lead_rejects_unassociated_web_search_mailbox() -> None:
     contact = lead["contacts"][0]
     assert contact["controlled_email_eligible"] is False
     assert not contact.get("preferred_initial")
+
+
+def test_empty_official_site_source_rejects_mailbox_host_mismatch() -> None:
+    """Live junk: site source with empty official_domain and mailbox≠page host."""
+    classified = evaluate_controlled_email_eligible(
+        _route(
+            "contato@smartclub.com.br",
+            source_type="site",
+            source_url="https://smartlink.com.br/contato",
+            ownership=OwnershipStatus.COMPANY_OWNED,
+            extra={"company_associated": True},
+        )
+    )
+    assert classified.controlled_email_eligible is False
+    assert classified.mailbox_company_evidence == "UNKNOWN"
+    assert "mailbox_source_host_mismatch" in classified.reason_codes
+    stamped = stamp_and_rank_feed_contacts(
+        [
+            {
+                "email": "contato@mattioli.eng.br",
+                "ownership_status": "COMPANY_OWNED",
+                "source_type": "site",
+                "source_url": "https://dinamica.com.br/contato",
+            }
+        ],
+        account_id=ACCOUNT_ID,
+        official_domain=None,
+    )
+    assert stamped[0]["controlled_email_eligible"] is False
+    assert not stamped[0].get("preferred_initial")
+    universe, intel, _ = _five_class_universe_intel_contacts()
+    universe = dict(universe)
+    universe["website"] = ""
+    universe["official_domain"] = ""
+    lead = map_lead(
+        universe,
+        intel=intel,
+        contacts_row={
+            "cnpj14": ACCOUNT_ID,
+            "contacts": [
+                {
+                    "email": "u003eancar@nectarc.com.br",
+                    "ownership_status": "COMPANY_OWNED",
+                    "source_type": "site",
+                    "source_url": "https://ancar.com.br/",
+                }
+            ],
+        },
+        conn=None,
+    )
+    assert lead is not None
+    assert lead["contacts"][0]["controlled_email_eligible"] is False
+
+
+def test_parser_minted_mailbox_host_is_not_eligible() -> None:
+    classified = evaluate_controlled_email_eligible(
+        _route(
+            "1@model.phone.replace",
+            source_type="site",
+            source_url="https://amrconstrucoes.com.br/contato",
+            ownership=OwnershipStatus.COMPANY_OWNED,
+        )
+    )
+    assert classified.controlled_email_eligible is False
+    assert "implausible_mailbox_host" in classified.reason_codes
+    stamped = stamp_and_rank_feed_contacts(
+        [
+            {
+                "email": "1@model.phone.replace",
+                "ownership_status": "COMPANY_OWNED",
+                "source_type": "contact_page",
+                "source_url": "https://amrconstrucoes.com.br/",
+            }
+        ],
+        account_id=ACCOUNT_ID,
+    )
+    assert stamped[0]["controlled_email_eligible"] is False
+
+
+def test_duplicate_preferred_mailbox_across_accounts_keeps_one() -> None:
+    universe_a, intel, _ = _five_class_universe_intel_contacts()
+    universe_a = dict(universe_a)
+    universe_a["cnpj14"] = "11111111000191"
+    universe_a["website"] = "https://energia.com.br"
+    universe_a["official_domain"] = "energia.com.br"
+    universe_b = dict(universe_a)
+    universe_b["cnpj14"] = "22222222000172"
+    contacts = {
+        "contacts": [
+            {
+                "email": "secretaria@energia.com.br",
+                "ownership_status": "COMPANY_OWNED",
+                "source_type": "site",
+                "source_url": "https://energia.com.br/contato",
+            }
+        ]
+    }
+    leads = build_leads(
+        [universe_a, universe_b],
+        [],
+        [
+            {"cnpj14": "11111111000191", **contacts},
+            {"cnpj14": "22222222000172", **contacts},
+        ],
+    )
+    preferred = [
+        (lead["company"]["cnpj14"], c["email"])
+        for lead in leads
+        for c in lead["contacts"]
+        if c.get("preferred_initial") and c.get("email")
+    ]
+    assert len(preferred) == 1
+    assert preferred[0][1] == "secretaria@energia.com.br"
+    gated = apply_cross_account_preferred_mailbox_gate(leads)
+    assert sum(1 for lead in gated for c in lead["contacts"] if c.get("preferred_initial")) == 1
 
 
 def test_hr_mailbox_not_controlled_eligible() -> None:

--- a/tests/test_email_reachability_engine.py
+++ b/tests/test_email_reachability_engine.py
@@ -183,7 +183,11 @@ def test_official_site_gmail_may_be_public_company_freemail() -> None:
     classified = evaluate_controlled_email_eligible(
         _route(
             "contato.empresa@gmail.com",
-            extra={"company_associated": True, "mailbox_company_evidence": "OBSERVED"},
+            extra={
+                "company_associated": True,
+                "mailbox_company_evidence": "OBSERVED",
+                "official_domain": "empresaexemplo.com.br",
+            },
         )
     )
     assert classified.route_class == EmailRouteClass.PUBLIC_COMPANY_FREEMAIL

--- a/tests/test_email_reachability_engine.py
+++ b/tests/test_email_reachability_engine.py
@@ -476,7 +476,11 @@ def test_stop_early_on_observed_licitacao_skips_person_search(monkeypatch) -> No
     assert search_calls["n"] == 0
     classified = evaluate_controlled_email_eligible(
         _route(
-            "licitacao@alphaengenharia.com.br", channel=ChannelType.ROLE_MAILBOX, relation=RouteRelation.ROUTES_TO_ROLE
+            "licitacao@alphaengenharia.com.br",
+            channel=ChannelType.ROLE_MAILBOX,
+            relation=RouteRelation.ROUTES_TO_ROLE,
+            source_url="https://alphaengenharia.com.br/",
+            extra={"official_domain": "alphaengenharia.com.br"},
         )
     )
     assert discovery_should_stop_for_commercial_value([classified]) is True


### PR DESCRIPTION
Closes the gap between "the classifier is correct" and "a fresh production cohort can actually be cut and handed off".

## Association gates

Adversarial QA on the live 50-member feed found, and this fixes:

- `site` source with empty `official_domain` treating foreign mailboxes as OBSERVED
- parser-minted host `model.phone.replace`
- the same preferred mailbox claimed by two accounts
- mailbox host != page host

The host-match rule is right for web pages, where publication on the company site is the only association proof. It is wrong for a company-authored document the datalake already binds to a CNPJ: those live on PNCP or transparency hosts that are never the company host, so the rule turned every document route into UNKNOWN and broke discovery stop-early. Those routes are now accepted only when the document CNPJ matches the account, `evidence_strength` is company-authored/official-CNPJ-linked, and the mailbox is not pattern-guessed. Freemail still needs a company page.

## Shipped cohort producer

The private cohort feed was being cut by an ad-hoc host script, so the selection rules lived nowhere and could not be re-run or reviewed. `scripts/ops/build_controlled_email_cohort.py` reads the exported `confenge.outreach.v1` chunks, keeps only accounts whose single `preferred_initial` mailbox survives the hard gates, caps without padding, and writes the feed `0600` under the private root with its SHA-256 and a redacted manifest. No mailbox, person or CNPJ leaves that root.

Dry-running it against the last real export surfaced a route the export had stamped eligible whose `source_url` host was `multisend-unsubscribe.gmail.com` and whose mailbox domain belonged to an unrelated company. The producer now re-derives each verdict from the contact's own provenance instead of trusting the stamp; on that export the cohort correctly resolves to zero.

## Export durability

The authoritative exporter fails closed on the first lead missing `target_fit_source_watermark`, and 12 of 8283 `TARGET_CONFIRMED` rows in the last full snapshot have none. A hot set of 500 draws from exactly that population, which is how the previous national export died. Those rows are now omitted from the published snapshot the same way store misses are, so one incomplete decision costs one account instead of the whole run.

The exporter also now publishes the official domain it judged against. The universe website field is empty for essentially every account, so the feed carried no domain even when discovery had proven one, leaving consumers with an association verdict they could not re-derive.

## Not in this PR

No mail is sent, no SMTP is opened, `auto_send` stays false. Warmbly owns delivery. The `CONFENGE-COMMERCIAL-READY-01` freeze gates are red here exactly as they are on `main` today: the freeze is bound to `0da81cce`, which stopped being an ancestor of `main` after the #447 squash. Rebinding must point at a commit that is on `main`, so it lands in the follow-up evidence PR.
