### PR TITLE
fix: replay mutable PNCP windows before closing

### DIFF
--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -22,6 +22,11 @@ Environment=CONTRACTS_READ_TIMEOUT=60
 Environment=CONTRACTS_PAGE_RETRY_MAX=5
 Environment=CONTRACTS_PAGE_RETRY_BASE_SECONDS=5
 Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30
+# The update-date population is legitimately mutable while PNCP retifications
+# move contracts between days. Replay from page 1; only a later stable full
+# pass may close the window. The whole oneshot remains bounded to 150 minutes.
+Environment=CONTRACTS_WINDOW_RETRY_MAX=2
+Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60
 # ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental
 # (/run/lock/extra-contracts-writer.lock). Do NOT wrap with outer flock on the
 # same path (would always exit 75). Exit 75 = lock busy (not a source failure).
@@ -35,7 +40,7 @@ SuccessExitStatus=75
 ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.crawl.run_contracts_incremental --days 7
 User=extra-consultoria
 Group=extra-consultoria
-TimeoutStartSec=90min
+TimeoutStartSec=150min
 Restart=no
 StandardOutput=journal
 StandardError=journal

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -83,6 +83,8 @@ _PAGE_RETRY_CAP_SECONDS = max(
     _PAGE_RETRY_BASE_SECONDS,
     float(os.getenv("CONTRACTS_PAGE_RETRY_CAP_SECONDS", "30")),
 )
