### PR TITLE
fix: restore canonical CONFENGE feed publication freshness

### DIFF
--- a/deploy/systemd/confenge-feed.env.example
+++ b/deploy/systemd/confenge-feed.env.example
@@ -1,0 +1,5 @@
+# Canonical CONFENGE feed cycle paths. No secrets belong in this file.
+CONFENGE_FEED_BUILD_ROOT=/var/lib/extra-consultoria/output
+CONFENGE_DURABLE_CONTACTS=/var/lib/extra-consultoria/output/contact-discovery/current/contacts.jsonl
+CONFENGE_FEED_PUBLISH_DIR=/opt/confenge-plane/feed-www
+CONFENGE_FEED_MAX_AGE_HOURS=24

--- a/deploy/systemd/extra-confenge-feed-cycle.service
+++ b/deploy/systemd/extra-confenge-feed-cycle.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=Extra Consultoria — build and atomically publish CONFENGE outreach feed
+After=network-online.target postgresql.service extra-confenge-target-fit-refresh.service
+Wants=network-online.target
+Requires=postgresql.service
+OnFailure=extra-onfailure@%n.service
+
+[Service]
+Type=oneshot
+User=extra-consultoria
+Group=extra-consultoria
+WorkingDirectory=/opt/extra-consultoria
+Environment=PYTHONPATH=/opt/extra-consultoria
+Environment=CONFENGE_FEED_MAX_AGE_HOURS=24
+EnvironmentFile=-/opt/extra-consultoria/.env
+EnvironmentFile=-/etc/extra-consultoria/confenge-feed.env
+ExecStart=/usr/bin/flock --nonblock /run/extra-confenge-feed/feed-cycle.lock /opt/extra-consultoria/.venv/bin/python -m scripts.ops.confenge_feed_cycle --output-root ${CONFENGE_FEED_BUILD_ROOT} --durable-contacts ${CONFENGE_DURABLE_CONTACTS} --publish-dir ${CONFENGE_FEED_PUBLISH_DIR} --max-age-hours ${CONFENGE_FEED_MAX_AGE_HOURS}
+TimeoutStartSec=6h
+Nice=15
+IOSchedulingClass=best-effort
+IOSchedulingPriority=6
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+LogsDirectory=extra-consultoria
+RuntimeDirectory=extra-confenge-feed
+RuntimeDirectoryMode=0750
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ReadWritePaths=/var/lib/extra-consultoria /var/log/extra-consultoria /opt/confenge-plane/feed-www
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=extra-confenge-feed-cycle
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/extra-confenge-feed-cycle.timer
+++ b/deploy/systemd/extra-confenge-feed-cycle.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer — regenerate CONFENGE outreach feed within 24h SLO
+
+[Timer]
+OnCalendar=*-*-* 00,12:20:00
+Persistent=true
+RandomizedDelaySec=10m
+Unit=extra-confenge-feed-cycle.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/extra-confenge-feed-monitor.service
+++ b/deploy/systemd/extra-confenge-feed-monitor.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Extra Consultoria — fail-closed CONFENGE public feed freshness monitor
+After=network-online.target
+OnFailure=extra-onfailure@%n.service
+
+[Service]
+Type=oneshot
+User=extra-consultoria
+Group=extra-consultoria
+WorkingDirectory=/opt/extra-consultoria
+Environment=PYTHONPATH=/opt/extra-consultoria
+Environment=CONFENGE_FEED_MAX_AGE_HOURS=24
+EnvironmentFile=-/opt/extra-consultoria/.env
+EnvironmentFile=-/etc/extra-consultoria/confenge-feed.env
+ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.confenge_activation check-publication --publish-dir ${CONFENGE_FEED_PUBLISH_DIR} --max-age-hours ${CONFENGE_FEED_MAX_AGE_HOURS}
+TimeoutStartSec=30m
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+LogsDirectory=extra-consultoria
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ReadWritePaths=/var/lib/extra-consultoria /var/log/extra-consultoria
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=extra-confenge-feed-monitor
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/extra-confenge-feed-monitor.timer
+++ b/deploy/systemd/extra-confenge-feed-monitor.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer — monitor CONFENGE public feed freshness hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+RandomizedDelaySec=5m
+Unit=extra-confenge-feed-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/extra-contact-discovery-worker@.service
+++ b/deploy/systemd/extra-contact-discovery-worker@.service
@@ -16,6 +16,7 @@ Environment=PYTHONPATH=/opt/extra-consultoria
 Environment=RESILIENCE_ENV=production
 EnvironmentFile=-/opt/extra-consultoria/.env
 EnvironmentFile=-/etc/extra-consultoria/crawler.env
+EnvironmentFile=-/etc/extra-consultoria/contact-discovery.env
 EnvironmentFile=-/etc/extra-cli/extra-collector.env
 ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.decision_unit_intelligence batch worker --loop --idle-sleep 5 --worker-id cd-worker-%i --out /var/lib/extra-consultoria/contact-discovery
 Restart=on-failure
@@ -29,6 +30,7 @@ UMask=0077
 NoNewPrivileges=true
 PrivateTmp=true
 PrivateDevices=true
