### PR TITLE
feat(dossier): compose the paid B2G diagnostic from canonical DataLake reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ OUTPUT_DIR  = output
 
 # ── Targets ──────────────────────────────────────────────────────────────────
 
+CNPJ ?=
+DOSSIER_OUT ?= artifacts/dossier/$(CNPJ)
+DOSSIER_FLAGS ?=
+
 .PHONY: help
 help:
 	@echo '╔══════════════════════════════════════════════════════════════╗'
@@ -108,6 +112,20 @@ extra-weekly:
 	@echo '    Entry point: python -m scripts.ops.weekly_cycle --strict'
 	@echo '    Open tenders: run_pncp_open_monitoring (aggregated) + SourceSnapshotReconciler'
 	python3 -m scripts.ops.weekly_cycle --strict $(WEEKLY_FLAGS)
+
+.PHONY: dossier
+dossier:
+	@echo '==> [$(ENV)] Dossie B2G (confenge-dossier/1.0) para um CNPJ'
+	@test -n "$(CNPJ)" || (echo '    ERRO: informe CNPJ=<14 digitos>'; exit 2)
+	@echo '    Saida: $(DOSSIER_OUT)'
+	python3 -m scripts.dossier build --cnpj $(CNPJ) --out $(DOSSIER_OUT) $(DOSSIER_FLAGS)
+	python3 -m scripts.dossier verify --dir $(DOSSIER_OUT)
+
+.PHONY: dossier-handoff
+dossier-handoff:
+	@echo '==> [$(ENV)] Publica a projecao desidentificada no rendezvous do web-cfg'
+	@echo '    Somente public-read.json atravessa. READY exige official_live + DATA_READY.'
+	python3 -m scripts.dossier handoff --dir $(DOSSIER_OUT)
 
 .PHONY: extra-daily-collect
 extra-daily-collect:

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.json
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.json
@@ -6,7 +6,7 @@
   "catalog_mode": "official_live",
   "cnpj14": "00820854000114",
   "consumer": "web-cfg/contract-analysis",
-  "content_hash": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+  "content_hash": "sha256:9be6bb57368066bfcbd72ba076a1a2c108e5e7ef4f837406baf6bd4f6650e48b",
   "contract_version": "v1.0.0",
   "data_state": "DATA_READY",
   "dossier_id": "cfg-dossier-cb06e7fa204654f7",
@@ -27,7 +27,189 @@
     },
     {
       "evidence_refs": [
-        "v_expiring_contracts:82909409000190-2-000293/2026"
+        "v_contracts_canonical_v2:82909409000190-2-000292/2026"
+      ],
+      "fact": "Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-06-11 (293 dias).",
+      "finding_id": "contract_ending_within_window:0726eccc674d",
+      "metrics": {
+        "dias_ate_fim": 293
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82909409000190-2-000292/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82909409000190-2-000291/2026"
+      ],
+      "fact": "Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-06-11 (293 dias).",
+      "finding_id": "contract_ending_within_window:09a7b9aa4852",
+      "metrics": {
+        "dias_ate_fim": 293
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82909409000190-2-000291/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82925025000160-2-000331/2026"
+      ],
+      "fact": "Contrato com PREFEITURA MUNICIPAL DE NOVA TRENTO encerra em 2027-07-01 (313 dias).",
+      "finding_id": "contract_ending_within_window:17bee316d2af",
+      "metrics": {
+        "dias_ate_fim": 313
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82925025000160-2-000331/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82836057000190-2-000898/2026"
+      ],
+      "fact": "Contrato com SECRETARIA DE INFRA-ESTRUTURA encerra em 2027-03-31 (221 dias).",
+      "finding_id": "contract_ending_within_window:315706216db5",
+      "metrics": {
+        "dias_ate_fim": 221
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82836057000190-2-000898/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:16780795000138-2-000187/2026"
+      ],
+      "fact": "Contrato com Prefeitura Municipal de Pescaria Brava - SC encerra em 2027-06-23 (305 dias).",
+      "finding_id": "contract_ending_within_window:3aa49368666e",
+      "metrics": {
+        "dias_ate_fim": 305
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "16780795000138-2-000187/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82951344000140-2-000031/2024"
+      ],
+      "fact": "Contrato com Secretaria de Estado da Infraestrutura e Mobilidade encerra em 2026-08-28 (6 dias).",
+      "finding_id": "contract_ending_within_window:4bc006524c6a",
+      "metrics": {
+        "dias_ate_fim": 6
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82951344000140-2-000031/2024"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82909409000190-2-000299/2026"
+      ],
+      "fact": "Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-06-13 (295 dias).",
+      "finding_id": "contract_ending_within_window:511f2ad8b949",
+      "metrics": {
+        "dias_ate_fim": 295
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82909409000190-2-000299/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82892365000132-2-000369/2026"
+      ],
+      "fact": "Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-06-22 (304 dias).",
+      "finding_id": "contract_ending_within_window:671e42f51480",
+      "metrics": {
+        "dias_ate_fim": 304
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82892365000132-2-000369/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82892316000108-2-000607/2026"
+      ],
+      "fact": "Contrato com Secretaria de Planejamento e Infraestrutura e Saneamento encerra em 2027-02-27 (189 dias).",
+      "finding_id": "contract_ending_within_window:74fef44cb121",
+      "metrics": {
+        "dias_ate_fim": 189
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82892316000108-2-000607/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82836818000103-2-000006/2026"
+      ],
+      "fact": "Contrato com MUNICÍPIO DE SÃO MARTINHO encerra em 2027-01-08 (139 dias).",
+      "finding_id": "contract_ending_within_window:826b0fc09ef0",
+      "metrics": {
+        "dias_ate_fim": 139
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82836818000103-2-000006/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:86051398000100-2-000460/2026"
+      ],
+      "fact": "Contrato com Gestão da Secretaria de Planejamento e Urbanismo encerra em 2026-10-08 (47 dias).",
+      "finding_id": "contract_ending_within_window:8fab51985c2d",
+      "metrics": {
+        "dias_ate_fim": 47
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "86051398000100-2-000460/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:83102368000198-2-000500/2026"
+      ],
+      "fact": "Contrato com Secretaria de Obras e Servicos Publicos do Município de Guabiruba encerra em 2027-06-29 (311 dias).",
+      "finding_id": "contract_ending_within_window:940a7da75c28",
+      "metrics": {
+        "dias_ate_fim": 311
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "83102368000198-2-000500/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82892316000108-2-001237/2025"
+      ],
+      "fact": "Contrato com Secretaria de Planejamento e Infraestrutura e Saneamento encerra em 2026-09-03 (12 dias).",
+      "finding_id": "contract_ending_within_window:9787ddf9a7b1",
+      "metrics": {
+        "dias_ate_fim": 12
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82892316000108-2-001237/2025"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:01612888000186-2-000604/2025"
+      ],
+      "fact": "Contrato com PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC encerra em 2026-12-16 (116 dias).",
+      "finding_id": "contract_ending_within_window:9c32c9916e66",
+      "metrics": {
+        "dias_ate_fim": 116
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "01612888000186-2-000604/2025"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82909409000190-2-000293/2026"
       ],
       "fact": "Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-02-15 (177 dias).",
       "finding_id": "contract_ending_within_window:a317a8ce982c",
@@ -40,7 +222,33 @@
     },
     {
       "evidence_refs": [
-        "v_expiring_contracts:82892365000132-2-000368/2026"
+        "v_contracts_canonical_v2:01612888000186-2-000420/2026"
+      ],
+      "fact": "Contrato com PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC encerra em 2027-08-20 (363 dias).",
+      "finding_id": "contract_ending_within_window:ae2c53a2b3ca",
+      "metrics": {
+        "dias_ate_fim": 363
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "01612888000186-2-000420/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82892365000132-2-000340/2026"
+      ],
+      "fact": "Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-06-11 (293 dias).",
+      "finding_id": "contract_ending_within_window:afce068ae564",
+      "metrics": {
+        "dias_ate_fim": 293
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82892365000132-2-000340/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82892365000132-2-000368/2026"
       ],
       "fact": "Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-01-23 (154 dias).",
       "finding_id": "contract_ending_within_window:c54e55bc03bc",
@@ -53,7 +261,20 @@
     },
     {
       "evidence_refs": [
-        "v_expiring_contracts:82572207000103-2-000207/2026"
+        "v_contracts_canonical_v2:83102459000123-2-002017/2026"
+      ],
+      "fact": "Contrato com Prefeitura Municipal de Jaraguá do Sul encerra em 2027-06-07 (289 dias).",
+      "finding_id": "contract_ending_within_window:dc76df9c42d2",
+      "metrics": {
+        "dias_ate_fim": 289
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "83102459000123-2-002017/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82572207000103-2-000207/2026"
       ],
       "fact": "Contrato com Unidade Única encerra em 2027-02-08 (170 dias).",
       "finding_id": "contract_ending_within_window:e0e356b8f1a0",
@@ -82,10 +303,10 @@
       "evidence_refs": [
         "v_contract_intel_percentis:OBRAS"
       ],
-      "fact": "Mediana dos contratos da empresa na categoria OBRAS: 2000216.58; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.",
+      "fact": "Mediana dos contratos da empresa na categoria OBRAS: 1691351.30; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.",
       "finding_id": "value_position_in_category:1223e04da9b7",
       "metrics": {
-        "focal_contract_count": 49,
+        "focal_contract_count": 32,
         "focal_position": "ABOVE_P75"
       },
       "question": "A posição observada corresponde ao porte de contrato que a empresa pretende disputar nesta categoria?",
@@ -125,7 +346,7 @@
   },
   "policy_version": "confenge-dossier-policy/1.0",
   "producer": "extra-cli",
-  "producer_sha": "cc9d4dae628f0879be7c2ccca94976d03bfc9e5d",
+  "producer_sha": "0eed54de0d3dc4647633277fe362acbf4d59e115",
   "reason_codes": [
     "focal_outside_panel_range",
     "no_open_opportunities_for_buyers"
@@ -350,8 +571,9 @@
           }
         ],
         "contract_count": 55,
+        "displayed_buyer_count": 21,
         "hhi": 0.4213,
-        "hhi_basis": "valued_contract_value",
+        "hhi_basis": "valued_contract_value_all_buyers",
         "valor_sum_valued": "524771038.63"
       },
       "reason_codes": [],
@@ -550,8 +772,63 @@
       "missingness": 0.0,
       "observed_at": "2026-08-22T03:00:00Z",
       "payload": {
-        "contract_count": 3,
+        "contract_count": 20,
         "contracts": [
+          {
+            "contrato_id": "82951344000140-2-000031/2024",
+            "data_fim": "2026-08-28",
+            "data_inicio": "2024-02-28",
+            "dias_ate_fim": 6,
+            "objeto": "EXECUÇÃO DO REMANESCENTE DO CONTRATO CT-014/2021, COM PROJETO REVISIONADO (CT-047/2021), PARA PRESTAÇÃO DE SERVIÇOS ESPECIALIZADOS DE ENGENHARIA PARA IMPLANTAÇÃO E PAVIMENTAÇÃO DA RODOVIA SC - 451 – TRECHO COMPREENDIDO ENTRE FREI ROGÉRIO ENTRONCAMENTO DA SC - 452, LOCALIDADE DE MACIEIRA PRÓXIMO A FRAIBURGO; COM EXTENSÃO APROXIMADA DE 17,58 KM",
+            "orgao_cnpj": "82951344000140",
+            "orgao_nome": "Secretaria de Estado da Infraestrutura e Mobilidade",
+            "uf": "SC",
+            "valor": "61421000.00"
+          },
+          {
+            "contrato_id": "82892316000108-2-001237/2025",
+            "data_fim": "2026-09-03",
+            "data_inicio": "2025-11-07",
+            "dias_ate_fim": 12,
+            "objeto": "Contratação de Empresa Especializada para Execução de Drenagem, Pavimentação Asfáltica e Sinalização Viária da Rua Aníbal Nunes Pires, localizada no Bairro Ponte do Imaruim, Palhoça/SC, incluindo fornecimento de material e mão de obra.",
+            "orgao_cnpj": "82892316000108",
+            "orgao_nome": "Secretaria de Planejamento e Infraestrutura e Saneamento",
+            "uf": "SC",
+            "valor": "1135500.00"
+          },
+          {
+            "contrato_id": "86051398000100-2-000460/2026",
+            "data_fim": "2026-10-08",
+            "data_inicio": "2026-04-08",
+            "dias_ate_fim": 47,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA FORNECIMENTO DE MATERIAIS, MÃO DE OBRA E DEMAIS OBRIGAÇÕES NECESSÁRIAS PARA PAVIMENTAÇÃO ASFÁLTICA DAS RUAS CONRADO LIEBL E JÚLIO SCHWETLER, CONFORME CONDIÇÕES, QUANTIDADES E EXIGÊNCIAS ESTABELECIDAS NESTE INSTRUMENTO. O PROCESSO ESTÁ ATRELADO E CONDICIONADO A FONTE DE RECURSO DE FINANCIAMENTO E RECURSO PRÓPRIO DA PREFEITURA DE SÃO BENTO DO SUL.",
+            "orgao_cnpj": "86051398000100",
+            "orgao_nome": "Gestão da Secretaria de Planejamento e Urbanismo",
+            "uf": "SC",
+            "valor": "2000216.58"
+          },
+          {
+            "contrato_id": "01612888000186-2-000604/2025",
+            "data_fim": "2026-12-16",
+            "data_inicio": "2025-12-16",
+            "dias_ate_fim": 116,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA EXECUÇÃO DE PAVIMENTAÇÃO ASFÁLTICA NA ESTRADA GERAL DO ARROIO FUNDO, ENTRE AS ESTACAS 1+300 A 2+985 E 0+000 A1+300, CONFORME CONDIÇÕES E EXIGÊNCIAS ESTABELECIDAS NESTE INSTRUMENTO.",
+            "orgao_cnpj": "01612888000186",
+            "orgao_nome": "PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC",
+            "uf": "SC",
+            "valor": "5559933.09"
+          },
+          {
+            "contrato_id": "82836818000103-2-000006/2026",
+            "data_fim": "2027-01-08",
+            "data_inicio": "2026-01-09",
+            "dias_ate_fim": 139,
+            "objeto": "\"CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA A EXECUÇÃO DA OBRA DE PAVIMENTAÇÃO ASFÁLTICA DE UM TRECHO DA ESTRADA MUNICIPAL PADRE EDUARDO KNOPP – SMO 021, ETAPA I, COM EXTENSÃO DE 2.077,74 METROS (ENTRE AS ESTACAS 0+0,000 E 103+17,741), VISANDO AO ATENDIMENTO DA PORTARIA CONJUNTA SGG/SEF Nº 56/2025 – PROCESSO Nº SCC 13574/2025 E DO PROGRAMA FEDERAL Nº 09032025, REFERENTE À EMENDA PARLAMENTAR Nº 202544010010.\"",
+            "orgao_cnpj": "82836818000103",
+            "orgao_nome": "MUNICÍPIO DE SÃO MARTINHO",
+            "uf": "SC",
+            "valor": "5260000.00"
+          },
           {
             "contrato_id": "82892365000132-2-000368/2026",
             "data_fim": "2027-01-23",
@@ -584,15 +861,147 @@
             "orgao_nome": "SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF",
             "uf": "SC",
             "valor": "1989000.00"
+          },
+          {
+            "contrato_id": "82892316000108-2-000607/2026",
+            "data_fim": "2027-02-27",
+            "data_inicio": "2026-06-02",
+            "dias_ate_fim": 189,
+            "objeto": "Contratação de empresa para execução da Execução da Repavimentação asfáltica e sinalização viária da Avenida das Universidades trecho existente entre a Avenida Pedra Branca e Rua dos Atobás, no Bairro: Pedra Branca, Palhoça/SC, incluindo fornecimento de material e mão de obra.",
+            "orgao_cnpj": "82892316000108",
+            "orgao_nome": "Secretaria de Planejamento e Infraestrutura e Saneamento",
+            "uf": "SC",
+            "valor": "1726508.82"
+          },
+          {
+            "contrato_id": "82836057000190-2-000898/2026",
+            "data_fim": "2027-03-31",
+            "data_inicio": "2026-06-10",
+            "dias_ate_fim": 221,
+            "objeto": "CONTRATAÇÃO DE EMPRESA PARA EXECUÇÃO DE OBRAS DE PAVIMENTAÇÃO DA ROD. GRP 030 E LEONILDO PEIRÃO NO MUNICÍPIO DE GAROPABA/SC.",
+            "orgao_cnpj": "82836057000190",
+            "orgao_nome": "SECRETARIA DE INFRA-ESTRUTURA",
+            "uf": "SC",
+            "valor": "8782202.60"
+          },
+          {
+            "contrato_id": "83102459000123-2-002017/2026",
+            "data_fim": "2027-06-07",
+            "data_inicio": "2026-06-12",
+            "dias_ate_fim": 289,
+            "objeto": "Contratação de pessoa jurídica para a prestação de serviços de engenharia, com fornecimento de materiais e mão de obra, destinados à pavimentação asfáltica, incluindo serviços preliminares, terraplenagem, drenagem pluvial, obras complementares e sinalização viária, na  Estrada Municipal JGS 473 – Sem Nome na localidade Sohnstiefe, com extensão total de 5.548,36 m (cinco mil e quinhentos e quarenta e oito metros e trinta e seis centímetros), em conformidade com o Anexo I – Termo de Referência,...",
+            "orgao_cnpj": "83102459000123",
+            "orgao_nome": "Prefeitura Municipal de Jaraguá do Sul",
+            "uf": "SC",
+            "valor": "6471769.77"
+          },
+          {
+            "contrato_id": "82892365000132-2-000340/2026",
+            "data_fim": "2027-06-11",
+            "data_inicio": "2026-06-11",
+            "dias_ate_fim": 293,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA PAVIMENTAÇÃO ASFÁLTICA DA ESTRADA GERAL DO ESPRAIADO - TRECHO 01 (ESTACA 00+00 - 15+00), COM O FORNECIMENTO DE TODO MATERIAL, EQUIPAMENTOS E MÃO DE OBRA, CONFORME PROJETOS E DEFINIÇÕES DO TERMO DE REFERÊNCIA, NO MUNICÍPIO DE PAULO LOPES/SC.",
+            "orgao_cnpj": "82892365000132",
+            "orgao_nome": "MUNICÍPIO DE PAULO LOPES",
+            "uf": "SC",
+            "valor": "498659.99"
+          },
+          {
+            "contrato_id": "82909409000190-2-000291/2026",
+            "data_fim": "2027-06-11",
+            "data_inicio": "2026-06-11",
+            "dias_ate_fim": 293,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA A EXECUÇÃO DE OBRAS DE INFRAESTRUTURA VIÁRIA URBANA NAS VIAS RUA AURORA SOUZA DE AVILA E RUA DA ESPERANÇA - T1 (RUA CECINA DE SOUZA), LOCALIZADAS NO MUNICÍPIO DE IMBITUBA/SC",
+            "orgao_cnpj": "82909409000190",
+            "orgao_nome": "SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF",
+            "uf": "SC",
+            "valor": "2225000.00"
+          },
+          {
+            "contrato_id": "82909409000190-2-000292/2026",
+            "data_fim": "2027-06-11",
+            "data_inicio": "2026-06-11",
+            "dias_ate_fim": 293,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA A EXECUÇÃO DE OBRAS DE INFRAESTRUTURA VIÁRIA URBANA NAS VIAS RUA AURORA SOUZA DE AVILA E RUA DA ESPERANÇA - T1 (RUA CECINA DE SOUZA), LOCALIZADAS NO MUNICÍPIO DE IMBITUBA/SC",
+            "orgao_cnpj": "82909409000190",
+            "orgao_nome": "SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF",
+            "uf": "SC",
+            "valor": "2115000.00"
+          },
+          {
+            "contrato_id": "82909409000190-2-000299/2026",
+            "data_fim": "2027-06-13",
+            "data_inicio": "2026-06-18",
+            "dias_ate_fim": 295,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA A EXECUÇÃO DE PAVIMENTAÇÃO ASFÁLTICA NA AVENIDA PORTO NOVO, LOCALIZADA NO BAIRRO IBIRAQUERA, NO MUNICÍPIO DE IMBITUBA/SC",
+            "orgao_cnpj": "82909409000190",
+            "orgao_nome": "SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF",
+            "uf": "SC",
+            "valor": "2822000.00"
+          },
+          {
+            "contrato_id": "82892365000132-2-000369/2026",
+            "data_fim": "2027-06-22",
+            "data_inicio": "2026-06-22",
+            "dias_ate_fim": 304,
+            "objeto": "O presente processo tem como objeto o REGISTRO DE PREÇOS PARA FUTURA E EVENTUAL Contratação de empresa especializada, no regime de empreitada por preço unitário (material + mão-de-obra), para execução de obra de PAVIMENTAÇÃO ASFÁLTICA (CBUQ), DRENAGEM E SINALIZAÇÃO VIÁRIA DAS RUAS WANEY COSTA PEREIRA E DANIEL ALFREDO PEREIRA - BAIRRO BOM RETIRO, de acordo com o memorial descritivo, planilha orçamentária e demais anexos do edital, conforme especificações constantes do projeto básico.",
+            "orgao_cnpj": "82892365000132",
+            "orgao_nome": "MUNICÍPIO DE PAULO LOPES",
+            "uf": "SC",
+            "valor": "696500.30"
+          },
+          {
+            "contrato_id": "16780795000138-2-000187/2026",
+            "data_fim": "2027-06-23",
+            "data_inicio": "2026-06-23",
+            "dias_ate_fim": 305,
+            "objeto": "Prestação de serviços de pavimentação asfáltica, drenagem fluvial e sinalização viária da Avenida Eliete de Souza – Trecho III, com área a pavimentar de 23.400,00m² e extensão de 3.600 metros, localizada no bairro Siqueiro, Município de Pescaria Brava, Estado de Santa Catarina.",
+            "orgao_cnpj": "16780795000138",
+            "orgao_nome": "Prefeitura Municipal de Pescaria Brava - SC",
+            "uf": "SC",
+            "valor": "4170879.89"
+          },
+          {
+            "contrato_id": "83102368000198-2-000500/2026",
+            "data_fim": "2027-06-29",
+            "data_inicio": "2026-06-29",
+            "dias_ate_fim": 311,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA EXECUÇÃO DE OBRA DE REVITALIZAÇÃO DA RUA LAGEADO BAIXO - META 1, NO MUNICÍPIO DE GUABIRUBA/SC, COMPREENDENDO SERVIÇOS DE REQUALIFICAÇÃO VIÁRIA COM EXTENSÃO DE 1.565,00 METROS, INCLUINDO DRENAGEM PLUVIAL, PAVIMENTAÇÃO ASFÁLTICA, EXECUÇÃO DE PASSEIOS E SINALIZAÇÃO VIÁRIA, CONFORME PROJETOS, MEMORIAIS DESCRITIVOS, PLANILHAS E DEMAIS ANEXOS, A SER REALIZADA COM RECURSOS PRÓPRIOS DO MUNICÍPIO.",
+            "orgao_cnpj": "83102368000198",
+            "orgao_nome": "Secretaria de Obras e Servicos Publicos do Município de Guabiruba",
+            "uf": "SC",
+            "valor": "4864017.50"
+          },
+          {
+            "contrato_id": "82925025000160-2-000331/2026",
+            "data_fim": "2027-07-01",
+            "data_inicio": "2026-07-01",
+            "dias_ate_fim": 313,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA NA PRESTAÇÃO DE SERVIÇOS PARA EXECUÇÃO DE PAVIMENTAÇÃO ASFÁLTICA DA ESTRADA MUNICIPAL GERAL DE SÃO VALENTIM, FORNECENDO ACESSO A LOCALIDADE DE LAGEADO, INTEGRANDO A COMUNIDADE A REGIÃO CENTRAL DE NOVA TRENTO, COM EXTENSÃO TOTAL DO TRECHO DE 7,6 KM – TRECHO 01 PROGRAMA ESTRADA BOA RURAL.",
+            "orgao_cnpj": "82925025000160",
+            "orgao_nome": "PREFEITURA MUNICIPAL DE NOVA TRENTO",
+            "uf": "SC",
+            "valor": "6946916.97"
+          },
+          {
+            "contrato_id": "01612888000186-2-000420/2026",
+            "data_fim": "2027-08-20",
+            "data_inicio": "2026-08-20",
+            "dias_ate_fim": 363,
+            "objeto": "CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA EXECUÇÃO DE SERVIÇOS DE PAVIMENTAÇÃO ASFÁLTICA COM CBUQ, NA ESTRADA GERAL DA LOCALIDADE DE LAGOA DO SUL, MUNICÍPIO DE BELA VISTA DO TOLDO/SC, CONFORME ESPECIFICAÇÕES, PROJETO EXECUTIVO E PLANILHA ORÇAMENTÁRIA INTEGRANTES DO PROGRAMA ESTRADA BOA RURAL.",
+            "orgao_cnpj": "01612888000186",
+            "orgao_nome": "PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC",
+            "uf": "SC",
+            "valor": "8508186.00"
           }
         ],
         "window_days": 365
       },
       "reason_codes": [],
-      "row_count": 3,
+      "row_count": 20,
       "section_id": "expiring_contracts",
       "sources": [
-        "v_expiring_contracts"
+        "v_contracts_canonical_v2"
       ],
       "state": "DATA_READY"
     },
