### PR TITLE
fix(backup): expose freshness metadata to health worker

### DIFF
--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -20,6 +20,7 @@
 #   BACKUP_RETENTION_DAILY      - Qtde diários a manter (def: 7)
 #   BACKUP_RETENTION_WEEKLY     - Qtde semanais a manter (def: 4)
 #   BACKUP_LOG_FILE             - Arquivo de log (def: /var/log/backup-database.log)
+#   BACKUP_OBSERVER_GROUP       - Grupo read-only que observa freshness (def: extra-consultoria)
 #   BACKUP_NOTIFY_CMD           - Comando executado em falha (opcional)
 #   SSHFS_OPTIONS               - Opções extras para sshfs (opcional)
 #
@@ -54,6 +55,7 @@ TEMP_DIR="${BACKUP_TEMP_DIR:-/tmp/pg-backup}"
 RETENTION_DAILY="${BACKUP_RETENTION_DAILY:-7}"
 RETENTION_WEEKLY="${BACKUP_RETENTION_WEEKLY:-4}"
 LOG_FILE="${BACKUP_LOG_FILE:-/var/log/backup-database.log}"
+OBSERVER_GROUP="${BACKUP_OBSERVER_GROUP:-extra-consultoria}"
 NOTIFY_CMD="${BACKUP_NOTIFY_CMD:-}"
 SSHFS_OPTS="${SSHFS_OPTIONS:--o reconnect,ServerAliveInterval=15,ServerAliveCountMax=3}"
 NFS_OPTS="${BACKUP_NFS_OPTIONS:-vers=3,nolock,hard,timeo=600,retrans=2}"
@@ -148,7 +150,7 @@ fi
 log "INFO" "=== Início da execução (modo: $MODE) ==="
 
 # Verifica dependências
-for cmd in pg_dump gzip; do
+for cmd in pg_dump gzip getent; do
   if ! command -v "$cmd" &>/dev/null; then
     log "FATAL" "Comando não encontrado: $cmd"
     notify_failure "Backup DB - Falha" "Comando não encontrado: $cmd"
@@ -277,6 +279,14 @@ ensure_remote_dirs() {
     return 0
   fi
   mkdir -p "$base/daily" "$base/weekly"
+  if ! getent group "$OBSERVER_GROUP" >/dev/null; then
+    log "FATAL" "Grupo observador de backup não existe: $OBSERVER_GROUP"
+    return 1
+  fi
+  # The health worker only needs directory traversal/listing to stat the newest
+  # immutable dump. Dump contents remain governed by their existing file mode.
+  chgrp "$OBSERVER_GROUP" "$base/daily" "$base/weekly"
+  chmod 0750 "$base/daily" "$base/weekly"
 }
 
 # ─── Backup ──────────────────────────────────────────────────────────────────

--- a/tests/test_backup_database_script_fail_closed.py
+++ b/tests/test_backup_database_script_fail_closed.py
@@ -24,3 +24,11 @@ def test_offsite_backup_is_published_atomically() -> None:
     assert publish in source
     assert source.index(staging) < source.index(copy) < source.index(publish)
     assert 'cp -f "$staging_path" "$dump_path"' not in source
+
+
+def test_offsite_directories_are_observable_without_exposing_dump_contents() -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'OBSERVER_GROUP="${BACKUP_OBSERVER_GROUP:-extra-consultoria}"' in source
+    assert 'chgrp "$OBSERVER_GROUP" "$base/daily" "$base/weekly"' in source
+    assert 'chmod 0750 "$base/daily" "$base/weekly"' in source
+    assert "chmod -R" not in source


### PR DESCRIPTION
## Outcome

Keeps off-site PostgreSQL dump contents private while allowing the `extra-consultoria` health worker to list/stat the immutable dump names used by the PNCP freshness contract.

## Live evidence

The 2026-08-24 off-site backup existed and completed successfully at 06:19 BRT, but `daily/` and `weekly/` were `0700/root`; the health worker consequently reported `BACKUP_UNAVAILABLE` and blocked the CONFENGE feed. After changing only directory group/mode to `extra-consultoria:0750`, the same live observer returned `available=true`, `offsite_age_hours≈13`, and the exact Aug 24 dump path. Dump file content modes were not changed.

## Verification

- backup fail-closed + PNCP freshness suites: 36 passed
- `bash -n`: passed
- Ruff: passed
- generated-artifacts policy: passed
- PR reviewability policy: passed

Relates to #277, #468, and #469.