+LogsDirectory=extra-consultoria
 ProtectSystem=strict
 ProtectHome=true
 ProtectKernelTunables=true

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@ Precedência: `DOD.md` → ADR vigente → código testado → evidência reprod
 | `docs/ops/dod-convergence.md` | Harness DOD |
 | `docs/ops/netcup-*.md`, handoffs Netcup | Host de record |
 | [`docs/ops/searxng-private-backend.md`](ops/searxng-private-backend.md) | SearXNG privado CONFENGE (HTTP boundary, runbook) |
+| [`docs/ops/confenge-activation-planner.md`](ops/confenge-activation-planner.md) | Ciclo canônico, publicação atômica e freshness do feed Warmbly |
 | `artifacts/campaigns/HISTORICAL-CONTRACTS-OPERATIONAL-CLOSURE-01/` | Campanha HC (STATUS/HANDOFF) |
 | `specs/001-*`, `specs/002-*` | Spec Kit dual / historical contracts |
 | `deploy/systemd/` | Units de produção |

--- a/docs/ops/confenge-activation-planner.md
+++ b/docs/ops/confenge-activation-planner.md
@@ -70,7 +70,25 @@ python -m scripts.confenge_outreach_pipeline run \
   --skip-contacts
 ```
 
-### Atomic publish
+### Recurring production cycle
+
+Production uses the canonical pipeline plus its existing atomic publisher. It does not copy a second flat feed or treat a repeated hash as success:
+
+```bash
+python -m scripts.ops.confenge_feed_cycle \
+  --output-root /var/lib/extra-consultoria/output \
+  --durable-contacts /var/lib/extra-consultoria/output/contact-discovery/current/contacts.jsonl \
+  --publish-dir /opt/confenge-plane/feed-www \
+  --max-age-hours 24
+```
+
+Install and enable `extra-confenge-feed-cycle.timer` (12-hour cadence) and `extra-confenge-feed-monitor.timer` (hourly validation). Configure the non-secret paths from `deploy/systemd/confenge-feed.env.example`. The service account needs write access to `/var/lib/extra-consultoria` and the publication root. Warmbly reads `/current/manifest.json`; the `current` symlink changes only after the full manifest, every chunk hash, full target-fit coverage, PNCP freshness and both feed timestamps pass validation.
+
+The durable state is `/var/lib/extra-consultoria/confenge-feed/publication-state.json`. It preserves the last successful publication while recording the latest generation and monitor result, duration, snapshot, watermark, lead/contact totals, deltas, route classes and provenance sources. Alerts append to `/var/lib/extra-consultoria/alerts/confenge-feed.jsonl` and trigger the normal systemd `OnFailure` path.
+
+`SAME_SNAPSHOT_NOT_FRESHNESS` exits non-zero and alerts. A green timer that produced no new snapshot is not freshness. A stale, partial or corrupt build is refused and the last valid `current` release remains served.
+
+### Manual atomic publish
 
 After a successful cycle:
 
@@ -81,6 +99,14 @@ python -m scripts.confenge_activation publish \
 ```
 
 Warmbly should read `.../current/manifest.json` only after atomic promote.
+
+Validate the public release independently:
+
+```bash
+python -m scripts.confenge_activation check-publication \
+  --publish-dir /opt/confenge-plane/feed-www \
+  --max-age-hours 24
+```
 
 ## Manifest summary fields
 

--- a/scripts/confenge_activation/cli.py
+++ b/scripts/confenge_activation/cli.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from scripts.confenge_activation import MODULE_VERSION, PLANNER_ID
 from scripts.confenge_activation.planner import run_activation_cycle
 from scripts.confenge_activation.policy import load_policy