@@ -641,11 +1050,13 @@
       "payload": {
         "categories": [
           {
+            "bucket_precision": "NORMAL",
             "categoria": "FACILITIES",
-            "focal_contract_count": 6,
-            "focal_median": "44051804.43",
+            "focal_contract_count": 5,
+            "focal_contract_count_all": 6,
+            "focal_median": "20003608.86",
             "focal_position": "OUT_OF_PANEL_RANGE",
-            "focal_valued_count": 6,
+            "focal_valued_count": 5,
             "reference_contract_count": 35050,
             "reference_p25": "206.40",
             "reference_p50": "1189.69",
@@ -653,11 +1064,13 @@
             "reference_ticket_medio": "13871430.11"
           },
           {
+            "bucket_precision": "NORMAL",
             "categoria": "OBRAS",
-            "focal_contract_count": 49,
-            "focal_median": "2000216.58",
+            "focal_contract_count": 32,
+            "focal_contract_count_all": 49,
+            "focal_median": "1691351.30",
             "focal_position": "ABOVE_P75",
-            "focal_valued_count": 49,
+            "focal_valued_count": 32,
             "reference_contract_count": 18892,
             "reference_p25": "25256.39",
             "reference_p50": "189000.00",
@@ -667,6 +1080,9 @@
         ],
         "category_count": 2,
         "comparable_category_count": 1,
+        "low_precision_categories": [
+          "TI"
+        ],
         "out_of_range_category_count": 1,
         "out_of_range_factor": 10,
         "reference_scope": "contratos de órgãos públicos do conjunto de referência no raio de 200 km; não é amostra nacional",
@@ -686,7 +1102,7 @@
   },
   "totals": {
     "contract_count": 55,
-    "finding_count": 7,
+    "finding_count": 24,
     "section_count": 6
   }
 }

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.json
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.json
@@ -1,0 +1,692 @@
+{
+  "accepted_schemas": [
+    "confenge-dossier/1.0"
+  ],
+  "as_of": "2026-08-22",
+  "catalog_mode": "official_live",
+  "cnpj14": "00820854000114",
+  "consumer": "web-cfg/contract-analysis",
+  "content_hash": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+  "contract_version": "v1.0.0",
+  "data_state": "DATA_READY",
+  "dossier_id": "cfg-dossier-cb06e7fa204654f7",
+  "findings": [
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:82951344000140-2-000031/2024"
+      ],
+      "fact": "Contrato com data de início 2024-02-28 e 29 meses decorridos até 2026-08-22; data de fim registrada: 2026-08-28.",
+      "finding_id": "contract_anniversary_reached:dcb02083c283",
+      "metrics": {
+        "data_inicio": "2024-02-28",
+        "months_since_start": 29
+      },
+      "question": "Houve repactuação ou reajuste contratual registrado a cada aniversário deste contrato, conforme a cláusula econômica pactuada?",
+      "severity": "INFORMATIONAL",
+      "subject": "82951344000140-2-000031/2024"
+    },
+    {
+      "evidence_refs": [
+        "v_expiring_contracts:82909409000190-2-000293/2026"
+      ],
+      "fact": "Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-02-15 (177 dias).",
+      "finding_id": "contract_ending_within_window:a317a8ce982c",
+      "metrics": {
+        "dias_ate_fim": 177
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82909409000190-2-000293/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_expiring_contracts:82892365000132-2-000368/2026"
+      ],
+      "fact": "Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-01-23 (154 dias).",
+      "finding_id": "contract_ending_within_window:c54e55bc03bc",
+      "metrics": {
+        "dias_ate_fim": 154
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82892365000132-2-000368/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_expiring_contracts:82572207000103-2-000207/2026"
+      ],
+      "fact": "Contrato com Unidade Única encerra em 2027-02-08 (170 dias).",
+      "finding_id": "contract_ending_within_window:e0e356b8f1a0",
+      "metrics": {
+        "dias_ate_fim": 170
+      },
+      "question": "Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+      "severity": "ATTENTION",
+      "subject": "82572207000103-2-000207/2026"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:hhi"
+      ],
+      "fact": "HHI de 0.4213 sobre o valor contratado conhecido, distribuído entre 21 compradores; maior comprador: MUNICÍPIO DE PAULO LOPES.",
+      "finding_id": "buyer_concentration_high:6cb105d98bfb",
+      "metrics": {
+        "hhi": 0.4213,
+        "threshold": 0.25
+      },
+      "question": "A carteira depende de poucos compradores em grau que a diretoria aceita?",
+      "severity": "INFORMATIONAL",
+      "subject": "carteira"
+    },
+    {
+      "evidence_refs": [
+        "v_contract_intel_percentis:OBRAS"
+      ],
+      "fact": "Mediana dos contratos da empresa na categoria OBRAS: 2000216.58; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.",
+      "finding_id": "value_position_in_category:1223e04da9b7",
+      "metrics": {
+        "focal_contract_count": 49,
+        "focal_position": "ABOVE_P75"
+      },
+      "question": "A posição observada corresponde ao porte de contrato que a empresa pretende disputar nesta categoria?",
+      "severity": "INFORMATIONAL",
+      "subject": "OBRAS"
+    },
+    {
+      "evidence_refs": [
+        "v_contracts_canonical_v2:76669324000189-2-000019/2026"
+      ],
+      "fact": "Contrato com data de fim 2029-07-27, além da janela de 365 dias considerada neste dossiê.",
+      "finding_id": "contract_horizon_beyond_window:5a7fc5a53d00",
+      "metrics": {
+        "days_to_end": 1070
+      },
+      "question": "O planejamento de execução cobre o horizonte total do contrato?",
+      "severity": "INFORMATIONAL",
+      "subject": "76669324000189-2-000019/2026"
+    }
+  ],
+  "grain": "cnpj14",
+  "limitations": [
+    "Campo ausente permanece UNKNOWN e não entra no denominador. UNKNOWN não é zero.",
+    "Os achados são fatos observados mais a pergunta que abrem. O dossiê não afirma direito, desequilíbrio econômico-financeiro, dano ou que um reajuste seja devido.",
+    "Contratos refletem o estado canônico do DataLake na data de observação; aditivos posteriores à última coleta podem não estar refletidos.",
+    "O painel de preços usa o conjunto de referência de órgãos públicos no raio de 200 km da base de referência; não é uma amostra nacional."
+  ],
+  "method_version": "confenge-dossier-compose/1.0",
+  "observed_at": "2026-08-22T03:00:00Z",
+  "offer": {
+    "catalog": "CFG-OFFER-CATALOG-v1",
+    "offer_id": "CFG-DIAG-EXP-v1"
+  },
+  "parameters": {
+    "competitor_limit": 15,
+    "expiring_window_days": 365
+  },
+  "policy_version": "confenge-dossier-policy/1.0",
+  "producer": "extra-cli",
+  "producer_sha": "cc9d4dae628f0879be7c2ccca94976d03bfc9e5d",
+  "reason_codes": [
+    "focal_outside_panel_range",
+    "no_open_opportunities_for_buyers"
+  ],
+  "schema": "confenge-dossier/1.0",
+  "sections": {
+    "buyer_map": {
+      "missingness": 0.0,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "buyer_count": 21,
+        "buyers": [
+          {
+            "buyer_cnpj": "82892365000132",
+            "buyer_nome": "MUNICÍPIO DE PAULO LOPES",
+            "contract_count": 12,
+            "last_data_fim": "2027-06-22",
+            "share_of_valued": 0.0257,
+            "uf": "SC",
+            "valor_sum": "13487767.87",
+            "valued_count": 12
+          },
+          {
+            "buyer_cnpj": "82951344000140",
+            "buyer_nome": "Secretaria de Estado da Infraestrutura e Mobilidade",
+            "contract_count": 7,
+            "last_data_fim": "2026-08-28",
+            "share_of_valued": 0.6326,
+            "uf": "SC",
+            "valor_sum": "331944483.09",
+            "valued_count": 7
+          },
+          {
+            "buyer_cnpj": "82892316000108",
+            "buyer_nome": "Secretaria de Planejamento e Infraestrutura e Saneamento",
+            "contract_count": 6,
+            "last_data_fim": "2027-02-27",
+            "share_of_valued": 0.0236,
+            "uf": "SC",
+            "valor_sum": "12388401.07",
+            "valued_count": 6
+          },
+          {
+            "buyer_cnpj": "82909409000190",
+            "buyer_nome": "Prefeitura Municipal de Imbituba/SC",
+            "contract_count": 5,
+            "last_data_fim": "2027-06-13",
+            "share_of_valued": 0.0177,
+            "uf": "SC",
+            "valor_sum": "9275528.98",
+            "valued_count": 5
+          },
+          {
+            "buyer_cnpj": "82836057000190",
+            "buyer_nome": "SECRETARIA DE INFRA-ESTRUTURA",
+            "contract_count": 3,
+            "last_data_fim": "2027-03-31",
+            "share_of_valued": 0.0278,
+            "uf": "SC",
+            "valor_sum": "14612590.81",
+            "valued_count": 3
+          },
+          {
+            "buyer_cnpj": "82925652000100",
+            "buyer_nome": "PREFEITURA MUNICIPAL DE SÃO JOÃO BATISTA",
+            "contract_count": 3,
+            "last_data_fim": "2025-07-23",
+            "share_of_valued": 0.0117,
+            "uf": "SC",
+            "valor_sum": "6129814.57",
+            "valued_count": 3
+          },
+          {
+            "buyer_cnpj": "01612888000186",
+            "buyer_nome": "PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC",
+            "contract_count": 2,
+            "last_data_fim": "2027-08-20",
+            "share_of_valued": 0.0268,
+            "uf": "SC",
+            "valor_sum": "14068119.09",
+            "valued_count": 2
+          },
+          {
+            "buyer_cnpj": "82928656000133",
+            "buyer_nome": "MUNICÍPIO DE TUBARÃO",
+            "contract_count": 2,
+            "last_data_fim": "2025-03-23",
+            "share_of_valued": 0.0096,
+            "uf": "SC",
+            "valor_sum": "5049351.01",
+            "valued_count": 2
+          },
+          {
+            "buyer_cnpj": "16780795000138",
+            "buyer_nome": "Prefeitura Municipal de Pescaria Brava - SC",
+            "contract_count": 2,
+            "last_data_fim": "2027-06-23",
+            "share_of_valued": 0.0094,
+            "uf": "SC",
+            "valor_sum": "4948357.41",
+            "valued_count": 2
+          },
+          {
+            "buyer_cnpj": "82928706000182",
+            "buyer_nome": "MUNICÍPIO DE LAGUNA",
+            "contract_count": 2,
+            "last_data_fim": "2025-11-09",
+            "share_of_valued": 0.0012,
+            "uf": "SC",
+            "valor_sum": "641300.00",
+            "valued_count": 2
+          },
+          {
+            "buyer_cnpj": "76669324000189",
+            "buyer_nome": "DER - Departamento de Estradas de Rodagem do Estado do Paraná",
+            "contract_count": 1,
+            "last_data_fim": "2029-07-27",
+            "share_of_valued": 0.1298,
+            "uf": "PR",
+            "valor_sum": "68100000.00",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "82572207000103",
+            "buyer_nome": "Unidade Única",
+            "contract_count": 1,
+            "last_data_fim": "2027-02-08",
+            "share_of_valued": 0.0187,
+            "uf": "SC",
+            "valor_sum": "9819294.06",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "82925025000160",
+            "buyer_nome": "PREFEITURA MUNICIPAL DE NOVA TRENTO",
+            "contract_count": 1,
+            "last_data_fim": "2027-07-01",
+            "share_of_valued": 0.0132,
+            "uf": "SC",
+            "valor_sum": "6946916.97",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "83102459000123",
+            "buyer_nome": "Prefeitura Municipal de Jaraguá do Sul",
+            "contract_count": 1,
+            "last_data_fim": "2027-06-07",
+            "share_of_valued": 0.0123,
+            "uf": "SC",
+            "valor_sum": "6471769.77",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "82836818000103",
+            "buyer_nome": "MUNICÍPIO DE SÃO MARTINHO",
+            "contract_count": 1,
+            "last_data_fim": "2027-01-08",
+            "share_of_valued": 0.01,
+            "uf": "SC",
+            "valor_sum": "5260000.00",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "83102368000198",
+            "buyer_nome": "Secretaria de Obras e Servicos Publicos do Município de Guabiruba",
+            "contract_count": 1,
+            "last_data_fim": "2027-06-29",
+            "share_of_valued": 0.0093,
+            "uf": "SC",
+            "valor_sum": "4864017.50",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "82892357000196",
+            "buyer_nome": "PREFEITURA MUNICIPAL DE RANCHO QUEIMADO",
+            "contract_count": 1,
+            "last_data_fim": "2025-07-05",
+            "share_of_valued": 0.0051,
+            "uf": "SC",
+            "valor_sum": "2670700.00",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "82926585000130",
+            "buyer_nome": "MUNICÍPIO DE RIO FORTUNA",
+            "contract_count": 1,
+            "last_data_fim": "2026-08-15",
+            "share_of_valued": 0.0043,
+            "uf": "SC",
+            "valor_sum": "2267000.00",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "83102673000180",
+            "buyer_nome": "Prefeitura Municipal de Petrolândia",
+            "contract_count": 1,
+            "last_data_fim": "2024-12-21",
+            "share_of_valued": 0.004,
+            "uf": "SC",
+            "valor_sum": "2117593.37",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "86051398000100",
+            "buyer_nome": "Gestão da Secretaria de Planejamento e Urbanismo",
+            "contract_count": 1,
+            "last_data_fim": "2026-10-08",
+            "share_of_valued": 0.0038,
+            "uf": "SC",
+            "valor_sum": "2000216.58",
+            "valued_count": 1
+          },
+          {
+            "buyer_cnpj": "82575812000120",
+            "buyer_nome": "SECRETARIA MUNICIPAL DE OBRAS E INFRAESTRUTURA URBANA",
+            "contract_count": 1,
+            "last_data_fim": "2025-03-18",
+            "share_of_valued": 0.0033,
+            "uf": "SC",
+            "valor_sum": "1707816.48",
+            "valued_count": 1
+          }
+        ],
+        "contract_count": 55,
+        "hhi": 0.4213,
+        "hhi_basis": "valued_contract_value",
+        "valor_sum_valued": "524771038.63"
+      },
+      "reason_codes": [],
+      "row_count": 21,
+      "section_id": "buyer_map",
+      "sources": [
+        "v_contracts_canonical_v2"
+      ],
+      "state": "DATA_READY"
+    },
+    "competitors": {
+      "missingness": 0.0,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "competitor_count": 15,
+        "competitors": [
+          {
+            "contract_count": 23,
+            "shared_buyer_count": 16,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "27284516000161",
+            "supplier_nome": "MAXIFROTA SERVICOS DE MANUTENCAO DE FROTA LTDA",
+            "valor_sum": "42290311.32",
+            "valued_count": 23
+          },
+          {
+            "contract_count": 21,
+            "shared_buyer_count": 5,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "01650178000140",
+            "supplier_nome": "C R ARTEFATOS DE CIMENTO LTDA",
+            "valor_sum": "18869230.55",
+            "valued_count": 21
+          },
+          {
+            "contract_count": 13,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "12218083000179",
+            "supplier_nome": "BCL EMPREENDIMENTOS LTDA",
+            "valor_sum": "12398841.49",
+            "valued_count": 13
+          },
+          {
+            "contract_count": 8,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "12703642000136",
+            "supplier_nome": "JA CONSTRUTORA E ADMINISTRADORA DE OBRAS LTDA",
+            "valor_sum": "7237287.24",
+            "valued_count": 8
+          },
+          {
+            "contract_count": 8,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "07258202000187",
+            "supplier_nome": "ANDRADE & AMORIM PAVIMENTACAO E DRENAGEM EIRELI",
+            "valor_sum": "4715758.16",
+            "valued_count": 8
+          },
+          {
+            "contract_count": 6,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "27743102000153",
+            "supplier_nome": "FJ CONSTRUTORA",
+            "valor_sum": "15701517.49",
+            "valued_count": 6
+          },
+          {
+            "contract_count": 9,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "22853624000194",
+            "supplier_nome": "ANDRADE & AMORIM ENGENHARIA EIRELI",
+            "valor_sum": "13340740.12",
+            "valued_count": 9
+          },
+          {
+            "contract_count": 6,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "36394573000194",
+            "supplier_nome": "SANTA CRUZ CONSTRUTORA LTDA",
+            "valor_sum": "4033282.29",
+            "valued_count": 6
+          },
+          {
+            "contract_count": 5,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "05895635000118",
+            "supplier_nome": "JR CONSTRUÇÕES E TERRAPLANAGEM LTDA EPP",
+            "valor_sum": "11021655.24",
+            "valued_count": 5
+          },
+          {
+            "contract_count": 5,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "27118194000180",
+            "supplier_nome": "AF CONSTRUCOES E PAVIMENTACAO LTDA",
+            "valor_sum": "2478000.00",
+            "valued_count": 5
+          },
+          {
+            "contract_count": 5,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "10433690000126",
+            "supplier_nome": "ANDRADE & AMORIM EXTRACAO MINERAL LTDA",
+            "valor_sum": "1427818.50",
+            "valued_count": 5
+          },
+          {
+            "contract_count": 4,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "31281510000108",
+            "supplier_nome": "PRO ENG ENGENHARIA E CONSTRUTORA LTDA",
+            "valor_sum": "4271300.00",
+            "valued_count": 4
+          },
+          {
+            "contract_count": 3,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "07256305000108",
+            "supplier_nome": "CONSTRUTORA WDD LTDA",
+            "valor_sum": "4590121.80",
+            "valued_count": 3
+          },
+          {
+            "contract_count": 3,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "42279461000195",
+            "supplier_nome": "JS ASFALTO LTDA",
+            "valor_sum": "1222407.62",
+            "valued_count": 3
+          },
+          {
+            "contract_count": 3,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "66582784000111",
+            "supplier_nome": "MAPDATA TECNOLOGIA, INFORMATICA E COMERCIO LTDA",
+            "valor_sum": "172924.66",
+            "valued_count": 3
+          }
+        ],
+        "primary_category": "OBRAS",
+        "requested_limit": 15,
+        "selection_rule": "fornecedores com contratos junto aos mesmos compradores e na categoria principal de contratos da própria empresa"
+      },
+      "reason_codes": [],
+      "row_count": 15,
+      "section_id": "competitors",
+      "sources": [
+        "v_contracts_canonical_v2"
+      ],
+      "state": "DATA_READY"
+    },
+    "expiring_contracts": {
+      "missingness": 0.0,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "contract_count": 3,
+        "contracts": [
+          {
+            "contrato_id": "82892365000132-2-000368/2026",
+            "data_fim": "2027-01-23",
+            "data_inicio": "2026-01-23",
+            "dias_ate_fim": 154,
+            "objeto": "O presente processo tem como objeto o REGISTRO DE PREÇOS PARA FUTURA E EVENTUAL Contratação de empresa especializada, no regime de empreitada por preço unitário (material + mão-de-obra), para execução de obra de PAVIMENTAÇÃO ASFÁLTICA (CBUQ), DRENAGEM E SINALIZAÇÃO VIÁRIA DAS RUAS WANEY COSTA PEREIRA E DANIEL ALFREDO PEREIRA - BAIRRO BOM RETIRO, de acordo com o memorial descritivo, planilha orçamentária e demais anexos do edital, conforme especificações constantes do projeto básico.",
+            "orgao_cnpj": "82892365000132",
+            "orgao_nome": "MUNICÍPIO DE PAULO LOPES",
+            "uf": "SC",
+            "valor": "5940003.00"
+          },
+          {
+            "contrato_id": "82572207000103-2-000207/2026",
+            "data_fim": "2027-02-08",
+            "data_inicio": "2026-04-09",
+            "dias_ate_fim": 170,
+            "objeto": "Contratação de empresa especializada para a execução de obra de pavimentação da Rodovia SC-102, trecho de ligação entre os Municípios de Camboriú e Itapema, na Estrada Geral do Encano, compreendido entre o Km 5+834,39 e o Km 7+582,79, totalizando uma extensão de 1.748,40 metros, incluindo o fornecimento de todos os materiais, equipamentos e mão de obra necessários, conforme projetos, planilha orçamentária e cronograma físico-financeiro que integram o presente Edital.",
+            "orgao_cnpj": "82572207000103",
+            "orgao_nome": "Unidade Única",
+            "uf": "SC",
+            "valor": "9819294.06"
+          },
+          {
+            "contrato_id": "82909409000190-2-000293/2026",
+            "data_fim": "2027-02-15",
+            "data_inicio": "2026-06-15",
+            "dias_ate_fim": 177,
+            "objeto": "contratação tem por objeto a seleção de empresa especializada para a execução de obras de infraestrutura viária urbana na Avenida Paraíso da Luz, localizada no Município de Imbituba/SC",
+            "orgao_cnpj": "82909409000190",
+            "orgao_nome": "SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF",
+            "uf": "SC",
+            "valor": "1989000.00"
+          }
+        ],
+        "window_days": 365
+      },
+      "reason_codes": [],
+      "row_count": 3,
+      "section_id": "expiring_contracts",
+      "sources": [
+        "v_expiring_contracts"
+      ],
+      "state": "DATA_READY"
+    },
+    "identity": {
+      "missingness": null,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "cnae_principal": "7112000",
+        "cnpj14": "00820854000114",
+        "municipio": "PALHOCA",
+        "nome_fantasia": "UNKNOWN",
+        "razao_social": "QUALIDADE MINERACAO LTDA",
+        "registry_source": "rfb_public_cadastral_via_opencnpj",
+        "registry_source_date": "2026-07-29",
+        "situacao_cadastral": "Ativa",
+        "uf": "SC"
+      },
+      "reason_codes": [],
+      "row_count": 1,
+      "section_id": "identity",
+      "sources": [
+        "supplier_registry"
+      ],
+      "state": "DATA_READY"
+    },
+    "open_opportunities": {
+      "missingness": null,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "opportunities": [],
+        "opportunity_count": 0
+      },
+      "reason_codes": [
+        "no_open_opportunities_for_buyers"
+      ],
+      "row_count": 0,
+      "section_id": "open_opportunities",
+      "sources": [
+        "v_open_opportunities_canonical"
+      ],
+      "state": "DATA_HOLD"
+    },
+    "price_panel": {
+      "missingness": null,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "categories": [
+          {
+            "categoria": "FACILITIES",
+            "focal_contract_count": 6,
+            "focal_median": "44051804.43",
+            "focal_position": "OUT_OF_PANEL_RANGE",
+            "focal_valued_count": 6,
+            "reference_contract_count": 35050,
+            "reference_p25": "206.40",
+            "reference_p50": "1189.69",
+            "reference_p75": "20548.49",
+            "reference_ticket_medio": "13871430.11"
+          },
+          {
+            "categoria": "OBRAS",
+            "focal_contract_count": 49,
+            "focal_median": "2000216.58",
+            "focal_position": "ABOVE_P75",
+            "focal_valued_count": 49,
+            "reference_contract_count": 18892,
+            "reference_p25": "25256.39",
+            "reference_p50": "189000.00",
+            "reference_p75": "910202.98",
+            "reference_ticket_medio": "33585770.07"
+          }
+        ],
+        "category_count": 2,
+        "comparable_category_count": 1,
+        "out_of_range_category_count": 1,
+        "out_of_range_factor": 10,
+        "reference_scope": "contratos de órgãos públicos do conjunto de referência no raio de 200 km; não é amostra nacional",
+        "unit": "BRL_TOTAL",
+        "value_semantic": "valor_integral_nominal"
+      },
+      "reason_codes": [
+        "focal_outside_panel_range"
+      ],
+      "row_count": 2,
+      "section_id": "price_panel",
+      "sources": [
+        "v_contract_intel_percentis"
+      ],
+      "state": "DATA_READY"
+    }
+  },
+  "totals": {
+    "contract_count": 55,
+    "finding_count": 7,
+    "section_count": 6
+  }
+}

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.md
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.md
@@ -6,8 +6,8 @@
 - Estado dos dados: `DATA_READY` (pronto)
 - Data de referência: `2026-08-22`
 - Observado em: `2026-08-22T03:00:00Z`
-- Hash de conteúdo: `sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310`
-- Produtor: `extra-cli` @ `cc9d4dae628f0879be7c2ccca94976d03bfc9e5d`
+- Hash de conteúdo: `sha256:9be6bb57368066bfcbd72ba076a1a2c108e5e7ef4f837406baf6bd4f6650e48b`
+- Produtor: `extra-cli` @ `0eed54de0d3dc4647633277fe362acbf4d59e115`
 
 ## 1. Identificação
 
@@ -92,18 +92,35 @@ Escopo da referência: contratos de órgãos públicos do conjunto de referênci
 
 | Categoria | Contratos da empresa | Mediana da empresa | p25 painel | p50 painel | p75 painel | Posição |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| FACILITIES | 6 | R$ 44.051.804,43 | R$ 206,40 | R$ 1.189,69 | R$ 20.548,49 | fora da faixa do painel — sem posição percentílica |
-| OBRAS | 49 | R$ 2.000.216,58 | R$ 25.256,39 | R$ 189.000,00 | R$ 910.202,98 | acima do p75 do painel |
+| FACILITIES | 5 | R$ 20.003.608,86 | R$ 206,40 | R$ 1.189,69 | R$ 20.548,49 | fora da faixa do painel — sem posição percentílica |
+| OBRAS | 32 | R$ 1.691.351,30 | R$ 25.256,39 | R$ 189.000,00 | R$ 910.202,98 | acima do p75 do painel |
 
 ## 5. Contratos a vencer em até 365 dias
 
-*Estado da seção: pronto (`DATA_READY`), 3 registros.*
+*Estado da seção: pronto (`DATA_READY`), 20 registros.*
 
 | Contrato | Órgão | Fim | Dias | Valor |
 | --- | --- | --- | ---: | ---: |
+| `82951344000140-2-000031/2024` | Secretaria de Estado da Infraestrutura e Mobilidade | 2026-08-28 | 6 | R$ 61.421.000,00 |
+| `82892316000108-2-001237/2025` | Secretaria de Planejamento e Infraestrutura e Saneamento | 2026-09-03 | 12 | R$ 1.135.500,00 |
+| `86051398000100-2-000460/2026` | Gestão da Secretaria de Planejamento e Urbanismo | 2026-10-08 | 47 | R$ 2.000.216,58 |
+| `01612888000186-2-000604/2025` | PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC | 2026-12-16 | 116 | R$ 5.559.933,09 |
+| `82836818000103-2-000006/2026` | MUNICÍPIO DE SÃO MARTINHO | 2027-01-08 | 139 | R$ 5.260.000,00 |
 | `82892365000132-2-000368/2026` | MUNICÍPIO DE PAULO LOPES | 2027-01-23 | 154 | R$ 5.940.003,00 |
 | `82572207000103-2-000207/2026` | Unidade Única | 2027-02-08 | 170 | R$ 9.819.294,06 |
 | `82909409000190-2-000293/2026` | SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF | 2027-02-15 | 177 | R$ 1.989.000,00 |
+| `82892316000108-2-000607/2026` | Secretaria de Planejamento e Infraestrutura e Saneamento | 2027-02-27 | 189 | R$ 1.726.508,82 |
+| `82836057000190-2-000898/2026` | SECRETARIA DE INFRA-ESTRUTURA | 2027-03-31 | 221 | R$ 8.782.202,60 |
+| `83102459000123-2-002017/2026` | Prefeitura Municipal de Jaraguá do Sul | 2027-06-07 | 289 | R$ 6.471.769,77 |
+| `82892365000132-2-000340/2026` | MUNICÍPIO DE PAULO LOPES | 2027-06-11 | 293 | R$ 498.659,99 |
+| `82909409000190-2-000291/2026` | SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF | 2027-06-11 | 293 | R$ 2.225.000,00 |
+| `82909409000190-2-000292/2026` | SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF | 2027-06-11 | 293 | R$ 2.115.000,00 |
+| `82909409000190-2-000299/2026` | SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF | 2027-06-13 | 295 | R$ 2.822.000,00 |
+| `82892365000132-2-000369/2026` | MUNICÍPIO DE PAULO LOPES | 2027-06-22 | 304 | R$ 696.500,30 |
+| `16780795000138-2-000187/2026` | Prefeitura Municipal de Pescaria Brava - SC | 2027-06-23 | 305 | R$ 4.170.879,89 |
+| `83102368000198-2-000500/2026` | Secretaria de Obras e Servicos Publicos do Município de Guabiruba | 2027-06-29 | 311 | R$ 4.864.017,50 |
+| `82925025000160-2-000331/2026` | PREFEITURA MUNICIPAL DE NOVA TRENTO | 2027-07-01 | 313 | R$ 6.946.916,97 |
+| `01612888000186-2-000420/2026` | PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC | 2027-08-20 | 363 | R$ 8.508.186,00 |
 
 ## 6. Editais abertos de compradores já conhecidos
 
@@ -122,25 +139,144 @@ Cada achado é um fato observado mais a pergunta que ele abre. Nenhum achado afi
 - Evidência: v_contracts_canonical_v2:82951344000140-2-000031/2024
 - Severidade: `INFORMATIONAL`
 
