### PR TITLE
fix(dossier): bind producer SHA to deployment marker

### DIFF
--- a/docs/contracts/confenge-dossier-v1.json
+++ b/docs/contracts/confenge-dossier-v1.json
@@ -61,6 +61,7 @@
     "claim_scan": "Every emitted document is scanned for forbidden claim tokens and metric keys before it is written. Official objeto text is exempt because the engine must not rewrite official text.",
     "panel_range": "A category where the focal median sits more than 10x outside the panel interquartile band yields OUT_OF_PANEL_RANGE and no percentile position.",
     "reference_scope": "Every price panel carries scope_id, geography, denominator, as_of, source/version, sample_count, coverage, missingness, method, hash and limitations. BOTH is the fail-closed default; NATIONAL never reuses a REGIONAL denominator and stays DATA_HOLD without an authorized comparable corpus.",
+    "producer_sha": "An explicit CONFENGE_REPOSITORY_SHA wins; otherwise a validated .deployed_sha is authoritative and Git is used only when no deploy marker exists. Invalid authoritative values do not fall back to stale Git metadata.",
     "content_hash": "content_hash covers the document with volatile fields (generated_at, observed_at, producer_sha, content_hash) stripped, so two runs over the same data agree byte for byte."
   },
   "privacy": {

--- a/docs/contracts/confenge-dossier-v1.md
+++ b/docs/contracts/confenge-dossier-v1.md
@@ -65,6 +65,10 @@ and not `DATA_READY` · `5` `DATA_REJECT`.
   not enough: a municipality buys stationery and asphalt from the same list.
 - `content_hash` strips volatile fields, so two runs over the same data agree
   byte for byte. `verify` recomputes it and fails on drift.
+- `producer_sha` resolves an explicit `CONFENGE_REPOSITORY_SHA` first, then a
+  validated `.deployed_sha`, and uses Git only in a worktree without a deploy
+  marker. An invalid authoritative value yields no SHA instead of silently
+  binding the artifact to a stale checkout.
 
 ## Findings
 

--- a/scripts/dossier/envelope.py
+++ b/scripts/dossier/envelope.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -74,21 +75,42 @@ LIMITATION_ACTIVE_ONLY = (
 )
 
 
-def producer_sha() -> str | None:
+SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def _valid_sha(value: str | None) -> str | None:
+    candidate = (value or "").strip()
+    return candidate.lower() if SHA_RE.fullmatch(candidate) else None
+
+
+def producer_sha(repo_root: Path | None = None) -> str | None:
+    """Bind the artifact to the code that actually produced it.
+
+    Deployments are rsynced without replacing the host's historical ``.git``
+    directory, so ``.deployed_sha`` is authoritative there.  An existing but
+    invalid marker fails closed instead of falling back to a stale checkout.
+    """
     env = os.environ.get("CONFENGE_REPOSITORY_SHA")
     if env:
-        return env.strip()
+        return _valid_sha(env)
+    root = repo_root or Path(__file__).resolve().parents[2]
+    marker = root / ".deployed_sha"
+    if marker.exists():
+        try:
+            return _valid_sha(marker.read_text(encoding="utf-8"))
+        except OSError:
+            return None
     try:
         out = subprocess.run(
             ["git", "rev-parse", "HEAD"],  # noqa: S607 -- git resolved from PATH by design; fixed argv, no shell
             capture_output=True,
             text=True,
             timeout=10,
-            cwd=Path(__file__).resolve().parents[2],
+            cwd=root,
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    return out.stdout.strip() or None if out.returncode == 0 else None
+    return _valid_sha(out.stdout) if out.returncode == 0 else None
 
 
 def _strip_volatile(value: Any) -> Any:

--- a/tests/dossier/test_dossier_engine.py
+++ b/tests/dossier/test_dossier_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from decimal import Decimal
 from pathlib import Path
 
@@ -37,6 +38,7 @@ from scripts.dossier.envelope import (
     LIMITATION_UNKNOWN,
     build_dossier,
     content_hash,
+    producer_sha,
     public_projection,
     scan_forbidden,
 )
@@ -89,6 +91,49 @@ def test_content_hash_changes_when_a_fact_changes(built):
     mutated = json.loads(json.dumps(document))
     mutated["sections"][SECTION_BUYER_MAP]["payload"]["buyer_count"] = 999
     assert content_hash(mutated) != content_hash(document)
+
+
+def test_producer_sha_prefers_explicit_valid_environment(tmp_path, monkeypatch):
+    env_sha = "A" * 40
+    (tmp_path / ".deployed_sha").write_text("b" * 40 + "\n", encoding="utf-8")
+    monkeypatch.setenv("CONFENGE_REPOSITORY_SHA", env_sha)
+
+    assert producer_sha(tmp_path) == env_sha.lower()
+
+
+def test_producer_sha_uses_deploy_marker_before_stale_git(tmp_path, monkeypatch):
+    deployed_sha = "c" * 40
+    (tmp_path / ".deployed_sha").write_text(deployed_sha + "\n", encoding="utf-8")
+    monkeypatch.delenv("CONFENGE_REPOSITORY_SHA", raising=False)
+
+    def unexpected_git(*args, **kwargs):
+        raise AssertionError("git must not override an existing deploy marker")
+
+    monkeypatch.setattr(subprocess, "run", unexpected_git)
+    assert producer_sha(tmp_path) == deployed_sha
+
+
+def test_producer_sha_rejects_invalid_authoritative_marker(tmp_path, monkeypatch):
+    (tmp_path / ".deployed_sha").write_text("stale-or-corrupt\n", encoding="utf-8")
+    monkeypatch.delenv("CONFENGE_REPOSITORY_SHA", raising=False)
+
+    def unexpected_git(*args, **kwargs):
+        raise AssertionError("invalid deploy marker must fail closed, not fall back to git")
+
+    monkeypatch.setattr(subprocess, "run", unexpected_git)
+    assert producer_sha(tmp_path) is None
+
+
+def test_producer_sha_uses_git_in_a_worktree_without_marker(tmp_path, monkeypatch):
+    git_sha = "d" * 40
+    monkeypatch.delenv("CONFENGE_REPOSITORY_SHA", raising=False)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout=git_sha + "\n", stderr=""),
+    )
+
+    assert producer_sha(tmp_path) == git_sha
 
 
 def test_fixture_run_declares_itself_a_fixture(built):


### PR DESCRIPTION
## Outcome

Binds dossier producer_sha to the code actually deployed on rsync-based production hosts.

## Root cause

The canonical deploy preserves the host historical .git directory and writes the exact deployed commit to .deployed_sha. The dossier producer previously read git rev-parse HEAD, so a live artifact emitted 14c8b247 while the deployed marker was 37b23258.

## Fail-closed resolution

- valid CONFENGE_REPOSITORY_SHA remains the explicit authority
- otherwise a validated 40-hex .deployed_sha is authoritative
- Git is consulted only when no deployment marker exists
- invalid authoritative environment or marker values return no SHA and never fall back to stale Git metadata

## Evidence

- 50 passed in tests/dossier/test_dossier_engine.py
- Ruff check and format PASS
- JSON contract validation PASS
- generated-artifacts-policy PASS
- draft reviewability PASS
- diff: 4 files, 76 insertions, 4 deletions

No deploy, database mutation, or issue mutation is included.