### PR TITLE
fix(target-fit): bound the dirty-queue claim's advisory locks by batch, not backlog

### DIFF
--- a/db/migrations/099_confenge_target_fit_bounded_claim.sql
+++ b/db/migrations/099_confenge_target_fit_bounded_claim.sql
@@ -1,0 +1,41 @@
+-- 099_confenge_target_fit_bounded_claim.sql
+-- Make the target-fit dirty-queue claim terminate early instead of sorting the
+-- whole backlog. Additive index swap only; no table rewrite, no data change.
+--
+-- Why: the claim query orders by (priority DESC, detected_at ASC) over the
+-- partial set status IN ('pending','retry'). The 071 index leads with `status`,
+-- which is already implied by the partial predicate, so an ordered walk over an
+-- IN-list of two values needs a merge-append; the planner instead chose
+-- scan + blocking Sort. A blocking Sort makes LIMIT useless: every backlog row
+-- is materialized (and every row-level qual evaluated) before the first tuple
+-- reaches the Limit node. With pg_try_advisory_xact_lock() as one of those
+-- quals that meant one advisory lock per backlog row, exhausting the
+-- cluster-global shared lock table ("out of shared memory").
+--
+-- Dropping the redundant leading `status` column gives an index whose order
+-- matches the ORDER BY exactly, so Limit terminates the walk after ~LIMIT rows.
+--
+-- Index build strategy: plain CREATE INDEX (not CONCURRENTLY). scripts/ops/
+-- apply_migrations.py rewrites CONCURRENTLY -> plain unless --allow-concurrent,
+-- and the build was measured at 125 ms on a 423k-row queue, so the short SHARE
+-- lock on the enqueue path is cheaper than the operational complexity of a
+-- concurrent build. lock_timeout below fails fast rather than queueing.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+-- Ordered exactly as the claim ORDER BY, so Limit can stop the walk early.
+CREATE INDEX IF NOT EXISTS confenge_tf_dirty_claim2_idx
+    ON public.confenge_target_fit_dirty (priority DESC, detected_at ASC)
+    WHERE status IN ('pending', 'retry');
+
+COMMENT ON INDEX public.confenge_tf_dirty_claim2_idx IS
+'Claim path for confenge_target_fit_dirty. Partial on the claimable statuses; key order matches the claim ORDER BY so LIMIT terminates the index walk instead of sorting the backlog.';
+
+-- Redundant once claim2 exists: same partial predicate, and the leading `status`
+-- column is implied by that predicate. No other query orders by this shape.
+DROP INDEX IF EXISTS public.confenge_tf_dirty_claim_idx;
+
+COMMIT;

--- a/db/rollback/099_confenge_target_fit_bounded_claim_rollback.sql
+++ b/db/rollback/099_confenge_target_fit_bounded_claim_rollback.sql
@@ -1,0 +1,17 @@
+-- 099_confenge_target_fit_bounded_claim_rollback.sql
+-- Restore the 071 claim index and drop the 099 replacement.
+-- Reverting the index alone re-exposes the unbounded-Sort claim plan, so this
+-- rollback is only safe together with reverting scripts/confenge_target_fit/store.py.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+CREATE INDEX IF NOT EXISTS confenge_tf_dirty_claim_idx
+    ON public.confenge_target_fit_dirty (status, priority DESC, detected_at ASC)
+    WHERE status IN ('pending', 'retry');
+
+DROP INDEX IF EXISTS public.confenge_tf_dirty_claim2_idx;
+
+COMMIT;

--- a/deploy/systemd/extra-confenge-target-fit-worker.service
+++ b/deploy/systemd/extra-confenge-target-fit-worker.service
@@ -3,6 +3,12 @@ Description=Extra Consultoria — CONFENGE target-fit worker (long-running)
 Documentation=file:/opt/extra-consultoria/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
 After=network-online.target postgresql.service
 Wants=network-online.target
