### PR TITLE
fix: survive bounded PNCP 502/503 bursts

### DIFF
--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -16,6 +16,12 @@ EnvironmentFile=/opt/extra-consultoria/.env
 # read budget is the production baseline; page retries and population
 # convergence remain fail-closed, so this does not accept partial windows.
 Environment=CONTRACTS_READ_TIMEOUT=60
+# Six bounded attempts span short PNCP 502/503 bursts instead of spending the
+# entire page retry budget in ~10s. Partial pages and population drift still
+# fail the window; the cap only affects how long transport recovery may take.
+Environment=CONTRACTS_PAGE_RETRY_MAX=5
+Environment=CONTRACTS_PAGE_RETRY_BASE_SECONDS=5
+Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30
 # ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental
 # (/run/lock/extra-contracts-writer.lock). Do NOT wrap with outer flock on the
 # same path (would always exit 75). Exit 75 = lock busy (not a source failure).

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -74,7 +74,15 @@ UPSERT_BATCH = int(os.getenv("CONTRACTS_UPSERT_BATCH", "500"))
 DEFAULT_PILOT_CKPT_DIR = str(_PROJECT_ROOT / "data" / "contracts_checkpoints" / "a5_next30d")
 
 # Pilot-level page retries (on top of contracts_crawler internal retries).
-_PAGE_RETRY_MAX = 3
+# Production may widen the *time window* for transient PNCP load-balancer
+# bursts.  The budget remains finite and every failed page still makes the
+# source window partial/fail-closed.
+_PAGE_RETRY_MAX = max(0, int(os.getenv("CONTRACTS_PAGE_RETRY_MAX", "3")))
+_PAGE_RETRY_BASE_SECONDS = max(0.0, float(os.getenv("CONTRACTS_PAGE_RETRY_BASE_SECONDS", "1")))
+_PAGE_RETRY_CAP_SECONDS = max(
+    _PAGE_RETRY_BASE_SECONDS,
+    float(os.getenv("CONTRACTS_PAGE_RETRY_CAP_SECONDS", "30")),
+)
 _PAGE_RETRYABLE = frozenset(
     {
         FetchStatus.HTTP_RATE_LIMIT,
@@ -325,6 +333,8 @@ def _fetch_page_with_retry(
     telemetry: list[dict[str, Any]] | None = None,
     sleeper: Callable[[float], None] = time.sleep,
     jitter: Callable[[float, float], float] = random.uniform,
+    base_delay_seconds: float = _PAGE_RETRY_BASE_SECONDS,
+    cap_delay_seconds: float = _PAGE_RETRY_CAP_SECONDS,
 ) -> Any:
     """Fetch one page with exponential backoff + jitter on 429/5xx/timeout.
 
@@ -356,9 +366,11 @@ def _fetch_page_with_retry(
             return last
         if last.status not in _PAGE_RETRYABLE or attempt >= max_retries:
             return last
-        # exponential backoff with full jitter: base 1s → 2 → 4 ...
-        base = 2**attempt
-        delay = base + jitter(0, base)  # noqa: S311 — retry jitter, not crypto
+        # Exponential backoff with bounded additive jitter.  Cap includes the
+        # jitter, so a configured production retry horizon remains auditable.
+        base = min(float(cap_delay_seconds), float(base_delay_seconds) * (2**attempt))
+        jitter_ceiling = min(base, max(0.0, float(cap_delay_seconds) - base))
+        delay = base + jitter(0, jitter_ceiling)  # noqa: S311 — retry jitter, not crypto
         if telemetry is not None:
             telemetry[-1]["backoff_seconds"] = round(delay, 3)
         logger.warning(

--- a/tests/test_incident_458.py
+++ b/tests/test_incident_458.py
@@ -120,6 +120,32 @@ def test_retry_is_bounded_with_backoff_jitter_and_telemetry(monkeypatch) -> None
     assert telemetry[0]["classification"]["class"] == "transient"
 
 
+def test_production_retry_window_is_finite_and_capped(monkeypatch) -> None:
+    from scripts.crawl import run_contracts_90d_pilot as pilot
+
+    outcomes = [*[_result(FetchStatus.HTTP_SERVER_ERROR) for _ in range(5)], _result(FetchStatus.SUCCESS_DATA)]
+    monkeypatch.setattr(pilot, "_fetch_page", lambda *_a, **_k: outcomes.pop(0))
+    sleeps: list[float] = []
+    telemetry: list[dict] = []
+
+    result = _fetch_page_with_retry(
+        "20260815",
+        "20260821",
+        19,
+        max_retries=5,
+        telemetry=telemetry,
+        sleeper=sleeps.append,
+        jitter=lambda _a, b: b,
+        base_delay_seconds=5,
+        cap_delay_seconds=30,
+    )
+
+    assert result.status == FetchStatus.SUCCESS_DATA
+    assert sleeps == [10.0, 20.0, 30.0, 30.0, 30.0]
+    assert len(telemetry) == 6
+    assert sum(sleeps) == 120.0
+
+
 def test_permanent_page_failure_is_not_retried(monkeypatch) -> None:
     from scripts.crawl import run_contracts_90d_pilot as pilot
 

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -548,6 +548,9 @@ def test_pncp_contracts_service_has_production_read_timeout() -> None:
     service = Path("deploy/systemd/pncp-contracts.service").read_text(encoding="utf-8")
 
     assert "Environment=CONTRACTS_READ_TIMEOUT=60" in service
+    assert "Environment=CONTRACTS_PAGE_RETRY_MAX=5" in service
+    assert "Environment=CONTRACTS_PAGE_RETRY_BASE_SECONDS=5" in service
+    assert "Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30" in service
 
 
 def test_collect_timer_snapshot_parses_systemd_stamps() -> None:


### PR DESCRIPTION
## Outcome

Makes the pilot-owned page retry horizon configurable and pins production to six total attempts with bounded 5/10/20/30/30s base delays (jitter included in the 30s cap).

The change is transport-only. Page failures still make the window partial, source-population drift is unchanged, lower-level hidden retries remain disabled, and the 90-minute systemd deadline still bounds the whole job.

## Live evidence

After #502 eliminated repeated 30s read timeouts, the 2026-08-19 window reached page 19 and then received 502/503 four times in ~10 seconds. The current hard-coded retry horizon rejected the window before a short load-balancer burst could clear.

## Verification

- `53 passed, 1 skipped` (existing real-DB test; no DSN in this local invocation)
- ruff: pass
- committed systemd validator: pass
- generated-artifacts policy: pass
- PR reviewability policy: pass

Relates to #468.
