### PR TITLE
fix: classify exact public registry mailboxes as company routes

### DIFF
--- a/scripts/decision_unit_intelligence/batch_projection.py
+++ b/scripts/decision_unit_intelligence/batch_projection.py
@@ -10,6 +10,27 @@ from typing import Any
 
 from scripts.decision_unit_intelligence.batch_contact_metadata import attach_projection_evidence
 from scripts.decision_unit_intelligence.batch_queue import ContactDiscoveryQueue, canonical_payload_hash
+from scripts.decision_unit_intelligence.controlled_email import (
+    CONTROLLED_EMAIL_POLICY_VERSION,
+    classify_account_email_routes,
+    feed_contact_from_classified,
+)
+from scripts.decision_unit_intelligence.models import (
+    AccountInvestigation,
+    ActionMode,
+    ChannelType,
+    ConfidenceLevel,
+    DecisionRoleClass,
+    DecisionUnitCandidate,
+    EpistemicClass,
+    FreshnessState,
+    OwnershipStatus,
+    ReachabilityClass,
+    ReachabilityRoute,
+    RouteRelation,
+    SuppressionState,
+)
+from scripts.decision_unit_intelligence.projection import is_email_safe_for_warmbly
 from scripts.decision_unit_intelligence.repository import write_json
 
 TERMINAL_JOB_STATUSES = frozenset({"SUCCEEDED", "BLOCKED", "DLQ", "CANCELLED"})
@@ -59,6 +80,143 @@ def _blocked_row(job: dict[str, Any], reason: str) -> dict[str, Any]:
     }
 
 