+# Stop restarting a worker that cannot start cleanly. Without a start limit a
+# crash-looping worker retries every RestartSec forever and keeps re-poisoning
+# the shared DataLake cluster. 4 failures inside 15 min -> unit enters `failed`
+# and stays down for a human. Reset with `systemctl reset-failed`.
+StartLimitIntervalSec=900
+StartLimitBurst=4
 
 [Service]
 Type=simple

--- a/scripts/confenge_target_fit/store.py
+++ b/scripts/confenge_target_fit/store.py
@@ -28,6 +28,11 @@ from scripts.confenge_target_fit.models import (
     TransitionEvent,
 )
 
+# Rows a single reclaim UPDATE may touch. Row locks and advisory locks share the
+# cluster-global lock table (max_locks_per_transaction * max_connections slots),
+# so no queue statement may take a number of locks proportional to the backlog.
+RECLAIM_BATCH_SIZE = 500
+
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
@@ -180,27 +185,79 @@ def requeue_company(
     return key
 
 
-def reclaim_expired_locks(conn: Any) -> int:
-    """Crash recovery: processing rows past lock TTL → pending/retry."""
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            UPDATE confenge_target_fit_dirty
-            SET status = CASE
-                    WHEN attempt_count >= 5 THEN 'dead'
-                    ELSE 'retry'
-                END,
-                next_retry_at = now(),
-                locked_by = NULL,
-                locked_until = NULL,
-                last_error = COALESCE(last_error, '') || ' [lock_expired]',
-                updated_at = now()
-            WHERE status = 'processing'
-              AND locked_until IS NOT NULL
-              AND locked_until < now()
-            """
-        )
-        return cur.rowcount or 0
+def reclaim_expired_locks(conn: Any, *, batch_size: int = RECLAIM_BATCH_SIZE) -> int:
+    """Crash recovery: processing rows past lock TTL → pending/retry.
+
+    Bounded and self-committing on purpose. The row locks an UPDATE takes come
+    out of the same cluster-global shared lock table as the claim's advisory
+    locks, so an unbounded reclaim riding inside the claim transaction could
+    exhaust it on its own. Each statement touches at most ``batch_size`` rows and
+    is committed immediately; the loop repeats until the backlog is drained, so
+    the semantics ("every expired lock is reclaimed") are unchanged.
+
+    Callers must not have uncommitted work pending — the intermediate commits
+    would publish it. ``claim_batch`` calls this before opening its own work.
+    """
+    total = 0
+    while True:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE confenge_target_fit_dirty
+                SET status = CASE
+                        WHEN attempt_count >= 5 THEN 'dead'
+                        ELSE 'retry'
+                    END,
+                    next_retry_at = now(),
+                    locked_by = NULL,
+                    locked_until = NULL,
+                    last_error = COALESCE(last_error, '') || ' [lock_expired]',
+                    updated_at = now()
+                WHERE id IN (
+                    SELECT id
+                    FROM confenge_target_fit_dirty
+                    WHERE status = 'processing'
+                      AND locked_until IS NOT NULL
+                      AND locked_until < now()
+                    ORDER BY locked_until ASC
+                    LIMIT %s
+                    FOR UPDATE SKIP LOCKED
+                )
+                """,
+                (batch_size,),
+            )
+            affected = cur.rowcount or 0
+        conn.commit()
+        total += affected
+        if affected < batch_size:
+            return total
+
+
+# Step 1 of the claim, kept as a module constant so tests can EXPLAIN the exact
+# statement that ships. See claim_batch for why the shape is load-bearing.
+CLAIM_CANDIDATES_SQL = """
+    WITH candidates AS MATERIALIZED (
+        SELECT id, company_key, priority, detected_at
+        FROM confenge_target_fit_dirty
+        WHERE status IN ('pending', 'retry')
+          AND (next_retry_at IS NULL OR next_retry_at <= now())
+        ORDER BY priority DESC, detected_at ASC
+        LIMIT %s
+        FOR UPDATE SKIP LOCKED
+    )
+    SELECT c.id, c.company_key, c.priority, c.detected_at
+    FROM candidates c
+    WHERE pg_try_advisory_xact_lock(hashtext(c.company_key))
+      AND NOT EXISTS (
+          SELECT 1
+          FROM confenge_target_fit_dirty p
+          WHERE p.company_key = c.company_key
+            AND p.status = 'processing'
+            AND p.locked_until IS NOT NULL
+            AND p.locked_until > now()
+      )
+    ORDER BY c.priority DESC, c.detected_at ASC
+"""
 
 
 def claim_batch(
@@ -218,36 +275,32 @@ def claim_batch(
       claim the same dirty id.
     - process_one also takes pg_try_advisory_xact_lock(company_key) so two
       workers cannot publish the same company even if two dirty rows raced in.
+
+    Advisory locks taken here are bounded by the candidate LIMIT, never by the
+    backlog size — see the MATERIALIZED CTE note below.
     """
+    # Runs (and commits) outside the claim transaction: its row locks must not
+    # be charged to the same shared-lock budget as the advisory locks below.
     reclaim_expired_locks(conn)
     now = _utcnow()
     lock_until = now + timedelta(seconds=lock_ttl_seconds)
+    candidate_limit = max(batch_size * 4, batch_size)
     with conn.cursor() as cur:
         # Step 1: lock candidate rows (skip locked), more than batch to allow
         # post-filter one-per-company.
-        cur.execute(
-            """
-            SELECT id, company_key, priority, detected_at
-            FROM confenge_target_fit_dirty
-            WHERE status IN ('pending', 'retry')
-              AND (next_retry_at IS NULL OR next_retry_at <= now())
-              AND pg_try_advisory_xact_lock(
-                    hashtext(confenge_target_fit_dirty.company_key)
-                  )
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM confenge_target_fit_dirty p
-                  WHERE p.company_key = confenge_target_fit_dirty.company_key
-                    AND p.status = 'processing'
-                    AND p.locked_until IS NOT NULL
-                    AND p.locked_until > now()
-              )
-            ORDER BY priority DESC, detected_at ASC
-            LIMIT %s
-            FOR UPDATE SKIP LOCKED
-            """,
-            (max(batch_size * 4, batch_size),),
-        )
+        #
+        # The candidate set MUST be bounded before any advisory lock is taken.
+        # pg_try_advisory_xact_lock() costs 1 to the planner, so as a plain WHERE
+        # qual it is pushed into the scan filter and evaluated on every scanned
+        # row; the xact-scoped locks it acquires are only released at COMMIT, so
+        # a large backlog exhausts the cluster-global lock table and takes every
+        # other DataLake session down with it ("out of shared memory").
+        #
+        # AS MATERIALIZED is load-bearing, not decoration: it forbids the planner
+        # from inlining the CTE, which is what keeps LIMIT strictly below the
+        # advisory lock. confenge_tf_dirty_claim2_idx (migration 099) matches the
+        # ORDER BY, so the Limit terminates the index walk instead of sorting.
+        cur.execute(CLAIM_CANDIDATES_SQL, (candidate_limit,))
         candidates = cur.fetchall() or []
         # Step 2: keep first row per company_key (already priority-ordered).
         # The transaction-scoped advisory lock above closes the cross-row race:

--- a/scripts/confenge_target_fit/worker.py
+++ b/scripts/confenge_target_fit/worker.py
@@ -46,6 +46,11 @@ from scripts.confenge_target_fit.store import (
 
 logger = logging.getLogger(__name__)
 
+# Consecutive failed cycles the loop absorbs (with backoff) before it gives up
+# and exits non-zero. systemd then applies StartLimitBurst and stops the unit
+# instead of restarting a broken worker against a shared database forever.
+MAX_CONSECUTIVE_CYCLE_FAILURES = 3
+
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
@@ -439,10 +444,19 @@ def run_worker_loop(
     cfg: TargetFitRefreshConfig | None = None,
     idle_sleep_seconds: float = 15.0,
     max_cycles: int | None = None,
+    max_consecutive_failures: int = MAX_CONSECUTIVE_CYCLE_FAILURES,
 ) -> None:
-    """Long-running worker (systemd Type=simple). Graceful on KeyboardInterrupt."""
+    """Long-running worker (systemd Type=simple). Graceful on KeyboardInterrupt.
+
+    A failing cycle is never swallowed: it is logged with its traceback, backed
+    off, and retried at most ``max_consecutive_failures`` times before the
+    exception is re-raised and the process exits non-zero. Fail-closed is
+    preserved — the backoff only stops a broken worker from re-running the same
+    poisoned cycle every RestartSec against a shared database.
+    """
     cfg = cfg or TargetFitRefreshConfig.from_env()
     cycles = 0
+    consecutive_failures = 0
     logger.info(
         "target-fit worker starting mode=%s batch=%s",
         cfg.async_mode,
@@ -450,7 +464,28 @@ def run_worker_loop(
     )
     try:
         while max_cycles is None or cycles < max_cycles:
-            stats = run_worker_cycle(dsn, cfg=cfg)
+            try:
+                stats = run_worker_cycle(dsn, cfg=cfg)
+            except KeyboardInterrupt:
+                raise
+            except Exception:
+                consecutive_failures += 1
+                if consecutive_failures >= max_consecutive_failures:
+                    logger.exception(
+                        "worker cycle failed %s times in a row — exiting",
+                        consecutive_failures,
+                    )
+                    raise
+                backoff = idle_sleep_seconds * (2 ** (consecutive_failures - 1))
+                logger.exception(
+                    "worker cycle failed (%s/%s) — backing off %.1fs",
+                    consecutive_failures,
+                    max_consecutive_failures,
+                    backoff,
+                )
+                time.sleep(backoff)
+                continue
+            consecutive_failures = 0
             cycles += 1
             logger.info(
                 "worker cycle done claimed=%s processed=%s up=%s down=%s skip=%s fail=%s",

--- a/tests/confenge_target_fit/test_claim_lock_bounded.py
+++ b/tests/confenge_target_fit/test_claim_lock_bounded.py
@@ -1,0 +1,281 @@
+"""Regression: the dirty-queue claim must never take locks proportional to the backlog.
+
+Incident: ``claim_batch`` evaluated ``pg_try_advisory_xact_lock`` as a row-level
+WHERE qual under a blocking Sort, so every backlog row took a transaction-scoped
+advisory lock before LIMIT saw a tuple. ~423k of them exhausted the
+cluster-global shared lock table ("out of shared memory"), which also denied
+locks to every other DataLake session and crash-looped the worker under systemd.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from scripts.confenge_target_fit.db import connect
+from scripts.confenge_target_fit.store import (
+    CLAIM_CANDIDATES_SQL,
+    claim_batch,
+    ensure_control_defaults,
+)
+
+DSN = os.environ.get("LOCAL_DATALAKE_DSN") or os.environ.get("CONFENGE_TARGET_FIT_STATE_DSN")
+
+pytestmark = [
+    pytest.mark.real_db,
+    pytest.mark.skipif(not DSN, reason="LOCAL_DATALAKE_DSN not set"),
+]
+
+# Backlog large enough that the pre-fix plan would blow the default shared lock
+# table (max_locks_per_transaction=64 * max_connections=100 = 6400 slots).
+BACKLOG_ROWS = 8000
+# cnpj_raiz is CHAR(8); this range is disjoint from every other test's roots.
+RAIZ_START = 30000000
+
+
+def _apply_migration() -> None:
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    subprocess.check_call(
+        [sys.executable, "-m", "scripts.ops.apply_migrations", "--dsn", DSN],
+        cwd=str(Path(__file__).resolve().parents[2]),
+    )
+
+
+@pytest.fixture(scope="module")
+def dsn():
+    _apply_migration()
+    return DSN
+
+
+@pytest.fixture
+def seeded_backlog(dsn):
+    """Seed BACKLOG_ROWS pending rows across distinct company_keys; drop them after."""
+    tag = f"bounded-claim-{uuid.uuid4().hex[:8]}"
+    conn = connect(dsn, readonly=False)
+    try:
+        ensure_control_defaults(conn)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO confenge_target_fit_dirty (
+                    company_key, cnpj_raiz, reason, source_entity, source_id,
+                    source_updated_at, source_watermark, priority, status,
+                    idempotency_key
+                )
+                SELECT 'cnpj_root:' || lpad(g::text, 8, '0'),
+                       lpad(g::text, 8, '0'),
+                       %s, 'test', g::text,
+                       now(), 'wm-bounded', 100, 'pending',
+                       %s || '-' || g
+                FROM generate_series(%s, %s) AS g
+                ON CONFLICT (idempotency_key) DO NOTHING
+                """,
+                (tag, tag, RAIZ_START, RAIZ_START + BACKLOG_ROWS - 1),
+            )
+            assert cur.rowcount == BACKLOG_ROWS
+        conn.commit()
+        with conn.cursor() as cur:
+            # Autovacuum keeps production stats representative; a freshly bulk
+            # loaded test table has none, and on stale stats the planner falls
+            # back to bitmap-scan + Sort inside the CTE. That costs latency but
+            # NOT the lock budget — the CTE boundary, not the index, is what
+            # bounds the advisory locks. ANALYZE so the plan assertions below
+            # test the shipped production plan.
+            cur.execute("ANALYZE confenge_target_fit_dirty")
+        conn.commit()
+        yield tag
+    finally:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM confenge_target_fit_dirty WHERE reason = %s", (tag,))
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def _advisory_locks_held(conn) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT count(*) AS n
+            FROM pg_locks
+            WHERE locktype = 'advisory' AND pid = pg_backend_pid()
+            """
+        )
+        row = cur.fetchone()
+        return int(row["n"] if isinstance(row, dict) else row[0])
+
+
+def test_claim_advisory_locks_bounded_by_batch(dsn, seeded_backlog):  # noqa: ARG001
+    """Advisory locks held mid-claim scale with the batch limit, not the backlog."""
+    batch_size = 50
+    # claim_batch over-fetches to allow the one-per-company post-filter.
+    candidate_limit = max(batch_size * 4, batch_size)
+
+    conn = connect(dsn, readonly=False)
+    try:
+        items = claim_batch(conn, worker_id="w-bounded", batch_size=batch_size, lock_ttl_seconds=60)
+        # Still inside the claim transaction: xact-scoped advisory locks are only
+        # released at COMMIT, so this is the peak the shared lock table must hold.
+        held = _advisory_locks_held(conn)
+        conn.commit()
+
+        assert held <= candidate_limit, (
+            f"claim took {held} advisory locks for a {BACKLOG_ROWS}-row backlog; "
+            f"must stay within the candidate limit {candidate_limit}"
+        )
+        assert held < BACKLOG_ROWS
+        assert len(items) == batch_size
+    finally:
+        conn.close()
+
+
+def test_claim_plan_does_not_scan_whole_backlog(dsn, seeded_backlog):
+    """The advisory lock is evaluated post-LIMIT, on the bounded candidate set."""
+    batch_size = 50
+    candidate_limit = max(batch_size * 4, batch_size)
+
+    conn = connect(dsn, readonly=False)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "EXPLAIN (ANALYZE, FORMAT JSON) " + CLAIM_CANDIDATES_SQL,
+                (candidate_limit,),
+            )
+            row = cur.fetchone()
+        plan = row["QUERY PLAN"] if isinstance(row, dict) else row[0]
+        if isinstance(plan, str):
+            import json as _json
+
+            plan = _json.loads(plan)
+        root = plan[0]["Plan"]
+
+        def walk(node):
+            yield node
+            for child in node.get("Plans", []) or []:
+                yield from walk(child)
+
+        nodes = list(walk(root))
+
+        def subtree(name: str) -> list[dict]:
+            for node in nodes:
+                if node.get("Subplan Name") == f"CTE {name}":
+                    return list(walk(node))
+            raise AssertionError(f"CTE {name} not found in plan")
+
+        # --- Hard invariant: the advisory lock is evaluated post-LIMIT. ---
+        # This holds regardless of which plan the CTE body gets, and it is what
+        # keeps the shared lock table safe.
+        lock_nodes = [n for n in nodes if "pg_try_advisory_xact_lock" in str(n.get("Filter", ""))]
+        assert lock_nodes, "advisory lock qual not found in plan"
+        for n in lock_nodes:
+            assert n["Node Type"] == "CTE Scan", (
+                f"advisory lock evaluated in {n['Node Type']}, must be post-LIMIT CTE Scan"
+            )
+            assert int(n["Actual Rows"]) <= candidate_limit, (
+                f"advisory lock evaluated on {n['Actual Rows']} rows for a "
+                f"{BACKLOG_ROWS}-row backlog; limit is {candidate_limit}"
+            )
+
+        candidate_nodes = subtree("candidates")
+        assert int(candidate_nodes[0]["Actual Rows"]) <= candidate_limit
+
+        # --- Plan quality: LIMIT terminates the ordered index walk. ---
+        # Needs the representative stats the fixture ANALYZEs in.
+        assert not any(n["Node Type"] == "Sort" for n in candidate_nodes), (
+            "blocking Sort inside the candidate CTE — LIMIT cannot terminate early"
+        )
+        index_names = {n.get("Index Name") for n in candidate_nodes if n.get("Index Name")}
+        assert "confenge_tf_dirty_claim2_idx" in index_names, (
+            f"candidate walk did not use the 099 claim index: {index_names}"
+        )
+        scanned = max(int(n["Actual Rows"]) for n in candidate_nodes)
+        assert scanned <= candidate_limit, f"candidate CTE emitted {scanned} rows; must stop at {candidate_limit}"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_claim_advisory_locks_bounded_without_index_plan(dsn, seeded_backlog):  # noqa: ARG001
+    """The lock bound comes from the CTE boundary, not from the index.
+
+    With enable_indexscan/enable_bitmapscan off the planner is forced back into
+    exactly the seq-scan + blocking-Sort shape that caused the incident. The
+    pre-fix statement evaluated pg_try_advisory_xact_lock inside that scan filter
+    and died with "out of shared memory"; the shipped statement must still take
+    at most `candidate_limit` advisory locks.
+    """
+    batch_size = 50
+    candidate_limit = max(batch_size * 4, batch_size)
+
+    conn = connect(dsn, readonly=False)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SET enable_indexscan = off")
+            cur.execute("SET enable_bitmapscan = off")
+            cur.execute("SET enable_indexonlyscan = off")
+        conn.commit()
+
+        items = claim_batch(conn, worker_id="w-noindex", batch_size=batch_size, lock_ttl_seconds=60)
+        held = _advisory_locks_held(conn)
+        conn.commit()
+
+        assert held <= candidate_limit, (
+            f"claim took {held} advisory locks under a seq-scan plan over a "
+            f"{BACKLOG_ROWS}-row backlog; limit is {candidate_limit}"
+        )
+        assert len(items) == batch_size
+    finally:
+        conn.close()
+
+
+def test_reclaim_drains_more_than_one_batch(dsn, seeded_backlog):
+    """Bounding reclaim per statement must not stop it from draining the backlog.
+
+    The reclaim UPDATE now runs in committed batches so its row locks never ride
+    inside the claim transaction. Semantics are unchanged: every expired lock is
+    still reclaimed, even when there are far more of them than one batch holds.
+    """
+    from scripts.confenge_target_fit.store import RECLAIM_BATCH_SIZE, reclaim_expired_locks
+
+    expired = RECLAIM_BATCH_SIZE * 2 + 7
+    assert expired < BACKLOG_ROWS
+
+    conn = connect(dsn, readonly=False)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE confenge_target_fit_dirty
+                SET status = 'processing',
+                    locked_by = 'dead-worker',
+                    locked_until = now() - interval '1 hour'
+                WHERE id IN (
+                    SELECT id FROM confenge_target_fit_dirty
+                    WHERE reason = %s ORDER BY id LIMIT %s
+                )
+                """,
+                (seeded_backlog, expired),
+            )
+            assert cur.rowcount == expired
+        conn.commit()
+
+        assert reclaim_expired_locks(conn) == expired
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) AS n FROM confenge_target_fit_dirty
+                WHERE reason = %s AND status = 'processing'
+                """,
+                (seeded_backlog,),
+            )
+            row = cur.fetchone()
+        assert int(row["n"] if isinstance(row, dict) else row[0]) == 0
+    finally:
+        conn.close()