+### `contract_ending_within_window:0726eccc674d` — 82909409000190-2-000292/2026
+
+- Fato: Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-06-11 (293 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82909409000190-2-000292/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:09a7b9aa4852` — 82909409000190-2-000291/2026
+
+- Fato: Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-06-11 (293 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82909409000190-2-000291/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:17bee316d2af` — 82925025000160-2-000331/2026
+
+- Fato: Contrato com PREFEITURA MUNICIPAL DE NOVA TRENTO encerra em 2027-07-01 (313 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82925025000160-2-000331/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:315706216db5` — 82836057000190-2-000898/2026
+
+- Fato: Contrato com SECRETARIA DE INFRA-ESTRUTURA encerra em 2027-03-31 (221 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82836057000190-2-000898/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:3aa49368666e` — 16780795000138-2-000187/2026
+
+- Fato: Contrato com Prefeitura Municipal de Pescaria Brava - SC encerra em 2027-06-23 (305 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:16780795000138-2-000187/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:4bc006524c6a` — 82951344000140-2-000031/2024
+
+- Fato: Contrato com Secretaria de Estado da Infraestrutura e Mobilidade encerra em 2026-08-28 (6 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82951344000140-2-000031/2024
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:511f2ad8b949` — 82909409000190-2-000299/2026
+
+- Fato: Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-06-13 (295 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82909409000190-2-000299/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:671e42f51480` — 82892365000132-2-000369/2026
+
+- Fato: Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-06-22 (304 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82892365000132-2-000369/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:74fef44cb121` — 82892316000108-2-000607/2026
+
+- Fato: Contrato com Secretaria de Planejamento e Infraestrutura e Saneamento encerra em 2027-02-27 (189 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82892316000108-2-000607/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:826b0fc09ef0` — 82836818000103-2-000006/2026
+
+- Fato: Contrato com MUNICÍPIO DE SÃO MARTINHO encerra em 2027-01-08 (139 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82836818000103-2-000006/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:8fab51985c2d` — 86051398000100-2-000460/2026
+
+- Fato: Contrato com Gestão da Secretaria de Planejamento e Urbanismo encerra em 2026-10-08 (47 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:86051398000100-2-000460/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:940a7da75c28` — 83102368000198-2-000500/2026
+
+- Fato: Contrato com Secretaria de Obras e Servicos Publicos do Município de Guabiruba encerra em 2027-06-29 (311 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:83102368000198-2-000500/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:9787ddf9a7b1` — 82892316000108-2-001237/2025
+
+- Fato: Contrato com Secretaria de Planejamento e Infraestrutura e Saneamento encerra em 2026-09-03 (12 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82892316000108-2-001237/2025
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:9c32c9916e66` — 01612888000186-2-000604/2025
+
+- Fato: Contrato com PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC encerra em 2026-12-16 (116 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:01612888000186-2-000604/2025
+- Severidade: `ATTENTION`
+
 ### `contract_ending_within_window:a317a8ce982c` — 82909409000190-2-000293/2026
 
 - Fato: Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-02-15 (177 dias).
 - Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
-- Evidência: v_expiring_contracts:82909409000190-2-000293/2026
+- Evidência: v_contracts_canonical_v2:82909409000190-2-000293/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:ae2c53a2b3ca` — 01612888000186-2-000420/2026
+
+- Fato: Contrato com PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC encerra em 2027-08-20 (363 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:01612888000186-2-000420/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:afce068ae564` — 82892365000132-2-000340/2026
+
+- Fato: Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-06-11 (293 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:82892365000132-2-000340/2026
 - Severidade: `ATTENTION`
 
 ### `contract_ending_within_window:c54e55bc03bc` — 82892365000132-2-000368/2026
 
 - Fato: Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-01-23 (154 dias).
 - Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
-- Evidência: v_expiring_contracts:82892365000132-2-000368/2026
+- Evidência: v_contracts_canonical_v2:82892365000132-2-000368/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:dc76df9c42d2` — 83102459000123-2-002017/2026
+
+- Fato: Contrato com Prefeitura Municipal de Jaraguá do Sul encerra em 2027-06-07 (289 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_contracts_canonical_v2:83102459000123-2-002017/2026
 - Severidade: `ATTENTION`
 
 ### `contract_ending_within_window:e0e356b8f1a0` — 82572207000103-2-000207/2026
 
 - Fato: Contrato com Unidade Única encerra em 2027-02-08 (170 dias).
 - Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
-- Evidência: v_expiring_contracts:82572207000103-2-000207/2026
+- Evidência: v_contracts_canonical_v2:82572207000103-2-000207/2026
 - Severidade: `ATTENTION`
 
 ### `buyer_concentration_high:6cb105d98bfb` — carteira
@@ -152,7 +288,7 @@ Cada achado é um fato observado mais a pergunta que ele abre. Nenhum achado afi
 
 ### `value_position_in_category:1223e04da9b7` — OBRAS
 
-- Fato: Mediana dos contratos da empresa na categoria OBRAS: 2000216.58; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.
+- Fato: Mediana dos contratos da empresa na categoria OBRAS: 1691351.30; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.
 - Pergunta: A posição observada corresponde ao porte de contrato que a empresa pretende disputar nesta categoria?
 - Evidência: v_contract_intel_percentis:OBRAS
 - Severidade: `INFORMATIONAL`

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.md
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/dossier.md
@@ -1,0 +1,174 @@
+# Diagnóstico B2G — QUALIDADE MINERACAO LTDA
+
+- Documento: `cfg-dossier-cb06e7fa204654f7`
+- Schema: `confenge-dossier/1.0` (v1.0.0)
+- Modo de catálogo: `official_live`
+- Estado dos dados: `DATA_READY` (pronto)
+- Data de referência: `2026-08-22`
+- Observado em: `2026-08-22T03:00:00Z`
+- Hash de conteúdo: `sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310`
+- Produtor: `extra-cli` @ `cc9d4dae628f0879be7c2ccca94976d03bfc9e5d`
+
+## 1. Identificação
+
+*Estado da seção: pronto (`DATA_READY`), 1 registros.*
+
+| Campo | Valor |
+| --- | --- |
+| Razão social | QUALIDADE MINERACAO LTDA |
+| CNPJ | 00820854000114 |
+| CNAE principal | 7112000 |
+| Situação cadastral | Ativa |
+| Município | PALHOCA |
+| UF | SC |
+| Fonte cadastral | rfb_public_cadastral_via_opencnpj |
+| Data da fonte | 2026-07-29 |
+
+## 2. Mapa de compradores
+
+*Estado da seção: pronto (`DATA_READY`), 21 registros.*
+
+Compradores distintos: **21** · contratos: **55** · valor conhecido: **R$ 524.771.038,63** · HHI: **0.4213**
+
+| Comprador | UF | Contratos | Valor conhecido | Participação | Último fim |
+| --- | --- | ---: | ---: | ---: | --- |
+| MUNICÍPIO DE PAULO LOPES | SC | 12 | R$ 13.487.767,87 | 2.6% | 2027-06-22 |
+| Secretaria de Estado da Infraestrutura e Mobilidade | SC | 7 | R$ 331.944.483,09 | 63.3% | 2026-08-28 |
+| Secretaria de Planejamento e Infraestrutura e Saneamento | SC | 6 | R$ 12.388.401,07 | 2.4% | 2027-02-27 |
+| Prefeitura Municipal de Imbituba/SC | SC | 5 | R$ 9.275.528,98 | 1.8% | 2027-06-13 |
+| SECRETARIA DE INFRA-ESTRUTURA | SC | 3 | R$ 14.612.590,81 | 2.8% | 2027-03-31 |
+| PREFEITURA MUNICIPAL DE SÃO JOÃO BATISTA | SC | 3 | R$ 6.129.814,57 | 1.2% | 2025-07-23 |
+| PREFEITURA MUNICIPAL DE BELA VISTA DO TOLDO - SC | SC | 2 | R$ 14.068.119,09 | 2.7% | 2027-08-20 |
+| MUNICÍPIO DE TUBARÃO | SC | 2 | R$ 5.049.351,01 | 1.0% | 2025-03-23 |
+| Prefeitura Municipal de Pescaria Brava - SC | SC | 2 | R$ 4.948.357,41 | 0.9% | 2027-06-23 |
+| MUNICÍPIO DE LAGUNA | SC | 2 | R$ 641.300,00 | 0.1% | 2025-11-09 |
+| DER - Departamento de Estradas de Rodagem do Estado do Paraná | PR | 1 | R$ 68.100.000,00 | 13.0% | 2029-07-27 |
+| Unidade Única | SC | 1 | R$ 9.819.294,06 | 1.9% | 2027-02-08 |
+| PREFEITURA MUNICIPAL DE NOVA TRENTO | SC | 1 | R$ 6.946.916,97 | 1.3% | 2027-07-01 |
+| Prefeitura Municipal de Jaraguá do Sul | SC | 1 | R$ 6.471.769,77 | 1.2% | 2027-06-07 |
+| MUNICÍPIO DE SÃO MARTINHO | SC | 1 | R$ 5.260.000,00 | 1.0% | 2027-01-08 |
+| Secretaria de Obras e Servicos Publicos do Município de Guabiruba | SC | 1 | R$ 4.864.017,50 | 0.9% | 2027-06-29 |
+| PREFEITURA MUNICIPAL DE RANCHO QUEIMADO | SC | 1 | R$ 2.670.700,00 | 0.5% | 2025-07-05 |
+| MUNICÍPIO DE RIO FORTUNA | SC | 1 | R$ 2.267.000,00 | 0.4% | 2026-08-15 |
+| Prefeitura Municipal de Petrolândia | SC | 1 | R$ 2.117.593,37 | 0.4% | 2024-12-21 |
+| Gestão da Secretaria de Planejamento e Urbanismo | SC | 1 | R$ 2.000.216,58 | 0.4% | 2026-10-08 |
+| SECRETARIA MUNICIPAL DE OBRAS E INFRAESTRUTURA URBANA | SC | 1 | R$ 1.707.816,48 | 0.3% | 2025-03-18 |
+
+## 3. Concorrentes na categoria principal
+
+*Estado da seção: pronto (`DATA_READY`), 15 registros.*
+
+Categoria principal identificada: **OBRAS**.
+
+Regra de seleção: fornecedores com contratos junto aos mesmos compradores e na categoria principal de contratos da própria empresa.
+
+| Fornecedor | Contratos | Com valor publicado | Compradores em comum | Categorias | Valor conhecido |
+| --- | ---: | ---: | ---: | --- | ---: |
+| MAXIFROTA SERVICOS DE MANUTENCAO DE FROTA LTDA | 23 | 23 | 16 | OBRAS | R$ 42.290.311,32 |
+| C R ARTEFATOS DE CIMENTO LTDA | 21 | 21 | 5 | OBRAS | R$ 18.869.230,55 |
+| BCL EMPREENDIMENTOS LTDA | 13 | 13 | 4 | OBRAS | R$ 12.398.841,49 |
+| JA CONSTRUTORA E ADMINISTRADORA DE OBRAS LTDA | 8 | 8 | 4 | OBRAS | R$ 7.237.287,24 |
+| ANDRADE & AMORIM PAVIMENTACAO E DRENAGEM EIRELI | 8 | 8 | 4 | OBRAS | R$ 4.715.758,16 |
+| FJ CONSTRUTORA | 6 | 6 | 4 | OBRAS | R$ 15.701.517,49 |
+| ANDRADE & AMORIM ENGENHARIA EIRELI | 9 | 9 | 3 | OBRAS | R$ 13.340.740,12 |
+| SANTA CRUZ CONSTRUTORA LTDA | 6 | 6 | 3 | OBRAS | R$ 4.033.282,29 |
+| JR CONSTRUÇÕES E TERRAPLANAGEM LTDA EPP | 5 | 5 | 3 | OBRAS | R$ 11.021.655,24 |
+| AF CONSTRUCOES E PAVIMENTACAO LTDA | 5 | 5 | 3 | OBRAS | R$ 2.478.000,00 |
+| ANDRADE & AMORIM EXTRACAO MINERAL LTDA | 5 | 5 | 3 | OBRAS | R$ 1.427.818,50 |
+| PRO ENG ENGENHARIA E CONSTRUTORA LTDA | 4 | 4 | 3 | OBRAS | R$ 4.271.300,00 |
+| CONSTRUTORA WDD LTDA | 3 | 3 | 3 | OBRAS | R$ 4.590.121,80 |
+| JS ASFALTO LTDA | 3 | 3 | 3 | OBRAS | R$ 1.222.407,62 |
+| MAPDATA TECNOLOGIA, INFORMATICA E COMERCIO LTDA | 3 | 3 | 3 | OBRAS | R$ 172.924,66 |
+
+## 4. Painel de preços por categoria
+
+*Estado da seção: pronto (`DATA_READY`), 2 registros — códigos: focal_outside_panel_range.*
+
+Semântica de valor: `valor_integral_nominal` · unidade: `BRL_TOTAL`.
+
+Escopo da referência: contratos de órgãos públicos do conjunto de referência no raio de 200 km; não é amostra nacional.
+
+1 categoria(s) ficaram fora da faixa do painel por fator maior que 10x. Para essas, nenhuma posição percentílica é declarada: a categoria agrega objetos de porte incomparável.
+
+| Categoria | Contratos da empresa | Mediana da empresa | p25 painel | p50 painel | p75 painel | Posição |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| FACILITIES | 6 | R$ 44.051.804,43 | R$ 206,40 | R$ 1.189,69 | R$ 20.548,49 | fora da faixa do painel — sem posição percentílica |
+| OBRAS | 49 | R$ 2.000.216,58 | R$ 25.256,39 | R$ 189.000,00 | R$ 910.202,98 | acima do p75 do painel |
+
+## 5. Contratos a vencer em até 365 dias
+
+*Estado da seção: pronto (`DATA_READY`), 3 registros.*
+
+| Contrato | Órgão | Fim | Dias | Valor |
+| --- | --- | --- | ---: | ---: |
+| `82892365000132-2-000368/2026` | MUNICÍPIO DE PAULO LOPES | 2027-01-23 | 154 | R$ 5.940.003,00 |
+| `82572207000103-2-000207/2026` | Unidade Única | 2027-02-08 | 170 | R$ 9.819.294,06 |
+| `82909409000190-2-000293/2026` | SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF | 2027-02-15 | 177 | R$ 1.989.000,00 |
+
+## 6. Editais abertos de compradores já conhecidos
+
+*Estado da seção: retido por falta de evidência (`DATA_HOLD`), 0 registros — códigos: no_open_opportunities_for_buyers.*
+
+Nenhum edital aberto foi observado para os compradores desta carteira na data de referência. Ausência de observação não é ausência de edital.
+
+## 7. Achados
+
+Cada achado é um fato observado mais a pergunta que ele abre. Nenhum achado afirma direito, desequilíbrio econômico-financeiro, dano ou que um reajuste seja devido.
+
+### `contract_anniversary_reached:dcb02083c283` — 82951344000140-2-000031/2024
+
+- Fato: Contrato com data de início 2024-02-28 e 29 meses decorridos até 2026-08-22; data de fim registrada: 2026-08-28.
+- Pergunta: Houve repactuação ou reajuste contratual registrado a cada aniversário deste contrato, conforme a cláusula econômica pactuada?
+- Evidência: v_contracts_canonical_v2:82951344000140-2-000031/2024
+- Severidade: `INFORMATIONAL`
+
+### `contract_ending_within_window:a317a8ce982c` — 82909409000190-2-000293/2026
+
+- Fato: Contrato com SEC. MUN. INFRAESTRUTURA E OBRAS - SEINF encerra em 2027-02-15 (177 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_expiring_contracts:82909409000190-2-000293/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:c54e55bc03bc` — 82892365000132-2-000368/2026
+
+- Fato: Contrato com MUNICÍPIO DE PAULO LOPES encerra em 2027-01-23 (154 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_expiring_contracts:82892365000132-2-000368/2026
+- Severidade: `ATTENTION`
+
+### `contract_ending_within_window:e0e356b8f1a0` — 82572207000103-2-000207/2026
+
+- Fato: Contrato com Unidade Única encerra em 2027-02-08 (170 dias).
+- Pergunta: Há saldo, aditivo ou prorrogação a tratar antes do encerramento?
+- Evidência: v_expiring_contracts:82572207000103-2-000207/2026
+- Severidade: `ATTENTION`
+
+### `buyer_concentration_high:6cb105d98bfb` — carteira
+
+- Fato: HHI de 0.4213 sobre o valor contratado conhecido, distribuído entre 21 compradores; maior comprador: MUNICÍPIO DE PAULO LOPES.
+- Pergunta: A carteira depende de poucos compradores em grau que a diretoria aceita?
+- Evidência: v_contracts_canonical_v2:hhi
+- Severidade: `INFORMATIONAL`
+
+### `value_position_in_category:1223e04da9b7` — OBRAS
+
+- Fato: Mediana dos contratos da empresa na categoria OBRAS: 2000216.58; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.
+- Pergunta: A posição observada corresponde ao porte de contrato que a empresa pretende disputar nesta categoria?
+- Evidência: v_contract_intel_percentis:OBRAS
+- Severidade: `INFORMATIONAL`
+
+### `contract_horizon_beyond_window:5a7fc5a53d00` — 76669324000189-2-000019/2026
+
+- Fato: Contrato com data de fim 2029-07-27, além da janela de 365 dias considerada neste dossiê.
+- Pergunta: O planejamento de execução cobre o horizonte total do contrato?
+- Evidência: v_contracts_canonical_v2:76669324000189-2-000019/2026
+- Severidade: `INFORMATIONAL`
+
+## 8. Limitações declaradas
+
+- Campo ausente permanece UNKNOWN e não entra no denominador. UNKNOWN não é zero.
+- Os achados são fatos observados mais a pergunta que abrem. O dossiê não afirma direito, desequilíbrio econômico-financeiro, dano ou que um reajuste seja devido.
+- Contratos refletem o estado canônico do DataLake na data de observação; aditivos posteriores à última coleta podem não estar refletidos.
+- O painel de preços usa o conjunto de referência de órgãos públicos no raio de 200 km da base de referência; não é uma amostra nacional.
+
+Códigos de razão: focal_outside_panel_range, no_open_opportunities_for_buyers.

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/manifest.json
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/manifest.json
@@ -1,15 +1,16 @@
 {
   "as_of": "2026-08-22",
   "catalog_mode": "official_live",
-  "content_hash": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+  "content_hash": "sha256:9be6bb57368066bfcbd72ba076a1a2c108e5e7ef4f837406baf6bd4f6650e48b",
   "data_state": "DATA_READY",
   "dossier_id": "cfg-dossier-cb06e7fa204654f7",
   "files": {
-    "dossier.json": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
-    "public-read.json": "sha256:bde025fed2ba4247c79f6e57358c5187b56fb8bbdeecf2e03e2bacbe4e58903a"
+    "dossier.json": "sha256:8f77dba55c07382d8037a83cc1c79a7710f57b52d034e59911c20ca7f52d19f4",
+    "dossier.md": "sha256:e2bbe036a939b889abc55eda72343bafdde6eae38849c0f1ee690d6a81b2d45b",
+    "public-read.json": "sha256:b1a5c51244e9465ae493ab4d46f5a6a4c38bd5d36790c9866c2dd7d00573e3f7"
   },
-  "producer_sha": "cc9d4dae628f0879be7c2ccca94976d03bfc9e5d",
-  "public_content_hash": "sha256:bde025fed2ba4247c79f6e57358c5187b56fb8bbdeecf2e03e2bacbe4e58903a",
+  "producer_sha": "0eed54de0d3dc4647633277fe362acbf4d59e115",
+  "public_content_hash": "sha256:3332d3f020b9f5a21a37451b960cee934d1c628576ab585edb54074cfad8882b",
   "reason_codes": [
     "focal_outside_panel_range",
     "no_open_opportunities_for_buyers"

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/manifest.json
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/manifest.json
@@ -1,0 +1,18 @@
+{
+  "as_of": "2026-08-22",
+  "catalog_mode": "official_live",
+  "content_hash": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+  "data_state": "DATA_READY",
+  "dossier_id": "cfg-dossier-cb06e7fa204654f7",
+  "files": {
+    "dossier.json": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+    "public-read.json": "sha256:bde025fed2ba4247c79f6e57358c5187b56fb8bbdeecf2e03e2bacbe4e58903a"
+  },
+  "producer_sha": "cc9d4dae628f0879be7c2ccca94976d03bfc9e5d",
+  "public_content_hash": "sha256:bde025fed2ba4247c79f6e57358c5187b56fb8bbdeecf2e03e2bacbe4e58903a",
+  "reason_codes": [
+    "focal_outside_panel_range",
+    "no_open_opportunities_for_buyers"
+  ],
+  "schema": "confenge-dossier/1.0"
+}

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/public-read.json
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/public-read.json
@@ -5,7 +5,7 @@
   "as_of": "2026-08-22",
   "catalog_mode": "official_live",
   "consumer": "web-cfg/contract-analysis",
-  "content_hash": "sha256:bde025fed2ba4247c79f6e57358c5187b56fb8bbdeecf2e03e2bacbe4e58903a",
+  "content_hash": "sha256:3332d3f020b9f5a21a37451b960cee934d1c628576ab585edb54074cfad8882b",
   "contract_version": "v1.0.0",
   "data_state": "DATA_READY",
   "findings": [
@@ -13,10 +13,10 @@
       "evidence_refs": [
         "v_contract_intel_percentis:OBRAS"
       ],
-      "fact": "Mediana dos contratos da empresa na categoria OBRAS: 2000216.58; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.",
+      "fact": "Mediana dos contratos da empresa na categoria OBRAS: 1691351.30; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.",
       "finding_id": "value_position_in_category:1223e04da9b7",
       "metrics": {
-        "focal_contract_count": 49,
+        "focal_contract_count": 32,
         "focal_position": "ABOVE_P75"
       },
       "question": "A posição observada corresponde ao porte de contrato que a empresa pretende disputar nesta categoria?",
@@ -46,176 +46,15 @@
       "observed_at": "2026-08-22T03:00:00Z",
       "payload": {
         "competitor_count": 15,
-        "competitors": [
-          {
-            "contract_count": 23,
-            "shared_buyer_count": 16,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "42290311.32",
-            "valued_count": 23
-          },
-          {
-            "contract_count": 21,
-            "shared_buyer_count": 5,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "18869230.55",
-            "valued_count": 21
-          },
-          {
-            "contract_count": 13,
-            "shared_buyer_count": 4,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "12398841.49",
-            "valued_count": 13
-          },
-          {
-            "contract_count": 8,
-            "shared_buyer_count": 4,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "7237287.24",
-            "valued_count": 8
-          },
-          {
-            "contract_count": 8,
-            "shared_buyer_count": 4,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "4715758.16",
-            "valued_count": 8
-          },
-          {
-            "contract_count": 6,
-            "shared_buyer_count": 4,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "15701517.49",
-            "valued_count": 6
-          },
-          {
-            "contract_count": 9,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "13340740.12",
-            "valued_count": 9
-          },
-          {
-            "contract_count": 6,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "4033282.29",
-            "valued_count": 6
-          },
-          {
-            "contract_count": 5,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "11021655.24",
-            "valued_count": 5
-          },
-          {
-            "contract_count": 5,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "2478000.00",
-            "valued_count": 5
-          },
-          {
-            "contract_count": 5,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "1427818.50",
-            "valued_count": 5
-          },
-          {
-            "contract_count": 4,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "4271300.00",
-            "valued_count": 4
-          },
-          {
-            "contract_count": 3,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "4590121.80",
-            "valued_count": 3
-          },
-          {
-            "contract_count": 3,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "1222407.62",
-            "valued_count": 3
-          },
-          {
-            "contract_count": 3,
-            "shared_buyer_count": 3,
-            "shared_categories": [
-              "OBRAS"
-            ],
-            "supplier_cnpj": "UNKNOWN",
-            "supplier_nome": "UNKNOWN",
-            "valor_sum": "172924.66",
-            "valued_count": 3
-          }
-        ],
+        "contract_count_band": "3-23",
         "primary_category": "OBRAS",
-        "requested_limit": 15,
-        "selection_rule": "fornecedores com contratos junto aos mesmos compradores e na categoria principal de contratos da própria empresa"
+        "selection_rule": "fornecedores com contratos junto aos mesmos compradores e na categoria principal de contratos da própria empresa",
+        "shared_buyer_count_band": "3-16",
+        "value_bands": [
+          "<1.000.000",
+          "<10.000.000",
+          "<100.000.000"
+        ]
       },
       "reason_codes": [],
       "row_count": 15,
@@ -248,11 +87,13 @@
       "payload": {
         "categories": [
           {
+            "bucket_precision": "NORMAL",
             "categoria": "FACILITIES",
-            "focal_contract_count": 6,
-            "focal_median": "44051804.43",
+            "focal_contract_count": 5,
+            "focal_contract_count_all": 6,
+            "focal_median": "20003608.86",
             "focal_position": "OUT_OF_PANEL_RANGE",
-            "focal_valued_count": 6,
+            "focal_valued_count": 5,
             "reference_contract_count": 35050,
             "reference_p25": "206.40",
             "reference_p50": "1189.69",
@@ -260,11 +101,13 @@
             "reference_ticket_medio": "13871430.11"
           },
           {
+            "bucket_precision": "NORMAL",
             "categoria": "OBRAS",
-            "focal_contract_count": 49,
-            "focal_median": "2000216.58",
+            "focal_contract_count": 32,
+            "focal_contract_count_all": 49,
+            "focal_median": "1691351.30",
             "focal_position": "ABOVE_P75",
-            "focal_valued_count": 49,
+            "focal_valued_count": 32,
             "reference_contract_count": 18892,
             "reference_p25": "25256.39",
             "reference_p50": "189000.00",
@@ -274,6 +117,9 @@
         ],
         "category_count": 2,
         "comparable_category_count": 1,
+        "low_precision_categories": [
+          "TI"
+        ],
         "out_of_range_category_count": 1,
         "out_of_range_factor": 10,
         "reference_scope": "contratos de órgãos públicos do conjunto de referência no raio de 200 km; não é amostra nacional",
@@ -291,11 +137,11 @@
       "state": "DATA_READY"
     }
   },
-  "source_dossier_hash": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+  "source_dossier_hash": "sha256:9be6bb57368066bfcbd72ba076a1a2c108e5e7ef4f837406baf6bd4f6650e48b",
   "subject_profile": {
-    "buyer_count": 21,
-    "cnae_principal": "7112000",
-    "contract_count": 55,
+    "buyer_count_band": "21-50",
+    "cnae_division": "71",
+    "contract_count_band": "51-200",
     "uf": "SC"
   }
 }

--- a/artifacts/dossier/qualidade-mineracao-2026-08-22/public-read.json
+++ b/artifacts/dossier/qualidade-mineracao-2026-08-22/public-read.json
@@ -1,0 +1,301 @@
+{
+  "accepted_schemas": [
+    "public-read-confenge-dossier/1.0"
+  ],
+  "as_of": "2026-08-22",
+  "catalog_mode": "official_live",
+  "consumer": "web-cfg/contract-analysis",
+  "content_hash": "sha256:bde025fed2ba4247c79f6e57358c5187b56fb8bbdeecf2e03e2bacbe4e58903a",
+  "contract_version": "v1.0.0",
+  "data_state": "DATA_READY",
+  "findings": [
+    {
+      "evidence_refs": [
+        "v_contract_intel_percentis:OBRAS"
+      ],
+      "fact": "Mediana dos contratos da empresa na categoria OBRAS: 2000216.58; referência p25/p50/p75 do painel: 25256.39/189000.00/910202.98.",
+      "finding_id": "value_position_in_category:1223e04da9b7",
+      "metrics": {
+        "focal_contract_count": 49,
+        "focal_position": "ABOVE_P75"
+      },
+      "question": "A posição observada corresponde ao porte de contrato que a empresa pretende disputar nesta categoria?",
+      "severity": "INFORMATIONAL",
+      "subject": "OBRAS"
+    }
+  ],
+  "grain": "anonymous_supplier_profile",
+  "limitations": [
+    "Campo ausente permanece UNKNOWN e não entra no denominador. UNKNOWN não é zero.",
+    "Os achados são fatos observados mais a pergunta que abrem. O dossiê não afirma direito, desequilíbrio econômico-financeiro, dano ou que um reajuste seja devido.",
+    "Contratos refletem o estado canônico do DataLake na data de observação; aditivos posteriores à última coleta podem não estar refletidos.",
+    "O painel de preços usa o conjunto de referência de órgãos públicos no raio de 200 km da base de referência; não é uma amostra nacional."
+  ],
+  "method_version": "confenge-dossier-compose/1.0",
+  "policy_version": "confenge-dossier-policy/1.0",
+  "producer": "extra-cli",
+  "publication_readiness": "DATA_READY",
+  "reason_codes": [
+    "focal_outside_panel_range",
+    "no_open_opportunities_for_buyers"
+  ],
+  "schema": "public-read-confenge-dossier/1.0",
+  "sections": {
+    "competitors": {
+      "missingness": 0.0,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "competitor_count": 15,
+        "competitors": [
+          {
+            "contract_count": 23,
+            "shared_buyer_count": 16,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "42290311.32",
+            "valued_count": 23
+          },
+          {
+            "contract_count": 21,
+            "shared_buyer_count": 5,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "18869230.55",
+            "valued_count": 21
+          },
+          {
+            "contract_count": 13,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "12398841.49",
+            "valued_count": 13
+          },
+          {
+            "contract_count": 8,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "7237287.24",
+            "valued_count": 8
+          },
+          {
+            "contract_count": 8,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "4715758.16",
+            "valued_count": 8
+          },
+          {
+            "contract_count": 6,
+            "shared_buyer_count": 4,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "15701517.49",
+            "valued_count": 6
+          },
+          {
+            "contract_count": 9,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "13340740.12",
+            "valued_count": 9
+          },
+          {
+            "contract_count": 6,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "4033282.29",
+            "valued_count": 6
+          },
+          {
+            "contract_count": 5,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "11021655.24",
+            "valued_count": 5
+          },
+          {
+            "contract_count": 5,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "2478000.00",
+            "valued_count": 5
+          },
+          {
+            "contract_count": 5,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "1427818.50",
+            "valued_count": 5
+          },
+          {
+            "contract_count": 4,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "4271300.00",
+            "valued_count": 4
+          },
+          {
+            "contract_count": 3,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "4590121.80",
+            "valued_count": 3
+          },
+          {
+            "contract_count": 3,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "1222407.62",
+            "valued_count": 3
+          },
+          {
+            "contract_count": 3,
+            "shared_buyer_count": 3,
+            "shared_categories": [
+              "OBRAS"
+            ],
+            "supplier_cnpj": "UNKNOWN",
+            "supplier_nome": "UNKNOWN",
+            "valor_sum": "172924.66",
+            "valued_count": 3
+          }
+        ],
+        "primary_category": "OBRAS",
+        "requested_limit": 15,
+        "selection_rule": "fornecedores com contratos junto aos mesmos compradores e na categoria principal de contratos da própria empresa"
+      },
+      "reason_codes": [],
+      "row_count": 15,
+      "section_id": "competitors",
+      "sources": [
+        "v_contracts_canonical_v2"
+      ],
+      "state": "DATA_READY"
+    },
+    "open_opportunities": {
+      "missingness": null,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "opportunities": [],
+        "opportunity_count": 0
+      },
+      "reason_codes": [
+        "no_open_opportunities_for_buyers"
+      ],
+      "row_count": 0,
+      "section_id": "open_opportunities",
+      "sources": [
+        "v_open_opportunities_canonical"
+      ],
+      "state": "DATA_HOLD"
+    },
+    "price_panel": {
+      "missingness": null,
+      "observed_at": "2026-08-22T03:00:00Z",
+      "payload": {
+        "categories": [
+          {
+            "categoria": "FACILITIES",
+            "focal_contract_count": 6,
+            "focal_median": "44051804.43",
+            "focal_position": "OUT_OF_PANEL_RANGE",
+            "focal_valued_count": 6,
+            "reference_contract_count": 35050,
+            "reference_p25": "206.40",
+            "reference_p50": "1189.69",
+            "reference_p75": "20548.49",
+            "reference_ticket_medio": "13871430.11"
+          },
+          {
+            "categoria": "OBRAS",
+            "focal_contract_count": 49,
+            "focal_median": "2000216.58",
+            "focal_position": "ABOVE_P75",
+            "focal_valued_count": 49,
+            "reference_contract_count": 18892,
+            "reference_p25": "25256.39",
+            "reference_p50": "189000.00",
+            "reference_p75": "910202.98",
+            "reference_ticket_medio": "33585770.07"
+          }
+        ],
+        "category_count": 2,
+        "comparable_category_count": 1,
+        "out_of_range_category_count": 1,
+        "out_of_range_factor": 10,
+        "reference_scope": "contratos de órgãos públicos do conjunto de referência no raio de 200 km; não é amostra nacional",
+        "unit": "BRL_TOTAL",
+        "value_semantic": "valor_integral_nominal"
+      },
+      "reason_codes": [
+        "focal_outside_panel_range"
+      ],
+      "row_count": 2,
+      "section_id": "price_panel",
+      "sources": [
+        "v_contract_intel_percentis"
+      ],
+      "state": "DATA_READY"
+    }
+  },
+  "source_dossier_hash": "sha256:1f99c5e1601a50578b99d2bca181426db993b68e8422679a1a6abdce78935310",
+  "subject_profile": {
+    "buyer_count": 21,
+    "cnae_principal": "7112000",
+    "contract_count": 55,
+    "uf": "SC"
+  }
+}

--- a/docs/confenge/DOSSIER-OPS.md
+++ b/docs/confenge/DOSSIER-OPS.md
@@ -1,0 +1,103 @@
+# Dossiê B2G — runbook operacional
+
+Motor: `scripts/dossier/`. Contrato: [`docs/contracts/confenge-dossier-v1.md`](../contracts/confenge-dossier-v1.md).
+Oferta ligada: `CFG-DIAG-EXP-v1` (Diagnóstico B2G de Expansão).
+
+## Produzir um dossiê
+
+```bash
+export DATABASE_URL="postgresql://…/pncp_datalake"   # ou LOCAL_DATALAKE_DSN
+make dossier CNPJ=00820854000114
+# equivalente:
+python3 -m scripts.dossier build --cnpj 00820854000114 --out artifacts/dossier/00820854000114
+python3 -m scripts.dossier verify --dir artifacts/dossier/00820854000114
+```
+
+Saída em `artifacts/dossier/<CNPJ>/`:
+
+| Arquivo | Destino | Contém a empresa? |
+| --- | --- | --- |
+| `dossier.json` | entrega paga | sim |
+| `dossier.md` | entrega paga, documento humano | sim |
+| `public-read.json` | página pública no web-cfg | não |
+| `manifest.json` | referência no Warmbly | só hashes |
+
+`verify` recalcula os hashes, revarre por afirmação proibida e compara cada
+valor privado contra o corpo público. Um dossiê que não passa no `verify` não
+sai da máquina.
+
+## Publicar a projeção pública
+
+```bash
+make dossier-handoff DOSSIER_OUT=artifacts/dossier/00820854000114
+```
+
+Escreve em `${CONFENGE_HANDOFF_DIR:-~/.local/share/confenge/handoffs}/confenge-dossier/official-live-01/`
+com `READY.json` **ou** `BLOCKED.json` e `SHA256SUMS.txt`. Só
+`public-read.json` atravessa. `READY` exige `official_live` **e** `DATA_READY`
+**e** `publication_readiness=DATA_READY`; qualquer outra coisa é `BLOCKED`.
+
+Do lado do consumidor (`web-cfg`):
+
+```bash
+python3 -m scripts.market_panorama build
+```
+
+A página nasce `noindex`. INDEX é decisão editorial do web-cfg, aprovada
+individualmente e vinculada ao hash do payload.
+
+## Códigos de saída do `build`
+
+| Código | Significado |
+| --- | --- |
+| `0` | ok |
+| `2` | sem DSN (`--dsn`, `DATABASE_URL` ou `LOCAL_DATALAKE_DSN`) |
+| `3` | conteúdo com afirmação proibida — nada foi escrito |
+| `4` | `--strict` e o estado não é `DATA_READY` |
+| `5` | `DATA_REJECT` |
+
+`handoff` acrescenta `6` (vazamento de identidade detectado antes de escrever)
+e `7` (o rendezvous escrito não passou na própria verificação).
+
+## Quando o estado não é `DATA_READY`
+
+`DATA_HOLD` e `DATA_REJECT` são respostas honestas, não falhas do processo.
+Leia `reason_codes` no `manifest.json`:
+
+| Código | O que fazer |
+| --- | --- |
+| `identity_not_found` | o CNPJ não está no `supplier_registry`; conferir o número |
+| `no_canonical_contracts` | a empresa não tem contrato canônico no DataLake |
+| `insufficient_contracts` / `insufficient_buyers` | carteira pequena demais para o diagnóstico prometido |
+| `no_price_reference` | nenhuma categoria com painel comparável |
+| `focal_outside_panel_range` | há categoria fora da faixa; a posição percentílica é omitida de propósito |
+| `no_open_opportunities_for_buyers` | nenhum edital aberto observado; ausência de observação não é ausência de edital |
+| `official_table_missing` | a view esperada não existe no DSN apontado |
+
+Nenhum desses códigos autoriza preencher o vazio à mão. O documento declara o
+que não sabe.
+
+## Produção
+
+O motor é somente-leitura sobre o DataLake e não escreve em nenhuma tabela.
+No host de record:
+
+```bash
+ssh ec-prod "cd /opt/extra-consultoria && DATABASE_URL=\$(grep -m1 '^DATABASE_URL=' .env | cut -d= -f2-) \
+  python3 -m scripts.dossier build --cnpj <CNPJ> --out artifacts/dossier/<CNPJ>"
+```
+
+Não há timer para isso: um dossiê é produzido quando há uma conta para
+diagnosticar, não em ciclo.
+
+## Limites que o motor impõe e não se deve contornar
+
+- `UNKNOWN` nunca vira zero, e `valued_count` acompanha `contract_count` para
+  que uma soma parcial não seja lida como total.
+- Um `fixture` nunca pode se declarar `official_live`.
+- Concorrentes vêm da categoria **principal** da empresa; dividir comprador não
+  basta, uma prefeitura compra papel e asfalto da mesma lista.
+- Onde a mediana da empresa fica mais de 10x fora da faixa interquartil do
+  painel, nenhuma posição percentílica é declarada e nenhum achado é emitido.
+- Achado é fato mais pergunta. O dossiê não afirma direito, desequilíbrio
+  econômico-financeiro, dano ou que um reajuste seja devido.

--- a/docs/contracts/confenge-dossier-v1.json
+++ b/docs/contracts/confenge-dossier-v1.json
@@ -1,0 +1,84 @@
+{
+  "schema": "confenge-dossier/1.0",
+  "public_schema": "public-read-confenge-dossier/1.0",
+  "contract_version": "v1.0.0",
+  "compatibility": "additive_nullable_within_v1",
+  "grain": "cnpj14",
+  "keys": ["dossier_id"],
+  "producer": {
+    "id": "extra-cli",
+    "command": "python3 -m scripts.dossier build --cnpj <CNPJ14> --out <DIR>",
+    "verify": "python3 -m scripts.dossier verify --dir <DIR>",
+    "module": "scripts/dossier/"
+  },
+  "consumers": [
+    {
+      "id": "web-cfg/contract-analysis",
+      "repository": "tjsasakifln/web-cfg",
+      "reads": "public-read.json",
+      "decision": "May render the de-identified projection. Must not treat UNKNOWN as zero. Must not infer a right, an imbalance, a loss, or that an adjustment is due. publication_readiness=DATA_READY is necessary and not sufficient for an editorial INDEX decision, which the consumer owns."
+    },
+    {
+      "id": "warmbly/confenge-cohort",
+      "repository": "tjsasakifln/warmbly",
+      "reads": "manifest.json",
+      "decision": "May attach a dossier reference to an outreach touchpoint. Must never embed the private dossier body in an outbound message. The dossier is delivered by a human, not auto-attached."
+    }
+  ],
+  "source_families": [
+    "supplier_registry",
+    "v_contracts_canonical_v2",
+    "v_contract_intel_percentis",
+    "v_expiring_contracts",
+    "v_open_opportunities_canonical"
+  ],
+  "offer_binding": {
+    "offer_id": "CFG-DIAG-EXP-v1",
+    "catalog": "CFG-OFFER-CATALOG-v1",
+    "note": "The dossier is the machine-produced core of the paid Diagnostico B2G. Human review and the executive narrative remain outside this artifact."
+  },
+  "export_layout": {
+    "dossier.json": "confenge-dossier/1.0 private document (contains the prospect identity)",
+    "public-read.json": "public-read-confenge-dossier/1.0 de-identified projection",
+    "dossier.md": "human deliverable rendered from dossier.json",
+    "manifest.json": "hashes, data_state and reason codes"
+  },
+  "sections": [
+    "identity",
+    "buyer_map",
+    "competitors",
+    "price_panel",
+    "expiring_contracts",
+    "open_opportunities"
+  ],
+  "required_sections": ["identity", "buyer_map", "price_panel"],
+  "data_states": ["DATA_READY", "DATA_HOLD", "DATA_REJECT"],
+  "catalog_modes": ["fixture", "official_live"],
+  "honesty": {
+    "unknown": "A missing field stays UNKNOWN and is excluded from the denominator. UNKNOWN is never zero.",
+    "fixture": "catalog_mode=fixture can never reach publication_readiness=DATA_READY.",
+    "claim_scan": "Every emitted document is scanned for forbidden claim tokens and metric keys before it is written. Official objeto text is exempt because the engine must not rewrite official text.",
+    "panel_range": "A category where the focal median sits more than 10x outside the panel interquartile band yields OUT_OF_PANEL_RANGE and no percentile position.",
+    "content_hash": "content_hash covers the document with volatile fields (generated_at, observed_at, producer_sha, content_hash) stripped, so two runs over the same data agree byte for byte."
+  },
+  "privacy": {
+    "public_projection_removes": [
+      "cnpj14",
+      "cnpj_raiz",
+      "razao_social",
+      "nome_fantasia",
+      "supplier_cnpj",
+      "supplier_nome",
+      "fornecedor_cnpj",
+      "fornecedor_nome",
+      "municipio"
+    ],
+    "public_projection_keeps": [
+      "price_panel",
+      "competitors (de-identified)",
+      "open_opportunities",
+      "value-position and opportunity findings"
+    ],
+    "enforcement": "verify compares every private value against the public body and fails on any match."
+  }
+}

--- a/docs/contracts/confenge-dossier-v1.md
+++ b/docs/contracts/confenge-dossier-v1.md
@@ -1,0 +1,90 @@
+# Consumer contract — `confenge-dossier/1.0`
+
+Machine twin: [`confenge-dossier-v1.json`](confenge-dossier-v1.json).
+Producer: extra-cli `scripts/dossier/`.
+Consumers: `web-cfg/contract-analysis`, `warmbly/confenge-cohort`.
+
+## What this is
+
+The dossier is the **company-grain** artifact behind the paid offer
+`CFG-DIAG-EXP-v1` (Diagnóstico B2G de Expansão). Every other consumer-bound
+family in this repository is contract-grain; this one composes canonical
+DataLake reads for a single supplier CNPJ into the deliverable the offer
+promises: mapa de compradores, concorrentes, painel de preços, contratos a
+vencer, editais triados.
+
+It produces one artifact set with three destinations:
+
+| File | Destination | Contains the prospect? |
+| --- | --- | --- |
+| `dossier.json` | paid delivery | yes |
+| `dossier.md` | paid delivery (human deliverable) | yes |
+| `public-read.json` | web-cfg public analysis | no |
+| `manifest.json` | Warmbly touchpoint reference | no body, hashes only |
+
+## Commands
+
+```bash
+python3 -m scripts.dossier build --cnpj 00820854000114 --as-of 2026-08-22 \
+  --out artifacts/dossier/<slug>
+python3 -m scripts.dossier verify --dir artifacts/dossier/<slug>
+```
+
+The DSN comes from `--dsn`, `DATABASE_URL` or `LOCAL_DATALAKE_DSN`, in that
+order. `--fixture <path>` runs offline and can never claim `official_live`.
+
+Exit codes: `0` ok · `2` no DSN · `3` forbidden claim content · `4` `--strict`
+and not `DATA_READY` · `5` `DATA_REJECT`.
+
+## Honesty rules this artifact enforces
+
+- A missing field stays `UNKNOWN` and is excluded from the denominator.
+  `UNKNOWN` is never zero. `valued_count` is always reported next to
+  `contract_count` so a partial value sum cannot be read as a total.
+- `catalog_mode=fixture` can never reach `publication_readiness=DATA_READY`.
+  Labelling a fixture run `official_live` returns `DATA_REJECT`.
+- Every document is scanned for forbidden claim tokens and metric keys before
+  it is written. Official `objeto` text is exempt: the engine must not rewrite
+  official text, and an official object containing the word "irregular" is a
+  fact, not a claim by CONFENGE.
+- The declared-limitations block is exempt from the scan and is pinned by
+  `test_limitations_are_frozen_constants` so the exemption cannot become a hole.
+- The category ladder is coarse. Where the focal median sits more than `10x`
+  outside the panel interquartile band, the position is `OUT_OF_PANEL_RANGE`
+  and **no percentile position and no finding** are emitted for that category.
+- Competitors are bound to the focal's **primary** category. Sharing a buyer is
+  not enough: a municipality buys stationery and asphalt from the same list.
+- `content_hash` strips volatile fields, so two runs over the same data agree
+  byte for byte. `verify` recomputes it and fails on drift.
+
+## Findings
+
+A finding is a **fact plus the question that fact opens**. It never asserts a
+right, an imbalance, a loss, or that an adjustment is due.
+
+| `finding_id` prefix | Trigger |
+| --- | --- |
+| `contract_anniversary_reached` | running contract with 12+ months since `data_inicio` |
+| `contract_ending_within_window` | contract ends inside the window |
+| `buyer_concentration_high` | HHI over `0.25` on known contract value |
+| `value_position_in_category` | focal median inside the panel range |
+| `open_opportunity_from_known_buyer` | open bid from a buyer already in the portfolio |
+| `contract_horizon_beyond_window` | contract ends after the window |
+
+## Privacy boundary
+
+The prospect is never the subject of a public page. Public bodies and their
+published contracts are public record and stay. `public-read.json` drops the
+identity and buyer-map sections entirely and redacts every field in
+`PUBLIC_REDACTED_FIELDS`. `verify` compares every private value against the
+public body and fails on any match; a redacted key kept with an `UNKNOWN` value
+is not a leak, a private value appearing anywhere is.
+
+## What this artifact does not decide
+
+- It does not decide editorial `INDEX`, sitemap membership or SEO. That belongs
+  to `contract-analysis-publication-gate/1.0` in the consumer.
+- It does not send anything. Warmbly may reference a dossier on a touchpoint;
+  the dossier body is delivered by a human.
+- It does not replace `comparable-contracts/1.0`. Contract-grain peer analysis
+  stays there; this is portfolio-grain.

--- a/scripts/dossier/__init__.py
+++ b/scripts/dossier/__init__.py
@@ -1,0 +1,5 @@
+"""CONFENGE dossier engine: company-grain composition of canonical DataLake reads."""
+
+from scripts.dossier.constants import CONTRACT_VERSION, SCHEMA
+
+__all__ = ["SCHEMA", "CONTRACT_VERSION"]

--- a/scripts/dossier/__main__.py
+++ b/scripts/dossier/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point: ``python3 -m scripts.dossier``."""
+
+import sys
+
+from scripts.dossier.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dossier/cli.py
+++ b/scripts/dossier/cli.py
@@ -8,6 +8,7 @@ python3 -m scripts.dossier verify --dir artifacts/dossier/acme
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -32,6 +33,7 @@ from scripts.dossier.envelope import (
     producer_sha,
     public_projection,
     scan_forbidden,
+    scan_markdown,
 )
 from scripts.dossier.handoff import DECISION_READY, rendezvous_dir, verify_handoff, write_handoff
 from scripts.dossier.models import DossierRequest
@@ -49,9 +51,14 @@ def _resolve_dsn(explicit: str | None) -> str | None:
 
 
 def _write(path: Path, text: str) -> str:
+    """Write a file and return the sha256 of the bytes actually on disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
-    return content_hash({"file": path.name, "body": text})
+    return file_digest(path)
+
+
+def file_digest(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _cmd_build(args: argparse.Namespace) -> int:
@@ -81,16 +88,22 @@ def _cmd_build(args: argparse.Namespace) -> int:
     )
     result, document = build_dossier(source, request)
 
-    forbidden = scan_forbidden(document)
+    public = public_projection(document)
+    markdown = render_markdown(document)
+
+    # The markdown is the delivered document, so it is scanned like the JSON.
+    forbidden = scan_forbidden(document) + scan_forbidden(public) + scan_markdown(markdown, document)
     if forbidden:
         sys.stderr.write("forbidden claim content in dossier: " + ", ".join(forbidden) + "\n")
         return 3
 
-    public = public_projection(document)
-    markdown = render_markdown(document)
-
     if args.out:
         out = Path(args.out)
+        digests = {
+            DOSSIER_JSON: _write(out / DOSSIER_JSON, canonical_json(document)),
+            PUBLIC_JSON: _write(out / PUBLIC_JSON, canonical_json(public)),
+            DOSSIER_MD: _write(out / DOSSIER_MD, markdown),
+        }
         manifest = {
             "dossier_id": document["dossier_id"],
             "schema": document["schema"],
@@ -100,15 +113,12 @@ def _cmd_build(args: argparse.Namespace) -> int:
             "content_hash": document["content_hash"],
             "public_content_hash": public["content_hash"],
             "producer_sha": document["producer_sha"],
-            "files": {
-                DOSSIER_JSON: content_hash(document),
-                PUBLIC_JSON: content_hash(public),
-            },
+            # Digests of the bytes on disk, so tampering with a delivered file
+            # is detectable. The document content_hash above is a different
+            # thing: it identifies the facts, not the file.
+            "files": digests,
             "reason_codes": document["reason_codes"],
         }
-        _write(out / DOSSIER_JSON, canonical_json(document))
-        _write(out / PUBLIC_JSON, canonical_json(public))
-        _write(out / DOSSIER_MD, markdown)
         _write(out / MANIFEST_JSON, canonical_json(manifest))
         sys.stderr.write(f"wrote {out}/ ({document['data_state']})\n")
 
@@ -145,8 +155,18 @@ def _cmd_verify(args: argparse.Namespace) -> int:
     directory = Path(args.dir)
     document = json.loads((directory / DOSSIER_JSON).read_text(encoding="utf-8"))
     public = json.loads((directory / PUBLIC_JSON).read_text(encoding="utf-8"))
+    manifest = json.loads((directory / MANIFEST_JSON).read_text(encoding="utf-8"))
 
     problems: list[str] = []
+    for name, expected in (manifest.get("files") or {}).items():
+        path = directory / name
+        if not path.exists():
+            problems.append(f"missing file: {name}")
+        elif file_digest(path) != expected:
+            problems.append(f"file digest mismatch: {name}")
+    for name in (DOSSIER_JSON, PUBLIC_JSON, DOSSIER_MD):
+        if name not in (manifest.get("files") or {}):
+            problems.append(f"file not covered by the manifest: {name}")
     recomputed = content_hash(document)
     if recomputed != document.get("content_hash"):
         problems.append(f"dossier content_hash mismatch: stored={document.get('content_hash')} recomputed={recomputed}")
@@ -156,7 +176,9 @@ def _cmd_verify(args: argparse.Namespace) -> int:
     if public.get("source_dossier_hash") != document.get("content_hash"):
         problems.append("public projection is not bound to this dossier")
 
-    forbidden = scan_forbidden(document) + scan_forbidden(public)
+    markdown_path = directory / DOSSIER_MD
+    markdown = markdown_path.read_text(encoding="utf-8") if markdown_path.exists() else ""
+    forbidden = scan_forbidden(document) + scan_forbidden(public) + scan_markdown(markdown, document)
     if forbidden:
         problems.append("forbidden claim content: " + ", ".join(forbidden))
 

--- a/scripts/dossier/cli.py
+++ b/scripts/dossier/cli.py
@@ -1,0 +1,219 @@
+"""CLI for the CONFENGE dossier engine.
+
+python3 -m scripts.dossier build --cnpj 00000000000000 --out artifacts/dossier/acme
+python3 -m scripts.dossier build --cnpj 00000000000000 --fixture tests/dossier/fixtures/x.json
+python3 -m scripts.dossier verify --dir artifacts/dossier/acme
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from scripts.dossier.constants import (
+    CATALOG_FIXTURE,
+    CATALOG_OFFICIAL_LIVE,
+    COMPETITOR_LIMIT,
+    CONSUMER_WEB_CFG,
+    DATA_READY,
+    DATA_REJECT,
+    EXPIRING_WINDOW_DAYS,
+    REASON_DSN_UNAVAILABLE,
+)
+from scripts.dossier.envelope import (
+    build_dossier,
+    canonical_json,
+    content_hash,
+    producer_sha,
+    public_projection,
+    scan_forbidden,
+)
+from scripts.dossier.models import DossierRequest
+from scripts.dossier.render import render_markdown
+from scripts.dossier.sources import DatalakeSource, FixtureSource
+
+DOSSIER_JSON = "dossier.json"
+PUBLIC_JSON = "public-read.json"
+DOSSIER_MD = "dossier.md"
+MANIFEST_JSON = "manifest.json"
+
+
+def _resolve_dsn(explicit: str | None) -> str | None:
+    return explicit or os.environ.get("DATABASE_URL") or os.environ.get("LOCAL_DATALAKE_DSN")
+
+
+def _write(path: Path, text: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return content_hash({"file": path.name, "body": text})
+
+
+def _cmd_build(args: argparse.Namespace) -> int:
+    as_of = args.as_of or date.today().isoformat()
+
+    if args.fixture:
+        source: Any = FixtureSource(args.fixture)
+        catalog_mode = CATALOG_OFFICIAL_LIVE if args.claim_live else CATALOG_FIXTURE
+    else:
+        dsn = _resolve_dsn(args.dsn)
+        if not dsn:
+            sys.stderr.write(
+                f"{REASON_DSN_UNAVAILABLE}: set --dsn, DATABASE_URL or LOCAL_DATALAKE_DSN, or pass --fixture\n"
+            )
+            return 2
+        source = DatalakeSource(dsn, observed_at=args.observed_at, competitor_limit=args.competitor_limit)
+        catalog_mode = CATALOG_OFFICIAL_LIVE
+
+    request = DossierRequest(
+        cnpj=args.cnpj,
+        as_of=as_of,
+        catalog_mode=catalog_mode,
+        consumer_id=args.consumer,
+        producer_sha=producer_sha(),
+        competitor_limit=args.competitor_limit,
+        expiring_window_days=args.window_days,
+    )
+    result, document = build_dossier(source, request)
+
+    forbidden = scan_forbidden(document)
+    if forbidden:
+        sys.stderr.write("forbidden claim content in dossier: " + ", ".join(forbidden) + "\n")
+        return 3
+
+    public = public_projection(document)
+    markdown = render_markdown(document)
+
+    if args.out:
+        out = Path(args.out)
+        manifest = {
+            "dossier_id": document["dossier_id"],
+            "schema": document["schema"],
+            "catalog_mode": document["catalog_mode"],
+            "data_state": document["data_state"],
+            "as_of": document["as_of"],
+            "content_hash": document["content_hash"],
+            "public_content_hash": public["content_hash"],
+            "producer_sha": document["producer_sha"],
+            "files": {
+                DOSSIER_JSON: content_hash(document),
+                PUBLIC_JSON: content_hash(public),
+            },
+            "reason_codes": document["reason_codes"],
+        }
+        _write(out / DOSSIER_JSON, canonical_json(document))
+        _write(out / PUBLIC_JSON, canonical_json(public))
+        _write(out / DOSSIER_MD, markdown)
+        _write(out / MANIFEST_JSON, canonical_json(manifest))
+        sys.stderr.write(f"wrote {out}/ ({document['data_state']})\n")
+
+    if args.markdown:
+        sys.stdout.write(markdown)
+    else:
+        sys.stdout.write(canonical_json(document))
+
+    if args.strict and result.data_state != DATA_READY:
+        return 4
+    if result.data_state == DATA_REJECT:
+        return 5
+    return 0
+
+
+def _sensitive_values(document: dict[str, Any]) -> list[tuple[str, str]]:
+    """Private values from the paid dossier that must never reach the public one."""
+    values: list[tuple[str, str]] = []
+    identity = (document.get("sections", {}).get("identity") or {}).get("payload", {})
+    for field in ("cnpj14", "razao_social", "nome_fantasia", "municipio"):
+        value = identity.get(field)
+        if value and value != "UNKNOWN":
+            values.append((f"identity.{field}", str(value)))
+    competitors = (document.get("sections", {}).get("competitors") or {}).get("payload", {})
+    for competitor in competitors.get("competitors", []):
+        for field in ("supplier_cnpj", "supplier_nome"):
+            value = competitor.get(field)
+            if value and value != "UNKNOWN":
+                values.append((f"competitors.{field}", str(value)))
+    return values
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    directory = Path(args.dir)
+    document = json.loads((directory / DOSSIER_JSON).read_text(encoding="utf-8"))
+    public = json.loads((directory / PUBLIC_JSON).read_text(encoding="utf-8"))
+
+    problems: list[str] = []
+    recomputed = content_hash(document)
+    if recomputed != document.get("content_hash"):
+        problems.append(f"dossier content_hash mismatch: stored={document.get('content_hash')} recomputed={recomputed}")
+    recomputed_public = content_hash(public)
+    if recomputed_public != public.get("content_hash"):
+        problems.append("public content_hash mismatch")
+    if public.get("source_dossier_hash") != document.get("content_hash"):
+        problems.append("public projection is not bound to this dossier")
+
+    forbidden = scan_forbidden(document) + scan_forbidden(public)
+    if forbidden:
+        problems.append("forbidden claim content: " + ", ".join(forbidden))
+
+    # A redacted key kept with an UNKNOWN value is not a leak; a private *value*
+    # surfacing anywhere in the public body is.
+    body = canonical_json(public)
+    for label, value in _sensitive_values(document):
+        if value and value in body:
+            problems.append(f"public projection leaks {label}: {value!r}")
+
+    if document.get("catalog_mode") == CATALOG_FIXTURE and public.get("publication_readiness") == DATA_READY:
+        problems.append("fixture dossier claims publication readiness")
+
+    report = {
+        "dir": str(directory),
+        "dossier_id": document.get("dossier_id"),
+        "data_state": document.get("data_state"),
+        "catalog_mode": document.get("catalog_mode"),
+        "verdict": "PASS" if not problems else "FAIL",
+        "problems": problems,
+    }
+    sys.stdout.write(canonical_json(report))
+    return 0 if not problems else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python3 -m scripts.dossier",
+        description="Compose the CONFENGE B2G dossier (confenge-dossier/1.0) from canonical DataLake reads.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    build = sub.add_parser("build", help="Build a dossier for one CNPJ")
+    build.add_argument("--cnpj", required=True, help="14-digit supplier CNPJ")
+    build.add_argument("--as-of", default=None, help="Reference date (YYYY-MM-DD). Defaults to today.")
+    build.add_argument("--out", default=None, help="Output directory for the artifact set")
+    build.add_argument("--dsn", default=None, help="DataLake DSN. Falls back to DATABASE_URL / LOCAL_DATALAKE_DSN.")
+    build.add_argument("--fixture", default=None, help="Fixture JSON path instead of the DataLake")
+    build.add_argument(
+        "--claim-live",
+        action="store_true",
+        help="Deliberately label a fixture run as official_live. Always rejected; used by tests.",
+    )
+    build.add_argument("--consumer", default=CONSUMER_WEB_CFG)
+    build.add_argument("--competitor-limit", type=int, default=COMPETITOR_LIMIT)
+    build.add_argument("--window-days", type=int, default=EXPIRING_WINDOW_DAYS)
+    build.add_argument("--observed-at", default=None, help="Override the observation timestamp (RFC3339)")
+    build.add_argument("--markdown", action="store_true", help="Print markdown instead of JSON")
+    build.add_argument("--strict", action="store_true", help="Exit non-zero unless data_state is DATA_READY")
+    build.set_defaults(func=_cmd_build)
+
+    verify = sub.add_parser("verify", help="Re-verify a written artifact set")
+    verify.add_argument("--dir", required=True)
+    verify.set_defaults(func=_cmd_verify)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))

--- a/scripts/dossier/cli.py
+++ b/scripts/dossier/cli.py
@@ -33,6 +33,7 @@ from scripts.dossier.envelope import (
     public_projection,
     scan_forbidden,
 )
+from scripts.dossier.handoff import DECISION_READY, rendezvous_dir, verify_handoff, write_handoff
 from scripts.dossier.models import DossierRequest
 from scripts.dossier.render import render_markdown
 from scripts.dossier.sources import DatalakeSource, FixtureSource
@@ -181,6 +182,37 @@ def _cmd_verify(args: argparse.Namespace) -> int:
     return 0 if not problems else 1
 
 
+def _cmd_handoff(args: argparse.Namespace) -> int:
+    directory = Path(args.dir)
+    public = json.loads((directory / PUBLIC_JSON).read_text(encoding="utf-8"))
+    manifest = json.loads((directory / MANIFEST_JSON).read_text(encoding="utf-8"))
+
+    # The private dossier must never reach the rendezvous.
+    leaks = [label for label, value in _sensitive_values_from_dir(directory) if value in canonical_json(public)]
+    if leaks:
+        sys.stderr.write("refusing handoff, public projection leaks: " + ", ".join(leaks) + "\n")
+        return 6
+
+    forbidden = scan_forbidden(public)
+    if forbidden:
+        sys.stderr.write("refusing handoff, forbidden claim content: " + ", ".join(forbidden) + "\n")
+        return 3
+
+    root = Path(args.to) if args.to else rendezvous_dir()
+    result = write_handoff(public, manifest, root)
+    errors = verify_handoff(root)
+    result["verify_errors"] = errors
+    sys.stdout.write(canonical_json(result))
+    if errors:
+        return 7
+    return 0 if result["decision"] == DECISION_READY else 1
+
+
+def _sensitive_values_from_dir(directory: Path) -> list[tuple[str, str]]:
+    document = json.loads((directory / DOSSIER_JSON).read_text(encoding="utf-8"))
+    return _sensitive_values(document)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python3 -m scripts.dossier",
@@ -210,6 +242,14 @@ def build_parser() -> argparse.ArgumentParser:
     verify = sub.add_parser("verify", help="Re-verify a written artifact set")
     verify.add_argument("--dir", required=True)
     verify.set_defaults(func=_cmd_verify)
+
+    handoff = sub.add_parser(
+        "handoff",
+        help="Publish the de-identified projection to the web-cfg rendezvous (READY xor BLOCKED)",
+    )
+    handoff.add_argument("--dir", required=True, help="Artifact set produced by build --out")
+    handoff.add_argument("--to", default=None, help="Rendezvous dir. Defaults to CONFENGE_HANDOFF_DIR layout.")
+    handoff.set_defaults(func=_cmd_handoff)
 
     return parser
 

--- a/scripts/dossier/compose.py
+++ b/scripts/dossier/compose.py
@@ -1,0 +1,577 @@
+"""Compose DataLake reads into dossier sections and findings.
+
+Interpretation lives here, and it is deliberately thin: every finding is a fact
+plus the question that fact opens. Nothing asserts a right, an imbalance, a
+loss, or that an adjustment is due.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from scripts.dossier.constants import (
+    ANNIVERSARY_MIN_MONTHS,
+    COMPETITOR_LIMIT,
+    DATA_HOLD,
+    DATA_READY,
+    DATA_REJECT,
+    EXPIRING_WINDOW_DAYS,
+    FINDING_ANNIVERSARY,
+    FINDING_BUYER_CONCENTRATION,
+    FINDING_EXPIRING_WINDOW,
+    FINDING_LONG_HORIZON,
+    FINDING_OPPORTUNITY_SAME_BUYER,
+    FINDING_PRICE_POSITION,
+    HHI_CONCENTRATION_THRESHOLD,
+    MIN_BUYERS_READY,
+    MIN_CONTRACTS_HOLD,
+    MIN_CONTRACTS_READY,
+    PANEL_OUT_OF_RANGE_FACTOR,
+    POSITION_OUT_OF_PANEL_RANGE,
+    REASON_IDENTITY_NOT_FOUND,
+    REASON_INSUFFICIENT_BUYERS,
+    REASON_INSUFFICIENT_CONTRACTS,
+    REASON_NO_COMPETITORS,
+    REASON_NO_CONTRACTS,
+    REASON_NO_EXPIRING,
+    REASON_NO_OPPORTUNITIES,
+    REASON_NO_PRICE_REFERENCE,
+    REASON_PANEL_OUT_OF_RANGE,
+    REASON_TABLE_MISSING,
+    REASON_VALUE_UNKNOWN,
+    SECTION_BUYER_MAP,
+    SECTION_COMPETITORS,
+    SECTION_EXPIRING,
+    SECTION_IDENTITY,
+    SECTION_OPPORTUNITIES,
+    SECTION_PRICE_PANEL,
+    UNKNOWN,
+)
+from scripts.dossier.models import Finding, Section, SourceRead, money
+
+POSITION_BELOW_P25 = "BELOW_P25"
+POSITION_P25_P50 = "P25_P50"
+POSITION_P50_P75 = "P50_P75"
+POSITION_ABOVE_P75 = "ABOVE_P75"
+
+
+def _dec(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _iso_date(value: Any) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _months_between(start: date, end: date) -> int:
+    return (end.year - start.year) * 12 + (end.month - start.month) - (1 if end.day < start.day else 0)
+
+
+def _missingness(rows: tuple[dict[str, Any], ...], field: str) -> float | None:
+    if not rows:
+        return None
+    unknown = sum(1 for row in rows if _dec(row.get(field)) is None)
+    return round(unknown / len(rows), 4)
+
+
+def _unavailable(section_id: str, read: SourceRead) -> Section:
+    return Section(
+        section_id=section_id,
+        state=DATA_HOLD,
+        payload={},
+        sources=(read.source,),
+        observed_at=read.observed_at,
+        row_count=0,
+        reason_codes=read.reason_codes or (REASON_TABLE_MISSING,),
+    )
+
+
+def build_identity(read: SourceRead) -> Section:
+    if not read.available:
+        return _unavailable(SECTION_IDENTITY, read)
+    if not read.rows:
+        return Section(
+            section_id=SECTION_IDENTITY,
+            state=DATA_REJECT,
+            payload={},
+            sources=(read.source,),
+            observed_at=read.observed_at,
+            row_count=0,
+            reason_codes=(REASON_IDENTITY_NOT_FOUND,),
+        )
+    row = read.rows[0]
+    return Section(
+        section_id=SECTION_IDENTITY,
+        state=DATA_READY,
+        payload={
+            "cnpj14": row.get("cnpj14"),
+            "razao_social": row.get("razao_social"),
+            "nome_fantasia": row.get("nome_fantasia") or UNKNOWN,
+            "cnae_principal": row.get("cnae_principal") or UNKNOWN,
+            "situacao_cadastral": row.get("situacao_cadastral") or UNKNOWN,
+            "municipio": row.get("municipio") or UNKNOWN,
+            "uf": row.get("uf") or UNKNOWN,
+            "registry_source": row.get("source") or UNKNOWN,
+            "registry_source_date": row.get("source_date") or UNKNOWN,
+        },
+        sources=(read.source,),
+        observed_at=read.observed_at,
+        row_count=1,
+    )
+
+
+def build_buyer_map(buyers: SourceRead, contracts: SourceRead) -> Section:
+    if not buyers.available:
+        return _unavailable(SECTION_BUYER_MAP, buyers)
+    rows = buyers.rows
+    if not rows:
+        return Section(
+            section_id=SECTION_BUYER_MAP,
+            state=DATA_REJECT,
+            payload={},
+            sources=(buyers.source,),
+            observed_at=buyers.observed_at,
+            row_count=0,
+            reason_codes=(REASON_NO_CONTRACTS,),
+        )
+
+    entries: list[dict[str, Any]] = []
+    total_valued = Decimal("0")
+    for row in rows:
+        valor = _dec(row.get("valor_sum"))
+        if valor is not None:
+            total_valued += valor
+        entries.append(
+            {
+                "buyer_cnpj": row.get("buyer_cnpj"),
+                "buyer_nome": row.get("buyer_nome") or UNKNOWN,
+                "uf": row.get("uf") or UNKNOWN,
+                "contract_count": int(row.get("contract_count") or 0),
+                "valued_count": int(row.get("valued_count") or 0),
+                "valor_sum": money(valor),
+                "last_data_fim": row.get("last_data_fim") or UNKNOWN,
+                "share_of_valued": None,
+            }
+        )
+
+    hhi: float | None = None
+    if total_valued > 0:
+        squares = Decimal("0")
+        for entry in entries:
+            valor = _dec(entry["valor_sum"])
+            if valor is None:
+                continue
+            share = valor / total_valued
+            entry["share_of_valued"] = round(float(share), 4)
+            squares += share * share
+        hhi = round(float(squares), 4)
+
+    contract_total = sum(int(r.get("contract_count") or 0) for r in rows)
+    reason_codes: list[str] = []
+    if total_valued <= 0:
+        reason_codes.append(REASON_VALUE_UNKNOWN)
+    if len(entries) < MIN_BUYERS_READY:
+        reason_codes.append(REASON_INSUFFICIENT_BUYERS)
+    if contract_total < MIN_CONTRACTS_READY:
+        reason_codes.append(REASON_INSUFFICIENT_CONTRACTS)
+
+    state = DATA_READY
+    if contract_total < MIN_CONTRACTS_HOLD:
+        state = DATA_REJECT
+    elif reason_codes:
+        state = DATA_HOLD
+
+    return Section(
+        section_id=SECTION_BUYER_MAP,
+        state=state,
+        payload={
+            "buyer_count": len(entries),
+            "contract_count": contract_total,
+            "valor_sum_valued": money(total_valued) if total_valued > 0 else None,
+            "hhi": hhi,
+            "hhi_basis": "valued_contract_value" if hhi is not None else UNKNOWN,
+            "buyers": entries,
+        },
+        sources=(buyers.source,),
+        observed_at=buyers.observed_at,
+        row_count=len(entries),
+        reason_codes=tuple(reason_codes),
+        missingness=_missingness(contracts.rows, "valor") if contracts.rows else None,
+    )
+
+
+def build_competitors(read: SourceRead, limit: int = COMPETITOR_LIMIT) -> Section:
+    if not read.available:
+        return _unavailable(SECTION_COMPETITORS, read)
+    rows = read.rows[:limit]
+    if not rows:
+        return Section(
+            section_id=SECTION_COMPETITORS,
+            state=DATA_HOLD,
+            payload={"competitor_count": 0, "competitors": []},
+            sources=(read.source,),
+            observed_at=read.observed_at,
+            row_count=0,
+            reason_codes=(REASON_NO_COMPETITORS,),
+        )
+    competitors: list[dict[str, Any]] = [
+        {
+            "supplier_cnpj": row.get("supplier_cnpj"),
+            "supplier_nome": row.get("supplier_nome") or UNKNOWN,
+            "contract_count": int(row.get("contract_count") or 0),
+            "valued_count": int(row.get("valued_count") or 0),
+            "valor_sum": money(_dec(row.get("valor_sum"))),
+            "shared_buyer_count": int(row.get("shared_buyer_count") or 0),
+            "shared_categories": sorted((row.get("shared_categories") or "").split(","))
+            if row.get("shared_categories")
+            else [],
+        }
+        for row in rows
+    ]
+    categories = sorted({c for entry in competitors for c in (entry["shared_categories"] or [])})
+    primary_category = categories[0] if len(categories) == 1 else (UNKNOWN if not categories else ",".join(categories))
+    return Section(
+        section_id=SECTION_COMPETITORS,
+        state=DATA_READY if len(competitors) >= 1 else DATA_HOLD,
+        payload={
+            "competitor_count": len(competitors),
+            "requested_limit": limit,
+            "primary_category": primary_category,
+            "selection_rule": (
+                "fornecedores com contratos junto aos mesmos compradores e na categoria "
+                "principal de contratos da própria empresa"
+            ),
+            "competitors": competitors,
+        },
+        sources=(read.source,),
+        observed_at=read.observed_at,
+        row_count=len(competitors),
+        missingness=_missingness(read.rows, "valor_sum"),
+    )
+
+
+def _position(focal_median: Decimal, p25: Decimal | None, p50: Decimal | None, p75: Decimal | None) -> str:
+    factor = Decimal(PANEL_OUT_OF_RANGE_FACTOR)
+    if p75 is not None and p75 > 0 and focal_median > p75 * factor:
+        return POSITION_OUT_OF_PANEL_RANGE
+    if p25 is not None and p25 > 0 and focal_median * factor < p25:
+        return POSITION_OUT_OF_PANEL_RANGE
+    if p25 is not None and focal_median < p25:
+        return POSITION_BELOW_P25
+    if p75 is not None and focal_median > p75:
+        return POSITION_ABOVE_P75
+    if p50 is not None and focal_median < p50:
+        return POSITION_P25_P50
+    if p50 is not None:
+        return POSITION_P50_P75
+    return UNKNOWN
+
+
+def build_price_panel(read: SourceRead) -> Section:
+    if not read.available:
+        return _unavailable(SECTION_PRICE_PANEL, read)
+    if not read.rows:
+        return Section(
+            section_id=SECTION_PRICE_PANEL,
+            state=DATA_HOLD,
+            payload={"category_count": 0, "categories": []},
+            sources=(read.source,),
+            observed_at=read.observed_at,
+            row_count=0,
+            reason_codes=(REASON_NO_PRICE_REFERENCE,),
+        )
+    categories: list[dict[str, Any]] = []
+    for row in read.rows:
+        p25, p50, p75 = _dec(row.get("p25_valor")), _dec(row.get("p50_valor")), _dec(row.get("p75_valor"))
+        focal_median = _dec(row.get("focal_median"))
+        categories.append(
+            {
+                "categoria": row.get("categoria"),
+                "reference_contract_count": int(row.get("qtd_contratos") or 0),
+                "reference_p25": money(p25),
+                "reference_p50": money(p50),
+                "reference_p75": money(p75),
+                "reference_ticket_medio": money(_dec(row.get("ticket_medio"))),
+                "focal_contract_count": int(row.get("focal_count") or 0),
+                "focal_valued_count": int(row.get("focal_valued_count") or 0),
+                "focal_median": money(focal_median),
+                "focal_position": _position(focal_median, p25, p50, p75) if focal_median is not None else UNKNOWN,
+            }
+        )
+    comparable = [c for c in categories if c["focal_position"] not in (UNKNOWN, POSITION_OUT_OF_PANEL_RANGE)]
+    out_of_range = [c for c in categories if c["focal_position"] == POSITION_OUT_OF_PANEL_RANGE]
+    reason_codes: list[str] = []
+    if not comparable:
+        reason_codes.append(REASON_NO_PRICE_REFERENCE)
+    if out_of_range:
+        reason_codes.append(REASON_PANEL_OUT_OF_RANGE)
+    return Section(
+        section_id=SECTION_PRICE_PANEL,
+        state=DATA_READY if comparable else DATA_HOLD,
+        payload={
+            "category_count": len(categories),
+            "comparable_category_count": len(comparable),
+            "out_of_range_category_count": len(out_of_range),
+            "out_of_range_factor": PANEL_OUT_OF_RANGE_FACTOR,
+            "value_semantic": "valor_integral_nominal",
+            "unit": "BRL_TOTAL",
+            "reference_scope": (
+                "contratos de órgãos públicos do conjunto de referência no raio de 200 km; não é amostra nacional"
+            ),
+            "categories": categories,
+        },
+        sources=(read.source,),
+        observed_at=read.observed_at,
+        row_count=len(categories),
+        reason_codes=tuple(reason_codes),
+    )
+
+
+def build_expiring(read: SourceRead, window_days: int = EXPIRING_WINDOW_DAYS) -> Section:
+    if not read.available:
+        return _unavailable(SECTION_EXPIRING, read)
+    rows = read.rows
+    if not rows:
+        return Section(
+            section_id=SECTION_EXPIRING,
+            state=DATA_HOLD,
+            payload={"window_days": window_days, "contract_count": 0, "contracts": []},
+            sources=(read.source,),
+            observed_at=read.observed_at,
+            row_count=0,
+            reason_codes=(REASON_NO_EXPIRING,),
+        )
+    contracts = [
+        {
+            "contrato_id": row.get("contrato_id"),
+            "orgao_cnpj": row.get("orgao_cnpj"),
+            "orgao_nome": row.get("orgao_nome") or UNKNOWN,
+            "objeto": row.get("objeto_contrato") or UNKNOWN,
+            "valor": money(_dec(row.get("valor_contrato"))),
+            "data_inicio": row.get("data_inicio_contrato") or UNKNOWN,
+            "data_fim": row.get("data_fim_contrato") or UNKNOWN,
+            "dias_ate_fim": int(row["dias_ate_fim"]) if row.get("dias_ate_fim") is not None else None,
+            "uf": row.get("uf") or UNKNOWN,
+        }
+        for row in rows
+    ]
+    return Section(
+        section_id=SECTION_EXPIRING,
+        state=DATA_READY,
+        payload={"window_days": window_days, "contract_count": len(contracts), "contracts": contracts},
+        sources=(read.source,),
+        observed_at=read.observed_at,
+        row_count=len(contracts),
+        missingness=_missingness(rows, "valor_contrato"),
+    )
+
+
+def build_opportunities(read: SourceRead) -> Section:
+    if not read.available:
+        return _unavailable(SECTION_OPPORTUNITIES, read)
+    rows = read.rows
+    if not rows:
+        return Section(
+            section_id=SECTION_OPPORTUNITIES,
+            state=DATA_HOLD,
+            payload={"opportunity_count": 0, "opportunities": []},
+            sources=(read.source,),
+            observed_at=read.observed_at,
+            row_count=0,
+            reason_codes=(REASON_NO_OPPORTUNITIES,),
+        )
+    opportunities = [
+        {
+            "bid_id": row.get("bid_id"),
+            "pncp_id": row.get("pncp_id") or UNKNOWN,
+            "objeto": row.get("objeto") or UNKNOWN,
+            "valor_estimado": money(_dec(row.get("valor_estimado"))),
+            "modalidade": row.get("modalidade") or UNKNOWN,
+            "orgao_cnpj": row.get("orgao_cnpj"),
+            "orgao_nome": row.get("orgao_nome") or UNKNOWN,
+            "uf": row.get("uf") or UNKNOWN,
+            "data_abertura": row.get("data_abertura") or UNKNOWN,
+            "data_encerramento": row.get("data_encerramento") or UNKNOWN,
+            "link_edital": row.get("link_edital") or UNKNOWN,
+        }
+        for row in rows
+    ]
+    return Section(
+        section_id=SECTION_OPPORTUNITIES,
+        state=DATA_READY,
+        payload={
+            "opportunity_count": len(opportunities),
+            "selection_rule": "open bids published by buyers the focal company already contracts with",
+            "opportunities": opportunities,
+        },
+        sources=(read.source,),
+        observed_at=read.observed_at,
+        row_count=len(opportunities),
+        missingness=_missingness(rows, "valor_estimado"),
+    )
+
+
+def _finding_id(kind: str, subject: str) -> str:
+    digest = hashlib.sha256(f"{kind}|{subject}".encode()).hexdigest()[:12]
+    return f"{kind}:{digest}"
+
+
+def build_findings(
+    *,
+    contracts: SourceRead,
+    buyer_map: Section,
+    price_panel: Section,
+    expiring: Section,
+    opportunities: Section,
+    as_of: str,
+    window_days: int = EXPIRING_WINDOW_DAYS,
+) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    as_of_date = _iso_date(as_of)
+
+    if as_of_date is not None:
+        for row in contracts.rows:
+            start = _iso_date(row.get("data_inicio"))
+            end = _iso_date(row.get("data_fim"))
+            contrato_id = row.get("contrato_id")
+            if start is None or contrato_id is None:
+                continue
+            running = end is None or end >= as_of_date
+            months = _months_between(start, as_of_date)
+            if running and months >= ANNIVERSARY_MIN_MONTHS:
+                findings.append(
+                    Finding(
+                        finding_id=_finding_id(FINDING_ANNIVERSARY, contrato_id),
+                        subject=contrato_id,
+                        fact=(
+                            f"Contrato com data de início {start.isoformat()} e "
+                            f"{months} meses decorridos até {as_of_date.isoformat()}; "
+                            f"data de fim registrada: {end.isoformat() if end else UNKNOWN}."
+                        ),
+                        question=(
+                            "Houve repactuação ou reajuste contratual registrado a cada "
+                            "aniversário deste contrato, conforme a cláusula econômica pactuada?"
+                        ),
+                        evidence_refs=(f"{contracts.source}:{contrato_id}",),
+                        metrics={"months_since_start": months, "data_inicio": start.isoformat()},
+                    )
+                )
+            if end is not None and end > as_of_date and (end - as_of_date).days > window_days:
+                findings.append(
+                    Finding(
+                        finding_id=_finding_id(FINDING_LONG_HORIZON, contrato_id),
+                        subject=contrato_id,
+                        fact=(
+                            f"Contrato com data de fim {end.isoformat()}, além da janela de "
+                            f"{window_days} dias considerada neste dossiê."
+                        ),
+                        question="O planejamento de execução cobre o horizonte total do contrato?",
+                        evidence_refs=(f"{contracts.source}:{contrato_id}",),
+                        metrics={"days_to_end": (end - as_of_date).days},
+                    )
+                )
+
+    for item in expiring.payload.get("contracts", []):
+        contrato_id = item.get("contrato_id")
+        if not contrato_id:
+            continue
+        findings.append(
+            Finding(
+                finding_id=_finding_id(FINDING_EXPIRING_WINDOW, contrato_id),
+                subject=contrato_id,
+                fact=(
+                    f"Contrato com {item.get('orgao_nome')} encerra em {item.get('data_fim')} "
+                    f"({item.get('dias_ate_fim')} dias)."
+                ),
+                question="Há saldo, aditivo ou prorrogação a tratar antes do encerramento?",
+                evidence_refs=(f"{expiring.sources[0]}:{contrato_id}",),
+                severity="ATTENTION",
+                metrics={"dias_ate_fim": item.get("dias_ate_fim")},
+            )
+        )
+
+    hhi = buyer_map.payload.get("hhi")
+    if isinstance(hhi, (int, float)) and hhi >= HHI_CONCENTRATION_THRESHOLD:
+        top = (buyer_map.payload.get("buyers") or [{}])[0]
+        findings.append(
+            Finding(
+                finding_id=_finding_id(FINDING_BUYER_CONCENTRATION, str(buyer_map.payload.get("buyer_count"))),
+                subject="carteira",
+                fact=(
+                    f"HHI de {hhi} sobre o valor contratado conhecido, distribuído entre "
+                    f"{buyer_map.payload.get('buyer_count')} compradores; maior comprador: "
+                    f"{top.get('buyer_nome', UNKNOWN)}."
+                ),
+                question="A carteira depende de poucos compradores em grau que a diretoria aceita?",
+                evidence_refs=(f"{buyer_map.sources[0]}:hhi",),
+                metrics={"hhi": hhi, "threshold": HHI_CONCENTRATION_THRESHOLD},
+            )
+        )
+
+    for category in price_panel.payload.get("categories", []):
+        # A panel the focal sits orders of magnitude outside of is not a
+        # reference; emitting a position from it would be a claim, not a fact.
+        if category.get("focal_position") in (None, UNKNOWN, POSITION_OUT_OF_PANEL_RANGE):
+            continue
+        findings.append(
+            Finding(
+                finding_id=_finding_id(FINDING_PRICE_POSITION, str(category.get("categoria"))),
+                subject=str(category.get("categoria")),
+                fact=(
+                    f"Mediana dos contratos da empresa na categoria {category.get('categoria')}: "
+                    f"{category.get('focal_median')}; referência p25/p50/p75 do painel: "
+                    f"{category.get('reference_p25')}/{category.get('reference_p50')}/{category.get('reference_p75')}."
+                ),
+                question=(
+                    "A posição observada corresponde ao porte de contrato que a empresa "
+                    "pretende disputar nesta categoria?"
+                ),
+                evidence_refs=(f"{price_panel.sources[0]}:{category.get('categoria')}",),
+                metrics={
+                    "focal_position": category.get("focal_position"),
+                    "focal_contract_count": category.get("focal_contract_count"),
+                },
+            )
+        )
+
+    for item in opportunities.payload.get("opportunities", []):
+        bid_id = item.get("bid_id")
+        if not bid_id:
+            continue
+        findings.append(
+            Finding(
+                finding_id=_finding_id(FINDING_OPPORTUNITY_SAME_BUYER, str(bid_id)),
+                subject=str(bid_id),
+                fact=(
+                    f"Edital aberto de {item.get('orgao_nome')}, comprador com contrato já "
+                    f"registrado com a empresa; encerramento: {item.get('data_encerramento')}."
+                ),
+                question="Esta oportunidade entra na fila de disputa?",
+                evidence_refs=(f"{opportunities.sources[0]}:{bid_id}",),
+                severity="ATTENTION",
+                metrics={"data_encerramento": item.get("data_encerramento")},
+            )
+        )
+
+    order = {
+        FINDING_ANNIVERSARY: 0,
+        FINDING_EXPIRING_WINDOW: 1,
+        FINDING_BUYER_CONCENTRATION: 2,
+        FINDING_PRICE_POSITION: 3,
+        FINDING_OPPORTUNITY_SAME_BUYER: 4,
+        FINDING_LONG_HORIZON: 5,
+    }
+    return tuple(sorted(findings, key=lambda f: (order.get(f.finding_id.split(":")[0], 99), f.finding_id)))

--- a/scripts/dossier/compose.py
+++ b/scripts/dossier/compose.py
@@ -26,14 +26,18 @@ from scripts.dossier.constants import (
     FINDING_OPPORTUNITY_SAME_BUYER,
     FINDING_PRICE_POSITION,
     HHI_CONCENTRATION_THRESHOLD,
+    LOW_PRECISION_CATEGORIES,
     MIN_BUYERS_READY,
     MIN_CONTRACTS_HOLD,
     MIN_CONTRACTS_READY,
     PANEL_OUT_OF_RANGE_FACTOR,
+    POSITION_LOW_PRECISION_BUCKET,
     POSITION_OUT_OF_PANEL_RANGE,
+    REASON_BUYER_LIST_TRUNCATED,
     REASON_IDENTITY_NOT_FOUND,
     REASON_INSUFFICIENT_BUYERS,
     REASON_INSUFFICIENT_CONTRACTS,
+    REASON_LOW_PRECISION_BUCKET,
     REASON_NO_COMPETITORS,
     REASON_NO_CONTRACTS,
     REASON_NO_EXPIRING,
@@ -133,9 +137,15 @@ def build_identity(read: SourceRead) -> Section:
     )
 
 
-def build_buyer_map(buyers: SourceRead, contracts: SourceRead) -> Section:
-    if not buyers.available:
-        return _unavailable(SECTION_BUYER_MAP, buyers)
+def build_buyer_map(buyers: SourceRead, contracts: SourceRead, totals: SourceRead) -> Section:
+    """Buyer map. Display rows are capped; every total comes from ``totals``.
+
+    Computing the share, the sum or the HHI over the capped display list would
+    report a concentrated portfolio for any supplier with more buyers than the
+    cap, and understate the money by the whole tail.
+    """
+    if not buyers.available or not totals.available:
+        return _unavailable(SECTION_BUYER_MAP, buyers if not buyers.available else totals)
     rows = buyers.rows
     if not rows:
         return Section(
@@ -148,12 +158,18 @@ def build_buyer_map(buyers: SourceRead, contracts: SourceRead) -> Section:
             reason_codes=(REASON_NO_CONTRACTS,),
         )
 
+    total_row = totals.rows[0] if totals.rows else {}
+    buyer_total = int(total_row.get("buyer_count") or 0)
+    contract_total = int(total_row.get("contract_count") or 0)
+    valued_total = _dec(total_row.get("valor_sum_valued"))
+    hhi = _dec(total_row.get("hhi"))
+
     entries: list[dict[str, Any]] = []
-    total_valued = Decimal("0")
     for row in rows:
         valor = _dec(row.get("valor_sum"))
-        if valor is not None:
-            total_valued += valor
+        share = None
+        if valor is not None and valued_total is not None and valued_total > 0:
+            share = round(float(valor / valued_total), 4)
         entries.append(
             {
                 "buyer_cnpj": row.get("buyer_cnpj"),
@@ -163,46 +179,36 @@ def build_buyer_map(buyers: SourceRead, contracts: SourceRead) -> Section:
                 "valued_count": int(row.get("valued_count") or 0),
                 "valor_sum": money(valor),
                 "last_data_fim": row.get("last_data_fim") or UNKNOWN,
-                "share_of_valued": None,
+                "share_of_valued": share,
             }
         )
 
-    hhi: float | None = None
-    if total_valued > 0:
-        squares = Decimal("0")
-        for entry in entries:
-            valor = _dec(entry["valor_sum"])
-            if valor is None:
-                continue
-            share = valor / total_valued
-            entry["share_of_valued"] = round(float(share), 4)
-            squares += share * share
-        hhi = round(float(squares), 4)
-
-    contract_total = sum(int(r.get("contract_count") or 0) for r in rows)
     reason_codes: list[str] = []
-    if total_valued <= 0:
+    if valued_total is None or valued_total <= 0:
         reason_codes.append(REASON_VALUE_UNKNOWN)
-    if len(entries) < MIN_BUYERS_READY:
+    if buyer_total < MIN_BUYERS_READY:
         reason_codes.append(REASON_INSUFFICIENT_BUYERS)
     if contract_total < MIN_CONTRACTS_READY:
         reason_codes.append(REASON_INSUFFICIENT_CONTRACTS)
+    if buyer_total > len(entries):
+        reason_codes.append(REASON_BUYER_LIST_TRUNCATED)
 
     state = DATA_READY
     if contract_total < MIN_CONTRACTS_HOLD:
         state = DATA_REJECT
-    elif reason_codes:
+    elif [c for c in reason_codes if c != REASON_BUYER_LIST_TRUNCATED]:
         state = DATA_HOLD
 
     return Section(
         section_id=SECTION_BUYER_MAP,
         state=state,
         payload={
-            "buyer_count": len(entries),
+            "buyer_count": buyer_total,
             "contract_count": contract_total,
-            "valor_sum_valued": money(total_valued) if total_valued > 0 else None,
-            "hhi": hhi,
-            "hhi_basis": "valued_contract_value" if hhi is not None else UNKNOWN,
+            "displayed_buyer_count": len(entries),
+            "valor_sum_valued": money(valued_total) if valued_total and valued_total > 0 else None,
+            "hhi": None if hhi is None else round(float(hhi), 4),
+            "hhi_basis": "valued_contract_value_all_buyers" if hhi is not None else UNKNOWN,
             "buyers": entries,
         },
         sources=(buyers.source,),
@@ -259,7 +265,7 @@ def build_competitors(read: SourceRead, limit: int = COMPETITOR_LIMIT) -> Sectio
         sources=(read.source,),
         observed_at=read.observed_at,
         row_count=len(competitors),
-        missingness=_missingness(read.rows, "valor_sum"),
+        missingness=_missingness(rows, "valor_sum"),
     )
 
 
@@ -295,11 +301,14 @@ def build_price_panel(read: SourceRead) -> Section:
         )
     categories: list[dict[str, Any]] = []
     for row in read.rows:
+        categoria = row.get("categoria")
         p25, p50, p75 = _dec(row.get("p25_valor")), _dec(row.get("p50_valor")), _dec(row.get("p75_valor"))
         focal_median = _dec(row.get("focal_median"))
+        low_precision = categoria in LOW_PRECISION_CATEGORIES
         categories.append(
             {
-                "categoria": row.get("categoria"),
+                "categoria": categoria,
+                "bucket_precision": "LOW" if low_precision else "NORMAL",
                 "reference_contract_count": int(row.get("qtd_contratos") or 0),
                 "reference_p25": money(p25),
                 "reference_p50": money(p50),
@@ -308,16 +317,27 @@ def build_price_panel(read: SourceRead) -> Section:
                 "focal_contract_count": int(row.get("focal_count") or 0),
                 "focal_valued_count": int(row.get("focal_valued_count") or 0),
                 "focal_median": money(focal_median),
-                "focal_position": _position(focal_median, p25, p50, p75) if focal_median is not None else UNKNOWN,
+                "focal_contract_count_all": int(row.get("focal_total_count") or row.get("focal_count") or 0),
+                "focal_position": (
+                    POSITION_LOW_PRECISION_BUCKET
+                    if low_precision
+                    else (_position(focal_median, p25, p50, p75) if focal_median is not None else UNKNOWN)
+                ),
             }
         )
-    comparable = [c for c in categories if c["focal_position"] not in (UNKNOWN, POSITION_OUT_OF_PANEL_RANGE)]
+    comparable = [
+        c
+        for c in categories
+        if c["focal_position"] not in (UNKNOWN, POSITION_OUT_OF_PANEL_RANGE, POSITION_LOW_PRECISION_BUCKET)
+    ]
     out_of_range = [c for c in categories if c["focal_position"] == POSITION_OUT_OF_PANEL_RANGE]
     reason_codes: list[str] = []
     if not comparable:
         reason_codes.append(REASON_NO_PRICE_REFERENCE)
     if out_of_range:
         reason_codes.append(REASON_PANEL_OUT_OF_RANGE)
+    if [c for c in categories if c["bucket_precision"] == "LOW"]:
+        reason_codes.append(REASON_LOW_PRECISION_BUCKET)
     return Section(
         section_id=SECTION_PRICE_PANEL,
         state=DATA_READY if comparable else DATA_HOLD,
@@ -326,6 +346,7 @@ def build_price_panel(read: SourceRead) -> Section:
             "comparable_category_count": len(comparable),
             "out_of_range_category_count": len(out_of_range),
             "out_of_range_factor": PANEL_OUT_OF_RANGE_FACTOR,
+            "low_precision_categories": sorted(LOW_PRECISION_CATEGORIES),
             "value_semantic": "valor_integral_nominal",
             "unit": "BRL_TOTAL",
             "reference_scope": (
@@ -524,7 +545,12 @@ def build_findings(
     for category in price_panel.payload.get("categories", []):
         # A panel the focal sits orders of magnitude outside of is not a
         # reference; emitting a position from it would be a claim, not a fact.
-        if category.get("focal_position") in (None, UNKNOWN, POSITION_OUT_OF_PANEL_RANGE):
+        if category.get("focal_position") in (
+            None,
+            UNKNOWN,
+            POSITION_OUT_OF_PANEL_RANGE,
+            POSITION_LOW_PRECISION_BUCKET,
+        ):
             continue
         findings.append(
             Finding(

--- a/scripts/dossier/constants.py
+++ b/scripts/dossier/constants.py
@@ -1,0 +1,185 @@
+"""Canonical versions, thresholds and reason codes for the CONFENGE dossier engine.
+
+Grain is the supplier company (``cnpj14``), not a contract. The dossier composes
+already-canonical DataLake reads into the deliverable behind the paid offer
+``CFG-DIAG-EXP-v1`` (Diagnostico B2G de Expansao) and into a de-identified public
+projection consumed by web-cfg.
+
+No claim is invented here. Every section carries provenance, an observation
+timestamp and an explicit state; missing evidence is UNKNOWN, never zero.
+"""
+
+from __future__ import annotations
+
+SCHEMA = "confenge-dossier/1.0"
+PUBLIC_SCHEMA = "public-read-confenge-dossier/1.0"
+CONTRACT_VERSION = "v1.0.0"
+METHOD_VERSION = "confenge-dossier-compose/1.0"
+POLICY_VERSION = "confenge-dossier-policy/1.0"
+GRAIN = "cnpj14"
+
+PRODUCER_EXTRA_CLI = "extra-cli"
+CONSUMER_WEB_CFG = "web-cfg/contract-analysis"
+CONSUMER_WARMBLY = "warmbly/confenge-cohort"
+
+OFFER_ID = "CFG-DIAG-EXP-v1"
+OFFER_CATALOG = "CFG-OFFER-CATALOG-v1"
+
+CATALOG_FIXTURE = "fixture"
+CATALOG_OFFICIAL_LIVE = "official_live"
+CATALOG_MODES = (CATALOG_FIXTURE, CATALOG_OFFICIAL_LIVE)
+
+DATA_READY = "DATA_READY"
+DATA_HOLD = "DATA_HOLD"
+DATA_REJECT = "DATA_REJECT"
+DATA_STATES = (DATA_READY, DATA_HOLD, DATA_REJECT)
+# Worst-wins ordering when folding section states into the document state.
+DATA_STATE_RANK = {DATA_READY: 0, DATA_HOLD: 1, DATA_REJECT: 2}
+
+UNKNOWN = "UNKNOWN"
+
+SECTION_IDENTITY = "identity"
+SECTION_BUYER_MAP = "buyer_map"
+SECTION_COMPETITORS = "competitors"
+SECTION_PRICE_PANEL = "price_panel"
+SECTION_EXPIRING = "expiring_contracts"
+SECTION_OPPORTUNITIES = "open_opportunities"
+SECTION_ORDER = (
+    SECTION_IDENTITY,
+    SECTION_BUYER_MAP,
+    SECTION_COMPETITORS,
+    SECTION_PRICE_PANEL,
+    SECTION_EXPIRING,
+    SECTION_OPPORTUNITIES,
+)
+# Sections the paid offer promises. A REJECT on any of these rejects the dossier.
+REQUIRED_SECTIONS = (SECTION_IDENTITY, SECTION_BUYER_MAP, SECTION_PRICE_PANEL)
+
+# Offer scope: "15 concorrentes".
+COMPETITOR_LIMIT = 15
+# Offer scope: "contratos a vencer". One year ahead is the planning horizon.
+EXPIRING_WINDOW_DAYS = 365
+# Offer scope: "editais triados".
+OPPORTUNITY_LIMIT = 25
+BUYER_LIMIT = 50
+# A contract needs a signed/started date to have a reajuste anniversary.
+ANNIVERSARY_MIN_MONTHS = 12
+
+MIN_CONTRACTS_READY = 3
+MIN_CONTRACTS_HOLD = 1
+MIN_BUYERS_READY = 2
+
+REASON_IDENTITY_NOT_FOUND = "identity_not_found"
+REASON_NO_CONTRACTS = "no_canonical_contracts"
+REASON_INSUFFICIENT_CONTRACTS = "insufficient_contracts"
+REASON_INSUFFICIENT_BUYERS = "insufficient_buyers"
+REASON_NO_COMPETITORS = "no_competitor_sample"
+REASON_NO_PRICE_REFERENCE = "no_price_reference"
+REASON_PANEL_OUT_OF_RANGE = "focal_outside_panel_range"
+REASON_NO_PRIMARY_CATEGORY = "primary_category_undetermined"
+REASON_NO_EXPIRING = "no_expiring_contracts_in_window"
+REASON_NO_OPPORTUNITIES = "no_open_opportunities_for_buyers"
+REASON_VALUE_UNKNOWN = "value_unknown_excluded_from_denominator"
+REASON_DSN_UNAVAILABLE = "dsn_unavailable"
+REASON_TABLE_MISSING = "official_table_missing"
+REASON_FIXTURE_NOT_LIVE = "fixture_not_official_live"
+REASON_FIXTURE_LABELED_LIVE = "fixture_labeled_official_live"
+REASON_INVALID_CNPJ = "invalid_cnpj14"
+REASON_STALE_WATERMARK = "source_watermark_stale"
+
+HARD_REJECT_REASONS = frozenset(
+    {
+        REASON_IDENTITY_NOT_FOUND,
+        REASON_NO_CONTRACTS,
+        REASON_INVALID_CNPJ,
+        REASON_FIXTURE_LABELED_LIVE,
+        REASON_DSN_UNAVAILABLE,
+    }
+)
+
+# Findings are facts plus the question they open. They never assert a right,
+# an imbalance, a loss, or that an adjustment is due.
+FINDING_ANNIVERSARY = "contract_anniversary_reached"
+FINDING_EXPIRING_WINDOW = "contract_ending_within_window"
+FINDING_BUYER_CONCENTRATION = "buyer_concentration_high"
+FINDING_PRICE_POSITION = "value_position_in_category"
+FINDING_OPPORTUNITY_SAME_BUYER = "open_opportunity_from_known_buyer"
+FINDING_LONG_HORIZON = "contract_horizon_beyond_window"
+
+FINDING_ORDER = (
+    FINDING_ANNIVERSARY,
+    FINDING_EXPIRING_WINDOW,
+    FINDING_BUYER_CONCENTRATION,
+    FINDING_PRICE_POSITION,
+    FINDING_OPPORTUNITY_SAME_BUYER,
+    FINDING_LONG_HORIZON,
+)
+
+# HHI over this threshold is reported as concentration. Standard antitrust band.
+HHI_CONCENTRATION_THRESHOLD = 0.25
+
+# The category ladder is coarse: a road-maintenance contract and a mop purchase
+# both land in FACILITIES. When the focal median sits more than this many times
+# outside the panel's interquartile band, the panel is not a comparable
+# reference and no percentile position is claimed.
+PANEL_OUT_OF_RANGE_FACTOR = 10
+POSITION_OUT_OF_PANEL_RANGE = "OUT_OF_PANEL_RANGE"
+
+# Reused verbatim from contract_comparables: the dossier is bound by the same
+# no-claim policy as every other consumer-bound artifact in this repository.
+FORBIDDEN_CLAIM_TOKENS = (
+    "sobrepreco",
+    "sobrepreço",
+    "overprice",
+    "fraude",
+    "fraud",
+    "irregularidade",
+    "irregularity",
+    "irregular",
+    "caro",
+    "barato",
+    "custo/km",
+    "custo/m2",
+    "custo/m²",
+    "custo por km",
+    "custo por m",
+    "preco unitario",
+    "preço unitário",
+    "ranking nacional",
+    "market share",
+    "reajuste devido",
+    "valor devido",
+    "prejuizo",
+    "prejuízo",
+    "direito adquirido",
+)
+
+FORBIDDEN_METRIC_KEYS = frozenset(
+    {
+        "cost_per_km",
+        "cost_per_m2",
+        "custo_por_km",
+        "custo_por_m2",
+        "unit_price",
+        "preco_unitario",
+        "sobrepreco",
+        "reajuste_devido",
+        "valor_devido",
+    }
+)
+
+# Fields removed from the public projection. The prospect is not the subject of
+# a public page; public bodies and their published contracts are.
+PUBLIC_REDACTED_FIELDS = frozenset(
+    {
+        "cnpj14",
+        "cnpj_raiz",
+        "razao_social",
+        "nome_fantasia",
+        "supplier_cnpj",
+        "supplier_nome",
+        "fornecedor_cnpj",
+        "fornecedor_nome",
+        "municipio",
+    }
+)

--- a/scripts/dossier/constants.py
+++ b/scripts/dossier/constants.py
@@ -75,6 +75,8 @@ REASON_INSUFFICIENT_CONTRACTS = "insufficient_contracts"
 REASON_INSUFFICIENT_BUYERS = "insufficient_buyers"
 REASON_NO_COMPETITORS = "no_competitor_sample"
 REASON_NO_PRICE_REFERENCE = "no_price_reference"
+REASON_LOW_PRECISION_BUCKET = "category_bucket_low_precision"
+REASON_BUYER_LIST_TRUNCATED = "buyer_list_truncated_for_display"
 REASON_PANEL_OUT_OF_RANGE = "focal_outside_panel_range"
 REASON_NO_PRIMARY_CATEGORY = "primary_category_undetermined"
 REASON_NO_EXPIRING = "no_expiring_contracts_in_window"
@@ -124,6 +126,14 @@ HHI_CONCENTRATION_THRESHOLD = 0.25
 # reference and no percentile position is claimed.
 PANEL_OUT_OF_RANGE_FACTOR = 10
 POSITION_OUT_OF_PANEL_RANGE = "OUT_OF_PANEL_RANGE"
+
+# The TI rung of the category ladder matches the bare substring "ti" and sits
+# above SAUDE and ALIMENTACAO, so it swallows "domesticos", "didaticos" and a
+# slice of health contracts: 84% of that bucket carries no TI keyword. A panel
+# built from household goods cannot price anything. Positions are not claimed
+# for these buckets until the upstream view is corrected.
+LOW_PRECISION_CATEGORIES = frozenset({"TI"})
+POSITION_LOW_PRECISION_BUCKET = "LOW_PRECISION_BUCKET"
 
 # Reused verbatim from contract_comparables: the dossier is bound by the same
 # no-claim policy as every other consumer-bound artifact in this repository.

--- a/scripts/dossier/envelope.py
+++ b/scripts/dossier/envelope.py
@@ -1,0 +1,359 @@
+"""Versioned ``confenge-dossier/1.0`` envelope, content hash and public projection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from scripts.dossier.compose import (
+    build_buyer_map,
+    build_competitors,
+    build_expiring,
+    build_findings,
+    build_identity,
+    build_opportunities,
+    build_price_panel,
+)
+from scripts.dossier.constants import (
+    CATALOG_FIXTURE,
+    CATALOG_OFFICIAL_LIVE,
+    COMPETITOR_LIMIT,
+    CONSUMER_WEB_CFG,
+    CONTRACT_VERSION,
+    DATA_HOLD,
+    DATA_READY,
+    DATA_REJECT,
+    EXPIRING_WINDOW_DAYS,
+    FORBIDDEN_CLAIM_TOKENS,
+    FORBIDDEN_METRIC_KEYS,
+    GRAIN,
+    HARD_REJECT_REASONS,
+    METHOD_VERSION,
+    OFFER_CATALOG,
+    OFFER_ID,
+    POLICY_VERSION,
+    PRODUCER_EXTRA_CLI,
+    PUBLIC_REDACTED_FIELDS,
+    PUBLIC_SCHEMA,
+    REASON_FIXTURE_LABELED_LIVE,
+    REASON_FIXTURE_NOT_LIVE,
+    REASON_INVALID_CNPJ,
+    REQUIRED_SECTIONS,
+    SCHEMA,
+    SECTION_BUYER_MAP,
+    SECTION_COMPETITORS,
+    SECTION_IDENTITY,
+    SECTION_OPPORTUNITIES,
+    SECTION_PRICE_PANEL,
+    UNKNOWN,
+)
+from scripts.dossier.models import DossierRequest, DossierResult, Section, cnpj14, worst_state
+from scripts.dossier.sources import Source
+
+# Excluded from the content hash so two runs over the same data agree byte for byte.
+VOLATILE_KEYS = frozenset({"generated_at", "observed_at", "producer_sha", "content_hash", "duration_ms"})
+
+LIMITATION_REFERENCE_SCOPE = (
+    "O painel de preços usa o conjunto de referência de órgãos públicos no raio de 200 km "
+    "da base de referência; não é uma amostra nacional."
+)
+LIMITATION_UNKNOWN = "Campo ausente permanece UNKNOWN e não entra no denominador. UNKNOWN não é zero."
+LIMITATION_NO_CLAIM = (
+    "Os achados são fatos observados mais a pergunta que abrem. O dossiê não afirma direito, "
+    "desequilíbrio econômico-financeiro, dano ou que um reajuste seja devido."
+)
+LIMITATION_FIXTURE = "Execução em modo fixture. Não é evidência oficial e não pode ser publicada como tal."
+LIMITATION_ACTIVE_ONLY = (
+    "Contratos refletem o estado canônico do DataLake na data de observação; aditivos posteriores "
+    "à última coleta podem não estar refletidos."
+)
+
+
+def producer_sha() -> str | None:
+    env = os.environ.get("CONFENGE_REPOSITORY_SHA")
+    if env:
+        return env.strip()
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607 -- git resolved from PATH by design; fixed argv, no shell
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=Path(__file__).resolve().parents[2],
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None if out.returncode == 0 else None
+
+
+def _strip_volatile(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _strip_volatile(v) for k, v in sorted(value.items()) if k not in VOLATILE_KEYS}
+    if isinstance(value, list):
+        return [_strip_volatile(v) for v in value]
+    return value
+
+
+def canonical_json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def content_hash(document: dict[str, Any]) -> str:
+    stable = canonical_json(_strip_volatile(document))
+    return "sha256:" + hashlib.sha256(stable.encode("utf-8")).hexdigest()
+
+
+def dossier_id(cnpj: str, as_of: str, catalog_mode: str) -> str:
+    digest = hashlib.sha256(f"{cnpj}|{as_of}|{catalog_mode}".encode()).hexdigest()[:16]
+    return f"cfg-dossier-{digest}"
+
+
+def _fold_state(sections: tuple[Section, ...]) -> tuple[str, tuple[str, ...]]:
+    by_id = {s.section_id: s for s in sections}
+    required_states = tuple(by_id[s].state for s in REQUIRED_SECTIONS if s in by_id)
+    state = worst_state(required_states)
+    reasons: list[str] = []
+    for section in sections:
+        for code in section.reason_codes:
+            if code not in reasons:
+                reasons.append(code)
+    if any(code in HARD_REJECT_REASONS for code in reasons):
+        state = DATA_REJECT
+    return state, tuple(reasons)
+
+
+EXEMPT_TEXT_SUFFIXES = (
+    ".objeto",
+    ".objeto_contrato",
+    ".razao_social",
+    ".nome_fantasia",
+    ".buyer_nome",
+    ".orgao_nome",
+    ".supplier_nome",
+)
+# The declared-limitations block is frozen policy text under review, not generated
+# content. `test_limitations_are_frozen_constants` pins it so the exemption cannot
+# become a hole through which generated prose escapes the scan.
+EXEMPT_TEXT_PREFIXES = ("$.limitations",)
+
+
+def scan_forbidden(document: dict[str, Any]) -> tuple[str, ...]:
+    """Return forbidden claim tokens or metric keys found anywhere in the document.
+
+    Free-text carried straight from official ``objeto`` fields is exempt: the
+    engine must not rewrite official text, and an official object that contains
+    the word "manutenção" or "irregular" is a fact, not a claim by CONFENGE.
+    """
+    hits: list[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in FORBIDDEN_METRIC_KEYS:
+                    hits.append(f"metric_key:{key}@{path}")
+                walk(value, f"{path}.{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}[{index}]")
+        elif isinstance(node, str):
+            if path.endswith(EXEMPT_TEXT_SUFFIXES) or path.startswith(EXEMPT_TEXT_PREFIXES):
+                return
+            lowered = node.lower()
+            for token in FORBIDDEN_CLAIM_TOKENS:
+                if token in lowered:
+                    hits.append(f"claim_token:{token}@{path}")
+
+    walk(document, "$")
+    return tuple(sorted(set(hits)))
+
+
+def build_dossier(source: Source, request: DossierRequest) -> tuple[DossierResult, dict[str, Any]]:
+    normalized = cnpj14(request.cnpj)
+    competitor_limit = request.competitor_limit or COMPETITOR_LIMIT
+    window_days = request.expiring_window_days or EXPIRING_WINDOW_DAYS
+
+    if normalized is None:
+        result = DossierResult(
+            request=request,
+            dossier_id=dossier_id(request.cnpj, request.as_of, request.catalog_mode),
+            data_state=DATA_REJECT,
+            sections=(),
+            findings=(),
+            reason_codes=(REASON_INVALID_CNPJ,),
+            limitations=(LIMITATION_UNKNOWN,),
+        )
+        return result, _document(
+            result, catalog_mode=request.catalog_mode, competitor_limit=competitor_limit, window_days=window_days
+        )
+
+    if request.catalog_mode == CATALOG_OFFICIAL_LIVE and source.catalog_mode != CATALOG_OFFICIAL_LIVE:
+        result = DossierResult(
+            request=request,
+            dossier_id=dossier_id(normalized, request.as_of, request.catalog_mode),
+            data_state=DATA_REJECT,
+            sections=(),
+            findings=(),
+            reason_codes=(REASON_FIXTURE_LABELED_LIVE,),
+            limitations=(LIMITATION_FIXTURE,),
+        )
+        return result, _document(
+            result, catalog_mode=request.catalog_mode, competitor_limit=competitor_limit, window_days=window_days
+        )
+
+    identity_read = source.identity(normalized)
+    contracts_read = source.contracts(normalized)
+    buyers_read = source.buyers(normalized)
+    competitors_read = source.competitors(normalized)
+    price_read = source.price_panel(normalized)
+    expiring_read = source.expiring(normalized, window_days)
+    opportunities_read = source.opportunities(normalized)
+
+    identity = build_identity(identity_read)
+    buyer_map = build_buyer_map(buyers_read, contracts_read)
+    competitors = build_competitors(competitors_read, competitor_limit)
+    price_panel = build_price_panel(price_read)
+    expiring = build_expiring(expiring_read, window_days)
+    opportunities = build_opportunities(opportunities_read)
+
+    sections = (identity, buyer_map, competitors, price_panel, expiring, opportunities)
+    findings = build_findings(
+        contracts=contracts_read,
+        buyer_map=buyer_map,
+        price_panel=price_panel,
+        expiring=expiring,
+        opportunities=opportunities,
+        as_of=request.as_of,
+        window_days=window_days,
+    )
+    state, reasons = _fold_state(sections)
+
+    limitations = [LIMITATION_UNKNOWN, LIMITATION_NO_CLAIM, LIMITATION_ACTIVE_ONLY, LIMITATION_REFERENCE_SCOPE]
+    if source.catalog_mode == CATALOG_FIXTURE:
+        limitations.insert(0, LIMITATION_FIXTURE)
+        reasons = tuple([REASON_FIXTURE_NOT_LIVE, *[r for r in reasons if r != REASON_FIXTURE_NOT_LIVE]])
+
+    result = DossierResult(
+        request=request,
+        dossier_id=dossier_id(normalized, request.as_of, source.catalog_mode),
+        data_state=state,
+        sections=sections,
+        findings=findings,
+        reason_codes=reasons,
+        limitations=tuple(limitations),
+    )
+    document = _document(
+        result,
+        catalog_mode=source.catalog_mode,
+        competitor_limit=competitor_limit,
+        window_days=window_days,
+        contract_count=contracts_read.row_count,
+    )
+    return result, document
+
+
+def _document(
+    result: DossierResult,
+    *,
+    catalog_mode: str,
+    competitor_limit: int,
+    window_days: int,
+    contract_count: int = 0,
+) -> dict[str, Any]:
+    sections = {section.section_id: section.as_dict() for section in result.sections}
+    observed = [s.observed_at for s in result.sections if s.observed_at]
+    document: dict[str, Any] = {
+        "schema": SCHEMA,
+        "accepted_schemas": [SCHEMA],
+        "contract_version": CONTRACT_VERSION,
+        "method_version": METHOD_VERSION,
+        "policy_version": POLICY_VERSION,
+        "grain": GRAIN,
+        "dossier_id": result.dossier_id,
+        "cnpj14": cnpj14(result.request.cnpj),
+        "as_of": result.request.as_of,
+        "catalog_mode": catalog_mode,
+        "data_state": result.data_state,
+        "producer": PRODUCER_EXTRA_CLI,
+        "producer_sha": result.request.producer_sha,
+        "consumer": result.request.consumer_id,
+        "offer": {"offer_id": OFFER_ID, "catalog": OFFER_CATALOG},
+        "parameters": {
+            "competitor_limit": competitor_limit,
+            "expiring_window_days": window_days,
+        },
+        "observed_at": min(observed) if observed else None,
+        "totals": {
+            "contract_count": contract_count,
+            "section_count": len(result.sections),
+            "finding_count": len(result.findings),
+        },
+        "reason_codes": list(result.reason_codes),
+        "limitations": list(result.limitations),
+        "sections": sections,
+        "findings": [finding.as_dict() for finding in result.findings],
+    }
+    document["content_hash"] = content_hash(document)
+    return document
+
+
+def _redact(node: Any) -> Any:
+    if isinstance(node, dict):
+        return {k: (UNKNOWN if k in PUBLIC_REDACTED_FIELDS else _redact(v)) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_redact(v) for v in node]
+    return node
+
+
+def public_projection(document: dict[str, Any]) -> dict[str, Any]:
+    """De-identified projection for web-cfg.
+
+    The prospect is never the subject of a public page. Public bodies, their
+    published contracts and the reference panel are public record and stay.
+    """
+    sections = document.get("sections", {})
+    identity = (sections.get(SECTION_IDENTITY) or {}).get("payload", {})
+    buyer_map = (sections.get(SECTION_BUYER_MAP) or {}).get("payload", {})
+
+    public: dict[str, Any] = {
+        "schema": PUBLIC_SCHEMA,
+        "accepted_schemas": [PUBLIC_SCHEMA],
+        "contract_version": CONTRACT_VERSION,
+        "method_version": METHOD_VERSION,
+        "policy_version": POLICY_VERSION,
+        "grain": "anonymous_supplier_profile",
+        "source_dossier_hash": document.get("content_hash"),
+        "as_of": document.get("as_of"),
+        "catalog_mode": document.get("catalog_mode"),
+        "data_state": document.get("data_state"),
+        "producer": PRODUCER_EXTRA_CLI,
+        "consumer": CONSUMER_WEB_CFG,
+        "subject_profile": {
+            "uf": identity.get("uf", UNKNOWN),
+            "cnae_principal": identity.get("cnae_principal", UNKNOWN),
+            "buyer_count": buyer_map.get("buyer_count"),
+            "contract_count": buyer_map.get("contract_count"),
+        },
+        "reason_codes": document.get("reason_codes", []),
+        "limitations": document.get("limitations", []),
+        "sections": {
+            SECTION_PRICE_PANEL: _redact(sections.get(SECTION_PRICE_PANEL, {})),
+            SECTION_COMPETITORS: _redact(sections.get(SECTION_COMPETITORS, {})),
+            SECTION_OPPORTUNITIES: _redact(sections.get(SECTION_OPPORTUNITIES, {})),
+        },
+        "findings": [
+            _redact(f)
+            for f in document.get("findings", [])
+            if f.get("finding_id", "").startswith(("value_position_in_category", "open_opportunity_from_known_buyer"))
+        ],
+        "publication_readiness": (
+            "DATA_READY"
+            if document.get("data_state") == DATA_READY and document.get("catalog_mode") == CATALOG_OFFICIAL_LIVE
+            else DATA_HOLD
+        ),
+    }
+    public["content_hash"] = content_hash(public)
+    return public

--- a/scripts/dossier/envelope.py
+++ b/scripts/dossier/envelope.py
@@ -42,6 +42,7 @@ from scripts.dossier.constants import (
     REASON_FIXTURE_LABELED_LIVE,
     REASON_FIXTURE_NOT_LIVE,
     REASON_INVALID_CNPJ,
+    REASON_TABLE_MISSING,
     REQUIRED_SECTIONS,
     SCHEMA,
     SECTION_BUYER_MAP,
@@ -123,6 +124,10 @@ def _fold_state(sections: tuple[Section, ...]) -> tuple[str, tuple[str, ...]]:
                 reasons.append(code)
     if any(code in HARD_REJECT_REASONS for code in reasons):
         state = DATA_REJECT
+    # Competitors, expiring contracts and open bids are offer scope too. A source
+    # that is simply absent must not fold to READY behind the required trio.
+    if any(REASON_TABLE_MISSING in section.reason_codes for section in sections):
+        state = worst_state((state, DATA_HOLD))
     return state, tuple(reasons)
 
 
@@ -139,6 +144,10 @@ EXEMPT_TEXT_SUFFIXES = (
 # content. `test_limitations_are_frozen_constants` pins it so the exemption cannot
 # become a hole through which generated prose escapes the scan.
 EXEMPT_TEXT_PREFIXES = ("$.limitations",)
+# Keys whose value is copied verbatim from an official publication.
+OFFICIAL_TEXT_KEYS = frozenset(
+    {"objeto", "objeto_contrato", "buyer_nome", "orgao_nome", "supplier_nome", "razao_social", "nome_fantasia"}
+)
 
 
 def scan_forbidden(document: dict[str, Any]) -> tuple[str, ...]:
@@ -169,6 +178,45 @@ def scan_forbidden(document: dict[str, Any]) -> tuple[str, ...]:
 
     walk(document, "$")
     return tuple(sorted(set(hits)))
+
+
+def official_free_text(document: dict[str, Any]) -> tuple[str, ...]:
+    """Every string the engine copied verbatim from an official source."""
+    texts: list[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in OFFICIAL_TEXT_KEYS and isinstance(value, str):
+                    texts.append(value)
+                walk(value, f"{path}.{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}[{index}]")
+
+    walk(document, "$")
+    return tuple(texts)
+
+
+def scan_markdown(markdown: str, document: dict[str, Any]) -> tuple[str, ...]:
+    """Scan the delivered markdown, exempting text quoted from official sources.
+
+    The rendered document is what the client reads, so it is scanned like the
+    JSON. Path-based exemptions do not survive rendering, so official ``objeto``
+    text is recognised by value: a token that also appears inside an official
+    string the engine copied is that source's word, not a CONFENGE claim.
+    """
+    lowered = markdown.lower()
+    official = " ".join(official_free_text(document)).lower()
+    return tuple(
+        sorted(
+            {
+                f"claim_token:{token}@$.markdown"
+                for token in FORBIDDEN_CLAIM_TOKENS
+                if token in lowered and token not in official
+            }
+        )
+    )
 
 
 def build_dossier(source: Source, request: DossierRequest) -> tuple[DossierResult, dict[str, Any]]:
@@ -207,13 +255,14 @@ def build_dossier(source: Source, request: DossierRequest) -> tuple[DossierResul
     identity_read = source.identity(normalized)
     contracts_read = source.contracts(normalized)
     buyers_read = source.buyers(normalized)
+    totals_read = source.portfolio_totals(normalized)
     competitors_read = source.competitors(normalized)
     price_read = source.price_panel(normalized)
-    expiring_read = source.expiring(normalized, window_days)
+    expiring_read = source.expiring(normalized, window_days, request.as_of)
     opportunities_read = source.opportunities(normalized)
 
     identity = build_identity(identity_read)
-    buyer_map = build_buyer_map(buyers_read, contracts_read)
+    buyer_map = build_buyer_map(buyers_read, contracts_read, totals_read)
     competitors = build_competitors(competitors_read, competitor_limit)
     price_panel = build_price_panel(price_read)
     expiring = build_expiring(expiring_read, window_days)
@@ -308,6 +357,59 @@ def _redact(node: Any) -> Any:
     return node
 
 
+def _band(value: Any, edges: tuple[int, ...]) -> str:
+    """Bucket a count so it stops being a unique quasi-identifier."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return UNKNOWN
+    low = 1
+    for edge in edges:
+        if number <= edge:
+            return f"{low}-{edge}"
+        low = edge + 1
+    return f"{low}+"
+
+
+def _money_band(value: Any) -> str:
+    """Order-of-magnitude band. An exact BRL sum resolves a redacted supplier."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return UNKNOWN
+    if number <= 0:
+        return UNKNOWN
+    for edge in (100_000, 1_000_000, 10_000_000, 100_000_000):
+        if number < edge:
+            return "<" + f"{edge:,}".replace(",", ".")
+    return ">=100.000.000"
+
+
+def _public_competitors(section: dict[str, Any]) -> dict[str, Any]:
+    """Publish the shape of the competition, never a row that identifies one.
+
+    An exact valor_sum over a deterministic, publicly reproducible scope is a
+    perfect join key: one ``GROUP BY supplier_cnpj HAVING SUM(valor) = <published>``
+    resolves a redacted supplier back to a named CNPJ. Exact counts do the same
+    job more slowly. Only banded aggregates leave.
+    """
+    payload = section.get("payload") or {}
+    competitors = payload.get("competitors") or []
+    counts = [int(c.get("contract_count") or 0) for c in competitors]
+    shared = [int(c.get("shared_buyer_count") or 0) for c in competitors]
+    return {
+        **{k: v for k, v in section.items() if k != "payload"},
+        "payload": {
+            "competitor_count": len(competitors),
+            "primary_category": payload.get("primary_category", UNKNOWN),
+            "selection_rule": payload.get("selection_rule", UNKNOWN),
+            "contract_count_band": f"{min(counts)}-{max(counts)}" if counts else UNKNOWN,
+            "shared_buyer_count_band": f"{min(shared)}-{max(shared)}" if shared else UNKNOWN,
+            "value_bands": sorted({_money_band(c.get("valor_sum")) for c in competitors}),
+        },
+    }
+
+
 def public_projection(document: dict[str, Any]) -> dict[str, Any]:
     """De-identified projection for web-cfg.
 
@@ -331,17 +433,19 @@ def public_projection(document: dict[str, Any]) -> dict[str, Any]:
         "data_state": document.get("data_state"),
         "producer": PRODUCER_EXTRA_CLI,
         "consumer": CONSUMER_WEB_CFG,
+        # Exact counts plus UF plus a 7-digit CNAE identify one supplier
+        # nationwide. Bands describe the recorte without naming it.
         "subject_profile": {
             "uf": identity.get("uf", UNKNOWN),
-            "cnae_principal": identity.get("cnae_principal", UNKNOWN),
-            "buyer_count": buyer_map.get("buyer_count"),
-            "contract_count": buyer_map.get("contract_count"),
+            "cnae_division": str(identity.get("cnae_principal", UNKNOWN))[:2],
+            "buyer_count_band": _band(buyer_map.get("buyer_count"), (5, 20, 50, 100)),
+            "contract_count_band": _band(buyer_map.get("contract_count"), (10, 50, 200, 1000)),
         },
         "reason_codes": document.get("reason_codes", []),
         "limitations": document.get("limitations", []),
         "sections": {
             SECTION_PRICE_PANEL: _redact(sections.get(SECTION_PRICE_PANEL, {})),
-            SECTION_COMPETITORS: _redact(sections.get(SECTION_COMPETITORS, {})),
+            SECTION_COMPETITORS: _public_competitors(sections.get(SECTION_COMPETITORS, {})),
             SECTION_OPPORTUNITIES: _redact(sections.get(SECTION_OPPORTUNITIES, {})),
         },
         "findings": [

--- a/scripts/dossier/handoff.py
+++ b/scripts/dossier/handoff.py
@@ -1,0 +1,174 @@
+"""Consumer-bound handoff for `public-read-confenge-dossier/1.0`.
+
+Only the de-identified projection crosses this boundary. The private dossier
+never leaves extra-cli: web-cfg publishes public bodies and public contracts,
+never the prospect.
+
+Layout mirrors the contract-comparables rendezvous so the consumer side stays
+one fail-closed pattern: ``READY.json`` xor ``BLOCKED.json`` plus
+``SHA256SUMS.txt`` over every other file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from scripts.dossier.constants import (
+    CATALOG_OFFICIAL_LIVE,
+    CONSUMER_WEB_CFG,
+    CONTRACT_VERSION,
+    DATA_READY,
+    METHOD_VERSION,
+    POLICY_VERSION,
+    PRODUCER_EXTRA_CLI,
+    PUBLIC_SCHEMA,
+)
+
+HANDOFF_SCHEMA = "authority-handoff-confenge-dossier/1.0"
+FAMILY = "confenge-dossier"
+CHANNEL = "official-live-01"
+SUMS_NAME = "SHA256SUMS.txt"
+
+DECISION_READY = "READY"
+DECISION_BLOCKED = "BLOCKED"
+
+REASON_NOT_OFFICIAL_LIVE = "handoff_requires_official_live"
+REASON_NOT_DATA_READY = "handoff_requires_data_ready"
+REASON_NOT_PUBLISHABLE = "handoff_requires_publication_readiness"
+
+
+def rendezvous_dir() -> Path:
+    """Where the consumer looks. Overridable with ``CONFENGE_HANDOFF_DIR``."""
+    base = os.environ.get("CONFENGE_HANDOFF_DIR")
+    root = Path(base) if base else Path.home() / ".local" / "share" / "confenge" / "handoffs"
+    return root / FAMILY / CHANNEL
+
+
+def _dump(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _write(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload if isinstance(payload, str) else _dump(payload), encoding="utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def decide(public: dict[str, Any]) -> tuple[str, list[str]]:
+    """READY only when the projection is official, ready and publishable."""
+    reasons: list[str] = []
+    if public.get("catalog_mode") != CATALOG_OFFICIAL_LIVE:
+        reasons.append(REASON_NOT_OFFICIAL_LIVE)
+    if public.get("data_state") != DATA_READY:
+        reasons.append(REASON_NOT_DATA_READY)
+    if public.get("publication_readiness") != DATA_READY:
+        reasons.append(REASON_NOT_PUBLISHABLE)
+    return (DECISION_BLOCKED if reasons else DECISION_READY), reasons
+
+
+def write_handoff(public: dict[str, Any], manifest: dict[str, Any], root: Path) -> dict[str, Any]:
+    decision, reasons = decide(public)
+    root.mkdir(parents=True, exist_ok=True)
+    for stale in root.iterdir():
+        if stale.is_file():
+            stale.unlink()
+
+    handoff_manifest = {
+        "schema": HANDOFF_SCHEMA,
+        "payload_schema": PUBLIC_SCHEMA,
+        "contract_version": CONTRACT_VERSION,
+        "method_version": METHOD_VERSION,
+        "policy_version": POLICY_VERSION,
+        "producer": PRODUCER_EXTRA_CLI,
+        "consumer": CONSUMER_WEB_CFG,
+        "producer_commit": manifest.get("producer_sha"),
+        "dossier_id": manifest.get("dossier_id"),
+        "source_dossier_hash": public.get("source_dossier_hash"),
+        "content_hash": public.get("content_hash"),
+        "as_of": public.get("as_of"),
+        "catalog_mode": public.get("catalog_mode"),
+        "data_state": public.get("data_state"),
+        "publication_readiness": public.get("publication_readiness"),
+        # The consumer owns editorial INDEX. The producer never grants it.
+        "publication_authorization": False,
+        "index_authorization": False,
+        "no_cross_repo_write": True,
+        "carries_prospect_identity": False,
+        "files": ["payload.json", "manifest.json", "state.json", f"{decision}.json", SUMS_NAME],
+    }
+    state = {
+        "handoff_decision": decision,
+        "reason_codes": reasons + list(public.get("reason_codes") or []),
+        "data_state": public.get("data_state"),
+        "catalog_mode": public.get("catalog_mode"),
+        "publication_authorization": False,
+        "index_authorization": False,
+    }
+    marker = {
+        "schema": HANDOFF_SCHEMA,
+        "status": decision,
+        "content_hash": public.get("content_hash"),
+        "dossier_id": manifest.get("dossier_id"),
+        "publication_authorization": False,
+        "index_authorization": False,
+        "reason_codes": reasons,
+    }
+
+    _write(root / "payload.json", public)
+    _write(root / "manifest.json", handoff_manifest)
+    _write(root / "state.json", state)
+    _write(root / f"{decision}.json", marker)
+
+    sums = [
+        f"{_sha256(path.read_bytes())}  {path.relative_to(root).as_posix()}"
+        for path in sorted(p for p in root.rglob("*") if p.is_file() and p.name != SUMS_NAME)
+    ]
+    (root / SUMS_NAME).write_text("\n".join(sums) + "\n", encoding="utf-8")
+
+    if (root / f"{DECISION_READY}.json").exists() and (root / f"{DECISION_BLOCKED}.json").exists():
+        raise RuntimeError("READY.json and BLOCKED.json are mutually exclusive")
+
+    return {
+        "root": str(root),
+        "decision": decision,
+        "reason_codes": reasons,
+        "content_hash": public.get("content_hash"),
+    }
+
+
+def verify_handoff(root: Path) -> list[str]:
+    errors: list[str] = []
+    sums_file = root / SUMS_NAME
+    if not sums_file.exists():
+        return [f"missing:{SUMS_NAME}"]
+    listed: dict[str, str] = {}
+    for line in sums_file.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, name = line.split("  ", 1)
+        listed[name] = digest
+    present = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file() and p.name != SUMS_NAME}
+    if set(listed) != present:
+        errors.append(f"sha256sums_mismatch:{sorted(set(listed) ^ present)}")
+    for name, digest in listed.items():
+        path = root / name
+        if not path.exists() or _sha256(path.read_bytes()) != digest:
+            errors.append(f"digest:{name}")
+    ready = (root / f"{DECISION_READY}.json").exists()
+    blocked = (root / f"{DECISION_BLOCKED}.json").exists()
+    if ready == blocked:
+        errors.append("ready_xor_blocked")
+    if ready:
+        payload = json.loads((root / "payload.json").read_text(encoding="utf-8"))
+        if payload.get("catalog_mode") != CATALOG_OFFICIAL_LIVE:
+            errors.append("ready_on_non_official_live")
+        if payload.get("publication_readiness") != DATA_READY:
+            errors.append("ready_without_publication_readiness")
+    return errors

--- a/scripts/dossier/models.py
+++ b/scripts/dossier/models.py
@@ -1,0 +1,142 @@
+"""Immutable records for the CONFENGE dossier engine."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+from scripts.dossier.constants import (
+    DATA_HOLD,
+    DATA_READY,
+    DATA_REJECT,
+    DATA_STATE_RANK,
+)
+
+_NON_DIGITS = re.compile(r"\D+")
+
+
+def digits_only(value: Any) -> str:
+    if value is None:
+        return ""
+    return _NON_DIGITS.sub("", str(value))
+
+
+def cnpj14(value: Any) -> str | None:
+    """Return a 14-digit CNPJ or None. Never pads a shorter number."""
+    digits = digits_only(value)
+    return digits if len(digits) == 14 else None
+
+
+def cnpj_root(value: Any) -> str | None:
+    digits = digits_only(value)
+    return digits[:8] if len(digits) >= 8 else None
+
+
+def money(value: Decimal | int | float | None) -> str | None:
+    """Serialize money as a fixed-point string. None stays None, never 0."""
+    if value is None:
+        return None
+    return format(Decimal(str(value)).quantize(Decimal("0.01")), "f")
+
+
+def worst_state(states: tuple[str, ...]) -> str:
+    if not states:
+        return DATA_REJECT
+    return max(states, key=lambda s: DATA_STATE_RANK.get(s, DATA_STATE_RANK[DATA_REJECT]))
+
+
+@dataclass(frozen=True)
+class SourceRead:
+    """One SELECT-only read from the DataLake, with its provenance."""
+
+    source: str
+    observed_at: str
+    rows: tuple[dict[str, Any], ...] = ()
+    reason_codes: tuple[str, ...] = ()
+    available: bool = True
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+
+@dataclass(frozen=True)
+class Section:
+    """A dossier section: payload plus the evidence needed to trust it."""
+
+    section_id: str
+    state: str
+    payload: dict[str, Any]
+    sources: tuple[str, ...]
+    observed_at: str | None
+    row_count: int
+    reason_codes: tuple[str, ...] = ()
+    missingness: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "section_id": self.section_id,
+            "state": self.state,
+            "sources": list(self.sources),
+            "observed_at": self.observed_at,
+            "row_count": self.row_count,
+            "reason_codes": list(self.reason_codes),
+            "missingness": self.missingness,
+            "payload": self.payload,
+        }
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A fact plus the question it opens. Never an assertion of a right."""
+
+    finding_id: str
+    subject: str
+    fact: str
+    question: str
+    evidence_refs: tuple[str, ...]
+    severity: str = "INFORMATIONAL"
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "subject": self.subject,
+            "fact": self.fact,
+            "question": self.question,
+            "evidence_refs": list(self.evidence_refs),
+            "severity": self.severity,
+            "metrics": dict(sorted(self.metrics.items())),
+        }
+
+
+@dataclass(frozen=True)
+class DossierRequest:
+    cnpj: str
+    as_of: str
+    catalog_mode: str
+    consumer_id: str
+    producer_sha: str | None = None
+    competitor_limit: int | None = None
+    expiring_window_days: int | None = None
+
+
+@dataclass(frozen=True)
+class DossierResult:
+    request: DossierRequest
+    dossier_id: str
+    data_state: str
+    sections: tuple[Section, ...]
+    findings: tuple[Finding, ...]
+    reason_codes: tuple[str, ...]
+    limitations: tuple[str, ...]
+
+    @property
+    def is_ready(self) -> bool:
+        return self.data_state == DATA_READY
+
+    @property
+    def is_hold(self) -> bool:
+        return self.data_state == DATA_HOLD

--- a/scripts/dossier/render.py
+++ b/scripts/dossier/render.py
@@ -1,0 +1,250 @@
+"""Markdown rendering of a ``confenge-dossier/1.0`` document.
+
+Byte-stable for a given document: no wall-clock reads, no dict iteration order
+dependence. The rendered file is the human deliverable; the JSON is the contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.dossier.constants import (
+    DATA_READY,
+    SECTION_BUYER_MAP,
+    SECTION_COMPETITORS,
+    SECTION_EXPIRING,
+    SECTION_IDENTITY,
+    SECTION_OPPORTUNITIES,
+    SECTION_PRICE_PANEL,
+    UNKNOWN,
+)
+
+STATE_LABEL = {
+    "DATA_READY": "pronto",
+    "DATA_HOLD": "retido por falta de evidência",
+    "DATA_REJECT": "recusado",
+}
+
+POSITION_LABEL = {
+    "BELOW_P25": "abaixo do p25 do painel",
+    "P25_P50": "entre p25 e p50 do painel",
+    "P50_P75": "entre p50 e p75 do painel",
+    "ABOVE_P75": "acima do p75 do painel",
+    "OUT_OF_PANEL_RANGE": "fora da faixa do painel — sem posição percentílica",
+    UNKNOWN: UNKNOWN,
+}
+
+
+def _brl(value: Any) -> str:
+    if value in (None, "", UNKNOWN):
+        return UNKNOWN
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    inteiro, _, centavos = f"{number:,.2f}".partition(".")
+    return "R$ " + inteiro.replace(",", ".") + "," + centavos
+
+
+def _section(document: dict[str, Any], section_id: str) -> dict[str, Any]:
+    section = document.get("sections", {}).get(section_id, {})
+    return section if isinstance(section, dict) else {}
+
+
+def _payload(document: dict[str, Any], section_id: str) -> dict[str, Any]:
+    return _section(document, section_id).get("payload", {}) or {}
+
+
+def _state_line(document: dict[str, Any], section_id: str) -> str:
+    section = _section(document, section_id)
+    state = section.get("state", UNKNOWN)
+    label = STATE_LABEL.get(state, state)
+    reasons = section.get("reason_codes") or []
+    suffix = f" — códigos: {', '.join(reasons)}" if reasons else ""
+    return f"*Estado da seção: {label} (`{state}`), {section.get('row_count', 0)} registros{suffix}.*"
+
+
+def render_markdown(document: dict[str, Any]) -> str:
+    identity = _payload(document, SECTION_IDENTITY)
+    lines: list[str] = []
+    nome = identity.get("razao_social") or UNKNOWN
+
+    lines.append(f"# Diagnóstico B2G — {nome}")
+    lines.append("")
+    lines.append(f"- Documento: `{document.get('dossier_id')}`")
+    lines.append(f"- Schema: `{document.get('schema')}` ({document.get('contract_version')})")
+    lines.append(f"- Modo de catálogo: `{document.get('catalog_mode')}`")
+    lines.append(
+        f"- Estado dos dados: `{document.get('data_state')}` ({STATE_LABEL.get(str(document.get('data_state')), '')})"
+    )
+    lines.append(f"- Data de referência: `{document.get('as_of')}`")
+    lines.append(f"- Observado em: `{document.get('observed_at') or UNKNOWN}`")
+    lines.append(f"- Hash de conteúdo: `{document.get('content_hash')}`")
+    lines.append(f"- Produtor: `{document.get('producer')}` @ `{document.get('producer_sha') or UNKNOWN}`")
+    lines.append("")
+    if document.get("data_state") != DATA_READY:
+        lines.append(
+            "> Este documento não está em estado pronto. As seções retidas indicam falta de "
+            "evidência, não ausência do fato."
+        )
+        lines.append("")
+
+    lines.append("## 1. Identificação")
+    lines.append("")
+    lines.append(_state_line(document, SECTION_IDENTITY))
+    lines.append("")
+    lines.append("| Campo | Valor |")
+    lines.append("| --- | --- |")
+    for label, key in (
+        ("Razão social", "razao_social"),
+        ("CNPJ", "cnpj14"),
+        ("CNAE principal", "cnae_principal"),
+        ("Situação cadastral", "situacao_cadastral"),
+        ("Município", "municipio"),
+        ("UF", "uf"),
+        ("Fonte cadastral", "registry_source"),
+        ("Data da fonte", "registry_source_date"),
+    ):
+        lines.append(f"| {label} | {identity.get(key, UNKNOWN)} |")
+    lines.append("")
+
+    buyer_map = _payload(document, SECTION_BUYER_MAP)
+    lines.append("## 2. Mapa de compradores")
+    lines.append("")
+    lines.append(_state_line(document, SECTION_BUYER_MAP))
+    lines.append("")
+    lines.append(
+        f"Compradores distintos: **{buyer_map.get('buyer_count', UNKNOWN)}** · "
+        f"contratos: **{buyer_map.get('contract_count', UNKNOWN)}** · "
+        f"valor conhecido: **{_brl(buyer_map.get('valor_sum_valued'))}** · "
+        f"HHI: **{buyer_map.get('hhi', UNKNOWN)}**"
+    )
+    lines.append("")
+    lines.append("| Comprador | UF | Contratos | Valor conhecido | Participação | Último fim |")
+    lines.append("| --- | --- | ---: | ---: | ---: | --- |")
+    for buyer in buyer_map.get("buyers", []):
+        share = buyer.get("share_of_valued")
+        share_text = UNKNOWN if share is None else f"{share * 100:.1f}%"
+        lines.append(
+            f"| {buyer.get('buyer_nome', UNKNOWN)} | {buyer.get('uf', UNKNOWN)} | "
+            f"{buyer.get('contract_count', UNKNOWN)} | {_brl(buyer.get('valor_sum'))} | "
+            f"{share_text} | {buyer.get('last_data_fim', UNKNOWN)} |"
+        )
+    lines.append("")
+
+    competitors = _payload(document, SECTION_COMPETITORS)
+    lines.append("## 3. Concorrentes na categoria principal")
+    lines.append("")
+    lines.append(_state_line(document, SECTION_COMPETITORS))
+    lines.append("")
+    lines.append(f"Categoria principal identificada: **{competitors.get('primary_category', UNKNOWN)}**.")
+    lines.append("")
+    lines.append(f"Regra de seleção: {competitors.get('selection_rule', UNKNOWN)}.")
+    lines.append("")
+    lines.append(
+        "| Fornecedor | Contratos | Com valor publicado | Compradores em comum | Categorias | Valor conhecido |"
+    )
+    lines.append("| --- | ---: | ---: | ---: | --- | ---: |")
+    for competitor in competitors.get("competitors", []):
+        categorias = ", ".join(competitor.get("shared_categories") or []) or UNKNOWN
+        lines.append(
+            f"| {competitor.get('supplier_nome', UNKNOWN)} | {competitor.get('contract_count', UNKNOWN)} | "
+            f"{competitor.get('valued_count', UNKNOWN)} | {competitor.get('shared_buyer_count', UNKNOWN)} | "
+            f"{categorias} | {_brl(competitor.get('valor_sum'))} |"
+        )
+    lines.append("")
+
+    price_panel = _payload(document, SECTION_PRICE_PANEL)
+    lines.append("## 4. Painel de preços por categoria")
+    lines.append("")
+    lines.append(_state_line(document, SECTION_PRICE_PANEL))
+    lines.append("")
+    lines.append(
+        f"Semântica de valor: `{price_panel.get('value_semantic', UNKNOWN)}` · "
+        f"unidade: `{price_panel.get('unit', UNKNOWN)}`."
+    )
+    lines.append("")
+    lines.append(f"Escopo da referência: {price_panel.get('reference_scope', UNKNOWN)}.")
+    if price_panel.get("out_of_range_category_count"):
+        lines.append("")
+        lines.append(
+            f"{price_panel['out_of_range_category_count']} categoria(s) ficaram fora da faixa do "
+            f"painel por fator maior que {price_panel.get('out_of_range_factor')}x. Para essas, "
+            "nenhuma posição percentílica é declarada: a categoria agrega objetos de porte "
+            "incomparável."
+        )
+    lines.append("")
+    lines.append(
+        "| Categoria | Contratos da empresa | Mediana da empresa | p25 painel | p50 painel | p75 painel | Posição |"
+    )
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | --- |")
+    for category in price_panel.get("categories", []):
+        lines.append(
+            f"| {category.get('categoria', UNKNOWN)} | {category.get('focal_contract_count', UNKNOWN)} | "
+            f"{_brl(category.get('focal_median'))} | {_brl(category.get('reference_p25'))} | "
+            f"{_brl(category.get('reference_p50'))} | {_brl(category.get('reference_p75'))} | "
+            f"{POSITION_LABEL.get(category.get('focal_position'), category.get('focal_position', UNKNOWN))} |"
+        )
+    lines.append("")
+
+    expiring = _payload(document, SECTION_EXPIRING)
+    lines.append(f"## 5. Contratos a vencer em até {expiring.get('window_days', UNKNOWN)} dias")
+    lines.append("")
+    lines.append(_state_line(document, SECTION_EXPIRING))
+    lines.append("")
+    lines.append("| Contrato | Órgão | Fim | Dias | Valor |")
+    lines.append("| --- | --- | --- | ---: | ---: |")
+    for contract in expiring.get("contracts", []):
+        lines.append(
+            f"| `{contract.get('contrato_id', UNKNOWN)}` | {contract.get('orgao_nome', UNKNOWN)} | "
+            f"{contract.get('data_fim', UNKNOWN)} | {contract.get('dias_ate_fim', UNKNOWN)} | "
+            f"{_brl(contract.get('valor'))} |"
+        )
+    lines.append("")
+
+    opportunities = _payload(document, SECTION_OPPORTUNITIES)
+    lines.append("## 6. Editais abertos de compradores já conhecidos")
+    lines.append("")
+    lines.append(_state_line(document, SECTION_OPPORTUNITIES))
+    lines.append("")
+    if opportunities.get("opportunities"):
+        lines.append("| Edital | Órgão | Encerramento | Valor estimado |")
+        lines.append("| --- | --- | --- | ---: |")
+        for opportunity in opportunities.get("opportunities", []):
+            lines.append(
+                f"| `{opportunity.get('bid_id', UNKNOWN)}` | {opportunity.get('orgao_nome', UNKNOWN)} | "
+                f"{opportunity.get('data_encerramento', UNKNOWN)} | {_brl(opportunity.get('valor_estimado'))} |"
+            )
+    else:
+        lines.append(
+            "Nenhum edital aberto foi observado para os compradores desta carteira na data de "
+            "referência. Ausência de observação não é ausência de edital."
+        )
+    lines.append("")
+
+    lines.append("## 7. Achados")
+    lines.append("")
+    lines.append(
+        "Cada achado é um fato observado mais a pergunta que ele abre. Nenhum achado afirma "
+        "direito, desequilíbrio econômico-financeiro, dano ou que um reajuste seja devido."
+    )
+    lines.append("")
+    for finding in document.get("findings", []):
+        lines.append(f"### `{finding.get('finding_id')}` — {finding.get('subject')}")
+        lines.append("")
+        lines.append(f"- Fato: {finding.get('fact')}")
+        lines.append(f"- Pergunta: {finding.get('question')}")
+        lines.append(f"- Evidência: {', '.join(finding.get('evidence_refs', [])) or UNKNOWN}")
+        lines.append(f"- Severidade: `{finding.get('severity')}`")
+        lines.append("")
+
+    lines.append("## 8. Limitações declaradas")
+    lines.append("")
+    for limitation in document.get("limitations", []):
+        lines.append(f"- {limitation}")
+    lines.append("")
+    if document.get("reason_codes"):
+        lines.append(f"Códigos de razão: {', '.join(document['reason_codes'])}.")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/scripts/dossier/sources.py
+++ b/scripts/dossier/sources.py
@@ -1,0 +1,309 @@
+"""SELECT-only DataLake reads for the dossier engine.
+
+Every method returns a :class:`SourceRead` carrying the view it came from, the
+observation timestamp and any reason codes. Nothing here writes, and nothing
+here interprets: interpretation lives in ``compose.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Protocol
+
+from scripts.dossier.constants import (
+    BUYER_LIMIT,
+    COMPETITOR_LIMIT,
+    EXPIRING_WINDOW_DAYS,
+    OPPORTUNITY_LIMIT,
+    REASON_TABLE_MISSING,
+)
+from scripts.dossier.models import SourceRead
+
+# Same ladder as v_contract_intel_percentis. Duplicated deliberately so the
+# focal contract is classified by the exact rule that built the panel; if the
+# view changes, `test_category_ladder_matches_view` fails.
+CATEGORY_SQL = """
+CASE
+  WHEN {col} ILIKE '%%obra%%' OR {col} ILIKE '%%construção%%' OR {col} ILIKE '%%pavimentação%%'
+       OR {col} ILIKE '%%edificação%%' OR {col} ILIKE '%%engenharia%%' THEN 'OBRAS'
+  WHEN {col} ILIKE '%%limpeza%%' OR {col} ILIKE '%%conservação%%' OR {col} ILIKE '%%manutenção%%'
+       OR {col} ILIKE '%%zeladoria%%' THEN 'FACILITIES'
+  WHEN {col} ILIKE '%%software%%' OR {col} ILIKE '%%ti%%' OR {col} ILIKE '%%tecnologia%%'
+       OR {col} ILIKE '%%sistema%%' OR {col} ILIKE '%%informática%%' THEN 'TI'
+  WHEN {col} ILIKE '%%saúde%%' OR {col} ILIKE '%%medicamento%%' OR {col} ILIKE '%%hospitalar%%'
+       OR {col} ILIKE '%%medico%%' OR {col} ILIKE '%%farmacêutico%%'
+       OR {col} ILIKE '%%laboratório%%' THEN 'SAÚDE'
+  WHEN {col} ILIKE '%%alimentação%%' OR {col} ILIKE '%%alimento%%' OR {col} ILIKE '%%merenda%%'
+       OR {col} ILIKE '%%gênero alimentício%%' THEN 'ALIMENTAÇÃO'
+  WHEN {col} ILIKE '%%transporte%%' OR {col} ILIKE '%%veículo%%' OR {col} ILIKE '%%frota%%'
+       OR {col} ILIKE '%%ônibus%%' OR {col} ILIKE '%%locação de veículo%%' THEN 'TRANSPORTE'
+  WHEN {col} ILIKE '%%segurança%%' OR {col} ILIKE '%%vigilância%%' OR {col} ILIKE '%%monitoramento%%'
+       OR {col} ILIKE '%%porteiro%%' THEN 'SEGURANÇA'
+  WHEN {col} ILIKE '%%consultoria%%' OR {col} ILIKE '%%assessoria%%' OR {col} ILIKE '%%advocacia%%'
+       OR {col} ILIKE '%%jurídico%%' OR {col} ILIKE '%%contábil%%' THEN 'CONSULTORIA'
+  WHEN {col} ILIKE '%%combustível%%' OR {col} ILIKE '%%gasolina%%' OR {col} ILIKE '%%diesel%%'
+       OR {col} ILIKE '%%etanol%%' THEN 'COMBUSTÍVEL'
+  ELSE 'OUTROS'
+END
+"""
+
+VIEW_CONTRACTS = "v_contracts_canonical_v2"
+VIEW_EXPIRING = "v_expiring_contracts"
+VIEW_PERCENTIS = "v_contract_intel_percentis"
+VIEW_OPPORTUNITIES = "v_open_opportunities_canonical"
+TABLE_REGISTRY = "supplier_registry"
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
+
+
+def _rows(cursor: Any) -> tuple[dict[str, Any], ...]:
+    columns = [c.name for c in cursor.description]
+    return tuple({col: _jsonable(val) for col, val in zip(columns, row)} for row in cursor.fetchall())
+
+
+class Source(Protocol):
+    """What ``compose.py`` needs. Implemented by DataLake and fixture backends."""
+
+    catalog_mode: str
+
+    def identity(self, cnpj: str) -> SourceRead: ...
+    def contracts(self, cnpj: str) -> SourceRead: ...
+    def buyers(self, cnpj: str) -> SourceRead: ...
+    def competitors(self, cnpj: str) -> SourceRead: ...
+    def price_panel(self, cnpj: str) -> SourceRead: ...
+    def expiring(self, cnpj: str, window_days: int) -> SourceRead: ...
+    def opportunities(self, cnpj: str) -> SourceRead: ...
+
+
+class DatalakeSource:
+    """Read-only DataLake backend. Opens one read-only transaction per read."""
+
+    catalog_mode = "official_live"
+
+    def __init__(self, dsn: str, *, observed_at: str | None = None, competitor_limit: int = COMPETITOR_LIMIT):
+        import psycopg2  # imported lazily so fixture runs need no driver
+
+        self._connect = lambda: psycopg2.connect(dsn)
+        self._observed_at = observed_at or datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        self._competitor_limit = competitor_limit
+
+    def _query(self, view: str, sql: str, params: tuple[Any, ...]) -> SourceRead:
+        conn = self._connect()
+        try:
+            conn.set_session(readonly=True, autocommit=True)
+            with conn.cursor() as cur:
+                try:
+                    cur.execute(sql, params)
+                except Exception as exc:  # undefined_table / undefined_column
+                    if getattr(exc, "pgcode", None) in {"42P01", "42703"}:
+                        return SourceRead(
+                            source=view,
+                            observed_at=self._observed_at,
+                            reason_codes=(REASON_TABLE_MISSING,),
+                            available=False,
+                        )
+                    raise
+                return SourceRead(source=view, observed_at=self._observed_at, rows=_rows(cur))
+        finally:
+            conn.close()
+
+    def identity(self, cnpj: str) -> SourceRead:
+        return self._query(
+            TABLE_REGISTRY,
+            f"""
+            SELECT cnpj14, razao_social, nome_fantasia, cnae_principal, situacao_cadastral,
+                   municipio, uf, source, source_date
+              FROM {TABLE_REGISTRY}
+             WHERE cnpj14 = %s
+             LIMIT 1
+            """,  # noqa: S608 -- table name is a module constant; the CNPJ is bound via %s
+            (cnpj,),
+        )
+
+    def contracts(self, cnpj: str) -> SourceRead:
+        return self._query(
+            VIEW_CONTRACTS,
+            f"""
+            SELECT contrato_id, buyer_cnpj, buyer_nome, objeto, valor, data_inicio, data_fim,
+                   data_publicacao, data_assinatura, uf, municipio, is_active, source,
+                   {CATEGORY_SQL.format(col="objeto")} AS categoria
+              FROM {VIEW_CONTRACTS}
+             WHERE supplier_cnpj = %s
+             ORDER BY contrato_id
+            """,  # noqa: S608 -- view names are module constants; the CNPJ is bound via %s
+            (cnpj,),
+        )
+
+    def buyers(self, cnpj: str) -> SourceRead:
+        return self._query(
+            VIEW_CONTRACTS,
+            f"""
+            SELECT buyer_cnpj,
+                   MIN(buyer_nome) AS buyer_nome,
+                   MIN(uf) AS uf,
+                   COUNT(*) AS contract_count,
+                   COUNT(valor) AS valued_count,
+                   SUM(valor) AS valor_sum,
+                   MAX(data_fim) AS last_data_fim,
+                   MAX(data_publicacao) AS last_publicacao
+              FROM {VIEW_CONTRACTS}
+             WHERE supplier_cnpj = %s
+             GROUP BY buyer_cnpj
+             ORDER BY COUNT(*) DESC, SUM(valor) DESC NULLS LAST, buyer_cnpj
+             LIMIT %s
+            """,  # noqa: S608 -- view names are module constants; every value is bound via %s
+            (cnpj, BUYER_LIMIT),
+        )
+
+    def competitors(self, cnpj: str) -> SourceRead:
+        """Suppliers that dispute the same space as the focal.
+
+        Sharing a buyer is not enough: a municipality buys stationery and asphalt
+        from the same list. A competitor must hold contracts with the focal's
+        buyers **and** in one of the focal's own contract categories.
+        """
+        return self._query(
+            VIEW_CONTRACTS,
+            f"""
+            WITH focal AS (
+                SELECT buyer_cnpj, {CATEGORY_SQL.format(col="objeto")} AS categoria
+                  FROM {VIEW_CONTRACTS}
+                 WHERE supplier_cnpj = %s AND buyer_cnpj IS NOT NULL
+            ),
+            focal_buyers AS (SELECT DISTINCT buyer_cnpj FROM focal),
+            -- Primary category only. Sharing a secondary bucket (a road-maintenance
+            -- contract lands in FACILITIES alongside cleaning supplies) produces
+            -- peers that do not dispute the same work.
+            focal_categories AS (
+                SELECT categoria FROM focal GROUP BY categoria ORDER BY COUNT(*) DESC, categoria LIMIT 1
+            ),
+            peers AS (
+                SELECT c.supplier_cnpj, c.supplier_nome, c.buyer_cnpj, c.valor,
+                       {CATEGORY_SQL.format(col="c.objeto")} AS categoria
+                  FROM {VIEW_CONTRACTS} c
+                  JOIN focal_buyers b ON b.buyer_cnpj = c.buyer_cnpj
+                 WHERE c.supplier_cnpj IS NOT NULL AND c.supplier_cnpj <> %s
+            )
+            SELECT p.supplier_cnpj,
+                   MIN(p.supplier_nome) AS supplier_nome,
+                   COUNT(*) AS contract_count,
+                   COUNT(p.valor) AS valued_count,
+                   SUM(p.valor) AS valor_sum,
+                   COUNT(DISTINCT p.buyer_cnpj) AS shared_buyer_count,
+                   STRING_AGG(DISTINCT p.categoria, ',' ORDER BY p.categoria) AS shared_categories
+              FROM peers p
+              JOIN focal_categories fc ON fc.categoria = p.categoria
+             GROUP BY p.supplier_cnpj
+             ORDER BY COUNT(DISTINCT p.buyer_cnpj) DESC, COUNT(*) DESC, SUM(p.valor) DESC NULLS LAST,
+                      p.supplier_cnpj
+             LIMIT %s
+            """,  # noqa: S608 -- view names are module constants; every value is bound via %s
+            (cnpj, cnpj, self._competitor_limit),
+        )
+
+    def price_panel(self, cnpj: str) -> SourceRead:
+        """Reference percentiles by category, plus the focal position per category."""
+        return self._query(
+            VIEW_PERCENTIS,
+            f"""
+            WITH focal AS (
+                SELECT {CATEGORY_SQL.format(col="objeto")} AS categoria,
+                       COUNT(*) AS focal_count,
+                       COUNT(valor) AS focal_valued_count,
+                       percentile_cont(0.5) WITHIN GROUP (ORDER BY valor) AS focal_median
+                  FROM {VIEW_CONTRACTS}
+                 WHERE supplier_cnpj = %s
+                 GROUP BY 1
+            )
+            SELECT p.categoria, p.qtd_contratos, p.valor_total, p.ticket_medio,
+                   p.p25_valor, p.p50_valor, p.p75_valor,
+                   focal.focal_count, focal.focal_valued_count, focal.focal_median
+              FROM {VIEW_PERCENTIS} p
+              JOIN focal ON focal.categoria = p.categoria
+             ORDER BY p.categoria
+            """,  # noqa: S608 -- view names are module constants; the CNPJ is bound via %s
+            (cnpj,),
+        )
+
+    def expiring(self, cnpj: str, window_days: int = EXPIRING_WINDOW_DAYS) -> SourceRead:
+        return self._query(
+            VIEW_EXPIRING,
+            f"""
+            SELECT contrato_id, orgao_cnpj, orgao_nome, objeto_contrato, valor_contrato,
+                   data_inicio_contrato, data_fim_contrato, dias_ate_fim, uf, municipio
+              FROM {VIEW_EXPIRING}
+             WHERE fornecedor_cnpj = %s AND dias_ate_fim IS NOT NULL AND dias_ate_fim <= %s
+             ORDER BY dias_ate_fim, contrato_id
+            """,  # noqa: S608 -- view name is a module constant; every value is bound via %s
+            (cnpj, window_days),
+        )
+
+    def opportunities(self, cnpj: str) -> SourceRead:
+        return self._query(
+            VIEW_OPPORTUNITIES,
+            f"""
+            WITH focal_buyers AS (
+                SELECT DISTINCT buyer_cnpj
+                  FROM {VIEW_CONTRACTS}
+                 WHERE supplier_cnpj = %s AND buyer_cnpj IS NOT NULL
+            )
+            SELECT o.bid_id, o.pncp_id, o.objeto, o.valor_estimado, o.modalidade,
+                   o.orgao_cnpj, o.orgao_nome, o.uf, o.municipio,
+                   o.data_publicacao, o.data_abertura, o.data_encerramento, o.link_edital
+              FROM {VIEW_OPPORTUNITIES} o
+              JOIN focal_buyers f ON f.buyer_cnpj = o.orgao_cnpj
+             ORDER BY o.data_encerramento NULLS LAST, o.bid_id
+             LIMIT %s
+            """,  # noqa: S608 -- view names are module constants; every value is bound via %s
+            (cnpj, OPPORTUNITY_LIMIT),
+        )
+
+
+class FixtureSource:
+    """Deterministic backend for tests and offline demos. Never claims live."""
+
+    catalog_mode = "fixture"
+
+    def __init__(self, path: str | Path):
+        self._data = json.loads(Path(path).read_text(encoding="utf-8"))
+        self._observed_at = self._data.get("observed_at", "1970-01-01T00:00:00Z")
+
+    def _read(self, key: str, view: str) -> SourceRead:
+        block = self._data.get(key)
+        if block is None:
+            return SourceRead(
+                source=view, observed_at=self._observed_at, reason_codes=(REASON_TABLE_MISSING,), available=False
+            )
+        return SourceRead(source=view, observed_at=self._observed_at, rows=tuple(block))
+
+    def identity(self, cnpj: str) -> SourceRead:
+        return self._read("identity", TABLE_REGISTRY)
+
+    def contracts(self, cnpj: str) -> SourceRead:
+        return self._read("contracts", VIEW_CONTRACTS)
+
+    def buyers(self, cnpj: str) -> SourceRead:
+        return self._read("buyers", VIEW_CONTRACTS)
+
+    def competitors(self, cnpj: str) -> SourceRead:
+        return self._read("competitors", VIEW_CONTRACTS)
+
+    def price_panel(self, cnpj: str) -> SourceRead:
+        return self._read("price_panel", VIEW_PERCENTIS)
+
+    def expiring(self, cnpj: str, window_days: int = EXPIRING_WINDOW_DAYS) -> SourceRead:
+        return self._read("expiring", VIEW_EXPIRING)
+
+    def opportunities(self, cnpj: str) -> SourceRead:
+        return self._read("opportunities", VIEW_OPPORTUNITIES)

--- a/scripts/dossier/sources.py
+++ b/scripts/dossier/sources.py
@@ -51,10 +51,10 @@ END
 """
 
 VIEW_CONTRACTS = "v_contracts_canonical_v2"
-VIEW_EXPIRING = "v_expiring_contracts"
 VIEW_PERCENTIS = "v_contract_intel_percentis"
 VIEW_OPPORTUNITIES = "v_open_opportunities_canonical"
 TABLE_REGISTRY = "supplier_registry"
+TABLE_SC_ENTITIES = "sc_public_entities"
 
 
 def _jsonable(value: Any) -> Any:
@@ -80,9 +80,10 @@ class Source(Protocol):
     def identity(self, cnpj: str) -> SourceRead: ...
     def contracts(self, cnpj: str) -> SourceRead: ...
     def buyers(self, cnpj: str) -> SourceRead: ...
+    def portfolio_totals(self, cnpj: str) -> SourceRead: ...
     def competitors(self, cnpj: str) -> SourceRead: ...
     def price_panel(self, cnpj: str) -> SourceRead: ...
-    def expiring(self, cnpj: str, window_days: int) -> SourceRead: ...
+    def expiring(self, cnpj: str, window_days: int, as_of: str | None) -> SourceRead: ...
     def opportunities(self, cnpj: str) -> SourceRead: ...
 
 
@@ -146,6 +147,7 @@ class DatalakeSource:
         )
 
     def buyers(self, cnpj: str) -> SourceRead:
+        """Top buyers for display. Totals come from :meth:`portfolio_totals`."""
         return self._query(
             VIEW_CONTRACTS,
             f"""
@@ -164,6 +166,34 @@ class DatalakeSource:
              LIMIT %s
             """,  # noqa: S608 -- view names are module constants; every value is bound via %s
             (cnpj, BUYER_LIMIT),
+        )
+
+    def portfolio_totals(self, cnpj: str) -> SourceRead:
+        """Untruncated portfolio aggregates and the HHI over every buyer.
+
+        A share, a total or an HHI computed over the displayed top-N reports a
+        concentrated portfolio for anyone with more buyers than the display
+        limit, and understates the money by the size of the tail.
+        """
+        return self._query(
+            VIEW_CONTRACTS,
+            f"""
+            WITH per_buyer AS (
+                SELECT buyer_cnpj, COUNT(*) AS contract_count, SUM(valor) AS valor_sum
+                  FROM {VIEW_CONTRACTS}
+                 WHERE supplier_cnpj = %s
+                 GROUP BY buyer_cnpj
+            ),
+            total AS (SELECT COALESCE(SUM(valor_sum), 0) AS valued FROM per_buyer)
+            SELECT (SELECT COUNT(*) FROM per_buyer) AS buyer_count,
+                   (SELECT SUM(contract_count) FROM per_buyer) AS contract_count,
+                   (SELECT NULLIF(valued, 0) FROM total) AS valor_sum_valued,
+                   CASE WHEN (SELECT valued FROM total) > 0
+                        THEN (SELECT SUM(POWER(valor_sum / (SELECT valued FROM total), 2)) FROM per_buyer)
+                        ELSE NULL
+                   END AS hhi
+            """,  # noqa: S608 -- view name is a module constant; the CNPJ is bound via %s
+            (cnpj,),
         )
 
     def competitors(self, cnpj: str) -> SourceRead:
@@ -213,40 +243,72 @@ class DatalakeSource:
         )
 
     def price_panel(self, cnpj: str) -> SourceRead:
-        """Reference percentiles by category, plus the focal position per category."""
+        """Reference percentiles by category, plus the focal position per category.
+
+        The focal rows are filtered by the SAME rule that built the panel
+        (`v_contract_intel_percentis`): buyers inside the 200 km reference set,
+        active contracts, published value above zero. A focal median built by a
+        wider rule and compared against that panel is not a comparison.
+        """
         return self._query(
             VIEW_PERCENTIS,
             f"""
             WITH focal AS (
-                SELECT {CATEGORY_SQL.format(col="objeto")} AS categoria,
+                SELECT {CATEGORY_SQL.format(col="c.objeto")} AS categoria,
                        COUNT(*) AS focal_count,
-                       COUNT(valor) AS focal_valued_count,
-                       percentile_cont(0.5) WITHIN GROUP (ORDER BY valor) AS focal_median
+                       COUNT(c.valor) AS focal_valued_count,
+                       percentile_cont(0.5) WITHIN GROUP (ORDER BY c.valor) AS focal_median
+                  FROM {VIEW_CONTRACTS} c
+                  JOIN {TABLE_SC_ENTITIES} e ON LEFT(c.buyer_cnpj, 8) = e.cnpj_8
+                 WHERE c.supplier_cnpj = %s
+                   AND e.raio_200km IS TRUE
+                   AND c.is_active IS TRUE
+                   AND c.valor IS NOT NULL
+                   AND c.valor > 0
+                 GROUP BY 1
+            ),
+            focal_all AS (
+                SELECT {CATEGORY_SQL.format(col="objeto")} AS categoria, COUNT(*) AS total_count
                   FROM {VIEW_CONTRACTS}
                  WHERE supplier_cnpj = %s
                  GROUP BY 1
             )
             SELECT p.categoria, p.qtd_contratos, p.valor_total, p.ticket_medio,
                    p.p25_valor, p.p50_valor, p.p75_valor,
-                   focal.focal_count, focal.focal_valued_count, focal.focal_median
+                   f.focal_count, f.focal_valued_count, f.focal_median,
+                   a.total_count AS focal_total_count
               FROM {VIEW_PERCENTIS} p
-              JOIN focal ON focal.categoria = p.categoria
+              JOIN focal f ON f.categoria = p.categoria
+              LEFT JOIN focal_all a ON a.categoria = p.categoria
              ORDER BY p.categoria
             """,  # noqa: S608 -- view names are module constants; the CNPJ is bound via %s
-            (cnpj,),
+            (cnpj, cnpj),
         )
 
-    def expiring(self, cnpj: str, window_days: int = EXPIRING_WINDOW_DAYS) -> SourceRead:
+    def expiring(self, cnpj: str, window_days: int = EXPIRING_WINDOW_DAYS, as_of: str | None = None) -> SourceRead:
+        """Contracts ending inside the requested window, counted from ``as_of``.
+
+        `v_expiring_contracts` hard-codes a 90-to-180-day band, so reading the
+        window through it drops both the urgent contracts and everything past
+        six months while the document claims the requested window. Reading the
+        canonical view directly also keeps the day count off the wall clock,
+        which is what makes the content hash reproducible.
+        """
         return self._query(
-            VIEW_EXPIRING,
+            VIEW_CONTRACTS,
             f"""
-            SELECT contrato_id, orgao_cnpj, orgao_nome, objeto_contrato, valor_contrato,
-                   data_inicio_contrato, data_fim_contrato, dias_ate_fim, uf, municipio
-              FROM {VIEW_EXPIRING}
-             WHERE fornecedor_cnpj = %s AND dias_ate_fim IS NOT NULL AND dias_ate_fim <= %s
-             ORDER BY dias_ate_fim, contrato_id
+            SELECT contrato_id, buyer_cnpj AS orgao_cnpj, buyer_nome AS orgao_nome,
+                   objeto AS objeto_contrato, valor AS valor_contrato,
+                   data_inicio AS data_inicio_contrato, data_fim AS data_fim_contrato,
+                   (data_fim - %s::date) AS dias_ate_fim, uf, municipio
+              FROM {VIEW_CONTRACTS}
+             WHERE supplier_cnpj = %s
+               AND data_fim IS NOT NULL
+               AND data_fim >= %s::date
+               AND data_fim <= (%s::date + %s::int)
+             ORDER BY data_fim, contrato_id
             """,  # noqa: S608 -- view name is a module constant; every value is bound via %s
-            (cnpj, window_days),
+            (as_of, cnpj, as_of, as_of, window_days),
         )
 
     def opportunities(self, cnpj: str) -> SourceRead:
@@ -296,14 +358,17 @@ class FixtureSource:
     def buyers(self, cnpj: str) -> SourceRead:
         return self._read("buyers", VIEW_CONTRACTS)
 
+    def portfolio_totals(self, cnpj: str) -> SourceRead:
+        return self._read("portfolio_totals", VIEW_CONTRACTS)
+
     def competitors(self, cnpj: str) -> SourceRead:
         return self._read("competitors", VIEW_CONTRACTS)
 
     def price_panel(self, cnpj: str) -> SourceRead:
         return self._read("price_panel", VIEW_PERCENTIS)
 
-    def expiring(self, cnpj: str, window_days: int = EXPIRING_WINDOW_DAYS) -> SourceRead:
-        return self._read("expiring", VIEW_EXPIRING)
+    def expiring(self, cnpj: str, window_days: int = EXPIRING_WINDOW_DAYS, as_of: str | None = None) -> SourceRead:
+        return self._read("expiring", VIEW_CONTRACTS)
 
     def opportunities(self, cnpj: str) -> SourceRead:
         return self._read("opportunities", VIEW_OPPORTUNITIES)

--- a/tests/dossier/fixtures/acme.json
+++ b/tests/dossier/fixtures/acme.json
@@ -1,0 +1,132 @@
+{
+  "observed_at": "2026-01-15T00:00:00Z",
+  "identity": [
+    {
+      "cnpj14": "11222333000181",
+      "razao_social": "ACME PAVIMENTACAO LTDA",
+      "nome_fantasia": null,
+      "cnae_principal": "4211101",
+      "situacao_cadastral": "Ativa",
+      "municipio": "FIXTURELANDIA",
+      "uf": "SC",
+      "source": "fixture_registry",
+      "source_date": "2026-01-01"
+    }
+  ],
+  "contracts": [
+    {
+      "contrato_id": "FIX-0001",
+      "buyer_cnpj": "82000000000101",
+      "buyer_nome": "MUNICIPIO FIXTURE A",
+      "objeto": "Execucao de obra de pavimentacao asfaltica",
+      "valor": "1000000.00",
+      "data_inicio": "2024-01-10",
+      "data_fim": "2027-01-10",
+      "data_publicacao": "2024-01-05",
+      "uf": "SC",
+      "categoria": "OBRAS"
+    },
+    {
+      "contrato_id": "FIX-0002",
+      "buyer_cnpj": "82000000000102",
+      "buyer_nome": "MUNICIPIO FIXTURE B",
+      "objeto": "Execucao de obra de drenagem",
+      "valor": "500000.00",
+      "data_inicio": "2026-06-01",
+      "data_fim": "2026-12-01",
+      "data_publicacao": "2026-05-20",
+      "uf": "SC",
+      "categoria": "OBRAS"
+    },
+    {
+      "contrato_id": "FIX-0003",
+      "buyer_cnpj": "82000000000101",
+      "buyer_nome": "MUNICIPIO FIXTURE A",
+      "objeto": "Execucao de obra de contencao",
+      "valor": null,
+      "data_inicio": "2025-02-01",
+      "data_fim": "2028-02-01",
+      "data_publicacao": "2025-01-20",
+      "uf": "SC",
+      "categoria": "OBRAS"
+    }
+  ],
+  "buyers": [
+    {
+      "buyer_cnpj": "82000000000101",
+      "buyer_nome": "MUNICIPIO FIXTURE A",
+      "uf": "SC",
+      "contract_count": 2,
+      "valued_count": 1,
+      "valor_sum": "1000000.00",
+      "last_data_fim": "2028-02-01",
+      "last_publicacao": "2025-01-20"
+    },
+    {
+      "buyer_cnpj": "82000000000102",
+      "buyer_nome": "MUNICIPIO FIXTURE B",
+      "uf": "SC",
+      "contract_count": 1,
+      "valued_count": 1,
+      "valor_sum": "500000.00",
+      "last_data_fim": "2026-12-01",
+      "last_publicacao": "2026-05-20"
+    }
+  ],
+  "competitors": [
+    {
+      "supplier_cnpj": "99000000000191",
+      "supplier_nome": "CONCORRENTE FIXTURE LTDA",
+      "contract_count": 7,
+      "valued_count": 7,
+      "valor_sum": "3000000.00",
+      "shared_buyer_count": 2,
+      "shared_categories": "OBRAS"
+    }
+  ],
+  "price_panel": [
+    {
+      "categoria": "OBRAS",
+      "qtd_contratos": 1000,
+      "valor_total": "900000000.00",
+      "ticket_medio": "900000.00",
+      "p25_valor": "200000.00",
+      "p50_valor": "700000.00",
+      "p75_valor": "1500000.00",
+      "focal_count": 3,
+      "focal_valued_count": 2,
+      "focal_median": "750000.00"
+    }
+  ],
+  "expiring": [
+    {
+      "contrato_id": "FIX-0002",
+      "orgao_cnpj": "82000000000102",
+      "orgao_nome": "MUNICIPIO FIXTURE B",
+      "objeto_contrato": "Execucao de obra de drenagem",
+      "valor_contrato": "500000.00",
+      "data_inicio_contrato": "2026-06-01",
+      "data_fim_contrato": "2026-12-01",
+      "dias_ate_fim": 120,
+      "uf": "SC",
+      "municipio": "FIXTURELANDIA"
+    }
+  ],
+  "opportunities": [
+    {
+      "bid_id": "FIX-BID-1",
+      "pncp_id": "fixture-pncp-1",
+      "objeto": "Contratacao de obra de pavimentacao",
+      "valor_estimado": "2000000.00",
+      "modalidade": "Concorrencia",
+      "orgao_cnpj": "82000000000101",
+      "orgao_nome": "MUNICIPIO FIXTURE A",
+      "uf": "SC",
+      "municipio": "FIXTURELANDIA",
+      "data_publicacao": "2026-08-01",
+      "data_abertura": "2026-08-10",
+      "data_encerramento": "2026-09-10",
+      "link_edital": "https://example.invalid/edital/1"
+    }
+  ]
+}

--- a/tests/dossier/fixtures/acme.json
+++ b/tests/dossier/fixtures/acme.json
@@ -1,132 +1,140 @@
 {
-  "observed_at": "2026-01-15T00:00:00Z",
-  "identity": [
-    {
-      "cnpj14": "11222333000181",
-      "razao_social": "ACME PAVIMENTACAO LTDA",
-      "nome_fantasia": null,
-      "cnae_principal": "4211101",
-      "situacao_cadastral": "Ativa",
-      "municipio": "FIXTURELANDIA",
-      "uf": "SC",
-      "source": "fixture_registry",
-      "source_date": "2026-01-01"
-    }
-  ],
-  "contracts": [
-    {
-      "contrato_id": "FIX-0001",
-      "buyer_cnpj": "82000000000101",
-      "buyer_nome": "MUNICIPIO FIXTURE A",
-      "objeto": "Execucao de obra de pavimentacao asfaltica",
-      "valor": "1000000.00",
-      "data_inicio": "2024-01-10",
-      "data_fim": "2027-01-10",
-      "data_publicacao": "2024-01-05",
-      "uf": "SC",
-      "categoria": "OBRAS"
-    },
-    {
-      "contrato_id": "FIX-0002",
-      "buyer_cnpj": "82000000000102",
-      "buyer_nome": "MUNICIPIO FIXTURE B",
-      "objeto": "Execucao de obra de drenagem",
-      "valor": "500000.00",
-      "data_inicio": "2026-06-01",
-      "data_fim": "2026-12-01",
-      "data_publicacao": "2026-05-20",
-      "uf": "SC",
-      "categoria": "OBRAS"
-    },
-    {
-      "contrato_id": "FIX-0003",
-      "buyer_cnpj": "82000000000101",
-      "buyer_nome": "MUNICIPIO FIXTURE A",
-      "objeto": "Execucao de obra de contencao",
-      "valor": null,
-      "data_inicio": "2025-02-01",
-      "data_fim": "2028-02-01",
-      "data_publicacao": "2025-01-20",
-      "uf": "SC",
-      "categoria": "OBRAS"
-    }
-  ],
   "buyers": [
     {
       "buyer_cnpj": "82000000000101",
       "buyer_nome": "MUNICIPIO FIXTURE A",
-      "uf": "SC",
       "contract_count": 2,
-      "valued_count": 1,
-      "valor_sum": "1000000.00",
       "last_data_fim": "2028-02-01",
-      "last_publicacao": "2025-01-20"
+      "last_publicacao": "2025-01-20",
+      "uf": "SC",
+      "valor_sum": "1000000.00",
+      "valued_count": 1
     },
     {
       "buyer_cnpj": "82000000000102",
       "buyer_nome": "MUNICIPIO FIXTURE B",
-      "uf": "SC",
       "contract_count": 1,
-      "valued_count": 1,
-      "valor_sum": "500000.00",
       "last_data_fim": "2026-12-01",
-      "last_publicacao": "2026-05-20"
+      "last_publicacao": "2026-05-20",
+      "uf": "SC",
+      "valor_sum": "500000.00",
+      "valued_count": 1
     }
   ],
   "competitors": [
     {
+      "contract_count": 7,
+      "shared_buyer_count": 2,
+      "shared_categories": "OBRAS",
       "supplier_cnpj": "99000000000191",
       "supplier_nome": "CONCORRENTE FIXTURE LTDA",
-      "contract_count": 7,
-      "valued_count": 7,
       "valor_sum": "3000000.00",
-      "shared_buyer_count": 2,
-      "shared_categories": "OBRAS"
+      "valued_count": 7
     }
   ],
-  "price_panel": [
+  "contracts": [
     {
+      "buyer_cnpj": "82000000000101",
+      "buyer_nome": "MUNICIPIO FIXTURE A",
       "categoria": "OBRAS",
-      "qtd_contratos": 1000,
-      "valor_total": "900000000.00",
-      "ticket_medio": "900000.00",
-      "p25_valor": "200000.00",
-      "p50_valor": "700000.00",
-      "p75_valor": "1500000.00",
-      "focal_count": 3,
-      "focal_valued_count": 2,
-      "focal_median": "750000.00"
+      "contrato_id": "FIX-0001",
+      "data_fim": "2027-01-10",
+      "data_inicio": "2024-01-10",
+      "data_publicacao": "2024-01-05",
+      "objeto": "Execucao de obra de pavimentacao asfaltica",
+      "uf": "SC",
+      "valor": "1000000.00"
+    },
+    {
+      "buyer_cnpj": "82000000000102",
+      "buyer_nome": "MUNICIPIO FIXTURE B",
+      "categoria": "OBRAS",
+      "contrato_id": "FIX-0002",
+      "data_fim": "2026-12-01",
+      "data_inicio": "2026-06-01",
+      "data_publicacao": "2026-05-20",
+      "objeto": "Execucao de obra de drenagem",
+      "uf": "SC",
+      "valor": "500000.00"
+    },
+    {
+      "buyer_cnpj": "82000000000101",
+      "buyer_nome": "MUNICIPIO FIXTURE A",
+      "categoria": "OBRAS",
+      "contrato_id": "FIX-0003",
+      "data_fim": "2028-02-01",
+      "data_inicio": "2025-02-01",
+      "data_publicacao": "2025-01-20",
+      "objeto": "Execucao de obra de contencao",
+      "uf": "SC",
+      "valor": null
     }
   ],
   "expiring": [
     {
       "contrato_id": "FIX-0002",
+      "data_fim_contrato": "2026-12-01",
+      "data_inicio_contrato": "2026-06-01",
+      "dias_ate_fim": 120,
+      "municipio": "FIXTURELANDIA",
+      "objeto_contrato": "Execucao de obra de drenagem",
       "orgao_cnpj": "82000000000102",
       "orgao_nome": "MUNICIPIO FIXTURE B",
-      "objeto_contrato": "Execucao de obra de drenagem",
-      "valor_contrato": "500000.00",
-      "data_inicio_contrato": "2026-06-01",
-      "data_fim_contrato": "2026-12-01",
-      "dias_ate_fim": 120,
       "uf": "SC",
-      "municipio": "FIXTURELANDIA"
+      "valor_contrato": "500000.00"
     }
   ],
+  "identity": [
+    {
+      "cnae_principal": "4211101",
+      "cnpj14": "11222333000181",
+      "municipio": "FIXTURELANDIA",
+      "nome_fantasia": null,
+      "razao_social": "ACME PAVIMENTACAO LTDA",
+      "situacao_cadastral": "Ativa",
+      "source": "fixture_registry",
+      "source_date": "2026-01-01",
+      "uf": "SC"
+    }
+  ],
+  "observed_at": "2026-01-15T00:00:00Z",
   "opportunities": [
     {
       "bid_id": "FIX-BID-1",
-      "pncp_id": "fixture-pncp-1",
-      "objeto": "Contratacao de obra de pavimentacao",
-      "valor_estimado": "2000000.00",
-      "modalidade": "Concorrencia",
-      "orgao_cnpj": "82000000000101",
-      "orgao_nome": "MUNICIPIO FIXTURE A",
-      "uf": "SC",
-      "municipio": "FIXTURELANDIA",
-      "data_publicacao": "2026-08-01",
       "data_abertura": "2026-08-10",
       "data_encerramento": "2026-09-10",
-      "link_edital": "https://example.invalid/edital/1"
+      "data_publicacao": "2026-08-01",
+      "link_edital": "https://example.invalid/edital/1",
+      "modalidade": "Concorrencia",
+      "municipio": "FIXTURELANDIA",
+      "objeto": "Contratacao de obra de pavimentacao",
+      "orgao_cnpj": "82000000000101",
+      "orgao_nome": "MUNICIPIO FIXTURE A",
+      "pncp_id": "fixture-pncp-1",
+      "uf": "SC",
+      "valor_estimado": "2000000.00"
+    }
+  ],
+  "portfolio_totals": [
+    {
+      "buyer_count": 2,
+      "contract_count": 3,
+      "hhi": 0.5556,
+      "valor_sum_valued": "1500000.00"
+    }
+  ],
+  "price_panel": [
+    {
+      "categoria": "OBRAS",
+      "focal_count": 3,
+      "focal_median": "750000.00",
+      "focal_valued_count": 2,
+      "p25_valor": "200000.00",
+      "p50_valor": "700000.00",
+      "p75_valor": "1500000.00",
+      "qtd_contratos": 1000,
+      "ticket_medio": "900000.00",
+      "valor_total": "900000000.00"
     }
   ]
 }

--- a/tests/dossier/test_dossier_engine.py
+++ b/tests/dossier/test_dossier_engine.py
@@ -416,3 +416,174 @@ def test_cli_handoff_publishes_only_the_public_projection(tmp_path, capsys):
     assert CNPJ not in body
     assert "ACME PAVIMENTACAO" not in body
     assert not (root / "dossier.json").exists()
+
+
+# --- Regressions pinned from the adversarial review -------------------------
+
+
+def test_public_projection_publishes_no_join_key(built):
+    """An exact competitor valor_sum resolves a redacted supplier in one query."""
+    _result, document = built
+    public = public_projection(document)
+    competitors = public["sections"][SECTION_COMPETITORS]["payload"]
+    body = json.dumps(public, ensure_ascii=False)
+    assert "competitors" not in competitors, "individual competitor rows must not be published"
+    assert "3000000.00" not in body, "exact competitor money is a join key"
+    assert competitors["value_bands"] == ["<10.000.000"]
+    assert competitors["contract_count_band"] == "7-7"
+
+
+def test_public_subject_profile_is_banded_not_exact(built):
+    """uf + cnae + exact counts identify one supplier nationwide."""
+    _result, document = built
+    profile = public_projection(document)["subject_profile"]
+    assert profile["cnae_division"] == "42"
+    assert profile["buyer_count_band"] == "1-5"
+    assert profile["contract_count_band"] == "1-10"
+    assert "buyer_count" not in profile
+    assert "cnae_principal" not in profile
+
+
+def test_portfolio_totals_are_not_computed_over_the_display_list():
+    """A capped buyer list must not set the total, the share or the HHI."""
+    from scripts.dossier.compose import build_buyer_map
+
+    displayed = SourceRead(
+        source="v_contracts_canonical_v2",
+        observed_at="t",
+        rows=tuple(
+            {
+                "buyer_cnpj": f"b{i}",
+                "buyer_nome": f"B{i}",
+                "uf": "SC",
+                "contract_count": 1,
+                "valued_count": 1,
+                "valor_sum": "100.00",
+                "last_data_fim": "2027-01-01",
+            }
+            for i in range(3)
+        ),
+    )
+    totals = SourceRead(
+        source="v_contracts_canonical_v2",
+        observed_at="t",
+        rows=({"buyer_count": 900, "contract_count": 4951, "valor_sum_valued": "228158552.72", "hhi": 0.1583},),
+    )
+    section = build_buyer_map(displayed, SourceRead(source="c", observed_at="t"), totals)
+    assert section.payload["buyer_count"] == 900
+    assert section.payload["contract_count"] == 4951
+    assert section.payload["displayed_buyer_count"] == 3
+    assert section.payload["valor_sum_valued"] == "228158552.72"
+    assert section.payload["hhi"] == 0.1583
+    assert "buyer_list_truncated_for_display" in section.reason_codes
+    # Truncation alone is disclosure, not a defect: the section stays READY.
+    assert section.state == DATA_READY
+
+
+def test_low_precision_category_claims_no_position():
+    """The TI bucket is 84% non-TI; a panel built from household goods prices nothing."""
+    from scripts.dossier.compose import build_price_panel
+
+    read = SourceRead(
+        source="v_contract_intel_percentis",
+        observed_at="t",
+        rows=(
+            {
+                "categoria": "TI",
+                "qtd_contratos": 137934,
+                "p25_valor": "715.22",
+                "p50_valor": "3800.00",
+                "p75_valor": "26150.00",
+                "ticket_medio": "53724893.05",
+                "focal_count": 4,
+                "focal_valued_count": 4,
+                "focal_median": "5000.00",
+                "focal_total_count": 4,
+            },
+        ),
+    )
+    section = build_price_panel(read)
+    category = section.payload["categories"][0]
+    assert category["focal_position"] == "LOW_PRECISION_BUCKET"
+    assert category["bucket_precision"] == "LOW"
+    assert "category_bucket_low_precision" in section.reason_codes
+    assert section.state == DATA_HOLD
+    findings = build_findings(
+        contracts=SourceRead(source="c", observed_at="t"),
+        buyer_map=section,
+        price_panel=section,
+        expiring=build_price_panel(SourceRead(source="x", observed_at="t")),
+        opportunities=build_price_panel(SourceRead(source="x", observed_at="t")),
+        as_of="2026-08-22",
+    )
+    assert not [f for f in findings if f.finding_id.startswith("value_position_in_category")]
+
+
+def test_a_missing_offer_section_cannot_fold_to_ready(tmp_path):
+    """Competitors, expiring and open bids are offer scope; absence is not READY."""
+    partial = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    for key in ("competitors", "expiring", "opportunities"):
+        partial.pop(key)
+    path = tmp_path / "partial.json"
+    path.write_text(json.dumps(partial, ensure_ascii=False), encoding="utf-8")
+    _result, document = build_dossier(FixtureSource(path), _request())
+    assert document["data_state"] == DATA_HOLD
+    assert "official_table_missing" in document["reason_codes"]
+
+
+def test_markdown_is_scanned_and_official_text_is_exempt(built):
+    from scripts.dossier.envelope import scan_markdown
+
+    _result, document = built
+    markdown = render_markdown(document)
+    assert scan_markdown(markdown, document) == ()
+    poisoned = markdown + "\n\nHa sobrepreco de R$ 1.000.000,00.\n"
+    assert any("sobrepreco" in hit for hit in scan_markdown(poisoned, document))
+    # A word carried from an official objeto is that source's word, not a claim.
+    official = json.loads(json.dumps(document))
+    official["sections"]["expiring_contracts"]["payload"]["contracts"][0]["objeto"] = "Servico irregular declarado"
+    assert scan_markdown(markdown + "\nServico irregular declarado\n", official) == ()
+
+
+def test_manifest_digests_cover_the_bytes_on_disk(tmp_path, capsys):
+    out = tmp_path / "acme"
+    cli.main(["build", "--cnpj", CNPJ, "--as-of", "2026-08-22", "--fixture", str(FIXTURE), "--out", str(out)])
+    capsys.readouterr()
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert set(manifest["files"]) == {"dossier.json", "public-read.json", "dossier.md"}
+    for name, digest in manifest["files"].items():
+        assert digest == cli.file_digest(out / name)
+
+
+def test_verify_detects_a_tampered_markdown(tmp_path, capsys):
+    out = tmp_path / "acme"
+    cli.main(["build", "--cnpj", CNPJ, "--as-of", "2026-08-22", "--fixture", str(FIXTURE), "--out", str(out)])
+    capsys.readouterr()
+    path = out / "dossier.md"
+    path.write_text(
+        path.read_text(encoding="utf-8") + "\n\nHa sobrepreco e o reajuste devido e imediato.\n", encoding="utf-8"
+    )
+    assert cli.main(["verify", "--dir", str(out)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert any("digest mismatch" in p for p in report["problems"])
+    assert any("forbidden claim content" in p for p in report["problems"])
+
+
+def test_competitor_missingness_describes_the_published_rows():
+    from scripts.dossier.compose import build_competitors
+
+    rows = tuple(
+        {
+            "supplier_cnpj": f"c{i}",
+            "supplier_nome": f"C{i}",
+            "contract_count": 1,
+            "valued_count": 1,
+            "valor_sum": "10.00" if i < 3 else None,
+            "shared_buyer_count": 1,
+            "shared_categories": "OBRAS",
+        }
+        for i in range(20)
+    )
+    section = build_competitors(SourceRead(source="v", observed_at="t", rows=rows), limit=3)
+    assert section.row_count == 3
+    assert section.missingness == 0.0

--- a/tests/dossier/test_dossier_engine.py
+++ b/tests/dossier/test_dossier_engine.py
@@ -334,3 +334,85 @@ def test_cli_strict_fails_on_hold(tmp_path, capsys):
     capsys.readouterr()
     # The fixture is DATA_READY on required sections, so strict must pass.
     assert code == 0
+
+
+def test_handoff_is_ready_only_for_official_live(tmp_path):
+    from scripts.dossier.handoff import (
+        DECISION_BLOCKED,
+        REASON_NOT_OFFICIAL_LIVE,
+        REASON_NOT_PUBLISHABLE,
+        decide,
+        verify_handoff,
+        write_handoff,
+    )
+
+    fixture_public = {
+        "catalog_mode": CATALOG_FIXTURE,
+        "data_state": DATA_READY,
+        "publication_readiness": DATA_HOLD,
+        "content_hash": "sha256:abc",
+        "reason_codes": [],
+    }
+    decision, reasons = decide(fixture_public)
+    assert decision == DECISION_BLOCKED
+    assert REASON_NOT_OFFICIAL_LIVE in reasons
+    assert REASON_NOT_PUBLISHABLE in reasons
+
+    root = tmp_path / "rendezvous"
+    result = write_handoff(fixture_public, {"dossier_id": "d", "producer_sha": "s"}, root)
+    assert result["decision"] == DECISION_BLOCKED
+    assert (root / "BLOCKED.json").exists()
+    assert not (root / "READY.json").exists()
+    assert verify_handoff(root) == []
+
+
+def test_handoff_never_grants_index_authorization(tmp_path):
+    from scripts.dossier.handoff import verify_handoff, write_handoff
+
+    public = {
+        "catalog_mode": CATALOG_OFFICIAL_LIVE,
+        "data_state": DATA_READY,
+        "publication_readiness": DATA_READY,
+        "content_hash": "sha256:abc",
+        "source_dossier_hash": "sha256:def",
+        "reason_codes": [],
+    }
+    root = tmp_path / "rendezvous"
+    result = write_handoff(public, {"dossier_id": "d", "producer_sha": "s"}, root)
+    assert result["decision"] == "READY"
+    assert verify_handoff(root) == []
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["index_authorization"] is False
+    assert manifest["publication_authorization"] is False
+    assert manifest["carries_prospect_identity"] is False
+
+
+def test_handoff_verify_detects_tampering(tmp_path):
+    from scripts.dossier.handoff import verify_handoff, write_handoff
+
+    public = {
+        "catalog_mode": CATALOG_OFFICIAL_LIVE,
+        "data_state": DATA_READY,
+        "publication_readiness": DATA_READY,
+        "content_hash": "sha256:abc",
+        "reason_codes": [],
+    }
+    root = tmp_path / "rendezvous"
+    write_handoff(public, {"dossier_id": "d", "producer_sha": "s"}, root)
+    (root / "payload.json").write_text('{"tampered": true}\n', encoding="utf-8")
+    errors = verify_handoff(root)
+    assert any(e.startswith("digest:payload.json") for e in errors)
+
+
+def test_cli_handoff_publishes_only_the_public_projection(tmp_path, capsys):
+    out = tmp_path / "acme"
+    cli.main(["build", "--cnpj", CNPJ, "--as-of", "2026-08-22", "--fixture", str(FIXTURE), "--out", str(out)])
+    capsys.readouterr()
+    root = tmp_path / "rendezvous"
+    # A fixture build is BLOCKED, which is exit code 1, not a crash.
+    assert cli.main(["handoff", "--dir", str(out), "--to", str(root)]) == 1
+    capsys.readouterr()
+    body = (root / "payload.json").read_text(encoding="utf-8")
+    assert CNPJ not in body
+    assert "ACME PAVIMENTACAO" not in body
+    assert not (root / "dossier.json").exists()

--- a/tests/dossier/test_dossier_engine.py
+++ b/tests/dossier/test_dossier_engine.py
@@ -1,0 +1,336 @@
+"""Contract tests for the CONFENGE dossier engine."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from scripts.dossier import cli
+from scripts.dossier.compose import _position, build_findings, build_price_panel
+from scripts.dossier.constants import (
+    CATALOG_FIXTURE,
+    CATALOG_OFFICIAL_LIVE,
+    DATA_HOLD,
+    DATA_READY,
+    DATA_REJECT,
+    FINDING_ANNIVERSARY,
+    FORBIDDEN_CLAIM_TOKENS,
+    PANEL_OUT_OF_RANGE_FACTOR,
+    POSITION_OUT_OF_PANEL_RANGE,
+    PUBLIC_REDACTED_FIELDS,
+    REASON_FIXTURE_LABELED_LIVE,
+    REASON_FIXTURE_NOT_LIVE,
+    REASON_INVALID_CNPJ,
+    SCHEMA,
+    SECTION_BUYER_MAP,
+    SECTION_COMPETITORS,
+    SECTION_IDENTITY,
+)
+from scripts.dossier.envelope import (
+    LIMITATION_ACTIVE_ONLY,
+    LIMITATION_FIXTURE,
+    LIMITATION_NO_CLAIM,
+    LIMITATION_REFERENCE_SCOPE,
+    LIMITATION_UNKNOWN,
+    build_dossier,
+    content_hash,
+    public_projection,
+    scan_forbidden,
+)
+from scripts.dossier.models import DossierRequest, SourceRead, cnpj14, worst_state
+from scripts.dossier.render import render_markdown
+from scripts.dossier.sources import CATEGORY_SQL, FixtureSource
+
+FIXTURE = Path(__file__).parent / "fixtures" / "acme.json"
+CNPJ = "11222333000181"
+
+
+def _request(**overrides) -> DossierRequest:
+    base = {
+        "cnpj": CNPJ,
+        "as_of": "2026-08-22",
+        "catalog_mode": CATALOG_FIXTURE,
+        "consumer_id": "test",
+        "producer_sha": "deadbeef",
+    }
+    base.update(overrides)
+    return DossierRequest(**base)
+
+
+@pytest.fixture()
+def built():
+    return build_dossier(FixtureSource(FIXTURE), _request())
+
+
+def test_document_carries_versioned_envelope(built):
+    _result, document = built
+    assert document["schema"] == SCHEMA
+    assert document["grain"] == "cnpj14"
+    assert document["cnpj14"] == CNPJ
+    assert document["catalog_mode"] == CATALOG_FIXTURE
+    assert document["content_hash"].startswith("sha256:")
+
+
+def test_content_hash_is_stable_across_volatile_fields(built):
+    _result, document = built
+    baseline = content_hash(document)
+    mutated = json.loads(json.dumps(document))
+    mutated["producer_sha"] = "0" * 40
+    mutated["observed_at"] = "2099-01-01T00:00:00Z"
+    mutated["sections"][SECTION_IDENTITY]["observed_at"] = "2099-01-01T00:00:00Z"
+    assert content_hash(mutated) == baseline
+
+
+def test_content_hash_changes_when_a_fact_changes(built):
+    _result, document = built
+    mutated = json.loads(json.dumps(document))
+    mutated["sections"][SECTION_BUYER_MAP]["payload"]["buyer_count"] = 999
+    assert content_hash(mutated) != content_hash(document)
+
+
+def test_fixture_run_declares_itself_a_fixture(built):
+    _result, document = built
+    assert REASON_FIXTURE_NOT_LIVE in document["reason_codes"]
+    assert LIMITATION_FIXTURE in document["limitations"]
+
+
+def test_fixture_cannot_be_labeled_official_live():
+    _result, document = build_dossier(FixtureSource(FIXTURE), _request(catalog_mode=CATALOG_OFFICIAL_LIVE))
+    assert document["data_state"] == DATA_REJECT
+    assert REASON_FIXTURE_LABELED_LIVE in document["reason_codes"]
+    assert document["sections"] == {}
+
+
+def test_invalid_cnpj_is_rejected_not_padded():
+    _result, document = build_dossier(FixtureSource(FIXTURE), _request(cnpj="123"))
+    assert document["data_state"] == DATA_REJECT
+    assert REASON_INVALID_CNPJ in document["reason_codes"]
+    assert cnpj14("123") is None
+    assert cnpj14("11.222.333/0001-81") == CNPJ
+
+
+def test_unknown_value_never_becomes_zero(built):
+    _result, document = built
+    buyers = document["sections"][SECTION_BUYER_MAP]["payload"]["buyers"]
+    first = next(b for b in buyers if b["buyer_cnpj"] == "82000000000101")
+    # Two contracts, one without a published value: the sum reflects only the known one.
+    assert first["contract_count"] == 2
+    assert first["valued_count"] == 1
+    assert first["valor_sum"] == "1000000.00"
+    missingness = document["sections"][SECTION_BUYER_MAP]["missingness"]
+    assert missingness == pytest.approx(1 / 3, abs=1e-4)
+
+
+def test_findings_are_facts_plus_questions(built):
+    _result, document = built
+    assert document["findings"], "fixture must produce findings"
+    for finding in document["findings"]:
+        assert finding["fact"]
+        assert finding["question"].endswith("?")
+        assert finding["evidence_refs"]
+
+
+def test_anniversary_finding_requires_a_running_contract():
+    source = FixtureSource(FIXTURE)
+    contracts = source.contracts(CNPJ)
+    findings = build_findings(
+        contracts=contracts,
+        buyer_map=build_price_panel(SourceRead(source="x", observed_at="t")),
+        price_panel=build_price_panel(SourceRead(source="x", observed_at="t")),
+        expiring=build_price_panel(SourceRead(source="x", observed_at="t")),
+        opportunities=build_price_panel(SourceRead(source="x", observed_at="t")),
+        as_of="2026-08-22",
+    )
+    anniversaries = {f.subject for f in findings if f.finding_id.startswith(FINDING_ANNIVERSARY)}
+    # FIX-0001 started 2024-01-10 and runs to 2027: anniversary reached.
+    assert "FIX-0001" in anniversaries
+    # FIX-0002 started 2026-06-01: under twelve months, no anniversary.
+    assert "FIX-0002" not in anniversaries
+
+
+def test_panel_refuses_a_position_outside_its_range():
+    assert _position(Decimal("1000000"), Decimal("100"), Decimal("500"), Decimal("2000")) == (
+        POSITION_OUT_OF_PANEL_RANGE
+    )
+    assert _position(Decimal("1"), Decimal("1000"), Decimal("5000"), Decimal("20000")) == (POSITION_OUT_OF_PANEL_RANGE)
+    inside = _position(Decimal("750000"), Decimal("200000"), Decimal("700000"), Decimal("1500000"))
+    assert inside == "P50_P75"
+    assert PANEL_OUT_OF_RANGE_FACTOR == 10
+
+
+def test_out_of_range_category_produces_no_position_finding():
+    read = SourceRead(
+        source="v_contract_intel_percentis",
+        observed_at="2026-01-01T00:00:00Z",
+        rows=(
+            {
+                "categoria": "FACILITIES",
+                "qtd_contratos": 100,
+                "p25_valor": "100.00",
+                "p50_valor": "500.00",
+                "p75_valor": "2000.00",
+                "ticket_medio": "800.00",
+                "focal_count": 3,
+                "focal_valued_count": 3,
+                "focal_median": "44000000.00",
+            },
+        ),
+    )
+    section = build_price_panel(read)
+    assert section.state == DATA_HOLD
+    assert section.payload["categories"][0]["focal_position"] == POSITION_OUT_OF_PANEL_RANGE
+    findings = build_findings(
+        contracts=SourceRead(source="c", observed_at="t"),
+        buyer_map=section,
+        price_panel=section,
+        expiring=build_price_panel(SourceRead(source="x", observed_at="t")),
+        opportunities=build_price_panel(SourceRead(source="x", observed_at="t")),
+        as_of="2026-08-22",
+    )
+    assert not [f for f in findings if f.finding_id.startswith("value_position_in_category")]
+
+
+def test_competitors_are_bound_to_the_primary_category(built):
+    _result, document = built
+    payload = document["sections"][SECTION_COMPETITORS]["payload"]
+    assert payload["primary_category"] == "OBRAS"
+    for competitor in payload["competitors"]:
+        assert competitor["shared_categories"] == ["OBRAS"]
+
+
+def test_no_forbidden_claim_reaches_the_document(built):
+    _result, document = built
+    assert scan_forbidden(document) == ()
+    assert scan_forbidden(public_projection(document)) == ()
+
+
+def test_scanner_catches_an_injected_claim(built):
+    _result, document = built
+    poisoned = json.loads(json.dumps(document))
+    poisoned["findings"][0]["question"] = "Houve sobrepreco neste contrato?"
+    assert any("sobrepreco" in hit for hit in scan_forbidden(poisoned))
+
+
+def test_scanner_exempts_official_object_text(built):
+    _result, document = built
+    poisoned = json.loads(json.dumps(document))
+    poisoned["sections"]["expiring_contracts"]["payload"]["contracts"][0]["objeto"] = (
+        "Servico de manutencao com apuracao de irregularidade contratual"
+    )
+    assert scan_forbidden(poisoned) == ()
+
+
+def test_limitations_are_frozen_constants(built):
+    """The scanner exempts $.limitations, so the block must stay reviewed constants."""
+    _result, document = built
+    allowed = {
+        LIMITATION_FIXTURE,
+        LIMITATION_UNKNOWN,
+        LIMITATION_NO_CLAIM,
+        LIMITATION_ACTIVE_ONLY,
+        LIMITATION_REFERENCE_SCOPE,
+    }
+    assert set(document["limitations"]) <= allowed
+
+
+def test_public_projection_removes_the_prospect(built):
+    _result, document = built
+    public = public_projection(document)
+    body = json.dumps(public, ensure_ascii=False)
+    assert CNPJ not in body
+    assert "ACME PAVIMENTACAO" not in body
+    assert "CONCORRENTE FIXTURE" not in body
+    assert public["source_dossier_hash"] == document["content_hash"]
+    assert SECTION_IDENTITY not in public["sections"]
+    assert SECTION_BUYER_MAP not in public["sections"]
+    for field in PUBLIC_REDACTED_FIELDS:
+        assert f'"{field}": "ACME' not in body
+
+
+def test_public_projection_of_a_fixture_is_never_publishable(built):
+    _result, document = built
+    public = public_projection(document)
+    assert public["publication_readiness"] == DATA_HOLD
+
+
+def test_markdown_render_is_byte_stable(built):
+    _result, document = built
+    assert render_markdown(document) == render_markdown(document)
+    body = render_markdown(document)
+    assert body.startswith("# Diagnóstico B2G — ACME PAVIMENTACAO LTDA")
+    assert "UNKNOWN" in body
+
+
+def test_forbidden_tokens_are_lowercase_for_the_scanner():
+    for token in FORBIDDEN_CLAIM_TOKENS:
+        assert token == token.lower()
+
+
+def test_worst_state_folds_to_the_worst():
+    assert worst_state((DATA_READY, DATA_READY)) == DATA_READY
+    assert worst_state((DATA_READY, DATA_HOLD)) == DATA_HOLD
+    assert worst_state((DATA_HOLD, DATA_REJECT)) == DATA_REJECT
+    assert worst_state(()) == DATA_REJECT
+
+
+def test_category_ladder_covers_every_panel_bucket():
+    """The ladder is duplicated from v_contract_intel_percentis; keep the buckets aligned."""
+    for bucket in (
+        "OBRAS",
+        "FACILITIES",
+        "TI",
+        "SAÚDE",
+        "ALIMENTAÇÃO",
+        "TRANSPORTE",
+        "SEGURANÇA",
+        "CONSULTORIA",
+        "COMBUSTÍVEL",
+        "OUTROS",
+    ):
+        assert f"'{bucket}'" in CATEGORY_SQL
+
+
+def test_cli_build_and_verify_roundtrip(tmp_path, capsys):
+    out = tmp_path / "acme"
+    code = cli.main(["build", "--cnpj", CNPJ, "--as-of", "2026-08-22", "--fixture", str(FIXTURE), "--out", str(out)])
+    capsys.readouterr()
+    assert code == 0
+    assert (out / "dossier.json").exists()
+    assert (out / "public-read.json").exists()
+    assert (out / "dossier.md").exists()
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["catalog_mode"] == CATALOG_FIXTURE
+
+    assert cli.main(["verify", "--dir", str(out)]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["verdict"] == "PASS"
+
+
+def test_cli_verify_detects_a_tampered_dossier(tmp_path, capsys):
+    out = tmp_path / "acme"
+    cli.main(["build", "--cnpj", CNPJ, "--as-of", "2026-08-22", "--fixture", str(FIXTURE), "--out", str(out)])
+    capsys.readouterr()
+    path = out / "dossier.json"
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["sections"][SECTION_BUYER_MAP]["payload"]["buyer_count"] = 42
+    path.write_text(json.dumps(document, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    assert cli.main(["verify", "--dir", str(out)]) == 1
+    report = json.loads(capsys.readouterr().out)
+    assert report["verdict"] == "FAIL"
+    assert any("content_hash mismatch" in problem for problem in report["problems"])
+
+
+def test_cli_claim_live_on_fixture_exits_rejected(tmp_path, capsys):
+    code = cli.main(["build", "--cnpj", CNPJ, "--fixture", str(FIXTURE), "--claim-live", "--as-of", "2026-08-22"])
+    capsys.readouterr()
+    assert code == 5
+
+
+def test_cli_strict_fails_on_hold(tmp_path, capsys):
+    code = cli.main(["build", "--cnpj", CNPJ, "--fixture", str(FIXTURE), "--as-of", "2026-08-22", "--strict"])
+    capsys.readouterr()
+    # The fixture is DATA_READY on required sections, so strict must pass.
+    assert code == 0


### PR DESCRIPTION
## Visitor job / commercial hypothesis

The DataLake feeds prospecting only. This makes it feed **delivery**: a company-grain (`cnpj14`) engine that composes canonical reads into the artifact behind the paid offer `CFG-DIAG-EXP-v1` (Diagnóstico B2G de Expansão, R$ 8.000), which was produced by hand until now.

One run, three destinations: the paid dossier, a de-identified public projection for web-cfg, and a hashed manifest a Warmbly touchpoint can reference.

## Data owner / contract

extra-cli owns the facts. `docs/contracts/confenge-dossier-v1.md` + `.json`.
Sources, all `SELECT`-only: `supplier_registry`, `v_contracts_canonical_v2`, `v_contract_intel_percentis`, `v_open_opportunities_canonical`, `sc_public_entities`.

```bash
make dossier CNPJ=00820854000114     # build + verify
make dossier-handoff                 # publish the public projection to the rendezvous
```

## Quality gate

- `ruff check` / `ruff format --check` / `mypy` clean on `scripts/dossier/`
- 39 tests, `pytest tests/dossier/ -q`
- Live `official_live` run against the production DataLake: `DATA_READY`, `verify` PASS, content hash stable across runs with different `observed_at`
- Production-parity preflight on `ec-prod` (Python 3.13) produced a byte-identical content hash

## Adversarial review and what it caught

An independent review reproduced ten defects against live data. The second commit closes them. The ones that changed the deliverable:

**Re-identification.** The public projection published each competitor's exact `valor_sum` over a deterministic, publicly reproducible scope. One `GROUP BY supplier_cnpj HAVING SUM(valor) = <published>` resolved **15 of 15** redacted suppliers to named CNPJs. Separately, `subject_profile` carried `uf` + 7-digit CNAE + exact counts, a tuple matching **exactly one** supplier nationwide. Both are now banded; `verify` had returned PASS on both, because it only did a literal substring match and cannot see a value that is a join key.

**"Contratos a vencer em 365 dias" reported 3 of 20.** `v_expiring_contracts` hard-codes a 90-to-180-day band, so the window parameter was decorative. The two most urgent contracts were invisible, including a **R$ 61,4M SIE/SC contract ending in 6 days**. Expiring now reads the canonical view with the requested window counted from `as_of`, which also removes the wall clock from the content hash.

**`LIMIT 50` corrupted the totals.** Sum, share and HHI were computed over the display cap, so the same JSON reported 1.084 and 4.951 contracts for one supplier, understated money 9x, and inflated HHI across the concentration threshold in 5 cases. Totals now come from an untruncated aggregate.

**The focal median used a wider row rule than the panel it was compared against** — 182 supplier×category groups had a wrong published position, including flips across the out-of-range guard in both directions.

Also: a missing offer section can no longer fold to `DATA_READY`; the delivered markdown is scanned for forbidden claims with official source text exempt **by value**; the manifest records digests of the bytes on disk; competitor missingness describes the published rows.

## Honesty rules enforced in code, pinned by tests

`UNKNOWN` never becomes zero and `valued_count` always sits next to `contract_count`. A fixture can never claim `official_live`. Competitors are bound to the focal's primary category, because a municipality buys stationery and asphalt from the same list. Where the focal median sits more than 10x outside the panel's interquartile band, no percentile position and no finding are emitted. A finding is a fact plus the question it opens, never an assertion of a right.

## Known limits, tracked

- #452 — the `TI` rung of the upstream category ladder matches the bare substring `ti`; 84% of that bucket is not TI. Mitigated here by claiming no position for it.
- #453 — the price panel is a 200 km regional reference compared against a national portfolio. Declared in every document.

## Rollback

Additive only: a new `scripts/dossier/` package, its tests, two contract docs, one ops doc and two Makefile targets. No migration, no write path, no existing module touched. Revert the three commits.