### PR TITLE
feat: enrich every TARGET_CONFIRMED account

### DIFF
--- a/deploy/systemd/extra-crawl-pncp.service
+++ b/deploy/systemd/extra-crawl-pncp.service
@@ -10,6 +10,7 @@ User=extra-consultoria
 Group=extra-consultoria
 WorkingDirectory=/opt/extra-consultoria
 Environment=PYTHONPATH=/opt/extra-consultoria
+Environment=PYTHONSAFEPATH=1
 Environment=RESILIENCE_ENV=production
 EnvironmentFile=/opt/extra-consultoria/.env
 # production env: operational paths under /var/lib; fail-closed on blocked sources

--- a/docs/ops/confenge-outreach-pipeline.md
+++ b/docs/ops/confenge-outreach-pipeline.md
@@ -55,8 +55,10 @@ python -m scripts.confenge_outreach_pipeline run \
 | `--durable-contacts` | Hash-verified derived projection from the durable waterfall; merged across the full decision universe |
 
 `--limit-downstream` does **not** limit universe discovery or feed decisions.
-It limits only expensive intelligence/contact work. The feed also includes
-valid-CNPJ exclusions and DNC. Missing target-fit rows become explicit
+It limits intelligence/contact work only in smoke/sample mode. In production,
+the activation hot set bounds network contact work while deterministic
+intelligence covers all authoritative `TARGET_CONFIRMED` accounts. The feed also
+includes valid-CNPJ exclusions and DNC. Missing target-fit rows become explicit
 `TARGET_FIT_MISSING` tombstones.
 
 With `--dsn`, decisions come from the mode-aware published target-fit store
@@ -69,6 +71,12 @@ outputs, not a second authority. Its discovery policy and input evidence must
 be uniform; mixed or incompatible policy versions fail closed. Same-run hot-set
 contacts corroborate/extend it by canonical CNPJ and mailbox, after which the
 bridge recalculates exactly one preferred initial route per account.
+
+In production activation mode, the hot set remains the canary/capacity boundary
+for network contact discovery, but it does not limit deterministic account
+intelligence. Every account in the authoritative `TARGET_CONFIRMED` snapshot is
+processed for service, public factual context and message spine before the
+complete decision feed is exported. Smoke/sample mode remains bounded.
 
 ## Outputs
 

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -198,6 +198,66 @@ def _dedupe_decision_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, An
     return out, duplicate_count
 
 
+def _select_intelligence_rows(
+    *,
+    decision_rows: list[dict[str, Any]],
+    downstream_rows: list[dict[str, Any]],
+    target_fit_snapshot_rows: list[dict[str, Any]],
+    include_all_target_confirmed: bool,
+) -> tuple[list[dict[str, Any]], dict[str, int | str]]:
+    """Select account-intelligence scope without using activation as a hard gate.
+
+    The activation hot set continues to bound contact/network work and preserve
+    its canary role. Account intelligence is local and deterministic, so a
+    production activation run also covers every account in the authoritative
+    ``TARGET_CONFIRMED`` snapshot.
+    """
+    target_cnpjs = {
+        cnpj
+        for row in target_fit_snapshot_rows
+        if str(row.get("target_fit_class") or "").upper() == "TARGET_CONFIRMED"
+        for cnpj in (canonical_cnpj14(row.get("cnpj14") or row.get("cnpj")),)
+        if cnpj
+    }
+    selected: list[dict[str, Any]] = []
+    selected_cnpjs: set[str] = set()
+
+    def _append(row: dict[str, Any]) -> None:
+        cnpj = canonical_cnpj14(row.get("cnpj14") or row.get("cnpj"))
+        if not cnpj or cnpj in selected_cnpjs:
+            return
+        selected.append(row)
+        selected_cnpjs.add(cnpj)
+
+    for row in downstream_rows:
+        _append(row)
+    if include_all_target_confirmed:
+        for row in decision_rows:
+            cnpj = canonical_cnpj14(row.get("cnpj14") or row.get("cnpj"))
+            if cnpj in target_cnpjs:
+                _append(row)
+
+    downstream_cnpjs = {
+        cnpj
+        for row in downstream_rows
+        for cnpj in (canonical_cnpj14(row.get("cnpj14") or row.get("cnpj")),)
+        if cnpj
+    }
+    covered_targets = len(target_cnpjs & selected_cnpjs)
+    return selected, {
+        "scope": (
+            "target_confirmed_plus_activation_hot_set"
+            if include_all_target_confirmed
+            else "downstream_sample_only"
+        ),
+        "target_confirmed_total": len(target_cnpjs),
+        "target_confirmed_processed": covered_targets,
+        "target_confirmed_missing": len(target_cnpjs) - covered_targets,
+        "activation_or_sample_count": len(downstream_cnpjs),
+        "selected_count": len(selected),
+    }
+
+
 def merge_contact_rows(
     durable_rows: list[dict[str, Any]],
     current_rows: list[dict[str, Any]],
@@ -625,7 +685,8 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             # Map hot set back to universe rows (preserve order of hot set)
             by_cnpj = {"".join(ch for ch in str(r.get("cnpj14") or "") if ch.isdigit()): r for r in universe_rows}
             sample_rows = [by_cnpj[c] for c in (p.cnpj14 for p in cycle.hot_set) if c in by_cnpj]
-            # Safety: never silent-truncate reservoir; expensive path is hot set only
+            # Preserve the activation canary for network contact work. Deterministic
+            # account intelligence expands to authoritative TARGET_CONFIRMED below.
             sample_path = dirs["sample"] / "downstream-hot-set.jsonl"
             _write_jsonl(sample_path, sample_rows)
             planned_cap = int(capacity) if capacity is not None else policy.capacity.planned_capacity()
@@ -639,7 +700,8 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 ),
                 "note": (
                     "Hot set is capacity-aware activation planning, not arbitrary Top-N. "
-                    "Full reservoir remains monitored; only hot set enters expensive stages. "
+                    "Full reservoir remains monitored; only hot set enters network contact discovery. "
+                    "Deterministic intelligence also covers authoritative TARGET_CONFIRMED. "
                     "--limit-downstream is smoke/batch-only and does NOT set commercial capacity."
                 ),
             }