### PR DESCRIPTION
`extra-confenge-target-fit-worker` had been crash-looping for roughly 145 hours — ~11,600 restarts at the unit's 45s cadence — and each attempt re-poisoned the cluster-wide lock table, so unrelated DataLake sessions were denied locks too.

## Reproduced first

Seeded 50k pending rows and ran the existing Step-1 statement verbatim:

```
BEGIN
ERROR:  out of shared memory
HINT:  You might need to increase max_locks_per_transaction.
```

The plan says why:

```
 Limit
   ->  LockRows
         ->  Sort                                   <-- BLOCKING
               ->  Hash Anti Join
                     ->  Seq Scan on confenge_target_fit_dirty
                           Filter: (... AND pg_try_advisory_xact_lock((hashtext(company_key))::bigint))
```

`pg_try_advisory_xact_lock` was a row-level `WHERE` qual, and `ORDER BY priority DESC, detected_at ASC` forced a blocking `Sort`. So every one of the ~423k matching rows had a lock taken on it before `LIMIT 200` saw a single tuple. Advisory xact locks are held to commit, so the transaction accumulated ~423k of them in shared memory.

Raising `max_locks_per_transaction` was not the fix — the bump from 64 to 512 was still three orders of magnitude short, and the lock table is cluster-global, which is why other connections died with it.

