### PR TITLE
fix(confenge): project terminal discovery failures as explicit blockers

### DIFF
--- a/docs/handoffs/confenge-contact-terminal-outcomes-20260824.md
+++ b/docs/handoffs/confenge-contact-terminal-outcomes-20260824.md
@@ -1,0 +1,39 @@
+# CONFENGE contact discovery terminal outcomes
+
+Date: 2026-08-24  
+Owner: `extra-cli`  
+Scope: durable contact discovery projection for `TARGET_CONFIRMED`
+
+## Contract
+
+Every account in the immutable cohort denominator must be projected exactly
+once as one of:
+
+- `EMAIL_ROUTE_READY`
+- `NO_PUBLIC_EMAIL_FOUND`
+- `BLOCKED_WITH_REASON`
+
+`SUCCEEDED` jobs require a verified output pointer, matching canonical payload
+hash, account and job identity, plus an explicit enrichment terminal. Any
+integrity failure remains fail-closed and prevents publication.
+
+`BLOCKED`, `DLQ` and `CANCELLED` jobs are themselves durable terminal evidence.
+They are projected as `BLOCKED_WITH_REASON` from the job's reason code, even if
+an earlier attempt left a valid but partial output file. A contact artifact is
+not required to prove that a provider failure is a blocker.
+
+Publication is allowed only when the population count, job denominator,
+terminal projection count and distinct terminal account count are equal, with
+zero integrity failures.
+
+## Production reproduction that closed the gap
+
+The full 2026-08-24 cohort reached 8,614 terminal jobs: 8,606 `SUCCEEDED` and 8
+`DLQ`. Before this repair, the exporter correctly refused promotion but reported
+`OUTPUT_ENRICHMENT_TERMINAL_MISSING=8`, because the eight DLQ rows retained
+partial outputs from earlier attempts. The regression test reproduces that
+exact state and proves a complete blocker projection without weakening output
+integrity for successful jobs.
+
+Runtime deployment, rerun identifiers and consumer reconciliation evidence are
+recorded on `extra-cli#469`; this handoff defines the durable code contract only.

--- a/scripts/decision_unit_intelligence/batch_projection.py
+++ b/scripts/decision_unit_intelligence/batch_projection.py
@@ -250,6 +250,18 @@ def build_contact_projection(
             blockers[reason] += 1
             continue
 
+        # Non-success terminal jobs are explicit account outcomes even when a
+        # prior retry left a well-formed partial output behind.  Never let that
+        # stale attempt payload hide the durable DLQ/BLOCKED/CANCELLED reason,
+        # and never require a contact artifact in order to project a blocker.
+        if status != "SUCCEEDED":
+            reason = str(job.get("last_reason_code") or status)
+            row = _blocked_row(job, reason)
+            rows.append(row)
+            states["BLOCKED_WITH_REASON"] += 1
+            blockers[reason] += 1
+            continue
+
         state = str((payload or {}).get("enrichment_state") or "")
         reason = str((payload or {}).get("enrichment_reason") or "")
         if state not in ENRICHMENT_TERMINALS:

--- a/tests/test_contact_discovery_batch.py
+++ b/tests/test_contact_discovery_batch.py
@@ -508,6 +508,65 @@ def test_complete_cohort_exports_verified_bridge_projection(dsn: str, tmp_path: 
     assert row["preferred_email_route"]["source_url"] == "https://acme.example.com/contato"
 
 
+def test_dlq_with_verified_partial_output_exports_explicit_blocker(
+    dsn: str,
+    tmp_path: Path,
+) -> None:
+    cohort = "c-dlq-partial-output"
+    cnpj = "11222333000181"
+    with connect(dsn) as connection:
+        queue = ContactDiscoveryQueue(connection)
+        _seed(
+            queue,
+            cohort=cohort,
+            accounts=[cnpj],
+            backend="searxng",
+            metadata={"population_count": 1},
+        )
+        job = queue.inspect(cohort_id=cohort)[0]
+        partial = {
+            "job_id": job["id"],
+            "canonical_account_id": cnpj,
+            "account": {"company_entity_id": cnpj},
+            "contact_projection": {},
+        }
+        partial_path = tmp_path / "partial-output.json"
+        partial_path.write_text(
+            json.dumps(partial, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE contact_discovery_jobs
+                SET status = 'DLQ', attempt_count = max_attempts,
+                    last_outcome = 'DLQ', last_reason_code = 'PROVIDER_HTTP_ERROR',
+                    output_pointer = %s, output_hash = %s
+                WHERE id = %s
+                """,
+                (str(partial_path), canonical_payload_hash(partial), job["id"]),
+            )
+
+        result = write_contact_projection(
+            queue,
+            cohort_id=cohort,
+            output_path=tmp_path / "contacts.jsonl",
+            report_path=tmp_path / "report.json",
+        )
+
+    assert result["written"] is True
+    assert result["terminal_coverage_complete"] is True
+    assert result["terminal_equation"]["holds"] is True
+    assert result["enrichment_states"] == {"BLOCKED_WITH_REASON": 1}
+    assert result["blockers"] == {"PROVIDER_HTTP_ERROR": 1}
+    assert result["integrity_failures"] == {}
+    row = json.loads((tmp_path / "contacts.jsonl").read_text(encoding="utf-8"))
+    assert row["canonical_account_id"] == cnpj
+    assert row["contacts"] == []
+    assert row["enrichment_state"] == "BLOCKED_WITH_REASON"
+    assert row["enrichment_reason"] == "PROVIDER_HTTP_ERROR"
+
+
 def test_export_reclassifies_signed_discovery_evidence_under_current_policy(
     dsn: str,
     tmp_path: Path,


### PR DESCRIPTION
Closes the production export gap found while completing #469.\n\n- projects durable BLOCKED/DLQ/CANCELLED jobs as BLOCKED_WITH_REASON even when an earlier attempt left a verified partial payload\n- keeps SUCCEEDED output integrity fail-closed\n- adds the exact DLQ-with-partial-output regression\n\nLive reproduction before fix: 8,614 terminal jobs, 8 DLQ, exporter refused with OUTPUT_ENRICHMENT_TERMINAL_MISSING=8. No partial projection was promoted.\n\nVerification:\n- 19 tests in tests/test_contact_discovery_batch.py passed\n- Ruff passed\n- generated-artifacts and PR-reviewability policies passed