### PR TITLE
fix(confenge): bind feed child to deployed release

### DIFF
--- a/scripts/ops/confenge_feed_cycle.py
+++ b/scripts/ops/confenge_feed_cycle.py
@@ -29,6 +29,26 @@ def _run_id() -> str:
     return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
+def _pipeline_runtime() -> tuple[Path, dict[str, str]]:
+    """Bind the child pipeline to the same immutable checkout as this runner.
+
+    Production deliberately runs this orchestrator from the canonical data/evidence
+    directory.  Invoking the child with ``python -m`` would therefore let an older
+    ``scripts`` package in that directory shadow the deployed release.  Execute the
+    release entrypoint by absolute path and put its repository root first on
+    ``PYTHONPATH`` while preserving the canonical working directory.
+    """
+
+    runtime_root = Path(__file__).resolve().parents[2]
+    entrypoint = runtime_root / "scripts" / "confenge_outreach_pipeline" / "__main__.py"
+    if not entrypoint.is_file():
+        raise FileNotFoundError(f"canonical outreach pipeline entrypoint not found: {entrypoint}")
+    env = os.environ.copy()
+    inherited_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (str(runtime_root), inherited_pythonpath) if part)
+    return entrypoint, env
+
+
 def run_cycle(
     *,
     output_root: Path,
@@ -46,10 +66,10 @@ def run_cycle(
 
     run_dir = output_root / f"confenge-feed-cycle-{_run_id()}"
     run_dir.mkdir(parents=True, exist_ok=False)
+    pipeline_entrypoint, pipeline_env = _pipeline_runtime()
     command = [
         sys.executable,
-        "-m",
-        "scripts.confenge_outreach_pipeline",
+        str(pipeline_entrypoint),
         "run",
         "--out",
         str(run_dir),
@@ -62,7 +82,13 @@ def run_cycle(
         "--no-resume",
         "--quiet",
     ]
-    completed = subprocess.run(command, check=False, text=True, capture_output=True)  # noqa: S603
+    completed = subprocess.run(  # noqa: S603
+        command,
+        check=False,
+        text=True,
+        capture_output=True,
+        env=pipeline_env,
+    )
     (run_dir / "cycle-command.json").write_text(
         json.dumps(
             {
@@ -79,8 +105,7 @@ def run_cycle(
     )
     if completed.returncode != 0:
         raise RuntimeError(
-            f"canonical outreach pipeline failed with exit {completed.returncode}: "
-            f"{completed.stderr[-2000:].strip()}"
+            f"canonical outreach pipeline failed with exit {completed.returncode}: {completed.stderr[-2000:].strip()}"
         )
 
     publication = atomic_publish_directory(

--- a/tests/test_confenge_feed_publication.py
+++ b/tests/test_confenge_feed_publication.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -12,6 +14,7 @@ from scripts.confenge_activation.publish import (
     check_current_publication,
     record_feed_cycle_state,
 )
+from scripts.ops import confenge_feed_cycle
 
 NOW = datetime(2026, 8, 24, 18, tzinfo=UTC)
 
@@ -184,3 +187,45 @@ def test_hash_mismatch_is_refused_before_promotion(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="chunk hash mismatch"):
         atomic_publish_directory(build, public, state_path=state, alert_ledger=alerts, now=NOW)
     assert not (public / "current").exists()
+
+
+def test_cycle_binds_child_pipeline_to_same_checkout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    durable_contacts = tmp_path / "contacts.jsonl"
+    durable_contacts.write_text("", encoding="utf-8")
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        run_dir = Path(command[command.index("--out") + 1])
+        (run_dir / "06_warmbly_feed").mkdir()
+        return subprocess.CompletedProcess(command, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(confenge_feed_cycle.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        confenge_feed_cycle,
+        "atomic_publish_directory",
+        lambda *_args, **_kwargs: {"ok": True},
+    )
+
+    result = confenge_feed_cycle.run_cycle(
+        output_root=tmp_path / "output",
+        durable_contacts=durable_contacts,
+        publish_dir=tmp_path / "public",
+        as_of=NOW.date(),
+        max_age_hours=24,
+        state_path=tmp_path / "state.json",
+        alert_ledger=tmp_path / "alerts.jsonl",
+    )
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    runtime_root = Path(confenge_feed_cycle.__file__).resolve().parents[2]
+    assert Path(command[1]) == runtime_root / "scripts/confenge_outreach_pipeline/__main__.py"
+    assert "-m" not in command
+    assert "--durable-contacts" in command
+    child_env = captured["env"]
+    assert isinstance(child_env, dict)
+    assert str(child_env["PYTHONPATH"]).split(os.pathsep)[0] == str(runtime_root)
+    assert result["ok"] is True


### PR DESCRIPTION
## Outcome

Prevents the production feed orchestrator from loading an older `scripts.confenge_outreach_pipeline` package from its canonical evidence working directory. The child pipeline is now executed by absolute entrypoint from the same immutable checkout as the orchestrator, with that checkout first on `PYTHONPATH`, while retaining the canonical working directory needed for PNCP evidence.

## Production failure reproduced

`confenge_feed_cycle` ran from `/opt/extra-consultoria` under an immutable release and its nested `python -m scripts.confenge_outreach_pipeline` resolved the older canonical package, rejecting `--durable-contacts`.

## Verification

- `22 passed` across feed publication and outreach pipeline tests
- regression asserts absolute same-checkout entrypoint, no `-m`, durable contact argument, and release-first `PYTHONPATH`
- generated-artifacts policy: PASS
- PR reviewability (draft): PASS

Refs #468
Refs #469