## The fix

Bound the candidate set *before* taking any lock. A `MATERIALIZED` CTE carrying `FOR UPDATE` cannot be inlined, so the advisory-lock qual is forced to run post-`LIMIT`:

```sql
WITH candidates AS MATERIALIZED (
    SELECT id, company_key, priority, detected_at
    FROM confenge_target_fit_dirty
    WHERE status IN ('pending', 'retry')
      AND (next_retry_at IS NULL OR next_retry_at <= now())
    ORDER BY priority DESC, detected_at ASC
    LIMIT %s
    FOR UPDATE SKIP LOCKED
)
SELECT c.id, c.company_key, c.priority, c.detected_at
FROM candidates c
WHERE pg_try_advisory_xact_lock(hashtext(c.company_key))
  AND NOT EXISTS (
      SELECT 1 FROM confenge_target_fit_dirty p
      WHERE p.company_key = c.company_key
        AND p.status = 'processing'
        AND p.locked_until IS NOT NULL
        AND p.locked_until > now()
  )
ORDER BY c.priority DESC, c.detected_at ASC
```

Migration 099 fixes the index so `LIMIT` can terminate the walk early. The old index led with `status` inside a partial index already filtered on `status`, which is why the planner reached for a Sort:

```sql
CREATE INDEX IF NOT EXISTS confenge_tf_dirty_claim2_idx
    ON public.confenge_target_fit_dirty (priority DESC, detected_at ASC)
    WHERE status IN ('pending', 'retry');
DROP INDEX IF EXISTS public.confenge_tf_dirty_claim_idx;
```