@@ -649,7 +711,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
                 "mode": "activation_hot_set",
                 "profile_counts": sample_profile_counts(sample_rows),
                 "note": (
-                    "Downstream rows selected by activation planner hot set. "
+                    "Network-contact rows selected by activation planner hot set. "
                     f"capacity={planned_cap}; reservoir={len(universe_rows)}."
                 ),
             }
@@ -704,7 +766,21 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
         # ── 3. Account intelligence ──────────────────────────────────────
         ckpt.mark_running("intelligence")
         save_checkpoint(out, ckpt)
-        intel_inputs = [universe_row_to_intelligence_input(r, as_of=as_of.isoformat()) for r in sample_rows]
+        intelligence_rows, intelligence_scope = _select_intelligence_rows(
+            decision_rows=decision_rows,
+            downstream_rows=sample_rows,
+            target_fit_snapshot_rows=target_fit_snapshot_rows,
+            include_all_target_confirmed=use_activation,
+        )
+        if use_activation and intelligence_scope["target_confirmed_missing"]:
+            raise ValueError(
+                "authoritative TARGET_CONFIRMED account missing from account-intelligence scope: "
+                f"missing={intelligence_scope['target_confirmed_missing']} "
+                f"total={intelligence_scope['target_confirmed_total']}"
+            )
+        intel_inputs = [
+            universe_row_to_intelligence_input(r, as_of=as_of.isoformat()) for r in intelligence_rows
+        ]
         intel_input_path = dirs["intel"] / "intelligence-inputs.jsonl"
         _write_jsonl(intel_input_path, intel_inputs)
 
@@ -734,11 +810,17 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             "raw_path": str(intel_raw_path),
             "bridge_path": str(bridge_intel_path),
             "count": len(dossiers),
+            **intelligence_scope,
             "service_distribution": dict(sorted(service_dist.items(), key=lambda x: (-x[1], x[0]))),
         }
         ckpt.mark_completed("intelligence", counts={"dossiers": len(dossiers)})
         save_checkpoint(out, ckpt)
-        _progress(cfg.progress, f"[intelligence] {len(dossiers)} / {len(universe_rows)} processed")
+        _progress(
+            cfg.progress,
+            f"[intelligence] {len(dossiers)} processed; "
+            f"TARGET_CONFIRMED={intelligence_scope['target_confirmed_processed']}/"
+            f"{intelligence_scope['target_confirmed_total']}",
+        )
 
         # ── 4. Contact resolution ────────────────────────────────────────
         ckpt.mark_running("contacts")
@@ -878,7 +960,7 @@ def run_pipeline(cfg: PipelineConfig) -> PipelineResult:
             export_result = export_outreach(export_cfg)
         stages["feed"] = export_result
         stages["feed_count"] = (export_result or {}).get("lead_count")