-from scripts.confenge_activation.publish import atomic_publish_directory
+from scripts.confenge_activation.publish import (
+    DEFAULT_ALERT_LEDGER,
+    DEFAULT_MAX_AGE_HOURS,
+    DEFAULT_STATE_PATH,
+    atomic_publish_directory,
+    check_current_publication,
+)
 from scripts.confenge_activation.store import (
     load_projections_jsonl,
     write_hot_set_jsonl,
@@ -47,6 +53,15 @@ def build_parser() -> argparse.ArgumentParser:
     pub = sub.add_parser("publish", help="Atomically publish a built feed directory")
     pub.add_argument("--build-dir", required=True, help="Completed feed build dir")
     pub.add_argument("--publish-dir", required=True, help="Publication root (current symlink)")
+    pub.add_argument("--max-age-hours", type=float, default=DEFAULT_MAX_AGE_HOURS)
+    pub.add_argument("--state", type=Path, default=DEFAULT_STATE_PATH)
+    pub.add_argument("--alert-ledger", type=Path, default=DEFAULT_ALERT_LEDGER)
+
+    check = sub.add_parser("check-publication", help="Validate freshness and integrity of the public current feed")
+    check.add_argument("--publish-dir", required=True, help="Publication root containing current symlink")
+    check.add_argument("--max-age-hours", type=float, default=DEFAULT_MAX_AGE_HOURS)
+    check.add_argument("--state", type=Path, default=DEFAULT_STATE_PATH)
+    check.add_argument("--alert-ledger", type=Path, default=DEFAULT_ALERT_LEDGER)
 
     return p
 
@@ -57,12 +72,28 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "publish":
         try:
-            result = atomic_publish_directory(Path(args.build_dir), Path(args.publish_dir))
+            result = atomic_publish_directory(
+                Path(args.build_dir),
+                Path(args.publish_dir),
+                max_age_hours=args.max_age_hours,
+                state_path=args.state,
+                alert_ledger=args.alert_ledger,
+            )
         except Exception as exc:  # noqa: BLE001
             print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
             return 1
         print(json.dumps(result, indent=2, ensure_ascii=False))
-        return 0
+        return 3 if result.get("skipped_same") else 0
+
+    if args.command == "check-publication":
+        result = check_current_publication(
+            Path(args.publish_dir),
+            max_age_hours=args.max_age_hours,
+            state_path=args.state,
+            alert_ledger=args.alert_ledger,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("ok") else 1
 
     if args.command == "plan":
         universe = Path(args.universe)

--- a/scripts/confenge_activation/publish.py
+++ b/scripts/confenge_activation/publish.py
@@ -10,8 +10,16 @@ import json
 import os
 import shutil
 import tempfile
+import time
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+MANIFEST_SCHEMA = "confenge.outreach.manifest.v1"
+FEED_SCHEMA = "confenge.outreach.v1"
+DEFAULT_MAX_AGE_HOURS = 24.0
+DEFAULT_STATE_PATH = Path("/var/lib/extra-consultoria/confenge-feed/publication-state.json")
+DEFAULT_ALERT_LEDGER = Path("/var/lib/extra-consultoria/alerts/confenge-feed.jsonl")
 
 
 def _sha256_file(path: Path) -> str:
@@ -30,11 +38,237 @@ def _fsync_dir(path: Path) -> None:
         os.close(fd)
 
 
+def _parse_timestamp(value: Any, *, field: str) -> datetime:
+    text = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} is missing or invalid: {text!r}") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    tmp = Path(raw_tmp)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True, default=str)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        _fsync_dir(path.parent)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON object required: {path}")
+    return payload
+
+
+def _read_state(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        return _read_json(path)
+    except (OSError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _append_alert(path: Path, *, reason: str, detail: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "event": "confenge_feed_publication_alert",
+        "reason": reason,
+        "project": "extra-cli",
+        **detail,
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True, default=str) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def record_feed_cycle_state(
+    state_path: Path,
+    *,
+    alert_ledger: Path,
+    status: str,
+    detail: dict[str, Any],
+    at: datetime | None = None,
+    alert_reason: str | None = None,
+) -> None:
+    """Persist end-to-end cycle state without erasing publication history."""
+    clock = (at or datetime.now(UTC)).astimezone(UTC)
+    cycle = {
+        "at": clock.isoformat().replace("+00:00", "Z"),
+        "status": status,
+        **detail,
+    }
+    state = _read_state(state_path)
+    _atomic_json(
+        state_path,
+        {
+            **state,
+            "schema_id": "confenge.feed_publication_state.v1",
+            "last_cycle_at": cycle["at"],
+            "last_cycle_status": status,
+            "cycle": cycle,
+        },
+    )
+    if alert_reason:
+        _append_alert(alert_ledger, reason=alert_reason, detail=cycle)
+
+
+def _provenance_source(contact: dict[str, Any]) -> str:
+    direct = str(contact.get("source") or contact.get("source_type") or "").strip()
+    if direct:
+        return direct
+    provenance = contact.get("provenance")
+    if isinstance(provenance, dict):
+        return str(
+            provenance.get("source")
+            or provenance.get("source_type")
+            or provenance.get("provider")
+            or "UNKNOWN"
+        )
+    return "UNKNOWN"
+
+
+def _validate_authoritative_manifest(
+    build_dir: Path,
+    manifest: dict[str, Any],
+    *,
+    max_age_hours: float,
+    now: datetime,
+) -> dict[str, Any]:
+    if manifest.get("schema_version") != MANIFEST_SCHEMA:
+        raise ValueError("unsupported or missing manifest schema_version")
+    source = manifest.get("source") if isinstance(manifest.get("source"), dict) else {}
+    run_id = str(source.get("run_id") or "").strip()
+    snapshot_hash = str(source.get("snapshot_hash") or "").strip()
+    if not run_id or not snapshot_hash:
+        raise ValueError("manifest source.run_id and source.snapshot_hash are required")
+
+    authority = manifest.get("authoritative_target_fit")
+    authority = authority if isinstance(authority, dict) else {}
+    if authority.get("coverage_complete") is not True:
+        raise ValueError("authoritative target-fit coverage_complete=true is required")
+    if authority.get("omission_preserves_authorization") is not False:
+        raise ValueError("authoritative target-fit omission must revoke prior authorization")
+    ordering = authority.get("ordering") if isinstance(authority.get("ordering"), dict) else {}
+    if ordering.get("watermarks_monotonic") is not True:
+        raise ValueError("authoritative target-fit watermarks must be monotonic")
+
+    generated_at = _parse_timestamp(manifest.get("generated_at"), field="manifest.generated_at")
+    watermark = _parse_timestamp(source.get("datalake_watermark"), field="source.datalake_watermark")
+    if generated_at > now + timedelta(minutes=5):
+        raise ValueError("manifest.generated_at is in the future")
+    generated_age = max(0.0, (now - generated_at).total_seconds() / 3600)
+    watermark_age = max(0.0, (now - watermark).total_seconds() / 3600)
+    if generated_age > max_age_hours:
+        raise ValueError(f"manifest stale: generated_at age {generated_age:.3f}h > {max_age_hours:.3f}h")
+    if watermark_age > max_age_hours:
+        raise ValueError(f"datalake watermark stale: age {watermark_age:.3f}h > {max_age_hours:.3f}h")
+
+    freshness = manifest.get("authoritative_source_freshness")
+    freshness = freshness if isinstance(freshness, dict) else {}
+    if freshness.get("contract_version") != "PNCP_CONTRACT_FRESHNESS/1.0":
+        raise ValueError("authoritative PNCP freshness contract is required")
+    if freshness.get("status") != "FRESH":
+        raise ValueError(f"authoritative PNCP freshness is not FRESH: {freshness.get('status') or 'MISSING'}")
+    if _parse_timestamp(freshness.get("expires_at"), field="authoritative_source_freshness.expires_at") <= now:
+        raise ValueError("authoritative PNCP freshness expired before publication")
+
+    chunks = manifest.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        raise ValueError("manifest must list at least one chunk")
+    if int(manifest.get("chunk_count") or -1) != len(chunks):
+        raise ValueError("manifest chunk_count does not match chunks")
+    total_leads = 0
+    accounts_with_contacts = 0
+    accounts_with_preferred_route = 0
+    contacts_total = 0
+    route_classes: dict[str, int] = {}
+    provenance_sources: dict[str, int] = {}
+    for expected_index, chunk in enumerate(chunks):
+        if not isinstance(chunk, dict):
+            raise ValueError(f"manifest chunk {expected_index} is not an object")
+        if int(chunk.get("chunk_index") or 0) != expected_index:
+            raise ValueError("manifest chunk indexes must be contiguous")
+        filename = str(chunk.get("file") or "").strip()
+        if not filename or Path(filename).name != filename:
+            raise ValueError(f"unsafe chunk file name: {filename!r}")
+        chunk_path = build_dir / filename
+        if not chunk_path.is_file():
+            raise FileNotFoundError(f"manifest references missing chunk {filename}")
+        actual_hash = _sha256_file(chunk_path)
+        expected_hash = str(chunk.get("content_hash") or "").strip()
+        if not expected_hash or actual_hash != expected_hash:
+            raise ValueError(f"chunk hash mismatch for {filename}: {actual_hash} != {expected_hash or 'MISSING'}")
+        payload = _read_json(chunk_path)
+        payload_source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
+        if payload.get("schema_version") != FEED_SCHEMA:
+            raise ValueError(f"unsupported chunk schema for {filename}")
+        if payload.get("generated_at") != manifest.get("generated_at"):
+            raise ValueError(f"chunk generated_at mismatch for {filename}")
+        if payload_source.get("run_id") != run_id or payload_source.get("snapshot_hash") != snapshot_hash:
+            raise ValueError(f"chunk source mismatch for {filename}")
+        leads = payload.get("leads")
+        if not isinstance(leads, list) or len(leads) != int(chunk.get("lead_count") or 0):
+            raise ValueError(f"chunk lead_count mismatch for {filename}")
+        total_leads += len(leads)
+        for lead in leads:
+            if not isinstance(lead, dict):
+                continue
+            contacts = [item for item in (lead.get("contacts") or []) if isinstance(item, dict)]
+            contacts_total += len(contacts)
+            if contacts:
+                accounts_with_contacts += 1
+            if any(item.get("preferred_initial") is True for item in contacts) or lead.get("preferred_email_route"):
+                accounts_with_preferred_route += 1
+            for contact in contacts:
+                route = str(contact.get("route_class") or "UNKNOWN")
+                source_name = _provenance_source(contact)
+                route_classes[route] = route_classes.get(route, 0) + 1
+                provenance_sources[source_name] = provenance_sources.get(source_name, 0) + 1
+    if total_leads != int(manifest.get("lead_count", -1)):
+        raise ValueError("manifest lead_count does not match chunk payloads")
+    if int(authority.get("full_decision_count", -1)) != total_leads:
+        raise ValueError("authoritative target-fit decision count does not match feed")
+    return {
+        "run_id": run_id,
+        "snapshot_hash": snapshot_hash,
+        "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
+        "datalake_watermark": watermark.isoformat().replace("+00:00", "Z"),
+        "generated_age_hours": round(generated_age, 6),
+        "watermark_age_hours": round(watermark_age, 6),
+        "lead_count": total_leads,
+        "chunk_count": len(chunks),
+        "accounts_with_contacts": accounts_with_contacts,
+        "accounts_with_preferred_route": accounts_with_preferred_route,
+        "contacts_total": contacts_total,
+        "route_class_distribution": dict(sorted(route_classes.items())),
+        "provenance_source_distribution": dict(sorted(provenance_sources.items())),
+    }
+
+
 def atomic_publish_directory(
     build_dir: Path,
     publish_dir: Path,
     *,
     current_name: str = "current",
+    max_age_hours: float = DEFAULT_MAX_AGE_HOURS,
+    state_path: Path = DEFAULT_STATE_PATH,
+    alert_ledger: Path = DEFAULT_ALERT_LEDGER,
+    now: datetime | None = None,
 ) -> dict[str, Any]:
     """Atomically promote build_dir contents to publish_dir/current via rename.
 
@@ -45,6 +279,8 @@ def atomic_publish_directory(
     If build_dir already contains a complete feed (manifest + chunks), we copy
     into a new release directory then swap the symlink.
     """
+    started = time.monotonic()
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
     build_dir = Path(build_dir)
     publish_dir = Path(publish_dir)
     publish_dir.mkdir(parents=True, exist_ok=True)
@@ -55,29 +291,65 @@ def atomic_publish_directory(
     if not manifest_path.is_file():
         raise FileNotFoundError(f"no manifest.json in {build_dir}")
 
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    source = manifest.get("source") if isinstance(manifest.get("source"), dict) else {}
-    run_id = str(source.get("run_id") or "run-unknown")
-    # Validate chunks listed in manifest exist and match hashes when present
-    chunks = manifest.get("chunks") or []
-    for ch in chunks:
-        if not isinstance(ch, dict):
-            continue
-        fname = ch.get("file")
-        if not fname:
-            continue
-        fp = build_dir / str(fname)
-        if not fp.is_file():
-            raise FileNotFoundError(f"manifest references missing chunk {fname}")
-        expected = ch.get("content_hash")
-        if expected:
-            actual = _sha256_file(fp)
-            if actual != expected:
-                raise ValueError(f"chunk hash mismatch for {fname}: {actual} != {expected}")
+    manifest = _read_json(manifest_path)
+    try:
+        metrics = _validate_authoritative_manifest(
+            build_dir,
+            manifest,
+            max_age_hours=max_age_hours,
+            now=clock,
+        )
+    except Exception as exc:
+        detail = {"build_dir": str(build_dir), "error": str(exc)}
+        _append_alert(alert_ledger, reason="PUBLICATION_REFUSED", detail=detail)
+        state = _read_state(state_path)
+        _atomic_json(
+            state_path,
+            {
+                **state,
+                "schema_id": "confenge.feed_publication_state.v1",
+                "last_attempt_at": clock.isoformat().replace("+00:00", "Z"),
+                "last_status": "REFUSED",
+                **detail,
+            },
+        )
+        raise
+    run_id = str(metrics["run_id"])
 
-    release_dir = releases / run_id
+    current = publish_dir / current_name
+    if current.is_dir():
+        try:
+            prior = _read_json(current / "manifest.json")
+        except (OSError, ValueError, json.JSONDecodeError):
+            prior = {}
+        prior_source = prior.get("source") if isinstance(prior.get("source"), dict) else {}
+        if str(prior_source.get("snapshot_hash") or "") == metrics["snapshot_hash"]:
+            result = {
+                "ok": False,
+                "skipped_same": True,
+                "reason": "SAME_SNAPSHOT_NOT_FRESHNESS",
+                "publish_dir": str(publish_dir.resolve()),
+                "current": str(current.resolve()),
+                **metrics,
+                "duration_seconds": round(time.monotonic() - started, 6),
+            }
+            _append_alert(alert_ledger, reason="SAME_SNAPSHOT_NOT_FRESHNESS", detail=result)
+            state = _read_state(state_path)
+            _atomic_json(
+                state_path,
+                {
+                    **state,
+                    "schema_id": "confenge.feed_publication_state.v1",
+                    "last_attempt_at": clock.isoformat().replace("+00:00", "Z"),
+                    "last_status": "SKIPPED_SAME_SNAPSHOT",
+                    **result,
+                },
+            )
+            return result
+
+    release_dir = releases / f"{run_id}-{str(metrics['snapshot_hash'])[:12]}"
     if release_dir.exists():
-        shutil.rmtree(release_dir)
+        raise FileExistsError(f"immutable feed release already exists: {release_dir}")
     # Copy into temp under releases then rename
     tmp = Path(tempfile.mkdtemp(prefix=".pub-", dir=str(releases)))
     try:
@@ -98,22 +370,98 @@ def atomic_publish_directory(
         raise
 
     # Atomic symlink swap: current -> releases/<run_id>
-    current = publish_dir / current_name
     link_tmp = publish_dir / f".{current_name}.tmp-{run_id}"
     if link_tmp.exists() or link_tmp.is_symlink():
         link_tmp.unlink()
     # Relative symlink for portability
-    rel_target = Path("releases") / run_id
+    rel_target = Path("releases") / release_dir.name
     link_tmp.symlink_to(rel_target, target_is_directory=True)
     os.replace(str(link_tmp), str(current))
     _fsync_dir(publish_dir)
 
-    return {
+    state = _read_state(state_path)
+    previous_contacts = state.get("contacts_total")
+    previous_accounts = state.get("accounts_with_contacts")
+    result = {
         "ok": True,
+        "skipped_same": False,
         "publish_dir": str(publish_dir.resolve()),
         "current": str(current.resolve()),
         "release_dir": str(release_dir.resolve()),
-        "run_id": run_id,
-        "snapshot_hash": source.get("snapshot_hash"),
-        "chunk_count": len(chunks),
+        **metrics,
+        "snapshot_changed": str(state.get("snapshot_hash") or "") != str(metrics["snapshot_hash"]),
+        "contact_count_delta": (
+            int(metrics["contacts_total"]) - int(previous_contacts)
+            if previous_contacts is not None
+            else None
+        ),
+        "accounts_with_contacts_delta": (
+            int(metrics["accounts_with_contacts"]) - int(previous_accounts)
+            if previous_accounts is not None
+            else None
+        ),
+        "duration_seconds": round(time.monotonic() - started, 6),
     }
+    _atomic_json(
+        state_path,
+        {
+            **state,
+            "schema_id": "confenge.feed_publication_state.v1",
+            "last_attempt_at": clock.isoformat().replace("+00:00", "Z"),
+            "last_success_at": clock.isoformat().replace("+00:00", "Z"),
+            "last_status": "PUBLISHED",
+            **result,
+        },
+    )
+    return result
+
+
+def check_current_publication(
+    publish_dir: Path,
+    *,
+    current_name: str = "current",
+    max_age_hours: float = DEFAULT_MAX_AGE_HOURS,
+    state_path: Path = DEFAULT_STATE_PATH,
+    alert_ledger: Path = DEFAULT_ALERT_LEDGER,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Fail closed when the publicly served current release is stale or corrupt."""
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
+    current = Path(publish_dir) / current_name
+    try:
+        manifest = _read_json(current / "manifest.json")
+        metrics = _validate_authoritative_manifest(
+            current,
+            manifest,
+            max_age_hours=max_age_hours,
+            now=clock,
+        )
+    except Exception as exc:
+        result = {"ok": False, "status": "UNHEALTHY", "current": str(current), "error": str(exc)}
+        _append_alert(alert_ledger, reason="PUBLIC_FEED_UNHEALTHY", detail=result)
+        state = _read_state(state_path)
+        _atomic_json(
+            state_path,
+            {
+                **state,
+                "schema_id": "confenge.feed_publication_state.v1",
+                "last_monitor_at": clock.isoformat().replace("+00:00", "Z"),
+                "last_monitor_status": "UNHEALTHY",
+                "monitor": result,
+                **result,
+            },
+        )
+        return result
+    result = {"ok": True, "status": "HEALTHY", "current": str(current.resolve()), **metrics}
+    state = _read_state(state_path)
+    _atomic_json(
+        state_path,
+        {
+            **state,
+            "schema_id": "confenge.feed_publication_state.v1",
+            "last_monitor_at": clock.isoformat().replace("+00:00", "Z"),
+            "last_monitor_status": "HEALTHY",
+            "monitor": result,
+        },
+    )
+    return result

--- a/scripts/ops/confenge_feed_cycle.py
+++ b/scripts/ops/confenge_feed_cycle.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Run the canonical CONFENGE feed pipeline and atomically publish its result.
+
+This is orchestration only: generation stays in confenge_outreach_pipeline and
+publication stays in confenge_activation.publish. It never sends mail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+from scripts.confenge_activation.publish import (
+    DEFAULT_ALERT_LEDGER,
+    DEFAULT_MAX_AGE_HOURS,
+    DEFAULT_STATE_PATH,
+    atomic_publish_directory,
+    record_feed_cycle_state,
+)
+
+
+def _run_id() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def run_cycle(
+    *,
+    output_root: Path,
+    durable_contacts: Path,
+    publish_dir: Path,
+    as_of: date,
+    max_age_hours: float,
+    state_path: Path,
+    alert_ledger: Path,
+) -> dict:
+    if not durable_contacts.is_file():
+        raise FileNotFoundError(f"durable contact projection not found: {durable_contacts}")
+    if not (os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL")):
+        raise RuntimeError("LOCAL_DATALAKE_DSN or DATABASE_URL is required")
+
+    run_dir = output_root / f"confenge-feed-cycle-{_run_id()}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+    command = [
+        sys.executable,
+        "-m",
+        "scripts.confenge_outreach_pipeline",
+        "run",
+        "--out",
+        str(run_dir),
+        "--as-of",
+        as_of.isoformat(),
+        "--use-activation-planner",
+        "--durable-contacts",
+        str(durable_contacts),
+        "--skip-contacts",
+        "--no-resume",
+        "--quiet",
+    ]
+    completed = subprocess.run(command, check=False, text=True, capture_output=True)  # noqa: S603
+    (run_dir / "cycle-command.json").write_text(
+        json.dumps(
+            {
+                "command": command[1:],
+                "exit_code": completed.returncode,
+                "stdout": completed.stdout[-20_000:],
+                "stderr": completed.stderr[-20_000:],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"canonical outreach pipeline failed with exit {completed.returncode}: "
+            f"{completed.stderr[-2000:].strip()}"
+        )
+
+    publication = atomic_publish_directory(
+        run_dir / "06_warmbly_feed",
+        publish_dir,
+        max_age_hours=max_age_hours,
+        state_path=state_path,
+        alert_ledger=alert_ledger,
+    )
+    result = {
+        "ok": bool(publication.get("ok")),
+        "run_dir": str(run_dir),
+        "durable_contacts": str(durable_contacts),
+        "publication": publication,
+    }
+    (run_dir / "cycle-result.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--durable-contacts", type=Path, required=True)
+    parser.add_argument("--publish-dir", type=Path, required=True)
+    parser.add_argument("--as-of", type=date.fromisoformat, default=date.today())
+    parser.add_argument("--max-age-hours", type=float, default=DEFAULT_MAX_AGE_HOURS)
+    parser.add_argument("--state", type=Path, default=DEFAULT_STATE_PATH)
+    parser.add_argument("--alert-ledger", type=Path, default=DEFAULT_ALERT_LEDGER)
+    args = parser.parse_args(argv)
+    started = time.monotonic()
+    attempted_at = datetime.now(UTC)
+    try:
+        result = run_cycle(
+            output_root=args.output_root,
+            durable_contacts=args.durable_contacts,
+            publish_dir=args.publish_dir,
+            as_of=args.as_of,
+            max_age_hours=args.max_age_hours,
+            state_path=args.state,
+            alert_ledger=args.alert_ledger,
+        )
+    except Exception as exc:  # noqa: BLE001
+        record_feed_cycle_state(
+            args.state,
+            alert_ledger=args.alert_ledger,
+            status="FAILED",
+            at=attempted_at,
+            alert_reason="FEED_CYCLE_FAILED",
+            detail={
+                "error": str(exc),
+                "duration_seconds": round(time.monotonic() - started, 6),
+                "output_root": str(args.output_root),
+                "durable_contacts": str(args.durable_contacts),
+                "publish_dir": str(args.publish_dir),
+            },
+        )
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 1
+    record_feed_cycle_state(
+        args.state,
+        alert_ledger=args.alert_ledger,
+        status="PUBLISHED" if result.get("ok") else str(result.get("publication", {}).get("reason") or "FAILED"),
+        at=attempted_at,
+        detail={
+            **result,
+            "duration_seconds": round(time.monotonic() - started, 6),
+        },
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result.get("ok") else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_confenge_activation_planner.py
+++ b/tests/test_confenge_activation_planner.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -309,6 +309,7 @@ def test_atomic_publish(tmp_path: Path):
             "snapshot_hash": "deadbeef",
             "profile_id": "p",
             "profile_version": "1",
+            "datalake_watermark": "2026-08-08T09:00:00Z",
         },
         "pagination": {"has_more": False, "chunk_index": 0},
         "leads": [],
@@ -320,13 +321,40 @@ def test_atomic_publish(tmp_path: Path):
     chash = hashlib.sha256(raw).hexdigest()
     manifest = {
         "schema_version": "confenge.outreach.manifest.v1",
+        "generated_at": payload["generated_at"],
         "source": payload["source"],
-        "chunks": [{"file": "chunk_0000.json", "content_hash": chash, "chunk_index": 0}],
+        "lead_count": 0,
+        "chunk_count": 1,
+        "chunks": [
+            {
+                "file": "chunk_0000.json",
+                "content_hash": chash,
+                "chunk_index": 0,
+                "lead_count": 0,
+            }
+        ],
         "deactivations": [],
+        "authoritative_target_fit": {
+            "coverage_complete": True,
+            "omission_preserves_authorization": False,
+            "full_decision_count": 0,
+            "ordering": {"watermarks_monotonic": True},
+        },
+        "authoritative_source_freshness": {
+            "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+            "status": "FRESH",
+            "expires_at": "2026-08-08T11:00:00Z",
+        },
     }
     (build / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     pub = tmp_path / "publish"
-    result = atomic_publish_directory(build, pub)
+    result = atomic_publish_directory(
+        build,
+        pub,
+        state_path=tmp_path / "state.json",
+        alert_ledger=tmp_path / "alerts.jsonl",
+        now=datetime(2026, 8, 8, 10, tzinfo=UTC),
+    )
     assert result["ok"]
     assert (pub / "current" / "manifest.json").is_file()
     assert (pub / "current" / "chunk_0000.json").is_file()

--- a/tests/test_confenge_feed_publication.py
+++ b/tests/test_confenge_feed_publication.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.confenge_activation.publish import (
+    atomic_publish_directory,
+    check_current_publication,
+    record_feed_cycle_state,
+)
+
+NOW = datetime(2026, 8, 24, 18, tzinfo=UTC)
+
+
+def _build(root: Path, *, snapshot: str = "snapshot-a", generated_at: datetime = NOW) -> Path:
+    root.mkdir()
+    generated = generated_at.isoformat().replace("+00:00", "Z")
+    source = {
+        "system": "extra-cli",
+        "run_id": f"run-{snapshot}",
+        "snapshot_hash": snapshot,
+        "repo_sha": "abc123",
+        "datalake_watermark": generated,
+    }
+    lead = {
+        "company": {"cnpj14": "12345678000195"},
+        "contacts": [
+            {
+                "email": "licitacao@example.com",
+                "route_class": "ROLE_OR_DEPARTMENT",
+                "source": "public_company_registry",
+                "preferred_initial": True,
+            }
+        ],
+    }
+    chunk = {
+        "schema_version": "confenge.outreach.v1",
+        "generated_at": generated,
+        "source": source,
+        "pagination": {"chunk_index": 0, "has_more": False},
+        "leads": [lead],
+    }
+    raw = (json.dumps(chunk, ensure_ascii=False, sort_keys=True) + "\n").encode()
+    (root / "chunk_0000.json").write_bytes(raw)
+    manifest = {
+        "schema_version": "confenge.outreach.manifest.v1",
+        "generated_at": generated,
+        "source": source,
+        "lead_count": 1,
+        "chunk_count": 1,
+        "chunks": [
+            {
+                "file": "chunk_0000.json",
+                "chunk_index": 0,
+                "content_hash": hashlib.sha256(raw).hexdigest(),
+                "lead_count": 1,
+                "has_more": False,
+            }
+        ],
+        "authoritative_target_fit": {
+            "coverage_complete": True,
+            "omission_preserves_authorization": False,
+            "full_decision_count": 1,
+            "ordering": {"watermarks_monotonic": True},
+        },
+        "authoritative_source_freshness": {
+            "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+            "status": "FRESH",
+            "expires_at": (generated_at + timedelta(hours=6)).isoformat().replace("+00:00", "Z"),
+        },
+        "deactivations": [],
+        "deactivation_count": 0,
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return root
+
+
+def _paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    return tmp_path / "public", tmp_path / "state.json", tmp_path / "alerts.jsonl"
+
+
+def test_publish_records_live_contact_metrics_and_immutable_release(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    result = atomic_publish_directory(
+        _build(tmp_path / "build"),
+        public,
+        state_path=state,
+        alert_ledger=alerts,
+        now=NOW,
+    )
+    assert result["ok"] is True
+    assert result["lead_count"] == 1
+    assert result["accounts_with_contacts"] == 1
+    assert result["accounts_with_preferred_route"] == 1
+    assert result["route_class_distribution"] == {"ROLE_OR_DEPARTMENT": 1}
+    assert result["snapshot_changed"] is True
+    assert result["contact_count_delta"] is None
+    assert (public / "current").is_symlink()
+    assert (public / "current" / "manifest.json").is_file()
+    assert json.loads(state.read_text())["last_status"] == "PUBLISHED"
+    assert not alerts.exists()
+
+
+def test_partial_manifest_is_refused_without_replacing_current(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(
+        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    prior = Path(first["current"]).resolve()
+    bad = _build(tmp_path / "bad", snapshot="snapshot-b")
+    manifest = json.loads((bad / "manifest.json").read_text())
+    manifest["authoritative_target_fit"]["coverage_complete"] = False
+    (bad / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    with pytest.raises(ValueError, match="coverage_complete"):
+        atomic_publish_directory(bad, public, state_path=state, alert_ledger=alerts, now=NOW)
+    assert (public / "current").resolve() == prior
+    assert "PUBLICATION_REFUSED" in alerts.read_text()
+
+
+def test_same_snapshot_is_not_freshness_and_alerts(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(
+        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    second = atomic_publish_directory(
+        _build(tmp_path / "second"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    assert second["ok"] is False
+    assert second["skipped_same"] is True
+    assert second["reason"] == "SAME_SNAPSHOT_NOT_FRESHNESS"
+    assert json.loads(state.read_text())["last_status"] == "SKIPPED_SAME_SNAPSHOT"
+    assert "SAME_SNAPSHOT_NOT_FRESHNESS" in alerts.read_text()
+
+
+def test_monitor_fails_after_24_hours_without_touching_publication(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(
+        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    result = check_current_publication(
+        public,
+        state_path=state,
+        alert_ledger=alerts,
+        now=NOW + timedelta(hours=25),
+    )
+    assert result["ok"] is False
+    assert result["status"] == "UNHEALTHY"
+    assert "stale" in result["error"]
+    assert (public / "current" / "manifest.json").is_file()
+    assert "PUBLIC_FEED_UNHEALTHY" in alerts.read_text()
+    saved = json.loads(state.read_text())
+    assert saved["last_success_at"] == NOW.isoformat().replace("+00:00", "Z")
+    assert saved["last_monitor_status"] == "UNHEALTHY"
+
+
+def test_cycle_failure_preserves_last_publication_and_records_alert(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(
+        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    record_feed_cycle_state(
+        state,
+        alert_ledger=alerts,
+        status="FAILED",
+        at=NOW + timedelta(hours=1),
+        alert_reason="FEED_CYCLE_FAILED",
+        detail={"error": "pipeline failed", "duration_seconds": 12.5},
+    )
+    saved = json.loads(state.read_text())
+    assert saved["last_status"] == "PUBLISHED"
+    assert saved["last_cycle_status"] == "FAILED"
+    assert saved["cycle"]["error"] == "pipeline failed"
+    assert "FEED_CYCLE_FAILED" in alerts.read_text()
+
+
+def test_hash_mismatch_is_refused_before_promotion(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    build = _build(tmp_path / "build")
+    (build / "chunk_0000.json").write_text("corrupt", encoding="utf-8")
+    with pytest.raises(ValueError, match="chunk hash mismatch"):
+        atomic_publish_directory(build, public, state_path=state, alert_ledger=alerts, now=NOW)
+    assert not (public / "current").exists()


### PR DESCRIPTION
Addresses #468 without closing it before live reconciliation.

- runs the existing canonical outreach pipeline on a 12-hour timer using the durable contact projection
- validates full target-fit coverage, PNCP freshness, generated_at, datalake watermark, every chunk hash and contact metrics before atomic promotion
- treats a repeated snapshot as non-fresh and records durable alerts/state
- preserves the last valid release on stale, partial, corrupt, or failed cycles
- adds an hourly public-feed monitor and production runbook

Safety: no send, approval, copy, target-fit, or Warmbly action policy is changed.

Local gates: 24 targeted tests; ruff; systemd validation; generated-artifact policy; PR reviewability policy.