### PR TITLE
fix(confenge): wire private search endpoint into contact cycle

### DIFF
--- a/deploy/systemd/contact-discovery.env.example
+++ b/deploy/systemd/contact-discovery.env.example
@@ -1,6 +1,7 @@
 # Canonical full-population contact-discovery cycle. No secrets belong here.
 CONFENGE_CONTACT_OUTPUT_ROOT=/var/lib/extra-consultoria/output/contact-discovery
 CONFENGE_CONTACT_SEARCH_BACKEND=searxng
+CONFENGE_SEARXNG_URL=http://127.0.0.1:18888
 CONFENGE_CONTACT_BACKEND_CONCURRENCY=12
 CONFENGE_CONTACT_DOMAIN_CONCURRENCY=1
 CONFENGE_CONTACT_POLL_SECONDS=30

--- a/tests/test_confenge_contact_cycle.py
+++ b/tests/test_confenge_contact_cycle.py
@@ -9,6 +9,7 @@ import pytest
 from scripts.ops.confenge_contact_cycle import run_cycle
 
 NOW = datetime(2026, 8, 24, 20, 0, tzinfo=UTC)
+ROOT = Path(__file__).resolve().parents[1]
 
 
 class FakeRunner:
@@ -185,3 +186,17 @@ def test_public_backend_and_positive_concurrency_are_required(tmp_path: Path) ->
             poll_seconds=0,
             timeout_seconds=1,
         )
+
+
+def test_systemd_cycle_and_workers_share_private_search_endpoint_contract() -> None:
+    env_path = ROOT / "deploy/systemd/contact-discovery.env.example"
+    cycle_path = ROOT / "deploy/systemd/extra-confenge-contact-cycle.service"
+    worker_path = ROOT / "deploy/systemd/extra-contact-discovery-worker@.service"
+
+    env = env_path.read_text(encoding="utf-8")
+    cycle = cycle_path.read_text(encoding="utf-8")
+    worker = worker_path.read_text(encoding="utf-8")
+
+    assert "CONFENGE_SEARXNG_URL=http://127.0.0.1:18888" in env
+    for unit in (cycle, worker):
+        assert "EnvironmentFile=-/etc/extra-consultoria/contact-discovery.env" in unit


### PR DESCRIPTION
## Outcome

Makes the continuous full-population contact-discovery deployment carry the private SearXNG endpoint through the shared `contact-discovery.env` contract consumed by both the coordinator and leased workers.

## Production evidence

The second full cohort `target-confirmed-auto-20260824T214641Z` was seeded at 8,614/8,614 under `a8cbcf...`, then failed closed before public discovery with `ValueError: searxng search backend requires --searxng-url`. Production SearXNG is healthy on loopback `127.0.0.1:18888`; the missing env contract was the blocker. Workers were stopped before further retries; the cohort remains resumable.

## Verification

- `tests/test_confenge_contact_cycle.py`: 5 passed
- Ruff: passed
- generated-artifacts policy: passed
- PR reviewability policy: passed

Relates to #469 and #468.