### PR TITLE
fix(pncp): manter timer ativo após falha do coletor

### DIFF
--- a/deploy/systemd/pncp-contracts.timer
+++ b/deploy/systemd/pncp-contracts.timer
@@ -10,7 +10,8 @@
 
 [Unit]
 Description=PNCP Contracts Crawler Timer — Extra Consultoria
-Requires=pncp-contracts.service
+# Do not add Requires=/BindsTo= for the triggered oneshot.  A failed source
+# attempt must leave this timer active so the next calendar slot can recover.
 
 [Timer]
 OnCalendar=*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo

--- a/docs/ops/incidents/PNCP-458.md
+++ b/docs/ops/incidents/PNCP-458.md
@@ -87,6 +87,20 @@ Relação com issues:
 
 O freshness SLO não foi relaxado. O soak foi endurecido para p95 `<=24h`.
 
+### Continuidade do timer após falha (2026-08-25)
+
+A auditoria live encontrou `Requires=pncp-contracts.service` no unit do timer.
+Como o coletor é `Type=oneshot`, um timeout/stop do serviço propagava a parada
+para o próprio timer: `UnitFileState=enabled`, mas `ActiveState=inactive` e sem
+`NextElapseUSecRealtime`. Reativar o timer com `Persistent=true` iniciava um
+catch-up imediato, ocultando o defeito até a próxima falha.
+
+O timer não deve vincular seu ciclo de vida ao oneshot que ele dispara.
+`Requires=`/`BindsTo=` para `pncp-contracts.service` são proibidos; uma tentativa
+falha continua fail-closed e alerta, enquanto o timer permanece `active/waiting`
+para a próxima janela de quatro horas. O aceite live exige provocar/observar um
+exit não-zero do serviço e provar que o timer conserva um próximo disparo.
+
 ## Validação local pré-PR
 
 - 244 testes focais/regressão passaram após rebase sobre #465, incluindo a

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -941,6 +941,14 @@ def test_shipped_timer_is_every_4h_or_6h_with_explicit_timezone() -> None:
     assert REASON_CADENCE_CANNOT_MEET_24H not in build_contract(_snapshot()).get("reason_codes")
 
 
+def test_shipped_timer_survives_triggered_oneshot_failure() -> None:
+    text = TIMER_UNIT_PATH.read_text(encoding="utf-8")
+
+    unit_section = text.split("[Timer]", 1)[0]
+    assert "Requires=pncp-contracts.service" not in unit_section
+    assert "BindsTo=pncp-contracts.service" not in unit_section
+
+
 def test_lock_busy_exit_75_is_not_fresh_or_closed_window() -> None:
     service = load_shipped_service_text()
     assert LOCK_BUSY_EXIT in parse_success_exit_statuses(service)


### PR DESCRIPTION
## Outcome

Mantém `pncp-contracts.timer` ativo após timeout/falha/stop do oneshot disparado, preservando o próximo slot de recuperação de quatro horas.

## Defeito live

Em 2026-08-25, `pncp-contracts.service` sofreu timeouts consecutivos do PNCP. O unit do timer continha `Requires=pncp-contracts.service`; ao parar/falhar o serviço, o timer ficava `enabled` porém `inactive/dead`, sem `NextElapseUSecRealtime`. Reativá-lo com `Persistent=true` disparava catch-up imediato e mascarava a perda de cadência.

## Mudança

- remove o vínculo de lifecycle `Requires=` entre timer e oneshot;
- documenta que `Requires=`/`BindsTo=` são proibidos para esse trigger;
- adiciona teste adversarial no contrato de freshness;
- registra diagnóstico/aceite live no runbook PNCP-458.

O coletor continua fail-closed e o SLO não foi relaxado.

Refs #468
Refs #458

## Validação

- `35 passed` — `tests/test_pncp_contract_freshness.py`
- `ruff check tests/test_pncp_contract_freshness.py`
- `systemd-analyze verify deploy/systemd/pncp-contracts.timer deploy/systemd/pncp-contracts.service`
- generated artifacts policy: PASS
- PR reviewability: PASS
- `git diff --check`: PASS

## Prova live pós-merge

Depois do deploy do SHA exato:

1. confirmar `pncp-contracts.timer=active/waiting` com próximo trigger;
2. observar um exit não-zero real do serviço enquanto o PNCP estiver indisponível;
3. provar que o timer conserva `ActiveState=active` e `NextElapseUSecRealtime` após a falha;
4. não promover freshness/feed até uma coleta integral aceita.
