### PR TITLE
fix: unify contact outcome hash canonicalization

### DIFF
--- a/scripts/decision_unit_intelligence/batch_outcomes.py
+++ b/scripts/decision_unit_intelligence/batch_outcomes.py
@@ -6,15 +6,13 @@ Discovery remains a black box. This module only classifies outcomes so
 
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from scripts.decision_unit_intelligence.batch_contact_metadata import attach_projection_evidence
-from scripts.decision_unit_intelligence.batch_queue import ClaimedDiscoveryJob
+from scripts.decision_unit_intelligence.batch_queue import ClaimedDiscoveryJob, canonical_payload_hash
 from scripts.decision_unit_intelligence.models import AccountInvestigation, AccountTerminal, ChannelType
 from scripts.decision_unit_intelligence.projection import project_warmbly_outreach
 from scripts.decision_unit_intelligence.repository import account_hash, write_json
@@ -317,15 +315,11 @@ def persist_outcome(outcome: Outcome, *, job: ClaimedDiscoveryJob, output_root: 
     directory = Path(output_root) / job.cohort_id
     path = directory / f"{job.canonical_account_id}.json"
     write_json(path, payload)
-    digest = hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
-    ).hexdigest()
+    digest = canonical_payload_hash(payload)
     if outcome.account_payload:
         payload["account_hash"] = account_hash(outcome.account_payload)
         write_json(path, payload)
-        digest = hashlib.sha256(
-            json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
-        ).hexdigest()
+        digest = canonical_payload_hash(payload)
     outcome.output_pointer = str(path)
     outcome.output_hash = digest
     return outcome

--- a/scripts/decision_unit_intelligence/batch_projection.py
+++ b/scripts/decision_unit_intelligence/batch_projection.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 from collections import Counter
 from datetime import UTC, datetime
@@ -10,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.decision_unit_intelligence.batch_contact_metadata import attach_projection_evidence
-from scripts.decision_unit_intelligence.batch_queue import ContactDiscoveryQueue
+from scripts.decision_unit_intelligence.batch_queue import ContactDiscoveryQueue, canonical_payload_hash
 from scripts.decision_unit_intelligence.repository import write_json
 
 TERMINAL_JOB_STATUSES = frozenset({"SUCCEEDED", "BLOCKED", "DLQ", "CANCELLED"})
@@ -21,11 +20,6 @@ ENRICHMENT_TERMINALS = frozenset(
 
 def _utcnow() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def _content_hash(payload: Any) -> str:
-    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def _read_verified_output(job: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
@@ -44,7 +38,7 @@ def _read_verified_output(job: dict[str, Any]) -> tuple[dict[str, Any] | None, s
         return None, "OUTPUT_UNREADABLE"
     if not isinstance(payload, dict):
         return None, "OUTPUT_NOT_OBJECT"
-    if expected and _content_hash(payload) != expected:
+    if expected and canonical_payload_hash(payload) != expected:
         return None, "OUTPUT_HASH_MISMATCH"
     if int(payload.get("job_id") or -1) != int(job["id"]):
         return None, "OUTPUT_JOB_ID_MISMATCH"
@@ -153,7 +147,7 @@ def build_contact_projection(
         and terminal_account_count == denominator
         and not integrity_failures
     )
-    projection_hash = _content_hash(rows)
+    projection_hash = canonical_payload_hash(rows)
     report = {
         "schema_id": "confenge.contact_discovery.projection_report.v1",
         "generated_at": _utcnow(),

--- a/scripts/decision_unit_intelligence/batch_queue.py
+++ b/scripts/decision_unit_intelligence/batch_queue.py
@@ -57,6 +57,15 @@ def budget_version_from_knobs(knobs: dict[str, Any]) -> str:
     return "budget." + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
 
 
+def canonical_payload_hash(payload: Any) -> str:
+    """Hash one JSON value with a single cross-writer canonical encoding."""
+    # Preserve the escaped-ASCII representation used by production worker
+    # outcomes before this helper was centralized. This keeps persisted hashes
+    # valid while making every writer and verifier use the same encoding.
+    raw = json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
 def idempotency_key(
     *,
     canonical_account_id: str,

--- a/scripts/decision_unit_intelligence/batch_snapshot.py
+++ b/scripts/decision_unit_intelligence/batch_snapshot.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from scripts.decision_unit_intelligence.batch_queue import ContactDiscoveryQueue
+from scripts.decision_unit_intelligence.batch_queue import ContactDiscoveryQueue, canonical_payload_hash
 from scripts.decision_unit_intelligence.repository import write_json
 
 PUBLISHABLE = {"SUCCEEDED", "BLOCKED", "DLQ", "CANCELLED"}
@@ -36,9 +35,7 @@ def reconcile_outputs(jobs: list[dict[str, Any]]) -> list[str]:
             errors.append(f"job {job['id']} output missing on disk: {pointer}")
             continue
         payload = json.loads(path.read_text(encoding="utf-8"))
-        recomputed = hashlib.sha256(
-            json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
-        ).hexdigest()
+        recomputed = canonical_payload_hash(payload)
         if recomputed != digest:
             errors.append(f"job {job['id']} output hash mismatch")
     return errors
@@ -96,9 +93,7 @@ def publish_snapshot(
             **evaluation,
         }
         write_json(Path(pointer), payload)
-        digest = hashlib.sha256(
-            json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
-        ).hexdigest()
+        digest = canonical_payload_hash(payload)
         queue.mark_cohort_published(
             cohort_id=cohort_id,
             snapshot_id=snapshot_id,
@@ -137,9 +132,7 @@ def publish_snapshot(
     }
     pointer = str(Path(output_root) / cohort_id / f"{snapshot_id}.json")
     write_json(Path(pointer), payload)
-    digest = hashlib.sha256(
-        json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
-    ).hexdigest()
+    digest = canonical_payload_hash(payload)
     queue.mark_cohort_published(
         cohort_id=cohort_id,
         snapshot_id=snapshot_id,

--- a/tests/test_contact_discovery_batch.py
+++ b/tests/test_contact_discovery_batch.py
@@ -117,7 +117,9 @@ def _auditable_role_account(cnpj: str) -> AccountInvestigation:
     return AccountInvestigation(
         company_entity_id=cnpj,
         cnpj=cnpj,
-        legal_name="ACME ENGENHARIA LTDA",
+        # Non-ASCII text is intentional: worker and projection must hash the
+        # same semantic JSON regardless of the pretty-printed file encoding.
+        legal_name="ACME ENGENHARIA SÃO JOSÉ LTDA",
         service_context="reajuste_14133",
         why_now="TARGET_CONFIRMED",
         routes=[


### PR DESCRIPTION
## Outcome

Unifies contact-discovery outcome, projection, and snapshot hashes on one canonical JSON encoding. The encoding deliberately preserves the escaped-ASCII representation already persisted by production workers, so existing audited outcomes remain valid.

## Production evidence

The 30-account canary for `target-confirmed-20260824T172500Z` exposed `OUTPUT_HASH_MISMATCH` for every succeeded result containing Brazilian non-ASCII company data. The writer used JSON default `ensure_ascii=true`, while the projection verifier used `ensure_ascii=false`. Workers remain stopped pending this fix.

## Verification

- `tests/test_contact_discovery_batch.py`: 17 passed
- adversarial account name includes `SÃO JOSÉ`
- Ruff: PASS
- `git diff --check`: PASS
- generated-artifacts policy: PASS
- PR reviewability policy: PASS

Follow-up to #469 and merged PR #473.