### PR TITLE
fix: open active company registry read only

### DIFF
--- a/scripts/company_registry/commercial_bridge.py
+++ b/scripts/company_registry/commercial_bridge.py
@@ -153,7 +153,7 @@ def fail_closed_commercial_precheck(
     if not db_path or not Path(str(db_path)).is_file():
         errors.append("ACTIVE_DB_MISSING")
     else:
-        conn = connect_db(db_path)
+        conn = connect_db(db_path, readonly=True)
         try:
             if count_table(conn, "establishments") < 1:
                 errors.append("INCOMPLETE_LOAD_EMPTY_ESTABLISHMENTS")

--- a/scripts/company_registry/diff.py
+++ b/scripts/company_registry/diff.py
@@ -36,8 +36,8 @@ def diff_releases(
             "new_release_id": new_release_id,
         }
 
-    old = connect_db(old_db)
-    new = connect_db(new_db)
+    old = connect_db(old_db, readonly=True)
+    new = connect_db(new_db, readonly=True)
     try:
         old_ids = {r["cnpj14"] for r in old.execute("SELECT cnpj14 FROM establishments")}
         new_ids = {r["cnpj14"] for r in new.execute("SELECT cnpj14 FROM establishments")}

--- a/scripts/company_registry/health.py
+++ b/scripts/company_registry/health.py
@@ -37,7 +37,7 @@ def health_report(*, smoke_cnpj: str | None = None) -> dict[str, Any]:
 
         dbp = Path(ptr["database_path"])
         if dbp.is_file():
-            conn = connect_db(dbp)
+            conn = connect_db(dbp, readonly=True)
             try:
                 counts = {
                     "establishments": count_table(conn, "establishments"),

--- a/scripts/company_registry/lookup.py
+++ b/scripts/company_registry/lookup.py
@@ -85,7 +85,7 @@ def lookup_cnpj(
             source_provenance={"reason": "no_active_release"},
         )
 
-    conn = connect_db(db_path)
+    conn = connect_db(db_path, readonly=True)
     try:
         row = lookup_row(conn, cnpj14)
         source_label = get_meta(conn, "source_label", "rfb_public_cadastral")

--- a/scripts/company_registry/store.py
+++ b/scripts/company_registry/store.py
@@ -96,8 +96,15 @@ CREATE INDEX IF NOT EXISTS idx_est_uf ON establishments(uf);
 """
 
 
-def connect_db(path: Path | str) -> sqlite3.Connection:
+def connect_db(path: Path | str, *, readonly: bool = False) -> sqlite3.Connection:
     p = Path(path)
+    if readonly:
+        if not p.is_file():
+            raise FileNotFoundError(p)
+        conn = sqlite3.connect(f"file:{p.resolve()}?mode=ro&immutable=1", uri=True)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only=ON")
+        return conn
     p.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(p))
     conn.row_factory = sqlite3.Row

--- a/tests/company_registry/test_normalization_and_lookup.py
+++ b/tests/company_registry/test_normalization_and_lookup.py
@@ -295,6 +295,28 @@ def test_cli_lookup_and_health(reg_root, fix_dir):
     assert main(["health", "--cnpj", meta["cnpjs"][0]]) == 0
 
 
+def test_active_release_lookup_is_truly_read_only(reg_root, fix_dir):
+    release_id = "rfb-cnpj-fixture-readonly"
+    raw = reg_root / "raw" / release_id
+    raw.mkdir(parents=True)
+    shutil.copy2(fix_dir / "Estabelecimentos0.zip", raw / "Estabelecimentos0.zip")
+    shutil.copy2(fix_dir / "Empresas0.zip", raw / "Empresas0.zip")
+    manifest = new_manifest(release_id)
+    set_status(manifest, ReleaseStatus.DOWNLOADED.value)
+    save_manifest(manifest)
+    db = db_path_for_release(release_id, staging=True)
+    load_zip_into_db(raw / "Estabelecimentos0.zip", db, kind_hint="estabelecimentos")
+    load_zip_into_db(raw / "Empresas0.zip", db, kind_hint="empresas")
+    activated = activate_release(release_id)
+    assert activated["ok"]
+    active_db = db_path_for_release(release_id, staging=False)
+    active_db.chmod(0o444)
+
+    meta = json.loads((fix_dir / "meta.json").read_text(encoding="utf-8"))
+    record = lookup_cnpj(meta["cnpjs"][0])
+    assert record.official_match_status == OfficialMatchStatus.MATCHED.value
+
+
 def test_partial_release_cannot_activate(reg_root):
     release_id = "rfb-cnpj-empty"
     m = new_manifest(release_id)


### PR DESCRIPTION
## Production defect

The active company-registry release is immutable and root-owned. Consumer lookups called `connect_db()` which always selected WAL and executed schema DDL, so the non-root contact worker failed with `sqlite3.OperationalError: attempt to write a readonly database`.

## Fix

- add explicit immutable SQLite read-only connections
- use them for lookup, health, diff and commercial precheck consumers
- keep loader/activation connections writable
- regression-test lookup against a mode `0444` active release

## Verification

- `pytest -o addopts='' tests/company_registry -q`: 20 passed
- Ruff: pass
- generated-artifacts policy: pass
- PR reviewability policy: pass

Supports the live execution evidence for #469. No sending behavior or target-fit gate changes.
