### PR TITLE
fix: bind runtime evidence to immutable release

### DIFF
--- a/scripts/crawl/run_evidence.py
+++ b/scripts/crawl/run_evidence.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import socket
 import subprocess
 import uuid
@@ -50,6 +51,8 @@ _ENV_SECRET_MARKERS = (
     "PRIVATE",
     "AUTH",
 )
+_IMMUTABLE_RELEASE_PARENT = "extra-consultoria-releases"
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
 
 def new_run_id(prefix: str = "run") -> str:
@@ -60,14 +63,33 @@ def new_run_id(prefix: str = "run") -> str:
     return f"{safe_prefix}-{stamp}-{short}"
 
 
+def runtime_release_sha(path: str | Path | None = None) -> str | None:
+    """Infer the deployed SHA from an immutable release directory, if present."""
+    resolved = Path(path or __file__).resolve()
+    for parent in resolved.parents:
+        if parent.parent.name == _IMMUTABLE_RELEASE_PARENT and _FULL_GIT_SHA_RE.fullmatch(parent.name):
+            return parent.name.lower()
+    return None
+
+
 def get_git_meta() -> dict[str, str | None]:
-    """Return git_sha and git_branch; soft-fail to None on any error."""
+    """Return code-bound git metadata without consulting an unrelated CWD repo."""
+    env_sha = (os.getenv("EXTRA_DEPLOYED_SHA") or os.getenv("GIT_SHA") or "").strip()
+    env_branch = (os.getenv("EXTRA_DEPLOYED_BRANCH") or os.getenv("GIT_BRANCH") or "").strip()
+    release_sha = runtime_release_sha()
+    if env_sha or release_sha:
+        return {
+            "git_sha": env_sha or release_sha,
+            "git_branch": env_branch or None,
+        }
+
     git_sha: str | None = None
     git_branch: str | None = None
+    repo_root = Path(__file__).resolve().parents[2]
     try:
         git_sha = (
-            subprocess.check_output(
-                ["git", "rev-parse", "HEAD"],  # noqa: S607
+            subprocess.check_output(  # noqa: S603
+                ["git", "-C", str(repo_root), "rev-parse", "HEAD"],  # noqa: S607
                 stderr=subprocess.DEVNULL,
                 timeout=5,
             )
@@ -79,8 +101,8 @@ def get_git_meta() -> dict[str, str | None]:
         git_sha = None
     try:
         git_branch = (
-            subprocess.check_output(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+            subprocess.check_output(  # noqa: S603
+                ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
                 stderr=subprocess.DEVNULL,
                 timeout=5,
             )

--- a/tests/test_run_evidence.py
+++ b/tests/test_run_evidence.py
@@ -14,6 +14,7 @@ from scripts.crawl.run_evidence import (
     get_git_meta,
     host_id,
     new_run_id,
+    runtime_release_sha,
     sha256_bytes,
     sha256_file,
 )
@@ -48,6 +49,20 @@ def test_get_git_meta_soft_fail_shape():
     # In this repo git should usually work; values may be str or None
     assert meta["git_sha"] is None or isinstance(meta["git_sha"], str)
     assert meta["git_branch"] is None or isinstance(meta["git_branch"], str)
+
+
+def test_runtime_release_sha_is_bound_to_immutable_release_path():
+    sha = "a" * 40
+    path = Path("/opt/extra-consultoria-releases") / sha / "scripts/crawl/run_evidence.py"
+    assert runtime_release_sha(path) == sha
+    assert runtime_release_sha("/opt/extra-consultoria/scripts/crawl/run_evidence.py") is None
+
+
+def test_get_git_meta_prefers_explicit_deployed_sha(monkeypatch: pytest.MonkeyPatch):
+    sha = "b" * 40
+    monkeypatch.setenv("EXTRA_DEPLOYED_SHA", sha)
+    monkeypatch.setenv("EXTRA_DEPLOYED_BRANCH", "main")
+    assert get_git_meta() == {"git_sha": sha, "git_branch": "main"}
 
 
 def test_host_id_is_short_hex():


### PR DESCRIPTION
## Outcome

Prevents production run evidence from reading `git rev-parse HEAD` from an unrelated data working directory. Runtime provenance now resolves in this order:

1. explicit `EXTRA_DEPLOYED_SHA` / `GIT_SHA`;
2. the 40-hex immutable `/opt/extra-consultoria-releases/<sha>/` directory;
3. the repository containing `run_evidence.py` via `git -C`.

## Live defect

The successful 7/7 PNCP observation executed from release `ea3dd98b...`, but its evidence inherited the old `/opt/extra-consultoria` HEAD. The feed remains unpublished. The source observation will be repeated after this fix is merged and deployed.

## Verification

- 59 targeted evidence/incremental/freshness tests passed
- Ruff, generated-artifacts policy, PR reviewability: pass

Tracks #468.