### PR TITLE
fix: stop contact cascade on exact registry routes

### DIFF
--- a/scripts/decision_unit_intelligence/controlled_email.py
+++ b/scripts/decision_unit_intelligence/controlled_email.py
@@ -636,12 +636,16 @@ def observed_contact_is_controlled_eligible_company_route(
     return is_actionable_controlled_company_route(evaluate_controlled_email_eligible(route))
 
 
-def observed_channels_have_controlled_eligible_route(channels: list[Any]) -> bool:
+def observed_channels_have_controlled_eligible_route(
+    channels: list[Any],
+    *,
+    account_id: str = "",
+) -> bool:
     """True when an observed public mailbox is already a control-eligible company route."""
     for channel in channels or []:
         extra = getattr(channel, "extra", None) or {}
         if isinstance(channel, dict):
-            if observed_contact_is_controlled_eligible_company_route(channel):
+            if observed_contact_is_controlled_eligible_company_route(channel, account_id=account_id):
                 return True
             continue
         epistemic = getattr(channel, "epistemic_class", None)
@@ -654,11 +658,12 @@ def observed_channels_have_controlled_eligible_route(channels: list[Any]) -> boo
             "ownership_status": ownership.value if hasattr(ownership, "value") else ownership,
             "source": getattr(channel, "source_type", None),
             "source_url": getattr(channel, "source_url", None),
+            "observed_at": getattr(channel, "observed_at", None),
             "channel_epistemic_class": epistemic.value if hasattr(epistemic, "value") else epistemic,
             "extra": extra,
             "pattern_guessed_email": extra.get("pattern_guessed") or extra.get("pattern_guessed_email"),
         }
-        if observed_contact_is_controlled_eligible_company_route(contact):
+        if observed_contact_is_controlled_eligible_company_route(contact, account_id=account_id):
             return True
     return False
 

--- a/scripts/decision_unit_intelligence/orchestrator.py
+++ b/scripts/decision_unit_intelligence/orchestrator.py
@@ -608,7 +608,10 @@ def investigate_account(
             observed_channels_have_controlled_eligible_route,
         )
 
-        has_observed_usable = observed_channels_have_controlled_eligible_route(normalized_channels)
+        has_observed_usable = observed_channels_have_controlled_eligible_route(
+            normalized_channels,
+            account_id=entity_id,
+        )
         routes.extend(
             maybe_infer_emails(
                 candidates=candidates,

--- a/scripts/decision_unit_intelligence/runner.py
+++ b/scripts/decision_unit_intelligence/runner.py
@@ -240,7 +240,10 @@ def run_account(
             p.provider_id for p in providers if getattr(p, "first_class", False) and getattr(p, "enabled", False)
         }
         attempted = {attempt.provider_id for attempt in ledger.attempts}
-        commercial_success = observed_channels_have_controlled_eligible_route(channels)
+        commercial_success = observed_channels_have_controlled_eligible_route(
+            channels,
+            account_id=cnpj,
+        )
         # Positive stop: a control-eligible company route is enough. Named person
         # is not required. Still require enabled first-class providers unless the
         # remaining work is public-search PERSON spend after a usable route.

--- a/tests/test_controlled_email_eligibility.py
+++ b/tests/test_controlled_email_eligibility.py
@@ -19,6 +19,7 @@ from scripts.decision_unit_intelligence.controlled_email import (
     classify_account_email_routes,
     classify_email_route_class,
     evaluate_controlled_email_eligible,
+    observed_channels_have_controlled_eligible_route,
     stamp_and_rank_feed_contacts,
 )
 from scripts.decision_unit_intelligence.email_validated.policy import decide_promotion
@@ -26,6 +27,7 @@ from scripts.decision_unit_intelligence.email_validated.schema import Adjudicati
 from scripts.decision_unit_intelligence.models import (
     AccountInvestigation,
     ActionMode,
+    ChannelObservation,
     ChannelType,
     ConfidenceLevel,
     DecisionRoleClass,
@@ -271,6 +273,30 @@ def test_registry_label_or_mismatched_cnpj_never_proves_company_association() ->
         assert classified.route_class == EmailRouteClass.PROBABILISTIC_OR_RISKY
         assert classified.controlled_email_eligible is False
         assert classified.mailbox_company_evidence == "UNKNOWN"
+
+
+def test_exact_registry_channel_stops_only_for_its_canonical_account() -> None:
+    channel = ChannelObservation(
+        observation_id="registry-channel",
+        company_entity_id=ACCOUNT_ID,
+        channel_type=ChannelType.GENERIC_CORPORATE_EMAIL,
+        channel_value="empresa@gmail.com",
+        source_type="company_registry",
+        observed_at="2026-08-24T00:00:00Z",
+        epistemic_class=EpistemicClass.OBSERVED,
+        ownership=OwnershipStatus.COMPANY_OWNED,
+        evidence_id="registry-evidence",
+        extra=_exact_registry_extra(),
+    )
+
+    assert observed_channels_have_controlled_eligible_route([channel], account_id=ACCOUNT_ID) is True
+    assert (
+        observed_channels_have_controlled_eligible_route(
+            [channel],
+            account_id="99888777000166",
+        )
+        is False
+    )
 
 
 def test_inferred_address_is_risky_outside_default_pilot() -> None:

--- a/tests/test_existing_contact_seed.py
+++ b/tests/test_existing_contact_seed.py
@@ -165,7 +165,20 @@ def test_official_registry_exact_cnpj_accepts_public_freemail_without_person() -
         )
     )
 
-    projected = project_warmbly_outreach(run_account(cnpj, providers=[provider], infer_email=False))
+    class MustNotRunAfterRegistryHit:
+        provider_id = "public_search"
+        tier = 4
+
+        def collect(self, _context: InvestigationContext):
+            raise AssertionError("exact registry route should stop later public-search spend")
+
+    projected = project_warmbly_outreach(
+        run_account(
+            cnpj,
+            providers=[provider, MustNotRunAfterRegistryHit()],
+            infer_email=False,
+        )
+    )
     preferred = projected["preferred_initial_route"]
 
     assert preferred["route_class"] == "PUBLIC_COMPANY_FREEMAIL"


### PR DESCRIPTION
## Outcome

Makes the live waterfall stop after a controlled-eligible exact Receita Federal company route. #477 fixed final projection, but live evidence showed the intermediate early-stop adapter discarded the canonical account ID and `observed_at`; exact registry association therefore failed during the crawl and unnecessarily spent public-search/document budget.

The route remains an observed company transport route, never a person and never `EMAIL_VALIDATED`.

## Evidence

- Reproduced live on a post-#477 job: official registry hit at 0 ms followed by ~15 s of unnecessary public search/documents.
- Passes canonical CNPJ into early-stop from both runner and orchestrator and preserves observed timestamp.
- Adversarial exact-account versus mismatched-account test added.
- Focused regression: 112 passed.
- Ruff, generated-artifacts policy and PR reviewability: PASS.

No target-fit, suppression, approval, copy, rate-limit or send gate changes.