Plain `CREATE INDEX`, measured at 125 ms on 423k rows. Dropping the 071 index is safe: identical partial predicate, and no query orders by the status-leading shape.

`reclaim_expired_locks` was an unbounded `UPDATE` in the *same* transaction, adding row locks to the same budget; it is now batched at 500. The unit gains `StartLimitIntervalSec=900` / `StartLimitBurst=4` so a genuinely broken worker stops instead of hammering, and the loop backs off after consecutive failures but still re-raises — fail-closed is unchanged.

## Proof, on a 423,012-row backlog

```
Sort  (actual time=6.675..6.685 rows=200 loops=1)
  CTE candidates
    ->  Limit  (actual time=5.989..6.234 rows=200 loops=1)
          ->  LockRows
                ->  Index Scan using confenge_tf_dirty_claim2_idx  (actual time=5.964..6.127 rows=200 loops=1)
  ->  Hash Right Anti Join
        ->  Hash
              ->  CTE Scan on candidates c  (actual time=5.999..6.457 rows=200 loops=1)
                    Filter: pg_try_advisory_xact_lock((hashtext(company_key))::bigint)
Execution Time: 6.791 ms

advisory_locks_held_in_txn = 193
```

No `Sort` under the CTE; the index scan emits 200 rows out of 423,014; and the lock qual has moved from a base-relation `Seq Scan` Filter to a post-`LIMIT` `CTE Scan` Filter. 193 locks, against `out of shared memory` before.