+_WINDOW_RETRY_MAX = max(0, int(os.getenv("CONTRACTS_WINDOW_RETRY_MAX", "0")))
+_WINDOW_RETRY_DELAY_SECONDS = max(0.0, float(os.getenv("CONTRACTS_WINDOW_RETRY_DELAY_SECONDS", "60")))
 _PAGE_RETRYABLE = frozenset(
     {
         FetchStatus.HTTP_RATE_LIMIT,
@@ -150,6 +152,28 @@ def classify_incident_error_text(message: str) -> dict[str, Any]:
     if "http_client_error" in text:
         return {"class": "permanent", "transience": "permanent", "owner": "request_contract"}
     return {"class": "permanent", "transience": "unknown", "owner": "unknown"}
+
+
+def should_replay_mutable_window(
+    errors: Sequence[str],
+    *,
+    pages_exhausted: bool,
+    persistence_failed: bool,
+    retries_used: int,
+    max_retries: int,
+) -> bool:
+    """Retry a fully read window only when source drift is the sole failure.
+
+    The replay starts from page 1 and must independently converge. It never
+    turns the discarded mixed-population pass into success.
+    """
+    return bool(
+        errors
+        and pages_exhausted
+        and not persistence_failed
+        and retries_used < max(0, int(max_retries))
+        and all(str(error).startswith("source_population_drift:") for error in errors)
+    )
 
 
 def evaluate_window_completion(
@@ -1037,6 +1061,7 @@ def run_pilot(
             "page_retries": 0,
             "pages_reprocessed": 0,
             "page_errors": 0,
+            "window_retries": 0,
             "windows_ok": 0,
             "windows_partial": 0,
             "windows_failed": 0,
@@ -1044,12 +1069,14 @@ def run_pilot(
         },
         "status": "running",
         "errors": [],
+        "window_retry_events": [],
     }
 
     conn = None if dry_run else psycopg2.connect(dsn)
     if conn is not None:
         conn.autocommit = False
 
+    window_retry_counts: dict[str, int] = {}
     try:
         cur_date = start
         while cur_date < today:
@@ -1395,6 +1422,50 @@ def run_pilot(
                     {"error": err, **classify_incident_error_text(err)}
                 )
                 fully_ok = False
+            retries_used = int(window_retry_counts.get(window_key) or 0)
+            if not fully_ok and should_replay_mutable_window(
+                window_errors,
+                pages_exhausted=pages_exhausted,
+                persistence_failed=persist_failed,
+                retries_used=retries_used,
+                max_retries=_WINDOW_RETRY_MAX,
+            ):
+                retry_number = retries_used + 1
+                window_retry_counts[window_key] = retry_number
+                report["totals"]["window_retries"] += 1
+                retry_event = {
+                    "window_key": window_key,
+                    "retry_number": retry_number,
+                    "max_retries": _WINDOW_RETRY_MAX,
+                    "delay_seconds": _WINDOW_RETRY_DELAY_SECONDS,
+                    "pages": window_pages,
+                    "transformed": window_transformed,
+                    "errors": window_errors[:5],
+                    "population_drift": drift_report,
+                }
+                report["window_retry_events"].append(retry_event)
+                checkpoint.last_error = "; ".join(window_errors[:3])
+                _apply_run_id_to_checkpoint(checkpoint, run_id)
+                save_checkpoint(checkpoint)
+                logger.warning(
+                    "Window %s will replay from page 1 after source drift "
+                    "retry=%d/%d sleep=%.1fs",
+                    window_key,
+                    retry_number,
+                    _WINDOW_RETRY_MAX,
+                    _WINDOW_RETRY_DELAY_SECONDS,
+                )
+                if output_json:
+                    interim = dict(report)
+                    interim["status"] = "running"
+                    interim["checkpoint"] = checkpoint.to_dict()
+                    Path(output_json).parent.mkdir(parents=True, exist_ok=True)
+                    Path(output_json).write_text(
+                        json.dumps(interim, indent=2, default=str),
+                        encoding="utf-8",
+                    )
+                time.sleep(_WINDOW_RETRY_DELAY_SECONDS)
+                continue
             usable_partial = bool(window_transformed > 0 and not persist_failed)
             w_status = "completed" if fully_ok else ("partial" if usable_partial else "failed")
             if fully_ok:

--- a/tests/test_incident_458.py
+++ b/tests/test_incident_458.py
@@ -19,6 +19,7 @@ from scripts.crawl.run_contracts_90d_pilot import (
     _fetch_page_with_retry,
     classify_incident_error_text,
     closed_crawl_range,
+    should_replay_mutable_window,
 )
 
 
@@ -144,6 +145,82 @@ def test_production_retry_window_is_finite_and_capped(monkeypatch) -> None:
     assert sleeps == [10.0, 20.0, 30.0, 30.0, 30.0]
     assert len(telemetry) == 6
     assert sum(sleeps) == 120.0
+
+
+def test_mutable_window_replay_is_bounded_and_source_drift_only() -> None:
+    drift = [
+        "source_population_drift:source_population_drift:population_shrink:totalRegistros 11925 -> 11921",
+        "source_population_drift:totalRegistros 11925 -> 11921",
+    ]
+
+    assert should_replay_mutable_window(
+        drift,
+        pages_exhausted=True,
+        persistence_failed=False,
+        retries_used=0,
+        max_retries=2,
+    )
+    assert not should_replay_mutable_window(
+        drift,
+        pages_exhausted=True,
+        persistence_failed=False,
+        retries_used=2,
+        max_retries=2,
+    )
+    assert not should_replay_mutable_window(
+        [*drift, "Page 19: [http_server_error] 503"],
+        pages_exhausted=True,
+        persistence_failed=False,
+        retries_used=0,
+        max_retries=2,
+    )
+    assert not should_replay_mutable_window(
+        drift,
+        pages_exhausted=True,
+        persistence_failed=True,
+        retries_used=0,
+        max_retries=2,
+    )
+
+
+def test_mutable_window_replay_closes_only_after_stable_full_pass(monkeypatch, tmp_path) -> None:
+    from scripts.crawl import run_contracts_90d_pilot as pilot
+
+    monkeypatch.setattr(pilot, "CONTRACTS_REQUEST_DELAY", 0)
+    monkeypatch.setattr(pilot, "CONTRACTS_JANELA_DELAY", 0)
+    monkeypatch.setattr(pilot, "UPSERT_BATCH", 1)
+    monkeypatch.setattr(pilot, "_WINDOW_RETRY_MAX", 1)
+    monkeypatch.setattr(pilot, "_WINDOW_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(pilot, "transform", lambda rows: rows)
+    totals = iter((2, 1, 2, 2))
+    calls: list[int] = []
+
+    def fetch(_start, _end, page, **_kwargs):
+        calls.append(page)
+        return FetchResult(
+            status=FetchStatus.SUCCESS_DATA,
+            items=[{"numeroControlePNCP": f"pass-{(len(calls) - 1) // 2}-page-{page}"}],
+            total_records=next(totals),
+            total_pages=2,
+            current_page=page,
+        )
+
+    monkeypatch.setattr(pilot, "_fetch_page", fetch)
+    report = pilot.run_pilot(
+        "",
+        days=1,
+        dry_run=True,
+        checkpoint_dir=str(tmp_path),
+        run_id="incident-458-window-replay",
+    )
+
+    assert report["status"] == "success"
+    assert report["totals"]["window_retries"] == 1
+    assert report["totals"]["windows_ok"] == 1
+    assert report["totals"]["windows_partial"] == 0
+    assert calls == [1, 2, 1, 2]
+    assert len(report["window_retry_events"]) == 1
+    assert report["windows"][0]["status"] == "completed"
 
 
 def test_permanent_page_failure_is_not_retried(monkeypatch) -> None:

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -551,6 +551,9 @@ def test_pncp_contracts_service_has_production_read_timeout() -> None:
     assert "Environment=CONTRACTS_PAGE_RETRY_MAX=5" in service
     assert "Environment=CONTRACTS_PAGE_RETRY_BASE_SECONDS=5" in service
     assert "Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30" in service
+    assert "Environment=CONTRACTS_WINDOW_RETRY_MAX=2" in service
+    assert "Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60" in service
+    assert "TimeoutStartSec=150min" in service
 
 
 def test_collect_timer_snapshot_parses_systemd_stamps() -> None:


### PR DESCRIPTION
## Outcome

When a PNCP update-date window is fully paginated but its population changes during the pass, discard that pass and replay the same daily window from page 1. Only a later independently stable pass can close the checkpoint.

Production is bounded to two window replays with 60s between them and a 150-minute oneshot deadline. Transport/page failures, persistence failures, mixed error classes, exhausted replay budget, and any still-unstable final pass remain partial/fail-closed.

## Live evidence

On 2026-08-25, after transport hardening, the 2026-08-18 update window twice completed 24/24 pages while legitimately shrinking as retifications moved contracts between update dates (`11925 -> 11921` in the latest attempt). The previous behavior made a mutable official endpoint operationally unrecoverable during business hours even though replay from page 1 is the existing documented resume policy.

## Verification

- `55 passed, 1 skipped` (the skipped test is the pre-existing real-DB test without a local DSN)
- Includes a run-level regression: discarded drift pass + stable replay -> one completed window, zero partial windows
- ruff: pass
- committed systemd validator: pass
- generated-artifacts policy: pass
- PR reviewability policy: pass

Relates to #468.