-        stages["expensive_enrichment_count"] = len(sample_rows)
+        stages["expensive_enrichment_count"] = len(intelligence_rows)
 
         # Persist funnel progress: mark exported / no-contact on projections
         if use_activation and cycle_projections:

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -16,6 +16,7 @@ from scripts.confenge_outreach_pipeline.pipeline import (
     PipelineConfig,
     _dedupe_decision_rows,
     _published_target_fit_snapshot,
+    _select_intelligence_rows,
     build_pipeline_contact_resolver,
     contact_job_meta,
     merge_contact_rows,
@@ -27,6 +28,53 @@ from scripts.warmbly_bridge.mapping import build_leads
 ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_CSV = ROOT / "tests" / "fixtures" / "confenge_universe" / "contracts_sample.csv"
 DNC_TXT = ROOT / "tests" / "fixtures" / "confenge_universe" / "dnc.txt"
+
+
+def test_account_intelligence_covers_target_confirmed_outside_hot_set() -> None:
+    hot = {"cnpj14": "11222333000181", "razao_social": "Canary"}
+    target_outside_hot = {"cnpj14": "22333444000155", "razao_social": "Target"}
+    non_target = {"cnpj14": "33444555000129", "razao_social": "Other"}
+
+    selected, metrics = _select_intelligence_rows(
+        decision_rows=[hot, target_outside_hot, non_target],
+        downstream_rows=[hot],
+        target_fit_snapshot_rows=[
+            {"cnpj14": hot["cnpj14"], "target_fit_class": "TARGET_CONFIRMED"},
+            {"cnpj14": target_outside_hot["cnpj14"], "target_fit_class": "TARGET_CONFIRMED"},
+            {"cnpj14": non_target["cnpj14"], "target_fit_class": "TARGET_OUT_OF_SCOPE"},
+        ],
+        include_all_target_confirmed=True,
+    )
+
+    assert [row["cnpj14"] for row in selected] == [hot["cnpj14"], target_outside_hot["cnpj14"]]
+    assert metrics == {
+        "scope": "target_confirmed_plus_activation_hot_set",
+        "target_confirmed_total": 2,
+        "target_confirmed_processed": 2,
+        "target_confirmed_missing": 0,
+        "activation_or_sample_count": 1,
+        "selected_count": 2,
+    }
+
+
+def test_smoke_sample_does_not_expand_account_intelligence_scope() -> None:
+    sample = {"cnpj14": "11222333000181"}
+    target_outside_sample = {"cnpj14": "22333444000155"}
+
+    selected, metrics = _select_intelligence_rows(
+        decision_rows=[sample, target_outside_sample],
+        downstream_rows=[sample],
+        target_fit_snapshot_rows=[
+            {"cnpj14": sample["cnpj14"], "target_fit_class": "TARGET_CONFIRMED"},
+            {"cnpj14": target_outside_sample["cnpj14"], "target_fit_class": "TARGET_CONFIRMED"},
+        ],
+        include_all_target_confirmed=False,
+    )
+
+    assert selected == [sample]
+    assert metrics["scope"] == "downstream_sample_only"
+    assert metrics["target_confirmed_processed"] == 1
+    assert metrics["target_confirmed_missing"] == 1
 
 
 def test_limit_downstream_does_not_shrink_universe(tmp_path: Path) -> None:
@@ -497,6 +545,10 @@ def test_production_activation_does_not_use_limit_downstream_as_capacity(tmp_pat
     assert act.get("capacity_this_round") != default_limit_downstream or planned == default_limit_downstream
     assert result.stages["sample"]["mode"] == "activation_hot_set"
     assert result.stages["universe_row_count"] >= result.stages["sample"]["count"]
+    intelligence = result.stages["account_intelligence"]
+    assert intelligence["scope"] == "target_confirmed_plus_activation_hot_set"
+    assert intelligence["target_confirmed_processed"] == intelligence["target_confirmed_total"]
+    assert intelligence["target_confirmed_missing"] == 0
 
 
 def test_cli_run_fixture_end_to_end(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Resultado

Remove o hot set como barreira acidental da etapa determinística de account intelligence. Em modo de ativação, toda conta do snapshot autoritativo TARGET_CONFIRMED recebe service/context/message spine; o hot set continua limitando somente descoberta de contato em rede e preserva seu papel de canário.

A execução falha fechada se uma conta TARGET_CONFIRMED não entrar no escopo de inteligência. Smoke/sample permanece limitado.

## Evidência local

- 20 testes do pipeline passaram
- 100 testes de account intelligence, bridge e publicação passaram
- ruff passou
- generated-artifacts policy passou
- PR reviewability passou
- binding canônico passou

Fecha a lacuna live observada em #469 e desbloqueia o consumer citado em warmbly#154/#155.