## The index alone masks the bug

Worth knowing: with the new index present, even the *pre-fix* SQL gets an ordered index scan and terminates early, so a naive lock-count test passes against broken code. The tests therefore bind to the shipped statement (`CLAIM_CANDIDATES_SQL` is a module constant the test `EXPLAIN`s) and one adversarial case disables index scans to force the incident's exact seq-scan + Sort plan. Against the pre-fix SQL they fail with:

```
AssertionError: advisory lock evaluated in Index Scan, must be post-LIMIT CTE Scan
AssertionError: claim took 8005 advisory locks under a seq-scan plan over a 8000-row backlog; limit is 200
```

and with migration 099 dropped: `blocking Sort inside the candidate CTE — LIMIT cannot terminate early`. The suite catches a regression in either half of the fix.

## Verification

`ruff check scripts/` and `ruff check tests/confenge_target_fit/` pass. `pytest tests/confenge_target_fit/ -q` → **74 passed** (70 pre-existing + 4 new). The three invariants that pin the current concurrency semantics all still pass: `test_claim_skip_locked_single_writer`, `test_claim_batch_one_per_company`, `test_concurrent_claim_same_company_single_writer`.

`ruff format --check scripts/` reports 451 files — byte-identical on clean `origin/main`, pre-existing drift. The unformatted hunks in the touched files are at lines this PR does not modify; reformatting would have buried the fix in 451 files of churn.

## Residual

- `reclaim_expired_locks` now commits internally. Only `claim_batch` and tests call it, and it runs first thing, so nothing is affected today — but it is a footgun, documented in the docstring.
- Rolling back 099 leaves `version='099'` in `public._migrations` (the existing rollback convention does not touch the ledger), so an operator must delete that row by hand before re-applying forward.
- Stale statistics change the CTE's *inner* plan on a freshly bulk-loaded table, costing latency but not the lock bound — the CTE boundary is what bounds locks, not the index.
- Not deployed. Deploying needs the migration applied plus `systemctl daemon-reload` and `systemctl reset-failed extra-confenge-target-fit-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
