### PR TITLE
fix: partition PNCP incremental freshness windows

### DIFF
--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -18,8 +18,9 @@ EnvironmentFile=/opt/extra-consultoria/.env
 # SuccessExitStatus=75 keeps systemd from treating expected writer contention as
 # a unit failure (avoids OnFailure storms). It is NOT a closed window and NOT
 # freshness success: PNCP_CONTRACT_FRESHNESS classifies LOCK_BUSY_NO_CLOSE and
-# the next 4h OnCalendar is the catch-up/retry. --days 7 is overlap for late
-# arrivals/retificações; checkpoint skips already-completed windows.
+# the next 4h OnCalendar is the catch-up/retry. --days 7 remains the overlap for
+# late arrivals/retificações, split by the runner into seven daily completion
+# units so mutable upstream pagination cannot invalidate the whole lookback.
 SuccessExitStatus=75
 ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.crawl.run_contracts_incremental --days 7
 User=extra-consultoria

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -954,6 +954,7 @@ def run_pilot(
     dsn: str,
     *,
     days: int = CONTRACTS_FULL_DAYS,
+    window_days: int = CONTRACTS_WINDOW_DAYS,
     output_json: str | None = None,
     dry_run: bool = False,
     checkpoint_dir: str | None = None,
@@ -962,13 +963,15 @@ def run_pilot(
     campaign_id: str | None = None,
     query_kind: str = "publication",
 ) -> dict[str, Any]:
+    if window_days < 1:
+        raise ValueError("window_days must be >= 1")
     started = datetime.now(UTC)
     mode = "full"
     today = utc_today()
     start, closed_through, range_end_exclusive = closed_crawl_range(today, days)
     if query_kind not in {"publication", "update"}:
         raise ValueError(f"unsupported contracts query_kind={query_kind!r}")
-    planned_windows = count_planned_windows(start, range_end_exclusive, CONTRACTS_WINDOW_DAYS)
+    planned_windows = count_planned_windows(start, range_end_exclusive, window_days)
     run_id = run_id or new_run_id(prefix="contracts-90d")
 
     ckpt_dir = _configure_checkpoint_dir(checkpoint_dir)
@@ -1002,7 +1005,7 @@ def run_pilot(
         "previous_run_ids": previous_run_ids,
         "mode": mode,
         "days": days,
-        "window_days": CONTRACTS_WINDOW_DAYS,
+        "window_days": window_days,
         "query_kind": query_kind,
         "window_boundary": "closed_through_d_minus_1",
         "planned_windows": planned_windows,
@@ -1040,7 +1043,7 @@ def run_pilot(
         while cur_date < today:
             # Half-open planning range [start, today): never checkpoint the open
             # current day as complete. This is the root boundary contract for #458.
-            window_end = min(cur_date + timedelta(days=CONTRACTS_WINDOW_DAYS - 1), closed_through)
+            window_end = min(cur_date + timedelta(days=window_days - 1), closed_through)
             window_key = f"{_fmt(cur_date)}_{_fmt(window_end)}"
             data_ini, data_fim = _fmt(cur_date), _fmt(window_end)
             w_started = time.time()
@@ -1628,6 +1631,7 @@ def run_pilot(
         command="scripts/crawl/run_contracts_90d_pilot.py",
         args={
             "days": days,
+            "window_days": window_days,
             "mode": mode,
             "dry_run": dry_run,
             "planned_windows": planned_windows,

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -57,23 +57,39 @@ logger = logging.getLogger("contracts_incremental")
 DEFAULT_CHECKPOINT_DIR = "data/contracts_checkpoints/incremental"
 DEFAULT_CAMPAIGN = "historical_contracts_incremental"
 INCREMENTAL_QUERY_KIND = "update"
+INCREMENTAL_WINDOW_DAYS = 1
 
 
-def current_incremental_window_key(*, days: int, today: date | None = None) -> str:
-    """Return the latest closed window key that must be revalidated."""
+def current_incremental_window_keys(
+    *,
+    days: int,
+    today: date | None = None,
+    window_days: int = INCREMENTAL_WINDOW_DAYS,
+) -> list[str]:
+    """Return every closed overlap window that must be revalidated.
+
+    Incremental observations deliberately use daily partitions.  A mutable
+    seven-day PNCP result set can change while 100+ pages are traversed; daily
+    windows keep the same lookback while making each completion unit small,
+    independently auditable, and retryable.
+    """
     from scripts.crawl.run_contracts_90d_pilot import (
-        CONTRACTS_WINDOW_DAYS,
         closed_crawl_range,
         iter_planned_window_keys,
         utc_today,
     )
 
     operational_today = today or utc_today()
-    start, closed_through, _exclusive_end = closed_crawl_range(operational_today, days)
-    keys = iter_planned_window_keys(start, closed_through, CONTRACTS_WINDOW_DAYS)
+    start, _closed_through, exclusive_end = closed_crawl_range(operational_today, days)
+    keys = iter_planned_window_keys(start, exclusive_end, window_days)
     if not keys:
         raise ValueError(f"incremental range produced no window for days={days}")
-    return keys[-1]
+    return keys
+
+
+def current_incremental_window_key(*, days: int, today: date | None = None) -> str:
+    """Return the latest daily window key (compatibility helper)."""
+    return current_incremental_window_keys(days=days, today=today)[-1]
 
 
 def reopen_current_window(checkpoint: object, *, window_key: str) -> bool:
@@ -90,6 +106,16 @@ def reopen_current_window(checkpoint: object, *, window_key: str) -> bool:
         return False
     setattr(checkpoint, "completed_windows", [key for key in completed if key != window_key])
     return True
+
+
+def reopen_incremental_windows(checkpoint: object, *, window_keys: list[str]) -> list[str]:
+    """Reopen the complete moving lookback, returning the removed keys."""
+    completed = list(getattr(checkpoint, "completed_windows", []) or [])
+    moving = set(window_keys)
+    reopened = [key for key in completed if key in moving]
+    if reopened:
+        setattr(checkpoint, "completed_windows", [key for key in completed if key not in moving])
+    return reopened
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -234,6 +260,7 @@ def _run_incremental(args: argparse.Namespace) -> int:
         meta["reset_cleared_run_id"] = True
         meta["campaign_role"] = "historical_contracts_incremental"
         meta["query_kind"] = INCREMENTAL_QUERY_KIND
+        meta["window_days"] = INCREMENTAL_WINDOW_DAYS
         data["meta"] = meta
         save_raw(cp_path, data)
         logger.info("Incremental checkpoint reset (archived prior file)")
@@ -254,7 +281,19 @@ def _run_incremental(args: argparse.Namespace) -> int:
                     f"query_kind mismatch existing={prior_query_kind!r} "
                     f"requested={INCREMENTAL_QUERY_KIND!r}; use --reset-checkpoint after archive"
                 )
+            prior_window_days = (data.get("meta") or {}).get("window_days")
+            if prior_window_days is None and data.get("completed_windows"):
+                raise ValueError(
+                    "checkpoint has completed windows without window_days binding; "
+                    "daily-window migration requires --reset-checkpoint after archive"
+                )
+            if prior_window_days is not None and int(prior_window_days) != INCREMENTAL_WINDOW_DAYS:
+                raise ValueError(
+                    f"window_days mismatch existing={prior_window_days!r} "
+                    f"requested={INCREMENTAL_WINDOW_DAYS!r}; use --reset-checkpoint after archive"
+                )
             data.setdefault("meta", {})["query_kind"] = INCREMENTAL_QUERY_KIND
+            data.setdefault("meta", {})["window_days"] = INCREMENTAL_WINDOW_DAYS
             save_raw(cp_path, data)
         except Exception as exc:  # noqa: BLE001
             # Wrong campaign/days → hard fail with guidance
@@ -266,17 +305,25 @@ def _run_incremental(args: argparse.Namespace) -> int:
             )
             return 1
 
-    # A completed moving window is not durable freshness evidence. Revalidate
-    # it on every 4h slot; success re-adds it, any failure remains fail-closed.
+    # Completed moving windows are not durable freshness evidence. Revalidate
+    # the full daily-partitioned lookback on every 4h slot; success re-adds
+    # every unit, while any failed unit remains fail-closed.
     checkpoint = load_checkpoint("full")
-    refresh_key = current_incremental_window_key(days=int(args.days))
-    if reopen_current_window(checkpoint, window_key=refresh_key):
+    refresh_keys = current_incremental_window_keys(days=int(args.days))
+    reopened = reopen_incremental_windows(checkpoint, window_keys=refresh_keys)
+    if reopened:
         save_checkpoint(checkpoint)
-        logger.info("Reopened current incremental window for refresh: %s", refresh_key)
+        logger.info(
+            "Reopened %d daily incremental windows for refresh: %s..%s",
+            len(reopened),
+            reopened[0],
+            reopened[-1],
+        )
 
     report = run_pilot(
         dsn=args.dsn,
         days=args.days,
+        window_days=INCREMENTAL_WINDOW_DAYS,
         output_json=str(args.output_json),
         checkpoint_dir=args.checkpoint_dir,
         dry_run=bool(args.dry_run),
@@ -295,6 +342,7 @@ def _run_incremental(args: argparse.Namespace) -> int:
         meta_after["checkpoint_version"] = int(meta_after.get("checkpoint_version") or 2)
         meta_after["capability"] = "historical_contracts"
         meta_after["query_kind"] = INCREMENTAL_QUERY_KIND
+        meta_after["window_days"] = INCREMENTAL_WINDOW_DAYS
         if report.get("run_id"):
             meta_after["attempt_run_id"] = report["run_id"]
             meta_after["run_id"] = report["run_id"]
@@ -305,6 +353,7 @@ def _run_incremental(args: argparse.Namespace) -> int:
 
     report["command"] = "run_contracts_incremental"
     report["incremental_days"] = args.days
+    report["window_days"] = INCREMENTAL_WINDOW_DAYS
     report["campaign_role"] = "historical_contracts_incremental"
     report["logical_job_id"] = str(args.logical_job_id)
     report["campaign_id"] = str(args.campaign_id)

--- a/tests/test_contracts_checkpoint_contract.py
+++ b/tests/test_contracts_checkpoint_contract.py
@@ -176,6 +176,7 @@ def test_incremental_cli_rebind_with_mocked_pilot(tmp_path: Path, monkeypatch: p
                 "meta": {
                     "run_id": "contracts-90d-stale",
                     "run_ids": ["contracts-90d-stale"],
+                    "window_days": 1,
                 },
             }
         ),

--- a/tests/test_contracts_incremental_refresh.py
+++ b/tests/test_contracts_incremental_refresh.py
@@ -6,7 +6,9 @@ from scripts.crawl.contracts_crawler import CrawlCheckpoint
 from scripts.crawl.run_contracts_90d_pilot import utc_today
 from scripts.crawl.run_contracts_incremental import (
     current_incremental_window_key,
+    current_incremental_window_keys,
     reopen_current_window,
+    reopen_incremental_windows,
 )
 
 
@@ -18,7 +20,7 @@ def test_pncp_operational_date_is_utc_across_brazil_midnight_boundary() -> None:
 
 def test_current_incremental_window_is_reopened_for_every_timer_slot() -> None:
     key = current_incremental_window_key(days=7, today=date(2026, 8, 22))
-    assert key == "20260815_20260821"
+    assert key == "20260821_20260821"
     checkpoint = CrawlCheckpoint(
         mode="full",
         completed_windows=["20260807_20260814", key],
@@ -36,3 +38,23 @@ def test_reopen_is_idempotent_after_a_failed_attempt() -> None:
     checkpoint = CrawlCheckpoint(mode="full", completed_windows=[])
     assert reopen_current_window(checkpoint, window_key="20260815_20260821") is False
     assert checkpoint.completed_windows == []
+
+
+def test_all_daily_overlap_windows_are_reopened_for_every_timer_slot() -> None:
+    keys = current_incremental_window_keys(days=7, today=date(2026, 8, 22))
+    assert keys == [
+        "20260815_20260815",
+        "20260816_20260816",
+        "20260817_20260817",
+        "20260818_20260818",
+        "20260819_20260819",
+        "20260820_20260820",
+        "20260821_20260821",
+    ]
+    checkpoint = CrawlCheckpoint(
+        mode="full",
+        completed_windows=["20260701_20260730", *keys],
+    )
+
+    assert reopen_incremental_windows(checkpoint, window_keys=keys) == keys
+    assert checkpoint.completed_windows == ["20260701_20260730"]


### PR DESCRIPTION
## Outcome

Splits the existing seven-day PNCP update lookback into seven daily, independently closed windows. This keeps the late-arrival overlap while reducing mutable upstream pagination from ~115 pages per completion unit to daily-sized units.

## Fail-closed migration

- Existing checkpoints without a `window_days` binding are refused.
- Production migration requires the existing checkpoint to be archived through `--reset-checkpoint`.
- Every daily window in the moving lookback is reopened on each 4h run.
- No pagination/freshness threshold is reduced.

## Production evidence motivating the change

Run `contracts-90d-20260825T070307Z-088023f23e` traversed all 115 pages but correctly refused completion after PNCP changed `totalRegistros` from 57,182 to 57,174 mid-traversal. The feed remained unpublished.

## Verification

- 111 passed, 1 skipped: incremental/checkpoint/incident/freshness suites
- Ruff: pass
- generated-artifacts policy: pass
- PR reviewability: pass

Tracks #468; live evidence will be added after deploy and full reconciliation.