### PR TITLE
fix: align PNCP production read timeout with baseline

### DIFF
--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -12,6 +12,10 @@ Type=oneshot
 WorkingDirectory=/opt/extra-consultoria
 Environment=PYTHONPATH=/opt/extra-consultoria
 EnvironmentFile=/opt/extra-consultoria/.env
+# PNCP routinely takes longer than urllib's 30s default under load. A 60s
+# read budget is the production baseline; page retries and population
+# convergence remain fail-closed, so this does not accept partial windows.
+Environment=CONTRACTS_READ_TIMEOUT=60
 # ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental
 # (/run/lock/extra-contracts-writer.lock). Do NOT wrap with outer flock on the
 # same path (would always exit 75). Exit 75 = lock busy (not a source failure).

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -544,6 +544,12 @@ def test_parse_dt_systemd_show_stamp() -> None:
     assert parse_dt("n/a") is None
 
 
+def test_pncp_contracts_service_has_production_read_timeout() -> None:
+    service = Path("deploy/systemd/pncp-contracts.service").read_text(encoding="utf-8")
+
+    assert "Environment=CONTRACTS_READ_TIMEOUT=60" in service
+
+
 def test_collect_timer_snapshot_parses_systemd_stamps() -> None:
     snap = collect_timer_snapshot(
         show_timer={


### PR DESCRIPTION
## Outcome

Pins `CONTRACTS_READ_TIMEOUT=60` in the production PNCP incremental unit. The crawler already supports this setting and the production baseline specifies a >=60s read budget; the deployed unit was silently using the 30s default.

This does **not** relax page retry bounds, pagination convergence, source-population drift checks, or freshness fail-closed behavior. Partial windows remain rejected.

## Live evidence

On 2026-08-25 the scheduled and immediate retry attempts observed repeated 30s read timeouts plus upstream 502/503 responses. The freshness contract correctly rejected those partial attempts. This change addresses only the avoidable 30s client budget mismatch.

## Verification

- `34 passed` — `tests/test_pncp_contract_freshness.py`
- committed systemd validator: pass
- generated-artifacts policy: pass
- PR reviewability policy: pass

Relates to #468.
