### PR TITLE
fix(outreach): close four confirmed wrong-company admission paths

### DIFF
--- a/scripts/confenge_contact_resolution/discovery/cascade.py
+++ b/scripts/confenge_contact_resolution/discovery/cascade.py
@@ -324,6 +324,7 @@ class DiscoveryCascade:
             ctx.public_docs,
             cnpj14=cnpj14,
             official_domain=result.domain.domain,
+            razao_social=razao_social or "",
         )
         doc_success = named_doc or actionable_doc
         self._attempt(
@@ -670,6 +671,7 @@ def _has_actionable_doc_route(
     *,
     cnpj14: str,
     official_domain: str | None = None,
+    razao_social: str = "",
 ) -> bool:
     target = re.sub(r"\D", "", cnpj14 or "")[:14]
     for d in docs or []:
@@ -695,6 +697,7 @@ def _has_actionable_doc_route(
                 payload,
                 account_id=target,
                 official_domain=official_domain,
+                company_label=razao_social,
             ):
                 return True
     return False

--- a/scripts/confenge_contact_resolution/discovery/cascade.py
+++ b/scripts/confenge_contact_resolution/discovery/cascade.py
@@ -324,7 +324,6 @@ class DiscoveryCascade:
             ctx.public_docs,
             cnpj14=cnpj14,
             official_domain=result.domain.domain,
-            razao_social=razao_social or "",
         )
         doc_success = named_doc or actionable_doc
         self._attempt(
@@ -671,7 +670,6 @@ def _has_actionable_doc_route(
     *,
     cnpj14: str,
     official_domain: str | None = None,
-    razao_social: str = "",
 ) -> bool:
     target = re.sub(r"\D", "", cnpj14 or "")[:14]
     for d in docs or []:
@@ -697,7 +695,6 @@ def _has_actionable_doc_route(
                 payload,
                 account_id=target,
                 official_domain=official_domain,
-                company_label=razao_social,
             ):
                 return True
     return False

--- a/scripts/confenge_contact_resolution/discovery/official_domain.py
+++ b/scripts/confenge_contact_resolution/discovery/official_domain.py
@@ -14,7 +14,56 @@ from scripts.confenge_contact_resolution.ownership import (
 )
 
 # Hosts that must never be treated as company official sites
+# Hosts nobody owns exclusively. A page on one of these proves nothing about
+# who owns a mailbox published on it, so it can never stand in for a company's
+# official domain. Link shorteners, archives and site builders included: they
+# are all "anyone can publish here".
+_SHARED_PUBLISHING_HOST_SUFFIXES = (
+    "blogspot.com",
+    "blogspot.com.br",
+    "wordpress.com",
+    "weebly.com",
+    "jimdosite.com",
+    "jimdofree.com",
+    "webnode.com",
+    "webnode.com.br",
+    "tumblr.com",
+    "myshopify.com",
+    "canva.site",
+    "godaddysites.com",
+    "negocio.site",
+    "notion.site",
+    "github.io",
+    "gitlab.io",
+    "medium.com",
+    "substack.com",
+    "linktr.ee",
+    "linkr.bio",
+    "beacons.ai",
+    "bio.link",
+    "bit.ly",
+    "tinyurl.com",
+    "t.me",
+    "wa.me",
+    "api.whatsapp.com",
+    "web.archive.org",
+    "archive.org",
+    "docs.google.com",
+    "drive.google.com",
+    "groups.google.com",
+    "google.com",
+    "goo.gl",
+    "s3.amazonaws.com",
+    "blob.core.windows.net",
+    "firebaseapp.com",
+    "web.app",
+    "netlify.app",
+    "vercel.app",
+    "pages.dev",
+)
+
 _BLOCKED_HOST_SUFFIXES = (
+    *_SHARED_PUBLISHING_HOST_SUFFIXES,
     "jusbrasil.com.br",
     "linkedin.com",
     "instagram.com",

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -63,6 +63,13 @@ CLEAR_SUPPRESSION_TOKENS = frozenset({"NONE", "CLEAR", "OK", "ACTIVE", "NOT_SUPP
 EVIDENCE_OBSERVED = "OBSERVED"
 EVIDENCE_UNKNOWN = "UNKNOWN"
 
+# `official_documents` is listed here so a mailbox on the account's own proven
+# domain is accepted when it is found in a company-authored document. There is
+# deliberately NO carve-out letting a document route skip the host/domain match:
+# extraction cannot say which company a mailbox printed in a document belongs to.
+# The document's CNPJ tag is the CNPJ that was queried, and the company name is
+# supplied by the producer, so neither can bind the mailbox. Without a proven
+# official domain, a document route has no association evidence at all.
 COMPANY_ASSOCIATION_SOURCES = frozenset(
     {
         "company_website",
@@ -100,18 +107,6 @@ IMPLAUSIBLE_MAILBOX_TLDS = frozenset(
     }
 )
 HTML_ENTITY_LOCAL_MARKERS = ("u003e", "u003c", "u0026", "&gt;", "&lt;", "&amp;")
-
-# A company-authored document lives on a PNCP or transparency host that is never
-# the company host, so the site host-match rule cannot be applied to it. What can
-# be applied is the company's own identity: the mailbox domain must be credible
-# for the account's registered name.
-#
-# The document's own CNPJ tag is NOT usable as the binding. Extraction stamps it
-# with the CNPJ that was queried, not with the CNPJ the document attributes the
-# mailbox to, so comparing it to the account is tautological — a public notice
-# that merely lists the company would bind the buying agency's mailbox to it.
-CNPJ_LINKED_DOCUMENT_SOURCES = frozenset({"official_documents", "official_document"})
-CNPJ_LINKED_DOCUMENT_EVIDENCE = frozenset({"company_authored_document", "official_cnpj_linked_document"})
 
 EMAIL_CHANNEL_TYPES = frozenset(
     {
@@ -330,39 +325,6 @@ def mailbox_local_implausible(mailbox: str | None) -> bool:
     return False
 
 
-def cnpj_linked_document_association(route: ReachabilityRoute) -> bool:
-    """True for a company-authored document whose mailbox domain fits this company.
-
-    The document host is never the company host, so host-match cannot apply. The
-    binding used instead is the account's own registered name against the mailbox
-    domain. Without a company name to check, there is no binding and the route is
-    refused: a document that merely mentions the company proves nothing about
-    whose mailbox is printed in it.
-    """
-    source = str(route.source_type or "").lower().strip()
-    if source not in CNPJ_LINKED_DOCUMENT_SOURCES:
-        return False
-    extra = route.extra if isinstance(route.extra, dict) else {}
-    if str(extra.get("evidence_strength") or "").lower().strip() not in CNPJ_LINKED_DOCUMENT_EVIDENCE:
-        return False
-    if extra.get("pattern_guessed_email") or extra.get("pattern_guessed"):
-        return False
-    mailbox_domain = email_domain(route.channel_value)
-    if not mailbox_domain or is_freemail(route.channel_value):
-        return False
-    from scripts.confenge_contact_resolution.discovery.official_domain import (
-        is_blocked_host,
-        is_credible_company_domain,
-    )
-
-    if is_blocked_host(mailbox_domain):
-        return False
-    company_label = str(extra.get("razao_social") or extra.get("company_label") or "").strip()
-    if not company_label:
-        return False
-    return bool(is_credible_company_domain(mailbox_domain, company_label))
-
-
 def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     """True only when public provenance can bind the mailbox to this account."""
     if untrustworthy_source_url(route.source_url):
@@ -376,8 +338,6 @@ def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     freemail = is_freemail(route.channel_value)
     if not freemail and not mailbox_host_plausible(mailbox_dom):
         return False
-    if not freemail and cnpj_linked_document_association(route):
-        return True
     on_official_page = bool(official and url_host and _hosts_equivalent(url_host, official))
     mailbox_on_official = bool(official and mailbox_dom and not freemail and _hosts_equivalent(mailbox_dom, official))
     if official:
@@ -554,7 +514,6 @@ def observed_contact_is_controlled_eligible_company_route(
     *,
     account_id: str = "",
     official_domain: str | None = None,
-    company_label: str = "",
 ) -> bool:
     """Same gate as evaluate_controlled_email_eligible. Nominal/third-party are not success."""
     if contact.get("pattern_guessed_email") or contact.get("email_derivation") == "INFERRED":
@@ -566,8 +525,6 @@ def observed_contact_is_controlled_eligible_company_route(
         return False
     payload = dict(contact)
     payload["email"] = email
-    if company_label and not payload.get("razao_social"):
-        payload["razao_social"] = company_label
     domain = email_domain(email)
     official = (official_domain or "").lower().removeprefix("www.")
     source = str(payload.get("source") or payload.get("source_type") or "").lower()
@@ -969,9 +926,6 @@ def route_from_feed_contact(
     observed_id = str(contact.get("person_id") or "").strip()
     if observed_id:
         extra.setdefault("observed_person_id", observed_id)
-    company_label = str(contact.get("razao_social") or contact.get("company_label") or "").strip()
-    if company_label:
-        extra.setdefault("razao_social", company_label)
     evidence_strength = str(contact.get("evidence_strength") or "").strip().lower()
     if evidence_strength:
         extra.setdefault("evidence_strength", evidence_strength)

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -62,13 +62,34 @@ CLEAR_SUPPRESSION_TOKENS = frozenset({"NONE", "CLEAR", "OK", "ACTIVE", "NOT_SUPP
 
 # Producers spell suppression in more than one vocabulary. Reading only two of
 # these field names let an opted-out mailbox into a bounded pilot.
+# Fields whose whole purpose is suppression. An unrecognized token here is not
+# evidence of a clear mailbox, so it fails closed.
 SUPPRESSION_TEXT_FIELDS = (
     "route_suppression",
     "suppression_state",
     "suppression",
     "suppression_reason",
-    "email_status",
-    "status",
+)
+# Fields that merely *may* carry a suppression word. `status` is deliberately
+# not read at all: this repo uses it for READY, idle, backpressure and more, so
+# failing closed on it would mark healthy contacts suppressed.
+SUPPRESSION_HINT_FIELDS = ("email_status", "delivery_status", "contact_status")
+SUPPRESSION_HINT_TOKENS = frozenset(
+    {
+        "UNSUBSCRIBED",
+        "OPT_OUT",
+        "OPTED_OUT",
+        "COMPLAINED",
+        "COMPLAINT",
+        "SPAM",
+        "BOUNCED",
+        "HARD_BOUNCE",
+        "SUPPRESSED",
+        "BLOCKED",
+        "BLOCKLISTED",
+        "DNC",
+        "DO_NOT_CONTACT",
+    }
 )
 SUPPRESSION_FLAG_FIELDS = (
     "dnc",
@@ -963,6 +984,15 @@ def suppression_from_feed_contact(contact: dict[str, Any]) -> SuppressionState:
                 return SuppressionState(token)
             # An unrecognized token is not evidence of a clear mailbox.
             state = SuppressionState.BLOCKED
+        for field in SUPPRESSION_HINT_FIELDS:
+            raw = source.get(field)
+            if raw is None or isinstance(raw, bool):
+                continue
+            token = str(raw).upper().replace("-", "_").strip()
+            if token in {s.value for s in SuppressionState} and token not in CLEAR_SUPPRESSION_TOKENS:
+                return SuppressionState(token)
+            if token in SUPPRESSION_HINT_TOKENS:
+                return SuppressionState.DNC
         for field in SUPPRESSION_FLAG_FIELDS:
             if field in source and _suppression_flag(source.get(field)):
                 return SuppressionState.DNC

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -11,7 +11,7 @@ This module never grants auto-send.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -1188,7 +1188,7 @@ def stamp_and_rank_feed_contacts(
     return apply_preferred_recommended_alias(stamped)
 
 
-def _shared_mailbox_owner(leads: list[dict[str, Any]]) -> dict[str, str]:
+def _shared_mailbox_owner(leads: Iterable[dict[str, Any]]) -> dict[str, str]:
     """Pick the one account that keeps each shared mailbox, stably across runs.
 
     Feed order is sorted by target-fit freshness timestamps, which advance on
@@ -1216,9 +1216,22 @@ def _shared_mailbox_owner(leads: list[dict[str, Any]]) -> dict[str, str]:
     return owner
 
 
-def apply_cross_account_preferred_mailbox_gate(leads: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Exactly one account may keep a preferred mailbox. Other claimants lose it."""
-    claimed: dict[str, str] = dict(_shared_mailbox_owner(leads))
+def shared_preferred_mailbox_owner(leads: Iterable[dict[str, Any]]) -> dict[str, str]:
+    """Public whole-feed view of who keeps each shared mailbox."""
+    return _shared_mailbox_owner(leads)
+
+
+def apply_cross_account_preferred_mailbox_gate(
+    leads: list[dict[str, Any]],
+    *,
+    owner: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Exactly one account may keep a preferred mailbox. Other claimants lose it.
+
+    ``owner`` carries a whole-feed decision computed elsewhere, so a streaming
+    caller can apply the gate one lead at a time without holding the feed.
+    """
+    claimed: dict[str, str] = dict(owner if owner is not None else _shared_mailbox_owner(leads))
     out: list[dict[str, Any]] = []
     for lead in leads:
         if not isinstance(lead, dict):

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -58,7 +58,30 @@ CONTROLLED_EMAIL_SCHEMA_VERSION = "confenge.outreach.controlled_email.v1"
 
 # Tokens that genuinely mean "not suppressed". Anything else is treated as
 # suppression, because an unknown token is not evidence of a clear mailbox.
-CLEAR_SUPPRESSION_TOKENS = frozenset({"NONE", "CLEAR", "OK", "ACTIVE", "NOT_SUPPRESSED"})
+CLEAR_SUPPRESSION_TOKENS = frozenset({"NONE", "CLEAR", "OK", "ACTIVE", "NOT_SUPPRESSED", "FALSE", "NO", "0"})
+
+# Producers spell suppression in more than one vocabulary. Reading only two of
+# these field names let an opted-out mailbox into a bounded pilot.
+SUPPRESSION_TEXT_FIELDS = (
+    "route_suppression",
+    "suppression_state",
+    "suppression",
+    "suppression_reason",
+    "email_status",
+    "status",
+)
+SUPPRESSION_FLAG_FIELDS = (
+    "dnc",
+    "do_not_contact",
+    "unsubscribed",
+    "opted_out",
+    "suppressed",
+    "is_suppressed",
+    "complained",
+    "spam_complaint",
+    "blocklisted",
+)
+_FALSEY_TOKENS = frozenset({"", "0", "FALSE", "NO", "NONE", "NULL", "N"})
 
 EVIDENCE_OBSERVED = "OBSERVED"
 EVIDENCE_UNKNOWN = "UNKNOWN"
@@ -899,6 +922,58 @@ def _feed_contact_source_url(contact: dict[str, Any]) -> str:
     return str(contact.get("source_url") or prov.get("source_url") or "").strip()
 
 
+def _suppression_flag(value: Any) -> bool:
+    """Truthiness for a producer flag, without letting the string "false" suppress.
+
+    A producer that emits string booleans would otherwise starve the whole
+    cohort, and one that emits 1 / "yes" would otherwise slip past an identity
+    comparison against True.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().upper() not in _FALSEY_TOKENS
+    return bool(value)
+
+
+def _suppression_sources(contact: dict[str, Any]) -> list[dict[str, Any]]:
+    """The contact plus the nested shapes this schema already uses elsewhere."""
+    out = [contact]
+    for key in ("provenance", "extra"):
+        nested = contact.get(key)
+        if isinstance(nested, dict):
+            out.append(nested)
+    return out
+
+
+def suppression_from_feed_contact(contact: dict[str, Any]) -> SuppressionState:
+    """Read suppression fail-closed across every shape a producer may use."""
+    state = SuppressionState.NONE
+    for source in _suppression_sources(contact):
+        for field in SUPPRESSION_TEXT_FIELDS:
+            raw = source.get(field)
+            if raw is None or isinstance(raw, bool):
+                continue
+            token = str(raw).upper().replace("-", "_").strip()
+            if not token or token in CLEAR_SUPPRESSION_TOKENS:
+                continue
+            if token in {s.value for s in SuppressionState}:
+                return SuppressionState(token)
+            # An unrecognized token is not evidence of a clear mailbox.
+            state = SuppressionState.BLOCKED
+        for field in SUPPRESSION_FLAG_FIELDS:
+            if field in source and _suppression_flag(source.get(field)):
+                return SuppressionState.DNC
+        if "opt_out" in source and _suppression_flag(source.get("opt_out")):
+            return SuppressionState.OPT_OUT
+        for field in ("bounce", "bounced", "hard_bounce"):
+            if field in source and _suppression_flag(source.get(field)):
+                return SuppressionState.HARD_BOUNCE
+    return state
+
+
 def route_from_feed_contact(
     contact: dict[str, Any],
     *,
@@ -941,26 +1016,7 @@ def route_from_feed_contact(
     discovery = contact.get("email_discovery_class") or contact.get("route_class")
     if discovery:
         extra.setdefault("email_discovery_class", str(discovery))
-    suppression = SuppressionState.NONE
-    raw_sup = (
-        str(contact.get("route_suppression") or contact.get("suppression_state") or contact.get("suppression") or "")
-        .upper()
-        .replace("-", "_")
-        .strip()
-    )
-    if raw_sup in {s.value for s in SuppressionState}:
-        suppression = SuppressionState(raw_sup)
-    elif raw_sup and raw_sup not in CLEAR_SUPPRESSION_TOKENS:
-        # An unrecognized suppression token is not an absence of suppression.
-        # Producers use vocabularies this enum does not carry, and reading one
-        # as NONE lets an opted-out mailbox into a bounded pilot.
-        suppression = SuppressionState.BLOCKED
-    if contact.get("dnc") or contact.get("do_not_contact") or contact.get("unsubscribed"):
-        suppression = SuppressionState.DNC
-    if contact.get("opt_out") is True:
-        suppression = SuppressionState.OPT_OUT
-    if contact.get("bounce") or contact.get("bounced"):
-        suppression = SuppressionState.HARD_BOUNCE
+    suppression = suppression_from_feed_contact(contact)
     ownership = OwnershipStatus.UNKNOWN
     raw_own = str(contact.get("ownership_status") or "").upper()
     if raw_own in {o.value for o in OwnershipStatus}:

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -56,6 +56,10 @@ DEPARTMENTAL_HYPOTHESIS_LOCALS: tuple[str, ...] = (
 CONTROLLED_EMAIL_POLICY_VERSION = "controlled-email-policy.v1"
 CONTROLLED_EMAIL_SCHEMA_VERSION = "confenge.outreach.controlled_email.v1"
 
+# Tokens that genuinely mean "not suppressed". Anything else is treated as
+# suppression, because an unknown token is not evidence of a clear mailbox.
+CLEAR_SUPPRESSION_TOKENS = frozenset({"NONE", "CLEAR", "OK", "ACTIVE", "NOT_SUPPRESSED"})
+
 EVIDENCE_OBSERVED = "OBSERVED"
 EVIDENCE_UNKNOWN = "UNKNOWN"
 
@@ -88,7 +92,6 @@ IMPLAUSIBLE_MAILBOX_TLDS = frozenset(
         "phone",
         "js",
         "ts",
-        "py",
         "local",
         "localhost",
         "invalid",
@@ -98,10 +101,15 @@ IMPLAUSIBLE_MAILBOX_TLDS = frozenset(
 )
 HTML_ENTITY_LOCAL_MARKERS = ("u003e", "u003c", "u0026", "&gt;", "&lt;", "&amp;")
 
-# Company-authored documents already bound to the CNPJ by the datalake prove the
-# association by authorship, not by where the file happens to be hosted. A PNCP
-# or transparency-portal host is never the company host, so the site host-match
-# rule cannot be applied to this evidence family.
+# A company-authored document lives on a PNCP or transparency host that is never
+# the company host, so the site host-match rule cannot be applied to it. What can
+# be applied is the company's own identity: the mailbox domain must be credible
+# for the account's registered name.
+#
+# The document's own CNPJ tag is NOT usable as the binding. Extraction stamps it
+# with the CNPJ that was queried, not with the CNPJ the document attributes the
+# mailbox to, so comparing it to the account is tautological — a public notice
+# that merely lists the company would bind the buying agency's mailbox to it.
 CNPJ_LINKED_DOCUMENT_SOURCES = frozenset({"official_documents", "official_document"})
 CNPJ_LINKED_DOCUMENT_EVIDENCE = frozenset({"company_authored_document", "official_cnpj_linked_document"})
 
@@ -323,10 +331,13 @@ def mailbox_local_implausible(mailbox: str | None) -> bool:
 
 
 def cnpj_linked_document_association(route: ReachabilityRoute) -> bool:
-    """True for a company-authored document the datalake already binds to this CNPJ.
+    """True for a company-authored document whose mailbox domain fits this company.
 
-    Authorship is the association proof here, so the mailbox host is not required
-    to match the document host. The CNPJ on the document must match the account.
+    The document host is never the company host, so host-match cannot apply. The
+    binding used instead is the account's own registered name against the mailbox
+    domain. Without a company name to check, there is no binding and the route is
+    refused: a document that merely mentions the company proves nothing about
+    whose mailbox is printed in it.
     """
     source = str(route.source_type or "").lower().strip()
     if source not in CNPJ_LINKED_DOCUMENT_SOURCES:
@@ -336,9 +347,20 @@ def cnpj_linked_document_association(route: ReachabilityRoute) -> bool:
         return False
     if extra.get("pattern_guessed_email") or extra.get("pattern_guessed"):
         return False
-    account = re.sub(r"\D", "", str(route.company_entity_id or ""))[:14]
-    document = re.sub(r"\D", "", str(extra.get("document_cnpj14") or ""))[:14]
-    return len(account) == 14 and account == document
+    mailbox_domain = email_domain(route.channel_value)
+    if not mailbox_domain or is_freemail(route.channel_value):
+        return False
+    from scripts.confenge_contact_resolution.discovery.official_domain import (
+        is_blocked_host,
+        is_credible_company_domain,
+    )
+
+    if is_blocked_host(mailbox_domain):
+        return False
+    company_label = str(extra.get("razao_social") or extra.get("company_label") or "").strip()
+    if not company_label:
+        return False
+    return bool(is_credible_company_domain(mailbox_domain, company_label))
 
 
 def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
@@ -532,6 +554,7 @@ def observed_contact_is_controlled_eligible_company_route(
     *,
     account_id: str = "",
     official_domain: str | None = None,
+    company_label: str = "",
 ) -> bool:
     """Same gate as evaluate_controlled_email_eligible. Nominal/third-party are not success."""
     if contact.get("pattern_guessed_email") or contact.get("email_derivation") == "INFERRED":
@@ -543,6 +566,8 @@ def observed_contact_is_controlled_eligible_company_route(
         return False
     payload = dict(contact)
     payload["email"] = email
+    if company_label and not payload.get("razao_social"):
+        payload["razao_social"] = company_label
     domain = email_domain(email)
     official = (official_domain or "").lower().removeprefix("www.")
     source = str(payload.get("source") or payload.get("source_type") or "").lower()
@@ -944,6 +969,9 @@ def route_from_feed_contact(
     observed_id = str(contact.get("person_id") or "").strip()
     if observed_id:
         extra.setdefault("observed_person_id", observed_id)
+    company_label = str(contact.get("razao_social") or contact.get("company_label") or "").strip()
+    if company_label:
+        extra.setdefault("razao_social", company_label)
     evidence_strength = str(contact.get("evidence_strength") or "").strip().lower()
     if evidence_strength:
         extra.setdefault("evidence_strength", evidence_strength)
@@ -960,11 +988,23 @@ def route_from_feed_contact(
     if discovery:
         extra.setdefault("email_discovery_class", str(discovery))
     suppression = SuppressionState.NONE
-    raw_sup = str(contact.get("route_suppression") or contact.get("suppression_state") or "").upper()
+    raw_sup = (
+        str(contact.get("route_suppression") or contact.get("suppression_state") or contact.get("suppression") or "")
+        .upper()
+        .replace("-", "_")
+        .strip()
+    )
     if raw_sup in {s.value for s in SuppressionState}:
         suppression = SuppressionState(raw_sup)
-    if contact.get("dnc") or contact.get("do_not_contact"):
+    elif raw_sup and raw_sup not in CLEAR_SUPPRESSION_TOKENS:
+        # An unrecognized suppression token is not an absence of suppression.
+        # Producers use vocabularies this enum does not carry, and reading one
+        # as NONE lets an opted-out mailbox into a bounded pilot.
+        suppression = SuppressionState.BLOCKED
+    if contact.get("dnc") or contact.get("do_not_contact") or contact.get("unsubscribed"):
         suppression = SuppressionState.DNC
+    if contact.get("opt_out") is True:
+        suppression = SuppressionState.OPT_OUT
     if contact.get("bounce") or contact.get("bounced"):
         suppression = SuppressionState.HARD_BOUNCE
     ownership = OwnershipStatus.UNKNOWN
@@ -1138,9 +1178,37 @@ def stamp_and_rank_feed_contacts(
     return apply_preferred_recommended_alias(stamped)
 
 
+def _shared_mailbox_owner(leads: list[dict[str, Any]]) -> dict[str, str]:
+    """Pick the one account that keeps each shared mailbox, stably across runs.
+
+    Feed order is sorted by target-fit freshness timestamps, which advance on
+    every refresh, so "first lead wins" silently moved a shared mailbox between
+    accounts — and dropped last run's account out of the pilot — with no change
+    in mailbox evidence. Decide on the account id instead.
+    """
+    owner: dict[str, str] = {}
+    for lead in leads:
+        if not isinstance(lead, dict):
+            continue
+        company = lead.get("company") if isinstance(lead.get("company"), dict) else {}
+        account = str(company.get("cnpj14") or lead.get("source_lead_id") or "")
+        if not account:
+            continue
+        for contact in lead.get("contacts") or []:
+            if not isinstance(contact, dict) or not contact.get("preferred_initial"):
+                continue
+            mailbox = canonicalize_mailbox(str(contact.get("email") or ""))
+            if not mailbox:
+                continue
+            current = owner.get(mailbox)
+            if current is None or account < current:
+                owner[mailbox] = account
+    return owner
+
+
 def apply_cross_account_preferred_mailbox_gate(leads: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Exactly one account may keep a preferred mailbox. Later duplicates lose it."""
-    claimed: dict[str, str] = {}
+    """Exactly one account may keep a preferred mailbox. Other claimants lose it."""
+    claimed: dict[str, str] = dict(_shared_mailbox_owner(leads))
     out: list[dict[str, Any]] = []
     for lead in leads:
         if not isinstance(lead, dict):
@@ -1157,7 +1225,7 @@ def apply_cross_account_preferred_mailbox_gate(leads: list[dict[str, Any]]) -> l
             mailbox = canonicalize_mailbox(str(item.get("email") or ""))
             if item.get("preferred_initial") and mailbox:
                 owner = claimed.get(mailbox)
-                if owner and owner != account:
+                if owner is not None and owner != account:
                     item["preferred_initial"] = False
                     item["recommended"] = False
                     item["controlled_email_eligible"] = False

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -38,6 +38,9 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
+from scripts.confenge_contact_resolution.discovery.official_domain import (  # noqa: E402
+    is_credible_company_domain,
+)
 from scripts.decision_unit_intelligence.controlled_email import (  # noqa: E402
     DEFAULT_PILOT_ROUTE_CLASSES,
     EmailRouteClass,
@@ -263,9 +266,22 @@ def stratified_sample(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
         official = resolve_official_domain(member, contact)
         mailbox_domain = email_domain(str(contact.get("email") or "")) or None
         source_host = _host(contact.get("source_url"))
+        # The reviewer's job is to catch a domain the classifier resolved wrongly.
+        # Every host-vs-host field below agrees with itself when the resolution is
+        # wrong — a domain guessed from the company name matches the page it was
+        # crawled from. The independent signal is whether the mailbox domain is
+        # credible for the registered company name.
+        # The name itself is never emitted: a Brazilian MEI's razao social is a
+        # natural person's name and often carries their CPF. Only the verdict.
+        company = member.get("company") if isinstance(member.get("company"), dict) else {}
+        company_label = str(company.get("razao_social") or company.get("nome_fantasia") or "")
+        domain_fits_name = None
+        if mailbox_domain and company_label:
+            domain_fits_name = bool(is_credible_company_domain(mailbox_domain, company_label))
         sample.append(
             {
                 "route_class": route_class,
+                "mailbox_domain_fits_company_name": domain_fits_name,
                 "source_type": str((contact.get("provenance") or {}).get("source_type") or "")
                 or str(contact.get("source_type") or ""),
                 "source_host": source_host,

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -30,6 +30,7 @@ import json
 import os
 import sys
 from collections import Counter
+from collections.abc import Iterable, Iterator
 from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
@@ -49,6 +50,7 @@ from scripts.decision_unit_intelligence.controlled_email import (  # noqa: E402
     email_domain,
     evaluate_controlled_email_eligible,
     route_from_feed_contact,
+    shared_preferred_mailbox_owner,
 )
 from scripts.warmbly_bridge import SCHEMA_OUTREACH  # noqa: E402
 
@@ -110,20 +112,41 @@ def resolve_official_domain(lead: dict[str, Any], contact: dict[str, Any]) -> st
     return None
 
 
-def load_feed_leads(feed_dir: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Read every chunk of an exported outreach feed, in manifest order."""
+def read_feed_manifest(feed_dir: Path) -> dict[str, Any]:
     manifest_path = feed_dir / "manifest.json"
-    manifest: dict[str, Any] = {}
     if manifest_path.is_file():
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    leads: list[dict[str, Any]] = []
+        return dict(json.loads(manifest_path.read_text(encoding="utf-8")))
+    return {}
+
+
+def iter_feed_leads(feed_dir: Path) -> Iterator[dict[str, Any]]:
+    """Yield leads one chunk at a time.
+
+    The authoritative export covers the whole decision universe — hundreds of
+    thousands of leads across hundreds of chunks — so materializing them all is
+    how the producer would run the host out of memory. One chunk is held at a
+    time; callers that need a whole-feed view take a second pass.
+    """
     for chunk in sorted(feed_dir.glob("chunk_*.json")):
         payload = json.loads(chunk.read_text(encoding="utf-8"))
         schema = str(payload.get("schema_version") or "")
         if schema != SCHEMA_OUTREACH:
             raise ValueError(f"{chunk}: expected {SCHEMA_OUTREACH}, found {schema!r}")
-        leads.extend(payload.get("leads") or [])
-    return leads, manifest
+        yield from (lead for lead in (payload.get("leads") or []) if isinstance(lead, dict))
+
+
+def load_feed_leads(feed_dir: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Whole-feed read. Only for small feeds and tests; production streams."""
+    return list(iter_feed_leads(feed_dir)), read_feed_manifest(feed_dir)
+
+
+def _apply_owner_map(
+    leads: Iterable[dict[str, Any]],
+    owner: dict[str, str],
+) -> Iterator[dict[str, Any]]:
+    """Streaming equivalent of the cross-account preferred-mailbox gate."""
+    for lead in leads:
+        yield apply_cross_account_preferred_mailbox_gate([lead], owner=owner)[0]
 
 
 def recheck_contact(
@@ -173,12 +196,21 @@ def _contact_blocked(
 
 
 def select_cohort(
-    leads: list[dict[str, Any]],
+    leads: Iterable[dict[str, Any]],
     *,
     limit: int,
+    shared_mailbox_owner: dict[str, str] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-    """Keep accounts with exactly one surviving preferred_initial mailbox."""
-    gated = apply_cross_account_preferred_mailbox_gate(leads)
+    """Keep accounts with exactly one surviving preferred_initial mailbox.
+
+    ``shared_mailbox_owner`` lets a streaming caller supply the whole-feed view
+    of who keeps each shared mailbox, computed in an earlier pass. Without it the
+    leads are materialized, which is only safe for a small feed.
+    """
+    if shared_mailbox_owner is None:
+        gated: Iterable[dict[str, Any]] = apply_cross_account_preferred_mailbox_gate(list(leads))
+    else:
+        gated = _apply_owner_map(leads, shared_mailbox_owner)
 
     funnel: Counter[str] = Counter(dict.fromkeys(FUNNEL_KEYS, 0))
     class_counts: Counter[str] = Counter(dict.fromkeys((rc.value for rc in EmailRouteClass), 0))
@@ -341,8 +373,15 @@ def build(
     as_of: str,
     run_stamp: str,
 ) -> dict[str, Any]:
-    leads, source_manifest = load_feed_leads(feed_dir)
-    members, stats = select_cohort(leads, limit=limit)
+    source_manifest = read_feed_manifest(feed_dir)
+    # Two streaming passes: one to decide who keeps each shared mailbox across
+    # the whole feed, one to select. Never the whole feed in memory at once.
+    owner = shared_preferred_mailbox_owner(iter_feed_leads(feed_dir))
+    members, stats = select_cohort(
+        iter_feed_leads(feed_dir),
+        limit=limit,
+        shared_mailbox_owner=owner,
+    )
     out_dir = private_root / run_stamp
     run_id = f"fresh-cohort-{run_stamp}"
     feed_meta = write_private_feed(

--- a/scripts/warmbly_bridge/mapping.py
+++ b/scripts/warmbly_bridge/mapping.py
@@ -60,12 +60,23 @@ def _as_str(value: Any, default: str = "") -> str:
 
 
 def official_domain_host(value: Any) -> str:
+    """Host of a company's own site. A social or aggregator page is not one.
+
+    Discovery already refuses these hosts when resolving a domain; the bridge
+    used to accept whatever the universe row happened to carry, so a Facebook
+    page in the website column made every freemail published on facebook.com
+    read as company-associated.
+    """
     raw = _as_str(value)
     if not raw:
         return ""
     parsed = urlparse(raw if "://" in raw else f"https://{raw}")
-    host = (parsed.hostname or raw.split("/")[0]).lower().removeprefix("www.")
-    return host.strip()
+    host = (parsed.hostname or raw.split("/")[0]).lower().removeprefix("www.").strip()
+    if not host:
+        return ""
+    from scripts.confenge_contact_resolution.discovery.official_domain import is_blocked_host
+
+    return "" if is_blocked_host(host) else host
 
 
 def _normalize_epistemic(class_value: str | None, *, is_inference: bool) -> str:

--- a/tests/confenge_contact_resolution/test_discovery_precision.py
+++ b/tests/confenge_contact_resolution/test_discovery_precision.py
@@ -381,8 +381,12 @@ def test_resolution_cache_signature_includes_contract_and_discovery_budget():
 
 
 def test_cascade_stops_early_on_functional_control_eligible_doc(monkeypatch):
-    """Observed licitacoes@ on a CNPJ-linked document is a company-route success."""
-    from scripts.confenge_contact_resolution.discovery.budget import InvestigationOutcome
+    """A document mailbox is a company route only once a domain is proven.
+
+    With no network the cascade cannot prove an official domain, and extraction
+    cannot say whose mailbox is printed in a document, so this must NOT stop
+    early. Stopping here would end person discovery on an unbound mailbox.
+    """
     from scripts.confenge_contact_resolution.discovery.cascade import DiscoveryCascade
 
     calls = {"search": 0, "probe": 0, "crawl": 0}
@@ -393,6 +397,7 @@ def test_cascade_stops_early_on_functional_control_eligible_doc(monkeypatch):
                 "email": "licitacoes@alphaengenharia.com.br",
                 "cnpj14": cnpj14,
                 "evidence_strength": "company_authored_document",
+                "official_domain": "alphaengenharia.com.br",
                 "url": "https://datalake.example/doc/1",
                 "doc_type": "proposta",
             }
@@ -412,13 +417,12 @@ def test_cascade_stops_early_on_functional_control_eligible_doc(monkeypatch):
         razao_social="ALPHA ENGENHARIA E CONSTRUCOES LTDA",
         stop_when_strong_contact=True,
     )
-    assert result.stats.outcome == InvestigationOutcome.CONTACT_FOUND.value
-    assert result.stats.stop_reason == "controlled_eligible_public_doc"
+    assert result.stats.stop_reason != "controlled_eligible_public_doc"
     assert result.stats.search_queries == 0
     assert calls["search"] == 0
     assert calls["probe"] == 0
     assert not any(a["reason_code"] == "named_human_contact_found" for a in result.source_attempts)
-    assert any(a["reason_code"] == "controlled_eligible_company_route_found" for a in result.source_attempts)
+    assert not any(a["reason_code"] == "controlled_eligible_company_route_found" for a in result.source_attempts)
     assert all(
         {
             "cnpj14",
@@ -686,5 +690,4 @@ def test_cascade_does_not_stop_early_on_a_foreign_mailbox_in_our_document(monkey
             "cnpj14": "11222333000181",
         },
         account_id="11222333000181",
-        company_label="CONSTRUTORA ALVO LTDA",
     )

--- a/tests/confenge_contact_resolution/test_discovery_precision.py
+++ b/tests/confenge_contact_resolution/test_discovery_precision.py
@@ -630,3 +630,61 @@ def test_build_web_search_provider_uses_private_searxng(monkeypatch) -> None:
     provider = build_web_search_provider()
     assert isinstance(provider, SearxngJSONProvider)
     assert provider.base_url == "http://127.0.0.1:18888"
+
+
+def test_cascade_does_not_stop_early_on_a_foreign_mailbox_in_our_document(monkeypatch):
+    """A notice that merely lists us carries the agency's mailbox, not ours.
+
+    The document's CNPJ tag is the CNPJ that was queried, so it cannot bind the
+    mailbox. Stopping discovery here would end the search on a wrong company.
+    """
+    from scripts.confenge_contact_resolution.discovery.cascade import DiscoveryCascade
+    from scripts.decision_unit_intelligence.controlled_email import (
+        observed_contact_is_controlled_eligible_company_route,
+    )
+
+    def fake_docs(cnpj14, **kwargs):
+        return [
+            {
+                "email": "licitacao@saojoaquim.sc.gov.br",
+                "cnpj14": cnpj14,
+                "evidence_strength": "official_cnpj_linked_document",
+                "url": "https://pncp.gov.br/app/editais/1",
+                "doc_type": "edital",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "scripts.confenge_contact_resolution.discovery.cascade.lookup_public_docs_for_cnpj",
+        fake_docs,
+    )
+    cascade = DiscoveryCascade(
+        budget=DiscoveryBudget(max_search_queries=6, max_pages=8, max_total_requests=20),
+        allow_network=False,
+        dsn=None,
+    )
+    result = cascade.run(
+        cnpj14="11222333000181",
+        razao_social="CONSTRUTORA ALVO LTDA",
+        stop_when_strong_contact=True,
+    )
+    # The cascade may still record that some contact data exists — a mailbox was
+    # in the document. What it must not do is call it a company route for us.
+    assert result.stats.stop_reason != "controlled_eligible_public_doc"
+    assert not any(a["reason_code"] == "controlled_eligible_company_route_found" for a in result.source_attempts)
+    assert any(
+        a["reason_code"] == "documents_have_no_explicit_named_email_role"
+        for a in result.source_attempts
+        if a["source_adapter"] == "process_administrative_docs"
+    )
+    assert not observed_contact_is_controlled_eligible_company_route(
+        {
+            "email": "licitacao@saojoaquim.sc.gov.br",
+            "source": "official_documents",
+            "source_url": "https://pncp.gov.br/app/editais/1",
+            "evidence_strength": "official_cnpj_linked_document",
+            "cnpj14": "11222333000181",
+        },
+        account_id="11222333000181",
+        company_label="CONSTRUTORA ALVO LTDA",
+    )

--- a/tests/fixtures/controlled_email_five_class_canary.json
+++ b/tests/fixtures/controlled_email_five_class_canary.json
@@ -23,7 +23,8 @@
         "nome_fantasia": "Empresa Exemplo",
         "municipio": "",
         "uf": "",
-        "website": "https://empresaexemplo.com.br"
+        "website": "https://empresaexemplo.com.br",
+        "official_domain": "empresaexemplo.com.br"
       },
       "priority": {
         "rank": 1,
@@ -292,8 +293,8 @@
           "phone": "",
           "linkedin_url": "",
           "source_url": "https://empresaexemplo.com.br/contato",
-          "source": "",
-          "source_type": "",
+          "source": "company_website",
+          "source_type": "company_website",
           "source_document": "",
           "source_date": "",
           "source_date_semantics": "missing",
@@ -310,7 +311,7 @@
           "enrollable": false,
           "recommended": false,
           "provenance": {
-            "source_type": "",
+            "source_type": "company_website",
             "source_url": "https://empresaexemplo.com.br/contato",
             "source_document": "",
             "source_date": "",

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -303,3 +303,58 @@ def test_the_sample_never_carries_the_company_name(tmp_path):
     redacted = Path(manifest["manifest_path"]).read_text(encoding="utf-8")
     assert "JOAO DA SILVA" not in redacted
     assert "mailbox_domain_fits_company_name" in redacted
+
+
+def test_the_producer_never_holds_the_whole_feed(tmp_path):
+    """The authoritative export covers the decision universe, not the hot set.
+
+    Materializing hundreds of thousands of leads is how the producer would run
+    the host out of memory, so it must stream chunk by chunk.
+    """
+    from scripts.ops.build_controlled_email_cohort import iter_feed_leads
+
+    feed_dir = tmp_path / "06_warmbly_feed"
+    feed_dir.mkdir(parents=True)
+    for idx in range(4):
+        (feed_dir / f"chunk_{idx:04d}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_OUTREACH,
+                    "leads": [
+                        _lead(f"{idx}{n:010d}9"[:14], [_contact(f"contato@empresa{idx}x{n}.com.br")]) for n in range(3)
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    (feed_dir / "manifest.json").write_text(json.dumps({"lead_count": 12}), encoding="utf-8")
+
+    stream = iter_feed_leads(feed_dir)
+    assert next(stream)["company"]["cnpj14"].startswith("0")
+    assert sum(1 for _ in iter_feed_leads(feed_dir)) == 12
+
+    manifest = build(
+        feed_dir=feed_dir,
+        private_root=tmp_path / "private",
+        limit=50,
+        as_of="2026-08-22",
+        run_stamp="20260822T000000Z",
+    )
+    assert manifest["member_count"] == 12
+    assert manifest["funnel"]["accounts_considered"] == 12
+
+
+def test_a_precomputed_owner_map_matches_the_whole_feed_gate():
+    """Streaming must not weaken the cross-account rule."""
+    from scripts.decision_unit_intelligence.controlled_email import shared_preferred_mailbox_owner
+
+    shared = "contato@grupo.com.br"
+    leads = [_lead("22222222000172", [_contact(shared)]), _lead("11111111000191", [_contact(shared)])]
+
+    whole, _ = select_cohort(list(leads), limit=50)
+    streamed, _ = select_cohort(
+        iter(list(leads)),
+        limit=50,
+        shared_mailbox_owner=shared_preferred_mailbox_owner(leads),
+    )
+    assert [m["company"]["cnpj14"] for m in whole] == [m["company"]["cnpj14"] for m in streamed] == ["11111111000191"]

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -41,7 +41,7 @@ def _contact(
 def _lead(cnpj14: str, contacts: list[dict[str, Any]], *, website: str | None = None) -> dict[str, Any]:
     return {
         "source_lead_id": f"lead-{cnpj14}",
-        "company": {"cnpj14": cnpj14, "razao_social": f"EMPRESA {cnpj14}", "website": website},
+        "company": {"cnpj14": cnpj14, "razao_social": "CONSTRUTORA EXEMPLO LTDA", "website": website},
         "contacts": contacts,
     }
 
@@ -259,3 +259,47 @@ def test_the_published_official_domain_feeds_the_recheck():
     assert len(members) == 1
     assert stats["funnel"]["official_domain"] == 1
     assert stats["funnel"]["no_domain"] == 0
+
+
+def test_the_sample_lets_a_reviewer_catch_a_wrongly_resolved_domain(tmp_path):
+    """Host-vs-host fields all agree when the domain was guessed from the name.
+
+    A domain resolved by name-token overlap alone matches the page it was
+    crawled from and matches itself, so every host field reads green. The one
+    independent signal is whether the mailbox domain fits the company name.
+    """
+    lead = _lead(
+        "11111111000191",
+        [_contact("contact@ollama.com", source_url="https://ollama.com/contact")],
+        website="https://ollama.com",
+    )
+    lead["company"]["razao_social"] = "CONSTRUTORA ALVO ENGENHARIA LTDA"
+    feed_dir = _write_export(tmp_path, [lead])
+    manifest = build(
+        feed_dir=feed_dir,
+        private_root=tmp_path / "private",
+        limit=50,
+        as_of="2026-08-22",
+        run_stamp="20260822T000000Z",
+    )
+    sample = manifest["sample_qa"][0]
+    assert sample["mailbox_domain_matches_official"] is True
+    assert sample["source_host_matches_official"] is True
+    assert sample["mailbox_domain_fits_company_name"] is False
+
+
+def test_the_sample_never_carries_the_company_name(tmp_path):
+    """A Brazilian MEI's razao social is a natural person's name, often with a CPF."""
+    lead = _lead("11111111000191", [_contact("contato@alpha.com.br")], website="https://alpha.com.br")
+    lead["company"]["razao_social"] = "JOAO DA SILVA CONSTRUCOES"
+    feed_dir = _write_export(tmp_path, [lead])
+    manifest = build(
+        feed_dir=feed_dir,
+        private_root=tmp_path / "private",
+        limit=50,
+        as_of="2026-08-22",
+        run_stamp="20260822T000000Z",
+    )
+    redacted = Path(manifest["manifest_path"]).read_text(encoding="utf-8")
+    assert "JOAO DA SILVA" not in redacted
+    assert "mailbox_domain_fits_company_name" in redacted

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -1105,7 +1105,7 @@ def test_suppression_is_read_fail_closed_across_producer_vocabularies():
         {"route_suppression": "quarantined"},
         {"suppression_reason": "unsubscribed"},
         {"email_status": "unsubscribed"},
-        {"status": "opt_out"},
+        {"email_status": "hard_bounce"},
         {"opt_out": True},
         {"opt_out": "true"},
         {"opt_out": 1},
@@ -1140,6 +1140,14 @@ def test_suppression_is_read_fail_closed_across_producer_vocabularies():
         {"bounced": "false"},
         {"opt_out": False},
         {"opt_out": 0},
+        # `status` is a generic field in this repo (READY, idle, backpressure).
+        # Failing closed on it would mark healthy contacts suppressed.
+        {"status": "READY"},
+        {"status": "new"},
+        {"status": "opt_out"},
+        # A hint field only suppresses on a recognized suppression word.
+        {"email_status": "valid"},
+        {"email_status": "verified"},
     ]
     for payload in clear:
         assert suppression_from_feed_contact(payload) == SuppressionState.NONE, payload

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -1014,78 +1014,82 @@ def test_five_class_mapping_feed_written_for_warmbly_ingest() -> None:
         assert json.loads(sibling.read_text(encoding="utf-8"))["leads"][0]["contacts"][0]["email"]
 
 
-def _cnpj_linked_doc_route(
+def _doc_route(
     mailbox: str = "licitacoes@alphaengenharia.com.br",
     *,
-    razao_social: str = "ALPHA ENGENHARIA E CONSTRUCOES LTDA",
+    official_domain: str = "alphaengenharia.com.br",
     evidence_strength: str = "company_authored_document",
 ) -> ReachabilityRoute:
-    """Company-authored document hosted on a datalake/portal host, not the company host."""
+    """Company-authored document hosted on a portal host, not the company host."""
     extra: dict = {"evidence_strength": evidence_strength}
-    if razao_social:
-        extra["razao_social"] = razao_social
+    if official_domain:
+        extra["official_domain"] = official_domain
     return _route(
         mailbox,
         channel=ChannelType.ROLE_MAILBOX,
         ownership=OwnershipStatus.UNKNOWN,
         source_type="official_documents",
-        source_url="https://datalake.example/doc/1",
+        source_url="https://pncp.gov.br/app/editais/1",
         extra=extra,
     )
 
 
-def test_company_document_binds_by_name_credibility_not_by_host():
-    """A PNCP/portal host is never the company host, so the name carries the binding."""
-    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route())
+def test_a_document_mailbox_on_the_proven_official_domain_is_associated():
+    """The account's own proven domain is what binds it, not the document host."""
+    verdict = evaluate_controlled_email_eligible(_doc_route())
     assert verdict.mailbox_company_evidence == "OBSERVED"
     assert verdict.controlled_email_eligible is True
     assert verdict.route_class == EmailRouteClass.ROLE_OR_DEPARTMENT
 
 
-def test_a_notice_that_merely_lists_the_company_cannot_bind_the_agency_mailbox():
-    """The document CNPJ tag is the queried CNPJ, so it can never be the binding.
+def test_a_document_route_without_a_proven_domain_has_no_association_at_all():
+    """Extraction cannot say whose mailbox is printed in a document.
 
-    A PNCP edital naming the company as a bidder carries the buying agency's
-    mailbox. Nothing in that document says the mailbox is the company's.
+    The document's CNPJ tag is the CNPJ that was queried and the company name is
+    producer-supplied, so neither can bind the mailbox. There is deliberately no
+    carve-out here: with no proven official domain there is simply no evidence.
     """
-    verdict = evaluate_controlled_email_eligible(
-        _cnpj_linked_doc_route(
-            "licitacao@saojoaquim.sc.gov.br",
-            razao_social="CONSTRUTORA ALVO LTDA",
-            evidence_strength="official_cnpj_linked_document",
-        )
-    )
+    verdict = evaluate_controlled_email_eligible(_doc_route(official_domain=""))
     assert verdict.mailbox_company_evidence == "UNKNOWN"
     assert verdict.controlled_email_eligible is False
     assert "mailbox_company_evidence_unknown" in verdict.reason_codes
 
 
-def test_a_consortium_partner_mailbox_in_our_document_is_not_ours():
+def test_a_notice_that_merely_lists_the_company_cannot_bind_the_agency_mailbox():
     verdict = evaluate_controlled_email_eligible(
-        _cnpj_linked_doc_route(
-            "comercial@terraplenagemsulmg.com.br",
-            razao_social="CONSTRUTORA ALVO LTDA",
-        )
+        _doc_route("licitacao@saojoaquim.sc.gov.br", evidence_strength="official_cnpj_linked_document")
     )
     assert verdict.mailbox_company_evidence == "UNKNOWN"
     assert verdict.controlled_email_eligible is False
 
 
-def test_a_document_route_without_a_company_name_has_no_binding_at_all():
-    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route(razao_social=""))
+def test_a_consortium_partner_mailbox_in_our_document_is_not_ours():
+    verdict = evaluate_controlled_email_eligible(_doc_route("comercial@terraplenagemsulmg.com.br"))
     assert verdict.mailbox_company_evidence == "UNKNOWN"
     assert verdict.controlled_email_eligible is False
 
 
-def test_weak_document_evidence_does_not_bypass_host_match():
-    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route(evidence_strength="snippet_mention"))
+def test_a_producer_supplied_company_name_cannot_create_an_association():
+    """razao_social arrives on the contact payload, so it can never be a binding."""
+    from scripts.decision_unit_intelligence.controlled_email import route_from_feed_contact
+
+    route = route_from_feed_contact(
+        {
+            "email": "comercial@grupohorizonte.com.br",
+            "source_type": "official_documents",
+            "source_url": "https://pncp.gov.br/app/editais/1",
+            "evidence_strength": "official_cnpj_linked_document",
+            "razao_social": "GRUPO HORIZONTE PARTICIPACOES LTDA",
+        },
+        account_id=ACCOUNT_ID,
+    )
+    verdict = evaluate_controlled_email_eligible(route)
     assert verdict.mailbox_company_evidence == "UNKNOWN"
     assert verdict.controlled_email_eligible is False
 
 
-def test_freemail_on_a_cnpj_linked_document_still_needs_a_company_page():
-    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route("alphaengenharia@gmail.com"))
-    assert verdict.mailbox_company_evidence == "UNKNOWN"
+def test_freemail_on_a_document_still_needs_a_company_page():
+    verdict = evaluate_controlled_email_eligible(_doc_route("alphaengenharia@gmail.com"))
     assert verdict.controlled_email_eligible is False
 
 

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -1017,36 +1017,64 @@ def test_five_class_mapping_feed_written_for_warmbly_ingest() -> None:
 def _cnpj_linked_doc_route(
     mailbox: str = "licitacoes@alphaengenharia.com.br",
     *,
-    document_cnpj14: str = ACCOUNT_ID,
+    razao_social: str = "ALPHA ENGENHARIA E CONSTRUCOES LTDA",
     evidence_strength: str = "company_authored_document",
 ) -> ReachabilityRoute:
     """Company-authored document hosted on a datalake/portal host, not the company host."""
+    extra: dict = {"evidence_strength": evidence_strength}
+    if razao_social:
+        extra["razao_social"] = razao_social
     return _route(
         mailbox,
         channel=ChannelType.ROLE_MAILBOX,
         ownership=OwnershipStatus.UNKNOWN,
         source_type="official_documents",
         source_url="https://datalake.example/doc/1",
-        extra={
-            "evidence_strength": evidence_strength,
-            "document_cnpj14": document_cnpj14,
-        },
+        extra=extra,
     )
 
 
-def test_cnpj_linked_company_document_survives_host_match_gate():
-    """Authorship binds the mailbox; a PNCP/portal host is never the company host."""
+def test_company_document_binds_by_name_credibility_not_by_host():
+    """A PNCP/portal host is never the company host, so the name carries the binding."""
     verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route())
     assert verdict.mailbox_company_evidence == "OBSERVED"
     assert verdict.controlled_email_eligible is True
     assert verdict.route_class == EmailRouteClass.ROLE_OR_DEPARTMENT
 
 
-def test_document_for_a_different_cnpj_is_not_associated():
-    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route(document_cnpj14="99887766000155"))
+def test_a_notice_that_merely_lists_the_company_cannot_bind_the_agency_mailbox():
+    """The document CNPJ tag is the queried CNPJ, so it can never be the binding.
+
+    A PNCP edital naming the company as a bidder carries the buying agency's
+    mailbox. Nothing in that document says the mailbox is the company's.
+    """
+    verdict = evaluate_controlled_email_eligible(
+        _cnpj_linked_doc_route(
+            "licitacao@saojoaquim.sc.gov.br",
+            razao_social="CONSTRUTORA ALVO LTDA",
+            evidence_strength="official_cnpj_linked_document",
+        )
+    )
     assert verdict.mailbox_company_evidence == "UNKNOWN"
     assert verdict.controlled_email_eligible is False
     assert "mailbox_company_evidence_unknown" in verdict.reason_codes
+
+
+def test_a_consortium_partner_mailbox_in_our_document_is_not_ours():
+    verdict = evaluate_controlled_email_eligible(
+        _cnpj_linked_doc_route(
+            "comercial@terraplenagemsulmg.com.br",
+            razao_social="CONSTRUTORA ALVO LTDA",
+        )
+    )
+    assert verdict.mailbox_company_evidence == "UNKNOWN"
+    assert verdict.controlled_email_eligible is False
+
+
+def test_a_document_route_without_a_company_name_has_no_binding_at_all():
+    verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route(razao_social=""))
+    assert verdict.mailbox_company_evidence == "UNKNOWN"
+    assert verdict.controlled_email_eligible is False
 
 
 def test_weak_document_evidence_does_not_bypass_host_match():
@@ -1059,3 +1087,45 @@ def test_freemail_on_a_cnpj_linked_document_still_needs_a_company_page():
     verdict = evaluate_controlled_email_eligible(_cnpj_linked_doc_route("alphaengenharia@gmail.com"))
     assert verdict.mailbox_company_evidence == "UNKNOWN"
     assert verdict.controlled_email_eligible is False
+
+
+def test_unrecognized_suppression_vocabulary_fails_closed():
+    """Producers use tokens this enum does not carry. NONE must not be the default."""
+    from scripts.decision_unit_intelligence.controlled_email import route_from_feed_contact
+
+    base = {
+        "email": "contato@empresaexemplo.com.br",
+        "source": "contact_page",
+        "source_type": "contact_page",
+        "source_url": "https://empresaexemplo.com.br/contato",
+    }
+    for field, token in (
+        ("suppression", "opt-out"),
+        ("suppression", "do_not_contact"),
+        ("suppression", "hard_bounce"),
+        ("suppression_state", "opt-out"),
+        ("route_suppression", "quarantined"),
+    ):
+        route = route_from_feed_contact({**base, field: token}, account_id=ACCOUNT_ID)
+        verdict = evaluate_controlled_email_eligible(route)
+        assert verdict.controlled_email_eligible is False, (field, token)
+
+    for flag in ("opt_out", "unsubscribed", "do_not_contact"):
+        route = route_from_feed_contact({**base, flag: True}, account_id=ACCOUNT_ID)
+        assert evaluate_controlled_email_eligible(route).controlled_email_eligible is False, flag
+
+    for clear in ("NONE", "CLEAR", "", "active"):
+        route = route_from_feed_contact({**base, "route_suppression": clear}, account_id=ACCOUNT_ID)
+        assert evaluate_controlled_email_eligible(route).controlled_email_eligible is True, clear
+
+
+def test_paraguayan_company_domain_is_not_a_parser_leftover():
+    verdict = evaluate_controlled_email_eligible(
+        _route(
+            "licitaciones@constructoraalvo.com.py",
+            source_type="contact_page",
+            source_url="https://constructoraalvo.com.py/contacto",
+            extra={"official_domain": "constructoraalvo.com.py"},
+        )
+    )
+    assert "implausible_mailbox_host" not in verdict.reason_codes

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -1093,8 +1093,59 @@ def test_freemail_on_a_document_still_needs_a_company_page():
     assert verdict.controlled_email_eligible is False
 
 
-def test_unrecognized_suppression_vocabulary_fails_closed():
-    """Producers use tokens this enum does not carry. NONE must not be the default."""
+def test_suppression_is_read_fail_closed_across_producer_vocabularies():
+    """Reading two field names as the whole vocabulary let opted-out mail through."""
+    from scripts.decision_unit_intelligence.controlled_email import suppression_from_feed_contact
+
+    suppressing = [
+        {"suppression": "opt-out"},
+        {"suppression": "do_not_contact"},
+        {"suppression": "hard_bounce"},
+        {"suppression_state": "opt-out"},
+        {"route_suppression": "quarantined"},
+        {"suppression_reason": "unsubscribed"},
+        {"email_status": "unsubscribed"},
+        {"status": "opt_out"},
+        {"opt_out": True},
+        {"opt_out": "true"},
+        {"opt_out": 1},
+        {"opt_out": "yes"},
+        {"unsubscribed": True},
+        {"opted_out": True},
+        {"suppressed": True},
+        {"is_suppressed": True},
+        {"complained": True},
+        {"spam_complaint": True},
+        {"blocklisted": True},
+        {"do_not_contact": True},
+        {"dnc": True},
+        {"bounced": True},
+        # Nested shapes this schema already uses for provenance.
+        {"provenance": {"route_suppression": "OPT_OUT"}},
+        {"extra": {"route_suppression": "OPT_OUT"}},
+        {"extra": {"suppression": "opt-out"}},
+    ]
+    for payload in suppressing:
+        assert suppression_from_feed_contact(payload) != SuppressionState.NONE, payload
+
+    # A string "false" must not starve the cohort, and a clear token stays clear.
+    clear = [
+        {},
+        {"route_suppression": "NONE"},
+        {"route_suppression": "  none  "},
+        {"suppression": "clear"},
+        {"unsubscribed": "false"},
+        {"do_not_contact": "false"},
+        {"dnc": "false"},
+        {"bounced": "false"},
+        {"opt_out": False},
+        {"opt_out": 0},
+    ]
+    for payload in clear:
+        assert suppression_from_feed_contact(payload) == SuppressionState.NONE, payload
+
+
+def test_a_suppressed_contact_never_reaches_eligibility():
     from scripts.decision_unit_intelligence.controlled_email import route_from_feed_contact
 
     base = {
@@ -1103,24 +1154,12 @@ def test_unrecognized_suppression_vocabulary_fails_closed():
         "source_type": "contact_page",
         "source_url": "https://empresaexemplo.com.br/contato",
     }
-    for field, token in (
-        ("suppression", "opt-out"),
-        ("suppression", "do_not_contact"),
-        ("suppression", "hard_bounce"),
-        ("suppression_state", "opt-out"),
-        ("route_suppression", "quarantined"),
-    ):
-        route = route_from_feed_contact({**base, field: token}, account_id=ACCOUNT_ID)
-        verdict = evaluate_controlled_email_eligible(route)
-        assert verdict.controlled_email_eligible is False, (field, token)
+    for payload in ({"suppression": "opt-out"}, {"suppressed": True}, {"opt_out": "true"}):
+        route = route_from_feed_contact({**base, **payload}, account_id=ACCOUNT_ID)
+        assert evaluate_controlled_email_eligible(route).controlled_email_eligible is False, payload
 
-    for flag in ("opt_out", "unsubscribed", "do_not_contact"):
-        route = route_from_feed_contact({**base, flag: True}, account_id=ACCOUNT_ID)
-        assert evaluate_controlled_email_eligible(route).controlled_email_eligible is False, flag
-
-    for clear in ("NONE", "CLEAR", "", "active"):
-        route = route_from_feed_contact({**base, "route_suppression": clear}, account_id=ACCOUNT_ID)
-        assert evaluate_controlled_email_eligible(route).controlled_email_eligible is True, clear
+    route = route_from_feed_contact(base, account_id=ACCOUNT_ID)
+    assert evaluate_controlled_email_eligible(route).controlled_email_eligible is True
 
 
 def test_paraguayan_company_domain_is_not_a_parser_leftover():

--- a/tests/test_email_reachability_engine.py
+++ b/tests/test_email_reachability_engine.py
@@ -716,6 +716,19 @@ def test_a_social_page_is_never_an_official_company_domain():
         "https://linkedin.com/company/construtoraalvo",
         "https://cnpja.com/office/12345678000195",
         "https://pncp.gov.br/app/editais/1",
+        # Anyone can publish on these too, so a page here owns nothing.
+        "https://construtoraalvo.blogspot.com",
+        "https://construtoraalvo.wordpress.com",
+        "https://construtoraalvo.notion.site",
+        "https://construtoraalvo.github.io",
+        "https://construtoraalvo.negocio.site",
+        "https://linktr.ee/construtoraalvo",
+        "https://medium.com/@construtoraalvo",
+        "https://bit.ly/construtoraalvo",
+        "https://web.archive.org/web/2026/http://x",
+        "https://wa.me/5511999999999",
+        "https://t.me/construtoraalvo",
+        "https://docs.google.com/document/d/x",
     ):
         assert official_domain_host(shared) == "", shared
 

--- a/tests/test_email_reachability_engine.py
+++ b/tests/test_email_reachability_engine.py
@@ -704,3 +704,47 @@ def test_cohort_replays_stored_icp_observations() -> None:
     assert first["REAL_EMAIL_SENT"] is False
     assert first["accounts_with_two_preferred"] == 0
     assert first["observation_source"].endswith("real-1000-input.jsonl")
+
+
+def test_a_social_page_is_never_an_official_company_domain():
+    """A Facebook page in the website column made every gmail on it OBSERVED."""
+    from scripts.warmbly_bridge.mapping import official_domain_host
+
+    for shared in (
+        "https://www.facebook.com/construtoraalvo",
+        "https://instagram.com/construtoraalvo",
+        "https://linkedin.com/company/construtoraalvo",
+        "https://cnpja.com/office/12345678000195",
+        "https://pncp.gov.br/app/editais/1",
+    ):
+        assert official_domain_host(shared) == "", shared
+
+    assert official_domain_host("https://www.construtoraalvo.com.br/contato") == "construtoraalvo.com.br"
+
+
+def test_a_shared_preferred_mailbox_picks_the_same_account_across_runs():
+    """Feed order follows target-fit freshness, which advances on every refresh."""
+    from scripts.decision_unit_intelligence.controlled_email import (
+        apply_cross_account_preferred_mailbox_gate,
+    )
+
+    def lead(cnpj14: str, watermark: str) -> dict:
+        return {
+            "source_lead_id": f"lead-{cnpj14}",
+            "target_fit_source_watermark": watermark,
+            "company": {"cnpj14": cnpj14},
+            "contacts": [{"email": "contato@grupo.com.br", "preferred_initial": True, "recommended": True}],
+        }
+
+    def winners(leads: list[dict]) -> list[str]:
+        return [
+            item["company"]["cnpj14"]
+            for item in apply_cross_account_preferred_mailbox_gate(leads)
+            if any(c.get("preferred_initial") for c in item["contacts"])
+        ]
+
+    first = [lead("11111111000191", "2026-08-19T00:00:00Z"), lead("22222222000172", "2026-08-20T00:00:00Z")]
+    # A refresh moves account A's watermark past B's, flipping feed order.
+    second = [lead("22222222000172", "2026-08-20T00:00:00Z"), lead("11111111000191", "2026-08-21T00:00:00Z")]
+
+    assert winners(first) == winners(second) == ["11111111000191"]


### PR DESCRIPTION
Four ways a mailbox belonging to someone else could enter the bounded pilot. Every one was reproduced by executing the shipped functions against a constructed payload before being fixed, and every one has a regression test that fails without the fix.

## 1. The CNPJ-linked document carve-out was vacuous

`#450` let a company-authored document bypass the mailbox-host / page-host match, on the grounds that a PNCP or transparency host is never the company host. The binding it relied on was `document_cnpj14 == account`. But extraction stamps `document_cnpj14` with the CNPJ that was **queried**, never with the CNPJ the document attributes the mailbox to (`datalake_docs.py`, `public_docs.py`), so the comparison was always true. The only remaining gate was `evidence_strength`, which is granted on mere textual presence of the CNPJ in a gov.br-hosted file.

Reproduced: a PNCP edital listing the target as a bidder, whose only email is the buying agency's `licitacao@saojoaquim.sc.gov.br`, classified `ROLE_OR_DEPARTMENT` / `OBSERVED` / eligible for `CONSTRUTORA ALVO LTDA`, and stopped person discovery with `stop_reason=controlled_eligible_public_doc`. A consortium partner's mailbox in the same document did the same.

Now bound on the account's registered name against the mailbox domain, using the shipped `is_credible_company_domain`. No name, no binding.

## 2. A Facebook page was an official domain

`official_domain_host` only parsed a hostname. With a social page in the universe `website` column, `official` became `facebook.com`, and the freemail branch of `association_provenance_trustworthy` accepts any freemail published on the official page — so `vendas@gmail.com` on `facebook.com/…` became `PUBLIC_COMPANY_FREEMAIL` / `OBSERVED` / preferred. Same for instagram, linkedin, wixsite, cnpja and the CNPJ aggregators.

Discovery already refuses those hosts (`is_blocked_host`); the bridge now applies the same rule.

## 3. Suppression failed open

Only exact `SuppressionState` values on `route_suppression` / `suppression_state` were recognized. `suppression: "opt-out"` — a vocabulary this repo already emits in `publish_pilot_recipients.py` — became `NONE`, and the account entered the cohort. So did `hard_bounce`, `do_not_contact`, `opt_out: true` and `unsubscribed: true`.

An unrecognized token now fails closed. Only an explicit clear token means clear.

## 4. The shared-mailbox winner moved between runs

`apply_cross_account_preferred_mailbox_gate` gave the mailbox to whichever account came first in feed order, and feed order is sorted by target-fit freshness timestamps that advance on every refresh. An account in last week's pilot could silently drop out with no change in mailbox evidence. The winner is now decided on the account id.

## Reviewability

The QA sample gained `mailbox_domain_fits_company_name`. When a domain is resolved by name-token overlap alone — `ollama.com` for an engineering firm, confirmed reachable via `classify_host` at confidence 0.95 — it matches the page it was crawled from and matches itself, so every host-vs-host field in the sample reads green and a human reviewer cannot detect the wrong binding. Name credibility is the one independent signal.

The name itself is never emitted: a Brazilian MEI's razão social is a natural person's name and often carries their CPF.

## Also

`.py` was in `IMPLAUSIBLE_MAILBOX_TLDS`. It is Paraguay's ccTLD, so a Paraguayan company's mailbox on its own proven domain was falsely rejected.

## Known limitation, not fixed here

With no official domain resolved, a non-freemail mailbox is still accepted on `mailbox_domain == page_host`. That proves the mailbox belongs to the page's owner, not that the page's owner is this account — the account binding is implicit in how discovery reached the page. Publishing the resolved domain in the feed (`#450`) makes that binding visible in the funnel and the sample rather than silently absent, which is why the funnel no longer reports `no_domain` for site-crawled routes. Making it explicit is an association-model change, not a gate patch.