+def _enum(enum_type: type[Any], raw: Any, default: Any) -> Any:
+    try:
+        return enum_type(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _candidate_from_stored(raw: dict[str, Any], account_id: str) -> DecisionUnitCandidate | None:
+    candidate_id = str(raw.get("candidate_id") or "").strip()
+    if not candidate_id:
+        return None
+    return DecisionUnitCandidate(
+        candidate_id=candidate_id,
+        company_entity_id=str(raw.get("company_entity_id") or account_id),
+        person_id=str(raw.get("person_id") or ""),
+        person_name=str(raw.get("person_name") or "").strip() or None,
+        observed_roles=[str(item) for item in (raw.get("observed_roles") or []) if item],
+        decision_role_class=_enum(
+            DecisionRoleClass,
+            raw.get("decision_role_class"),
+            DecisionRoleClass.UNKNOWN,
+        ),
+        identity_confidence=_enum(
+            ConfidenceLevel,
+            raw.get("identity_confidence"),
+            ConfidenceLevel.UNKNOWN,
+        ),
+        role_confidence=_enum(
+            ConfidenceLevel,
+            raw.get("role_confidence"),
+            ConfidenceLevel.UNKNOWN,
+        ),
+        suitability=_enum(
+            ConfidenceLevel,
+            raw.get("suitability"),
+            ConfidenceLevel.UNKNOWN,
+        ),
+    )
+
+
+def _route_from_stored(raw: dict[str, Any], account_id: str) -> ReachabilityRoute | None:
+    route_id = str(raw.get("route_id") or "").strip()
+    channel_value = str(raw.get("channel_value") or "").strip()
+    if not route_id or not channel_value:
+        return None
+    return ReachabilityRoute(
+        route_id=route_id,
+        company_entity_id=str(raw.get("company_entity_id") or account_id),
+        channel_type=_enum(ChannelType, raw.get("channel_type"), ChannelType.OTHER_PUBLIC_BUSINESS_ROUTE),
+        reachability_class=_enum(
+            ReachabilityClass,
+            raw.get("reachability_class"),
+            ReachabilityClass.R0_NO_ACTIONABLE_ROUTE,
+        ),
+        action_mode=_enum(ActionMode, raw.get("action_mode"), ActionMode.NEEDS_ENRICHMENT),
+        decision_unit_candidate_id=str(raw.get("decision_unit_candidate_id") or "").strip() or None,
+        target_role=str(raw.get("target_role") or "").strip() or None,
+        channel_value=channel_value,
+        route_relation=_enum(
+            RouteRelation,
+            raw.get("route_relation"),
+            RouteRelation.ACCOUNT_LEVEL_ONLY,
+        ),
+        epistemic_class=_enum(
+            EpistemicClass,
+            raw.get("epistemic_class"),
+            EpistemicClass.UNKNOWN,
+        ),
+        source_type=str(raw.get("source_type") or "").strip() or None,
+        source_url=str(raw.get("source_url") or "").strip() or None,
+        evidence_ids=[str(item) for item in (raw.get("evidence_ids") or []) if item],
+        route_confidence=_enum(
+            ConfidenceLevel,
+            raw.get("route_confidence"),
+            ConfidenceLevel.UNKNOWN,
+        ),
+        freshness=_enum(FreshnessState, raw.get("freshness"), FreshnessState.UNKNOWN),
+        ownership=_enum(OwnershipStatus, raw.get("ownership"), OwnershipStatus.UNKNOWN),
+        suppression=_enum(SuppressionState, raw.get("suppression"), SuppressionState.NONE),
+        reason_codes=[str(item) for item in (raw.get("reason_codes") or []) if item],
+        observed_at=str(raw.get("observed_at") or "").strip() or None,
+        suitability=_enum(
+            ConfidenceLevel,
+            raw.get("suitability"),
+            ConfidenceLevel.UNKNOWN,
+        ),
+        extra=dict(raw.get("extra") or {}) if isinstance(raw.get("extra"), dict) else {},
+    )
+
+
+def _current_policy_projection(
+    stored_projection: dict[str, Any],
+    *,
+    account: dict[str, Any],
+) -> dict[str, Any]:
+    """Reclassify immutable discovery evidence under the current route policy.
+
+    Crawling and classification are deliberately separate: a policy repair must
+    apply to already collected evidence without rewriting signed job outputs or
+    spending another public-search budget.
+    """
+    account_id = str(account.get("company_entity_id") or account.get("cnpj") or "").strip()
+    if not account_id:
+        return stored_projection
+    candidates = [
+        candidate
+        for raw in (account.get("candidates") or [])
+        if isinstance(raw, dict)
+        if (candidate := _candidate_from_stored(raw, account_id)) is not None
+    ]
+    routes = [
+        route
+        for raw in (account.get("routes") or [])
+        if isinstance(raw, dict)
+        if (route := _route_from_stored(raw, account_id)) is not None
+    ]
+    restored = AccountInvestigation(
+        company_entity_id=account_id,
+        cnpj=str(account.get("cnpj") or account_id),
+        legal_name=str(account.get("legal_name") or "").strip() or None,
+        service_context=str(account.get("service_context") or "generic"),
+        why_now=str(account.get("why_now") or "").strip() or None,
+        candidates=candidates,
+        routes=routes,
+        policy_version=str(account.get("policy_version") or "dui.policy.v1"),
+        extra=dict(account.get("extra") or {}) if isinstance(account.get("extra"), dict) else {},
+    )
+    ranking = classify_account_email_routes(
+        restored,
+        named_person_safe=is_email_safe_for_warmbly,
+    )
+    current = dict(stored_projection)
+    current.update(ranking.to_dict())
+    current["contacts"] = [feed_contact_from_classified(item) for item in ranking.classified_routes]
+    return current
+
+
 def build_contact_projection(
     queue: ContactDiscoveryQueue,
     *,
@@ -101,10 +259,17 @@ def build_contact_projection(
         projection = projection if isinstance(projection, dict) else {}
         account = (payload or {}).get("account")
         account = account if isinstance(account, dict) else {}
+        projection = _current_policy_projection(projection, account=account)
         projection = attach_projection_evidence(projection, account=account)
         contacts = [dict(item) for item in (projection.get("contacts") or []) if isinstance(item, dict)]
         preferred = projection.get("preferred_initial_route")
         preferred = preferred if isinstance(preferred, dict) else None
+        if status == "SUCCEEDED" and preferred:
+            state = "EMAIL_ROUTE_READY"
+            reason = "CONTROLLED_EMAIL_ROUTE_SELECTED"
+        elif status == "SUCCEEDED" and state == "EMAIL_ROUTE_READY":
+            state = "BLOCKED_WITH_REASON"
+            reason = "CURRENT_POLICY_NO_ELIGIBLE_ROUTE"
         domain = ((account.get("extra") or {}).get("domain_resolution") or {}).get("canonical_domain")
         row = {
             "cnpj14": str(job["canonical_account_id"]),
@@ -184,6 +349,7 @@ def build_contact_projection(
         "provenance_source_distribution": dict(sorted(sources.items())),
         "integrity_failures": dict(sorted(integrity_failures.items())),
         "projection_hash": projection_hash,
+        "controlled_email_policy_version": CONTROLLED_EMAIL_POLICY_VERSION,
         "policy_version": progress.get("policy_version"),
         "input_evidence_version": progress.get("input_evidence_version"),
         "code_sha": progress.get("code_sha"),

--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -34,6 +34,7 @@ from scripts.decision_unit_intelligence.models import (
     ReachabilityRoute,
     RouteRelation,
     SuppressionState,
+    normalize_cnpj,
 )
 from scripts.decision_unit_intelligence.reachability import (
     email_domain,
@@ -53,7 +54,7 @@ DEPARTMENTAL_HYPOTHESIS_LOCALS: tuple[str, ...] = (
     "contato",
 )
 
-CONTROLLED_EMAIL_POLICY_VERSION = "controlled-email-policy.v1"
+CONTROLLED_EMAIL_POLICY_VERSION = "controlled-email-policy.v2"
 CONTROLLED_EMAIL_SCHEMA_VERSION = "confenge.outreach.controlled_email.v1"
 
 # Tokens that genuinely mean "not suppressed". Anything else is treated as
@@ -369,6 +370,45 @@ def mailbox_local_implausible(mailbox: str | None) -> bool:
     return False
 
 
+def _exact_registry_company_association(route: ReachabilityRoute) -> bool:
+    """Recognize a public cadastral mailbox joined to this exact CNPJ.
+
+    A registry label or COMPANY_OWNED flag alone is intentionally insufficient.
+    The producer must carry the matched official authority, immutable release
+    provenance, and the exact normalized CNPJ through to the route.
+    """
+    source = str(route.source_type or "").lower().strip()
+    if source not in {"company_registry", "registry"}:
+        return False
+    if route.epistemic_class != EpistemicClass.OBSERVED:
+        return False
+    if route.ownership != OwnershipStatus.COMPANY_OWNED:
+        return False
+    if not str(route.observed_at or "").strip():
+        return False
+    extra = route.extra if isinstance(route.extra, dict) else {}
+    if extra.get("company_associated") is not True:
+        return False
+    if str(extra.get("mailbox_company_evidence") or "").upper() != EVIDENCE_OBSERVED:
+        return False
+    if str(extra.get("official_match_status") or "").upper() != "MATCHED":
+        return False
+    authority = str(extra.get("official_authority") or "").upper().strip()
+    if authority != "RECEITA_FEDERAL":
+        return False
+    registry_cnpj = normalize_cnpj(str(extra.get("registry_cnpj14") or ""))
+    account_cnpj = normalize_cnpj(route.company_entity_id)
+    if not registry_cnpj or registry_cnpj != account_cnpj:
+        return False
+    release_id = str(extra.get("official_release_id") or "").strip()
+    provenance = extra.get("source_provenance")
+    if not release_id or not isinstance(provenance, dict):
+        return False
+    if str(provenance.get("release_id") or "").strip() != release_id:
+        return False
+    return True
+
+
 def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     """True only when public provenance can bind the mailbox to this account."""
     if untrustworthy_source_url(route.source_url):
@@ -382,6 +422,8 @@ def association_provenance_trustworthy(route: ReachabilityRoute) -> bool:
     freemail = is_freemail(route.channel_value)
     if not freemail and not mailbox_host_plausible(mailbox_dom):
         return False
+    if _exact_registry_company_association(route):
+        return True
     on_official_page = bool(official and url_host and _hosts_equivalent(url_host, official))
     mailbox_on_official = bool(official and mailbox_dom and not freemail and _hosts_equivalent(mailbox_dom, official))
     if official:
@@ -513,11 +555,13 @@ def classify_email_route_class(
     if person_ev == EVIDENCE_OBSERVED and _observed_person_name(route, person):
         return EmailRouteClass.DIRECT_PERSON
 
-    if looks_nominal_local(value) and person_ev != EVIDENCE_OBSERVED:
-        return EmailRouteClass.PROBABILISTIC_OR_RISKY
-
+    # An exact public-company association proves a transport route, not the
+    # identity of whoever reads a nominal-looking local part.
     if company_ev == EVIDENCE_OBSERVED:
         return EmailRouteClass.GENERIC_COMPANY
+
+    if looks_nominal_local(value) and person_ev != EVIDENCE_OBSERVED:
+        return EmailRouteClass.PROBABILISTIC_OR_RISKY
     return EmailRouteClass.PROBABILISTIC_OR_RISKY
 
 

--- a/tests/fixtures/controlled_email_five_class_canary.json
+++ b/tests/fixtures/controlled_email_five_class_canary.json
@@ -131,7 +131,7 @@
           "channel_epistemic_class": "OBSERVED",
           "route_freshness": "FRESH",
           "route_suppression": "NONE",
-          "policy_version": "controlled-email-policy.v1",
+          "policy_version": "controlled-email-policy.v2",
           "schema_version": "confenge.outreach.controlled_email.v1",
           "reason_codes": [
             "route_class:DIRECT_PERSON",
@@ -206,7 +206,7 @@
           "channel_epistemic_class": "OBSERVED",
           "route_freshness": "FRESH",
           "route_suppression": "NONE",
-          "policy_version": "controlled-email-policy.v1",
+          "policy_version": "controlled-email-policy.v2",
           "schema_version": "confenge.outreach.controlled_email.v1",
           "reason_codes": [
             "route_class:ROLE_OR_DEPARTMENT",
@@ -281,7 +281,7 @@
           "channel_epistemic_class": "OBSERVED",
           "route_freshness": "FRESH",
           "route_suppression": "NONE",
-          "policy_version": "controlled-email-policy.v1",
+          "policy_version": "controlled-email-policy.v2",
           "schema_version": "confenge.outreach.controlled_email.v1",
           "reason_codes": [
             "route_class:GENERIC_COMPANY",
@@ -356,7 +356,7 @@
           "channel_epistemic_class": "OBSERVED",
           "route_freshness": "FRESH",
           "route_suppression": "NONE",
-          "policy_version": "controlled-email-policy.v1",
+          "policy_version": "controlled-email-policy.v2",
           "schema_version": "confenge.outreach.controlled_email.v1",
           "reason_codes": [
             "route_class:PUBLIC_COMPANY_FREEMAIL",
@@ -433,7 +433,7 @@
           "channel_epistemic_class": "INFERRED",
           "route_freshness": "FRESH",
           "route_suppression": "NONE",
-          "policy_version": "controlled-email-policy.v1",
+          "policy_version": "controlled-email-policy.v2",
           "schema_version": "confenge.outreach.controlled_email.v1",
           "reason_codes": [
             "route_class:PROBABILISTIC_OR_RISKY",

--- a/tests/test_contact_discovery_batch.py
+++ b/tests/test_contact_discovery_batch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import threading
 from pathlib import Path
@@ -20,6 +21,7 @@ from scripts.decision_unit_intelligence.batch_outcomes import (
 from scripts.decision_unit_intelligence.batch_projection import write_contact_projection
 from scripts.decision_unit_intelligence.batch_queue import (
     ContactDiscoveryQueue,
+    canonical_payload_hash,
     connect,
     idempotency_key,
 )
@@ -150,6 +152,47 @@ def _auditable_role_account(cnpj: str) -> AccountInvestigation:
         terminal=AccountTerminal.ACTIONABLE_ROUTE,
         ledger=SearchLedger(tiers_completed=[0, 1, 2, 3]),
         extra={"domain_resolution": {"canonical_domain": "acme.example.com"}},
+    )
+
+
+def _exact_registry_freemail_account(cnpj: str) -> AccountInvestigation:
+    return AccountInvestigation(
+        company_entity_id=cnpj,
+        cnpj=cnpj,
+        legal_name="ACME ENGENHARIA LTDA",
+        service_context="reajuste_14133",
+        why_now="TARGET_CONFIRMED",
+        routes=[
+            ReachabilityRoute(
+                route_id=f"registry-{cnpj}",
+                company_entity_id=cnpj,
+                channel_type=ChannelType.GENERIC_CORPORATE_EMAIL,
+                reachability_class=ReachabilityClass.R5_CORPORATE_ONLY,
+                action_mode=ActionMode.GENERIC_EMAIL_LAST_RESORT,
+                channel_value="acmeengenharia@gmail.com",
+                route_relation=RouteRelation.ACCOUNT_LEVEL_ONLY,
+                epistemic_class=EpistemicClass.OBSERVED,
+                source_type="company_registry",
+                freshness=FreshnessState.FRESH,
+                ownership=OwnershipStatus.COMPANY_OWNED,
+                observed_at="2026-08-24T12:00:00Z",
+                extra={
+                    "company_associated": True,
+                    "mailbox_company_evidence": "OBSERVED",
+                    "mailbox_person_evidence": "UNKNOWN",
+                    "official_match_status": "MATCHED",
+                    "official_authority": "RECEITA_FEDERAL",
+                    "official_release_id": "rfb-2026-08",
+                    "registry_cnpj14": cnpj,
+                    "source_provenance": {
+                        "release_id": "rfb-2026-08",
+                        "source_label": "rfb_public_cadastral_via_opencnpj",
+                    },
+                },
+            )
+        ],
+        terminal=AccountTerminal.ACTIONABLE_ROUTE,
+        ledger=SearchLedger(tiers_completed=[0, 1, 2, 3]),
     )
 
 
@@ -445,6 +488,7 @@ def test_complete_cohort_exports_verified_bridge_projection(dsn: str, tmp_path: 
     assert result["target_fit_mode"] == "SHADOW"
     assert result["target_fit_classifier_sha"] == "sha256:target-fit-test"
     assert result["sector_classifier_sha"] == "sha256:sector-test"
+    assert result["controlled_email_policy_version"] == "controlled-email-policy.v2"
     assert result["terminal_equation"] == {
         "population_count": 1,
         "job_denominator": 1,
@@ -462,6 +506,69 @@ def test_complete_cohort_exports_verified_bridge_projection(dsn: str, tmp_path: 
     assert row["contacts"][0]["mailbox_department"] == "licitacoes"
     assert row["contacts"][0]["provenance"]["source_type"] == "company_website"
     assert row["preferred_email_route"]["source_url"] == "https://acme.example.com/contato"
+
+
+def test_export_reclassifies_signed_discovery_evidence_under_current_policy(
+    dsn: str,
+    tmp_path: Path,
+) -> None:
+    cohort = "c-policy-reprojection"
+    cnpj = "11222333000181"
+    with connect(dsn) as connection:
+        _seed(
+            ContactDiscoveryQueue(connection),
+            cohort=cohort,
+            accounts=[cnpj],
+            backend="searxng",
+            metadata={"population_count": 1},
+        )
+    worker = ContactDiscoveryWorker(
+        dsn=dsn,
+        worker_id="policy-reprojection-worker",
+        output_root=tmp_path / "outputs",
+        admission_probe=lambda: [],
+        discovery=lambda job: _exact_registry_freemail_account(job.canonical_account_id),
+    )
+    assert worker.run_once()["status"] == "SUCCEEDED"
+
+    # Model a job signed before the policy fix: keep immutable discovery evidence,
+    # but remove the then-unrecognized preferred route from its derived projection.
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        job = queue.inspect(cohort_id=cohort)[0]
+        output_path = Path(str(job["output_pointer"]))
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        payload["contact_projection"] = {
+            "contacts": [],
+            "preferred_initial_route": None,
+            "classified_email_routes": [],
+        }
+        payload["enrichment_state"] = "BLOCKED_WITH_REASON"
+        payload["enrichment_reason"] = "WATERFALL_PROVIDER_FAILURE"
+        output_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        digest = canonical_payload_hash(payload)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE contact_discovery_jobs SET output_hash = %s WHERE id = %s",
+                (digest, job["id"]),
+            )
+        result = write_contact_projection(
+            queue,
+            cohort_id=cohort,
+            output_path=tmp_path / "contacts.jsonl",
+            report_path=tmp_path / "report.json",
+        )
+
+    assert result["written"] is True
+    assert result["enrichment_states"] == {"EMAIL_ROUTE_READY": 1}
+    assert result["accounts_with_preferred_route"] == 1
+    row = json.loads((tmp_path / "contacts.jsonl").read_text(encoding="utf-8"))
+    assert row["preferred_email_route"]["route_class"] == "PUBLIC_COMPANY_FREEMAIL"
+    assert row["preferred_email_route"]["email_validated"] is False
+    assert row["preferred_email_route"]["person_name"] is None
 
 
 def test_projection_refuses_population_job_denominator_mismatch(dsn: str, tmp_path: Path) -> None:

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -202,6 +202,77 @@ def test_unassociated_gmail_is_blocked_unknown() -> None:
     assert "unassociated_freemail" in classified.reason_codes
 
 
+def _exact_registry_extra(*, cnpj: str = ACCOUNT_ID) -> dict:
+    return {
+        "company_associated": True,
+        "mailbox_company_evidence": "OBSERVED",
+        "mailbox_person_evidence": "UNKNOWN",
+        "official_match_status": "MATCHED",
+        "official_authority": "RECEITA_FEDERAL",
+        "official_release_id": "rfb-2026-08",
+        "registry_cnpj14": cnpj,
+        "source_provenance": {
+            "release_id": "rfb-2026-08",
+            "source_label": "rfb_public_cadastral_via_opencnpj",
+        },
+    }
+
+
+def test_exact_registry_freemail_is_public_company_route_without_person() -> None:
+    route = _route(
+        "empresa@gmail.com",
+        source_type="company_registry",
+        source_url=None,
+        extra=_exact_registry_extra(),
+    )
+    classified = evaluate_controlled_email_eligible(route, person=None)
+
+    assert classified.route_class == EmailRouteClass.PUBLIC_COMPANY_FREEMAIL
+    assert classified.controlled_email_eligible is True
+    assert classified.mailbox_company_evidence == "OBSERVED"
+    assert classified.mailbox_person_evidence == "UNKNOWN"
+    assert classified.person_name is None
+    assert classified.email_validated is False
+
+
+def test_exact_registry_nominal_local_is_company_route_not_invented_person() -> None:
+    route = _route(
+        "joao.silva@empresaexemplo.com.br",
+        source_type="company_registry",
+        source_url=None,
+        extra=_exact_registry_extra(),
+    )
+    classified = evaluate_controlled_email_eligible(route, person=None)
+
+    assert classified.route_class == EmailRouteClass.GENERIC_COMPANY
+    assert classified.controlled_email_eligible is True
+    assert classified.mailbox_person_evidence == "UNKNOWN"
+    assert classified.person_name is None
+    assert classified.email_validated is False
+    assert "person_unknown" in classified.reason_codes
+
+
+def test_registry_label_or_mismatched_cnpj_never_proves_company_association() -> None:
+    ownership_only = _route(
+        "empresa@gmail.com",
+        source_type="company_registry",
+        source_url=None,
+        extra={},
+    )
+    mismatch = _route(
+        "empresa@gmail.com",
+        source_type="company_registry",
+        source_url=None,
+        extra=_exact_registry_extra(cnpj="99888777000166"),
+    )
+
+    for route in (ownership_only, mismatch):
+        classified = evaluate_controlled_email_eligible(route, person=None)
+        assert classified.route_class == EmailRouteClass.PROBABILISTIC_OR_RISKY
+        assert classified.controlled_email_eligible is False
+        assert classified.mailbox_company_evidence == "UNKNOWN"
+
+
 def test_inferred_address_is_risky_outside_default_pilot() -> None:
     route = _route(
         "joao.silva@empresaexemplo.com.br",
@@ -799,7 +870,17 @@ def test_five_class_synthetic_canary_snapshot() -> None:
     assert gmail["route_class"] == EmailRouteClass.PUBLIC_COMPANY_FREEMAIL.value
     assert gmail["person_id"] is None
     contacts = stamp_and_rank_feed_contacts(
-        [{"email": r.channel_value, "ownership_status": "COMPANY_OWNED", "source_url": r.source_url} for r in routes],
+        [
+            {
+                "email": route.channel_value,
+                "ownership_status": "COMPANY_OWNED",
+                "source_url": route.source_url,
+                "channel_epistemic_class": route.epistemic_class.value,
+                "email_discovery_class": (route.extra or {}).get("email_discovery_class"),
+                "reason_codes": route.reason_codes,
+            }
+            for route in routes
+        ],
         account_id=ACCOUNT_ID,
         official_domain="empresaexemplo.com.br",
     )

--- a/tests/test_email_reachability_engine.py
+++ b/tests/test_email_reachability_engine.py
@@ -320,12 +320,17 @@ def test_two_sources_same_mailbox_dedupe_and_one_preferred() -> None:
     assert stamped[0]["corroborated"] is True
 
 
-def test_nominal_mailbox_without_person_is_risky() -> None:
+def test_nominal_mailbox_with_company_association_is_generic_not_person() -> None:
     classified = evaluate_controlled_email_eligible(
         _route("joao.silva@empresaexemplo.com.br", channel=ChannelType.DIRECT_EMAIL)
     )
-    assert classified.route_class == EmailRouteClass.PROBABILISTIC_OR_RISKY
-    assert classified.controlled_email_eligible is False
+    assert classified.route_class == EmailRouteClass.GENERIC_COMPANY
+    assert classified.controlled_email_eligible is True
+    assert classified.mailbox_company_evidence == "OBSERVED"
+    assert classified.mailbox_person_evidence == "UNKNOWN"
+    assert classified.person_id is None
+    assert classified.person_name is None
+    assert classified.email_validated is False
 
 
 def test_pattern_generated_stays_inferred_risky() -> None:
@@ -534,16 +539,16 @@ def _cascade_with_site_email(monkeypatch, email: str):
     return result, search_calls
 
 
-def test_nominal_mailbox_without_person_does_not_stop_cascade(monkeypatch) -> None:
+def test_nominal_mailbox_with_official_company_association_stops_cascade(monkeypatch) -> None:
     result, search_calls = _cascade_with_site_email(monkeypatch, "joao.silva@alphaengenharia.com.br")
-    assert result.stats.stop_reason != "official_site_controlled_eligible_route"
-    assert search_calls["n"] >= 1
+    assert result.stats.stop_reason == "official_site_controlled_eligible_route"
+    assert search_calls["n"] == 0
     assert (
         observed_contact_is_controlled_eligible_company_route(
             {"email": "joao.silva@alphaengenharia.com.br", "source": "company_website"},
             official_domain="alphaengenharia.com.br",
         )
-        is False
+        is True
     )
 
 

--- a/tests/test_existing_contact_seed.py
+++ b/tests/test_existing_contact_seed.py
@@ -147,6 +147,33 @@ def test_official_registry_exact_cnpj_accepts_public_company_mailbox_without_per
     assert route.extra["official_domain"] == "construtoracadastro.com.br"
 
 
+def test_official_registry_exact_cnpj_accepts_public_freemail_without_person() -> None:
+    cnpj = "11222333000181"
+    provider = OfficialCompanyRegistryProvider(
+        lookup=lambda _cnpj: OfficialCompanyRecord(
+            cnpj=cnpj,
+            official_match_status=OfficialMatchStatus.MATCHED.value,
+            official_authority="RECEITA_FEDERAL",
+            official_release_id="rfb-2026-07",
+            legal_name="Construtora Cadastro Ltda",
+            email="construtoracadastro@gmail.com",
+            fetched_from_local_registry_at="2026-08-24T12:00:00Z",
+            source_provenance={
+                "release_id": "rfb-2026-07",
+                "source_label": "rfb_public_cadastral",
+            },
+        )
+    )
+
+    projected = project_warmbly_outreach(run_account(cnpj, providers=[provider], infer_email=False))
+    preferred = projected["preferred_initial_route"]
+
+    assert preferred["route_class"] == "PUBLIC_COMPANY_FREEMAIL"
+    assert preferred["mailbox_person_evidence"] == "UNKNOWN"
+    assert preferred["person_name"] is None
+    assert preferred["email_validated"] is False
+
+
 def test_unavailable_official_registry_is_recorded_without_stopping_later_sources() -> None:
     cnpj = "11222333000181"
     provider = OfficialCompanyRegistryProvider(


### PR DESCRIPTION
Closes the classification gap found during the live #469 waterfall.

What changes:
- trusts a Receita Federal public-registry mailbox only when exact CNPJ, authority, immutable release provenance, observed timestamp, ownership, and explicit company-association evidence all agree;
- keeps incomplete/mismatched registry evidence fail-closed;
- treats a nominal-looking local part with observed company association but no observed person as GENERIC_COMPANY, never DIRECT_PERSON or EMAIL_VALIDATED;
- bumps the controlled route policy to v2;
- reprojects immutable stored discovery evidence at export time, so already-crawled accounts receive the repaired policy without mutating signed job outputs or repeating public discovery spend;
- recalculates terminal enrichment state from the current preferred route.

Safety remains unchanged: probabilistic/inferred routes stay outside the default pilot; suppression, freshness and mailbox validity still fail closed; this code grants no send authorization.

Verification:
- 70 focused tests passed across controlled eligibility, registry seeding and the durable batch/export path;
- adversarial exact-CNPJ mismatch and ownership-only cases remain blocked;
- Ruff and diff checks pass;
- generated-artifact and PR-reviewability policies pass.

Related: #469, #370.
