### PR TITLE
fix(crawl): replay verified pre-CAS raw checkpoints

### DIFF
--- a/scripts/crawl/resilience/state.py
+++ b/scripts/crawl/resilience/state.py
@@ -261,9 +261,9 @@ class RawStore:
         if not digest:
             if "payload" not in envelope:
                 raise ValueError("raw envelope has neither CAS digest nor legacy payload")
-            payload = envelope["payload"]
+            legacy_payload = envelope["payload"]
             canonical = json.dumps(
-                payload,
+                legacy_payload,
                 ensure_ascii=False,
                 sort_keys=True,
                 separators=(",", ":"),
@@ -276,7 +276,7 @@ class RawStore:
             provenance = envelope.get("provenance")
             return {
                 "envelope": envelope,
-                "payload": payload,
+                "payload": legacy_payload,
                 "provenance": provenance if isinstance(provenance, dict) else {},
             }
         body_path = self.root / "cas" / digest[:2] / digest[2:4] / f"{digest}.body"

--- a/scripts/crawl/resilience/state.py
+++ b/scripts/crawl/resilience/state.py
@@ -254,6 +254,31 @@ class RawStore:
         path = Path(envelope_path)
         envelope = json.loads(path.read_text(encoding="utf-8"))
         digest = str(envelope.get("body_sha256") or "")
+        # Raw envelopes written before the CAS migration stored the canonical
+        # payload inline. Production checkpoints are durable across releases,
+        # so replay must verify and consume that historical shape instead of
+        # resolving an empty digest as ``raw/cas/.body``.
+        if not digest:
+            if "payload" not in envelope:
+                raise ValueError("raw envelope has neither CAS digest nor legacy payload")
+            payload = envelope["payload"]
+            canonical = json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode()
+            expected = str(envelope.get("content_hash") or "")
+            actual = hashlib.sha256(canonical).hexdigest()
+            if not expected or actual != expected:
+                raise ValueError("legacy raw body hash mismatch")
+            provenance = envelope.get("provenance")
+            return {
+                "envelope": envelope,
+                "payload": payload,
+                "provenance": provenance if isinstance(provenance, dict) else {},
+            }
         body_path = self.root / "cas" / digest[:2] / digest[2:4] / f"{digest}.body"
         body = body_path.read_bytes()
         if hashlib.sha256(body).hexdigest() != digest:

--- a/tests/test_local_resilience.py
+++ b/tests/test_local_resilience.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from dataclasses import replace
@@ -198,6 +199,48 @@ def test_raw_archive_same_request_identity_is_stable(tmp_path: Path) -> None:
     assert first == second
     saved = json.loads(first.read_text(encoding="utf-8"))
     assert saved["provenance"]["response_headers"] == {}
+
+
+def test_raw_archive_replays_verified_pre_cas_envelope(tmp_path: Path) -> None:
+    store = RawStore(tmp_path / "raw")
+    payload = {"data": [{"objeto": "pavimentação"}], "pagination": {"empty": False}}
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    legacy = tmp_path / "legacy.json"
+    legacy.write_text(
+        json.dumps(
+            {
+                "source": "pncp",
+                "content_hash": hashlib.sha256(canonical).hexdigest(),
+                "payload": payload,
+                "provenance": {"adapter_version": "pre-cas"},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = store.load_reference(legacy)
+
+    assert loaded["payload"] == payload
+    assert loaded["provenance"] == {"adapter_version": "pre-cas"}
+    assert not (tmp_path / "raw" / "cas" / ".body").exists()
+
+
+def test_raw_archive_rejects_tampered_pre_cas_envelope(tmp_path: Path) -> None:
+    legacy = tmp_path / "legacy.json"
+    legacy.write_text(
+        json.dumps({"content_hash": "0" * 64, "payload": {"data": ["tampered"]}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="legacy raw body hash mismatch"):
+        RawStore(tmp_path / "raw").load_reference(legacy)
 
 
 @pytest.mark.database


### PR DESCRIPTION
## Production defect
`extra-crawl-pncp.service` replayed durable pre-CAS checkpoints through the CAS-only loader, resolved the absent digest to `raw/cas/.body`, and failed six windows.

## Fix
- detect the historical inline-payload envelope shape
- recompute its exact legacy canonical SHA-256 before replay
- reject missing or tampered historical payloads fail-closed
- keep current CAS envelope handling unchanged

## Evidence
- production run `resilient-local-20260823T025937Z-7c3163adea` reproduced the defect
- focused regressions: 2 passed
- full module before this focused rerun: 54 passed, 1 skipped (coverage finalization was interrupted after test completion due concurrent local coverage writers)
- Ruff check/format clean
- no email sent