### PR TITLE
fix(pncp): align incremental windows to UTC

### DIFF
--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -84,6 +84,14 @@ _PAGE_RETRYABLE = frozenset(
 )
 
 
+def utc_today(now: datetime | None = None) -> date:
+    """Return the PNCP operational date in UTC, independent of host TZ."""
+    instant = now or datetime.now(UTC)
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=UTC)
+    return instant.astimezone(UTC).date()
+
+
 def iter_planned_window_keys(start: date, end: date, window_days: int = CONTRACTS_WINDOW_DAYS) -> list[str]:
     """Date-window keys the pilot will attempt between start and end.
 
@@ -616,7 +624,7 @@ def seal_pilot_artifact(
 
     started = datetime.now(UTC)
     mode = "full"
-    today = date.today()
+    today = utc_today()
     start = today - timedelta(days=days)
     planned_windows = count_planned_windows(start, today, CONTRACTS_WINDOW_DAYS)
     run_id = run_id or new_run_id(prefix="contracts-seal")
@@ -863,7 +871,7 @@ def run_pilot(
 ) -> dict[str, Any]:
     started = datetime.now(UTC)
     mode = "full"
-    today = date.today()
+    today = utc_today()
     start = today - timedelta(days=days)
     planned_windows = count_planned_windows(start, today, CONTRACTS_WINDOW_DAYS)
     run_id = run_id or new_run_id(prefix="contracts-90d")

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -62,9 +62,10 @@ def current_incremental_window_key(*, days: int, today: date | None = None) -> s
     from scripts.crawl.run_contracts_90d_pilot import (
         CONTRACTS_WINDOW_DAYS,
         iter_planned_window_keys,
+        utc_today,
     )
 
-    end = today or datetime.now(UTC).date()
+    end = today or utc_today()
     keys = iter_planned_window_keys(end - timedelta(days=days), end, CONTRACTS_WINDOW_DAYS)
     if not keys:
         raise ValueError(f"incremental range produced no window for days={days}")

--- a/tests/test_contracts_incremental_refresh.py
+++ b/tests/test_contracts_incremental_refresh.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 
 from scripts.crawl.contracts_crawler import CrawlCheckpoint
+from scripts.crawl.run_contracts_90d_pilot import utc_today
 from scripts.crawl.run_contracts_incremental import (
     current_incremental_window_key,
     reopen_current_window,
 )
+
+
+def test_pncp_operational_date_is_utc_across_brazil_midnight_boundary() -> None:
+    brazil = timezone(-timedelta(hours=3))
+    local_late_evening = datetime(2026, 8, 22, 23, 28, tzinfo=brazil)
+    assert utc_today(local_late_evening) == date(2026, 8, 23)
 
 
 def test_current_incremental_window_is_reopened_for_every_timer_slot() -> None:


### PR DESCRIPTION
## Production finding

At 2026-08-22 23:28 BRT / 2026-08-23 02:28 UTC, the incremental wrapper reopened the UTC window `20260816_20260823`, while the underlying pilot planned the host-local window `20260815_20260822` and skipped it as already complete. Freshness correctly stayed UNKNOWN with `UNCLOSED_CURRENT_WINDOW`.

## Fix

Use one explicit UTC operational date in both paths. This removes the BRT/UTC midnight split without changing thresholds or treating a skipped window as closed.

## Evidence

- regression proves 2026-08-22 23:28 -03 maps to PNCP operational date 2026-08-23
- focused tests: 3 passed
- Ruff and PR policies: PASS

No feed was generated and no email was sent from the failed production attempt.