### PR TITLE
feat(confenge): exportar papel tipado de contratada

### DIFF
--- a/DOD.md
+++ b/DOD.md
@@ -405,6 +405,16 @@ Um item pode ser marcado como concluído apenas quando pelo menos uma das evidê
 
 ### 2.7 Inteligência comercial CONFENGE — prioridade imediata
 
+> **Decisão vigente do founder em 25/08/2026:** para a campanha específica de
+> primeiro toque de roteamento, ADR-037 substitui a exigência anterior de
+> revisão/aprovação humana individual. O agente pode reconciliar evidência,
+> selecionar uma rota observada, gerar, revisar, reparar, aprovar e enfileirar
+> sob `CFG-FIRST-TOUCH-ROUTING-v1`. Órgão contratante, `UNKNOWN`, conflito de
+> papel, mailbox sem associação, suppression, opt-out, bounce, reply, kill
+> switch ou falha de readback continuam bloqueando. Follow-ups e conversas após
+> resposta permanecem fora dessa autoridade. Esta decisão não marca item como
+> aceito sem teste, CI, deploy e evidência operacional no estado correspondente.
+
 > **Objetivo imediato:** usar o dataset canônico de contratos para identificar pessoas jurídicas com dores, transições ou complexidade B2G observáveis e priorizar a prospecção humana da CONFENGE.
 >
 > **Regra de linguagem:** antes de validação com resultados comerciais reais, o sistema produz **sinais de necessidade/aderência** e um **score de priorização**. Não denomina esses resultados como desejo, intenção de compra, probabilidade de contratação ou propensão estatística.
@@ -463,13 +473,13 @@ Um item pode ser marcado como concluído apenas quando pelo menos uma das evidê
 - [ ] Cada item possui estado comercial controlado: `NEW`, `REVIEWED`, `QUALIFIED`, `DISQUALIFIED`, `CONTACTED`, `REPLIED`, `MEETING`, `PROPOSAL`, `WON`, `LOST` ou `DO_NOT_CONTACT`.
 - [ ] Revisões, overrides e desqualificações registram autor, data e motivo.
 - [ ] Dados de contato, quando enriquecidos, possuem origem lícita e data de verificação; o ranking funciona mesmo sem esse enriquecimento.
-- [ ] A fila informa uma ação humana concreta e uma mensagem de valor compatível com o sinal, sem automatizar contato em nome da CONFENGE.
+- [ ] A fila informa uma ação concreta e uma mensagem compatível com o sinal. O primeiro toque de roteamento pode usar ADR-037; demais contatos permanecem humanos ou exigem nova policy.
 - [ ] A rotina evita milhares de alertas: há limite configurável, supressão de repetição e indicação do que mudou desde a execução anterior.
 - [ ] Limites de fila, amostra e hot set controlam apresentação ou vazão, mas toda empresa do universo permanece materializada e reconsiderável conforme novos sinais.
 
 #### Validação, aprendizado comercial e claims
 
-- [ ] Os top-20, ou todos os casos quando houver menos, passam por revisão manual inicial de Tiago contra o perfil comercial.
+- [ ] Os top-20, ou todos os casos quando houver menos, passam por QA do perfil comercial; isso não cria gate de revisão individual de mensagem sob ADR-037.
 - [ ] Cem por cento dos top-10 possuem CNPJ, evidência contratual reproduzível e pelo menos um sinal confirmado; caso contrário o gate falha.
 - [ ] A validação mede `precision@10`, `precision@20`, cobertura dos campos, estabilidade do ranking e concordância entre score e revisão humana.
 - [ ] O baseline inicial é comparado com uma seleção simples, como valor contratado ou recência, para provar ganho de priorização.
@@ -478,7 +488,7 @@ Um item pode ser marcado como concluído apenas quando pelo menos uma das evidê
 - [ ] Resultados de contato real retroalimentam a avaliação e o ajuste de sinais, sem reescrever silenciosamente o histórico.
 - [ ] Não são usados atributos pessoais sensíveis ou proxies discriminatórios; `DO_NOT_CONTACT` e restrições legais/comerciais são respeitados.
 - [ ] O `confenge.outreach.v1` publica uma decisão target-fit completa para todo CNPJ endereçável do universo reconciliado, inclusive OUT, insuficiente, stale, DNC, downgrades e tombstones; omissão nunca preserva autorização anterior.
-- [ ] O primeiro ciclo de uso real registra decisões de Tiago, contatos realizados e resultados observados, inclusive quando não houver conversão.
+- [ ] O primeiro ciclo de uso real registra decisões delegadas/humanas conforme a policy, contatos realizados e resultados observados, inclusive quando não houver conversão.
 
 #### Contact resolution público e defensável
 
@@ -497,7 +507,7 @@ Um item pode ser marcado como concluído apenas quando pelo menos uma das evidê
 - [ ] O pipeline lê o dataset canônico de contratos e gera a fila por um comando CLI reproduzível.
 - [ ] Pelo menos 12 sinais estão implementados, testados e explicáveis, ou os não computáveis estão explicitamente identificados sem falso-verde.
 - [ ] Os top-10 passam pela validação de evidência e os top-20 pela revisão humana inicial.
-- [ ] O GO do piloto exige pelo menos 10 leads explicitamente aprovados entre decisões humanas atribuíveis; a meta de reserva 900 é reportada separadamente e não bloqueia o piloto controlado.
+- [ ] O GO operacional exige leads aprovados por autoridade atribuível: humana nos fluxos gerais ou delegada sob ADR-037; a meta de reserva 900 é reportada separadamente e não bloqueia o primeiro toque controlado.
 - [ ] A fila registra estado, próximo passo, feedback e outcomes comerciais.
 - [ ] Existe relatório de baseline, limitações, métricas de qualidade e comparação com ranking simples.
 - [ ] Tiago aceita formalmente a fila como utilizável para iniciar a prospecção da CONFENGE.

--- a/docs/architecture/adr/ADR-036-confenge-universe-and-pilot-go-separation.md
+++ b/docs/architecture/adr/ADR-036-confenge-universe-and-pilot-go-separation.md
@@ -4,6 +4,9 @@
 **Date:** 2026-08-10
 **Capability:** CONFENGE commercial activation
 
+**Amended 2026-08-25:** ADR-037 replaces items 7 and 8 only for the standard
+first-touch routing campaign. Other flows retain the human gate below.
+
 ## Context
 
 Os pacotes de fechamento misturavam três populações distintas: todos os fornecedores presentes no histórico contratual, as empresas pertencentes ao setor de construção e o estado comercial mutável de target-fit. A reserva de contatos `EMAIL_SEND_READY` é uma quarta métrica operacional. Contagens de snapshots históricos chegaram a coincidir ou divergir sem provar relação entre os conjuntos; nenhuma delas é constante. A publicação de evidência também alterava o HEAD e provocava PRs sucessivos de SHA rebind.
@@ -16,8 +19,8 @@ Os pacotes de fechamento misturavam três populações distintas: todos os forne
 4. A dimensão setorial e target-fit compartilham CDC/dirty queue, mas possuem materializações e históricos independentes. Enriquecimento contínuo enumera todo `CONSTRUCTION_UNIVERSE`; target-fit, contato, DNC e provenance controlam somente prioridade e envio.
 5. Top-N, auditorias, hot sets, Top-20, ESR e a reserva 900 são subsets/métricas de validação ou operação. Não podem limitar scan, classificação, materialização, enriquecimento contínuo ou reconsideração.
 6. `confenge.go_no_go.v2` separa `UNIVERSE_HEALTH`, `PILOT_QUALITY`, `HUMAN_ACCEPTANCE`, `PILOT_GO` e `NATIONAL_RESERVOIR_HEALTH`.
-7. O piloto pode receber GO abaixo de 900 quando o universo está reconciliado, os gates técnicos passam, o Top-20 foi revisado e ao menos 10 leads foram aprovados por humano atribuível.
-8. Mesmo após GO, Warmbly permanece `PAUSED_MANUAL_START`, e-mail apenas, WhatsApp desligado e 10 envios/h até comando explícito de Tiago.
+7. Fora de ADR-037, o piloto pode receber GO abaixo de 900 quando o universo está reconciliado, os gates técnicos passam, o Top-20 foi revisado e ao menos 10 leads foram aprovados por humano atribuível. O primeiro toque de roteamento usa a autoridade delegada e versionada da ADR-037.
+8. Fora de ADR-037, o Warmbly permanece `PAUSED_MANUAL_START` após GO. Na campanha delegada, pausa e kill switch continuam operacionais e só são liberados de forma explícita para a cadência existente; e-mail permanece o único canal e WhatsApp continua desligado.
 9. `evaluated_code_sha` identifica o código provado; `evidence_publication_sha` identifica somente a publicação de ponteiros. A segunda identidade não invalida a primeira.
 10. `scripts.confenge_activation.pilot_go_policy.evaluate_pilot_go` é a única autoridade de decisão terminal; o emissor de pacote apenas coleta gates e delega à política. Emissores anteriores são `SUPERSEDED_NON_TERMINAL`.
 11. O rebuild setorial integral lê contratos ordenados por CNPJ-raiz no snapshot, fecha cada raiz uma única vez e publica por staging bounded. `row_batch_size` e `root_batch_size` são controles de I/O/memória, nunca limites de população; checkpoints registram linhas e raízes processadas antes da troca atômica da materialização corrente.

--- a/docs/architecture/adr/ADR-037-confenge-contractor-role-first-touch.md
+++ b/docs/architecture/adr/ADR-037-confenge-contractor-role-first-touch.md
@@ -1,0 +1,61 @@
+# ADR-037 — Papel da contratada e primeiro toque delegado da CONFENGE
+
+**Status:** Accepted by founder decision
+
+**Date:** 2026-08-25
+**Capability:** CONFENGE commercial activation
+
+## Context
+
+A presença de um CNPJ em um registro contratual não prova que a pessoa jurídica
+é fornecedora do Poder Público. O mesmo registro contém a parte privada
+contratada e a parte pública contratante. Além disso, a revisão humana
+individual de cada mensagem deixou de ser o gate da campanha específica de
+primeiro toque de roteamento.
+
+## Decision
+
+1. `v_contracts_canonical_v2` e `contract_role_links` são a autoridade de papel.
+   O feed projeta `contractor_role` com policy `contract-party-role.v1`.
+2. `CONTRACTOR_ROLE_CONFIRMED` exige correspondência do CNPJ de 14 dígitos do
+   lead com o CNPJ da parte fornecedora, diferença em relação ao CNPJ ou raiz da
+   compradora e papéis semânticos explícitos. Correspondência apenas por raiz
+   preserva evidência para auditoria, mas permanece `UNKNOWN` até existir vínculo
+   específico da filial. Rótulo ausente nunca recebe default.
+3. Correspondência com a compradora domina qualquer evidência positiva e vira
+   `PARTY_ROLE_CONFLICT`. Ausência ou ambiguidade vira `UNKNOWN`. Ambos bloqueiam
+   o primeiro toque.
+4. A projeção preserva CNPJs, papéis, IDs de contrato, source run, observado em,
+   versão, reason codes e SHA-256 da evidência. Warmbly não reclassifica papel.
+5. O agente CLI cruza essa evidência com fonte web original atual e escolhe uma
+   única mailbox observada por CNPJ-raiz. Snippet, MX e email sintetizado não
+   provam associação.
+6. Somente o primeiro email curto de roteamento pode usar
+   `CFG-FIRST-TOUCH-ROUTING-v1`. A decisão é `DELEGATED_POLICY_APPROVE`, com
+   `approved_by_type=delegated_agent`, autoridade
+   `founder-approved-first-touch-policy` e `approved_by` humano vazio.
+7. O agente pode reparar copy e repetir QA até três vezes. Falha factual, de
+   identidade, papel ou provenance permanece `HOLD`.
+8. Warmbly continua como única autoridade de suppression, policy, fila,
+   scheduling, cadência e outcomes. `QUEUED` exige readback da fila canônica.
+   Kill switch, pausas, limites e janela comercial permanecem fail-closed.
+9. A decisão altera os itens de aprovação humana de ADR-036 e DOD §2.7 apenas
+   para esta finalidade. Follow-up, resposta, WhatsApp e mudança material de
+   copy ou finalidade exigem nova policy ou autoridade humana.
+
+## Consequences
+
+- Órgãos contratantes não podem entrar na campanha como leads.
+- O feed permanece snapshot integral de decisão e não autoriza envio sozinho.
+- Não existe fila, CRM, scheduler ou geração por LLM em runtime adicional.
+- Dados reais, emails e dumps permanecem fora do Git conforme ADR-020.
+- A decisão está aceita; implementação em branch, CI, deploy e execução live
+  conservam seus tiers honestos e não são inferidos deste documento.
+
+## Verification
+
+- Testes adversariais cobrem inversão, `UNKNOWN`, raiz de fornecedor e ausência
+  de rótulo de papel.
+- O schema `confenge.outreach.v1` aceita a projeção aditiva.
+- A prova operacional final deve reconciliar contratadas confirmadas, contatos,
+  QA, holds, aprovações delegadas, queue readback, duplicatas, envios e replies.

--- a/docs/architecture/adr/INDEX.md
+++ b/docs/architecture/adr/INDEX.md
@@ -1,6 +1,6 @@
 # Índice de ADRs — Extra Consultoria
 
-**Atualizado:** 2026-08-13
+**Atualizado:** 2026-08-25
 
 | ADR | Título | Status |
 |-----|--------|--------|
@@ -19,6 +19,7 @@
 | ADR-034 | CONFENGE commercial lead evidence model | **Accepted** (2026-07-25) |
 | ADR-035 | CONFENGE authoritative target-fit feed | **Proposed** (2026-08-12) |
 | ADR-036 | Universo integral e GO do piloto CONFENGE | **Proposed** (2026-08-10) |
+| ADR-037 | Papel da contratada e primeiro toque delegado da CONFENGE | **Accepted by founder decision** (2026-08-25) |
 
 ## ADRs revogadas / supersedidas
 

--- a/docs/stories/story-469-contact-discovery-at-scale.md
+++ b/docs/stories/story-469-contact-discovery-at-scale.md
@@ -35,7 +35,7 @@ quality_gate_tools: ["pytest", "ruff", "dod_controller", "coderabbit"]
 8. Manifesto/relatório do ciclo expõe, no denominador correto, pelo menos: `population_count`, `population_hash`, `population_as_of`, modo e SHAs dos classificadores, jobs por estado, equação população = jobs = contas terminais, contas tentadas, contas com algum contato, contas com e-mail, contas com contato utilizável, contas incorporadas ao feed, pendentes, bloqueadas/DLQ e distribuição de reason codes. Fixture valida lógica, não prova escala live.
 9. Testes adversariais cobrem seleção integral sem truncamento, prioridade A1/A2, idempotência, projeção de job para contato, merge entre snapshot durável e hot set, conflito de política/input, deduplicação, ausência de contato, stale target-fit e DNC. As suítes focadas e a regressão canônica passam sem `skip`/`xfail` ou mocks irreais.
 10. Evidência live da story fecha 100% da população `TARGET_CONFIRMED` corrente versionada nas três condições terminais e reconcilia separadamente 8.245/8.245 contas do baseline, sem usar o número antigo para truncar o run nem omitir candidatos novos. Registra o yield legitimamente obtido sem impor porcentagem arbitrária e publica hashes, timestamps, parâmetros, distribuição por route class/provenance/reason code e amostra auditável protegida fora do Git. Amostra de 30/100/1.000 valida a onda; não fecha este AC.
-11. Segurança operacional é preservada e reconfirmada: `CONFENGE_AUTO_SEND_ENABLED=false`, kill switch de envio pausado, `confenge_dispatch_control.paused=true`, zero envios e zero aprovações automáticas. Esta story não altera `min_wait_time=600s`, `confenge.composer.v6`, o fluxo Comercial → Rascunhos nem o Warmbly.
+11. Segurança operacional é preservada e reconfirmada: `CONFENGE_AUTO_SEND_ENABLED=false`, autorun global desligado, kill switch e `confenge_dispatch_control` obedecidos. ADR-037 permite aprovação delegada apenas ao primeiro toque versionado; não altera `min_wait_time=600s`, composer, fila, scheduler, suppression ou follow-ups do Warmbly.
 12. Runbook, ADR/handoff e DOD recebem os deltas/evidências cabíveis. O item só pode virar `ACCEPTED` no `main`, com CI verde e o teste específico passando; somente então qualquer checkbox correspondente do `DOD.md` pode ser marcado.
 13. O waterfall determinístico/incremental reutiliza, nesta ordem aproximada conforme yield medido: contatos canônicos/históricos já existentes; dados públicos cadastrais ligados por CNPJ; website/domínio oficial; documentos e fontes B2G já coletados; busca pública adicional bounded. Não contorna login/CAPTCHA/paywall/robots, não depende de provider pago e não promove mailbox inferida por padrão a fato.
 14. Por account, uma única `preferred email route` é selecionada na ordem default `DIRECT_PERSON` → `ROLE_OR_DEPARTMENT` → `GENERIC_COMPANY` → `PUBLIC_COMPANY_FREEMAIL`; alternativas permanecem armazenadas/rankeadas e não são usadas simultaneamente no primeiro toque. Bounce definitivo pode liberar a próxima rota somente pela policy do Warmbly.
@@ -114,7 +114,7 @@ quality_gate_tools: ["pytest", "ruff", "dod_controller", "coderabbit"]
   - [ ] Publicar funil/estados/reason codes no manifesto leve e no relatório operacional.
   - [ ] Atualizar o runbook de batch e unidade systemd somente no raio necessário.
   - [ ] Executar testes focados, Ruff, source contracts, full suite e golden path conforme aplicável.
-  - [ ] Reconfirmar zero sends/approvals e controles pausados; não tocar composer/cohort/min_wait_time.
+  - [ ] Reconciliar sends e approvals por tipo de autoridade, provar controles e não tocar composer/cohort/min_wait_time.
 - [ ] Task 5 — Produzir prova live e handoff (AC: 10, 12)
   - [ ] Executar a seleção/enqueue/worker no host autorizado com budget explícito e fechar o denominador corrente versionado (`population_count`/hash/`as_of`/modo/SHAs), reconciliando também o baseline de 8.245.
   - [ ] Publicar feed novo apenas se os gates autoritativos passarem; armazenar PII/evidência pesada fora do Git.
@@ -189,7 +189,7 @@ GPT-5 Codex (Dex / @dev)
 
 ### Completion Notes List
 
-- Implementação local cobre seleção integral, terminais honestos, projeção hash-verificada e composição no feed.
+- Implementação local cobre seleção integral, terminais honestos, projeção hash-verificada e composição no feed. ADR-037 adiciona o papel contratada/contratante sem fazer o feed autorizar envio sozinho.
 - Artefatos históricos de contatos agora entram como inputs explícitos, SHA-256-bound e verificados no primeiro degrau do worker; alteração/missing vira blocker nominal.
 - O cadastro oficial local é consultado por CNPJ exato; e-mail cadastral preserva release/autoridade, não inventa pessoa e registra indisponibilidade como blocker factual de waterfall. Freemail público continua regido pela associação defensável da policy ativa.
 - Evidência live do denominador corrente versionado, reconciliação 8.245/8.245 do baseline, deploy e aceitação continuam abertos; fixture não foi tratada como prova operacional.

--- a/docs/stories/story-confenge-human-recipient-evidence-01.md
+++ b/docs/stories/story-confenge-human-recipient-evidence-01.md
@@ -6,6 +6,14 @@
 **Capability:** Authoritative, auditable human-recipient resolution for the Warmbly pilot
 **DOD item:** `DOD-definition-of-done-extra-1cd551b906` (OPEN; do not accept before main + CI + live evidence)
 
+> **Superseded for eligible first touch on 2026-08-25:** this story preserves
+> the historical named-human experiment and its then-current safety evidence.
+> ADR-037 and `CFG-FIRST-TOUCH-ROUTING-v1` now accept attributable
+> `DIRECT_PERSON`, `ROLE_OR_DEPARTMENT`, `GENERIC_COMPANY` and
+> `PUBLIC_COMPANY_FREEMAIL` routes. A named human and individual human approval
+> are therefore not prerequisites for an eligible first touch; unknown,
+> conflict and unattributed routes still fail closed.
+
 ## Goal
 
 Replace the old functional-mailbox interpretation of `EMAIL_SEND_READY` with a

--- a/scripts/confenge_outreach_pipeline/adapt.py
+++ b/scripts/confenge_outreach_pipeline/adapt.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from scripts.confenge_outreach_pipeline.party_role import project_contractor_role
+
 
 def _digits(value: Any) -> str:
     return "".join(ch for ch in str(value or "") if ch.isdigit())
@@ -119,6 +121,10 @@ def universe_row_to_intelligence_input(
                 "publication_date": c.get("data_publicacao") or c.get("publication_date"),
                 "uf": c.get("uf"),
                 "orgao": c.get("orgao_nome") or c.get("orgao"),
+                "supplier_cnpj14": c.get("supplier_cnpj14") or c.get("fornecedor_cnpj"),
+                "supplier_role": c.get("supplier_role"),
+                "buyer_cnpj14": c.get("buyer_cnpj14") or c.get("orgao_cnpj"),
+                "buyer_role": c.get("buyer_role"),
                 "has_addendum": has_addendum,
                 "addendum_count": int(c.get("addendum_count") or (1 if has_addendum else 0)),
                 "has_reajuste": has_reajuste,
@@ -162,6 +168,13 @@ def universe_row_to_intelligence_input(
     cnpj = _digits(row.get("cnpj14") or row.get("cnpj") or "")
     ce = row.get("construction_evidence") if isinstance(row.get("construction_evidence"), dict) else {}
 
+    party_role = project_contractor_role(
+        cnpj,
+        contracts,
+        source_run_id=str(row.get("source_run_id") or ""),
+        observed_at=str(row.get("target_fit_source_watermark") or as_of_value),
+    )
+
     return {
         "cnpj": cnpj,
         "cnpj14": cnpj,
@@ -175,6 +188,7 @@ def universe_row_to_intelligence_input(
         "commercial_state": commercial_state,
         "signals": signals,
         "contracts": contracts,
+        "contractor_role": party_role,
         "evidence": [],
         "source_lead_id": row.get("source_lead_id") or f"cnpj:{cnpj}",
         "priority_score": row.get("priority_score"),
@@ -282,6 +296,10 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
                 "publication_date": c.get("publication_date"),
                 "agency": c.get("orgao") or c.get("agency"),
                 "uf": c.get("uf"),
+                "supplier_cnpj14": c.get("supplier_cnpj14") or c.get("fornecedor_cnpj"),
+                "supplier_role": c.get("supplier_role"),
+                "buyer_cnpj14": c.get("buyer_cnpj14") or c.get("orgao_cnpj"),
+                "buyer_role": c.get("buyer_role"),
             }
         )
 
@@ -312,6 +330,15 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
         dossier.get("why_this_account")
         or (f"empresa com execução pública de engenharia/construção observável: {razao}" if razao else "")
     )
+
+    party_role = dossier.get("contractor_role")
+    if not isinstance(party_role, dict):
+        party_role = project_contractor_role(
+            cnpj,
+            bridge_contracts,
+            source_run_id=str(dossier.get("source_run_id") or ""),
+            observed_at=str(dossier.get("as_of") or ""),
+        )
 
     return {
         "cnpj14": cnpj,
@@ -361,6 +388,7 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
             "why_now_code": str(why.get("trigger") or why.get("code") or "").upper(),
         },
         "contracts": bridge_contracts,
+        "contractor_role": party_role,
         "evidence": evidence,
         "inferences": inferences,
         "primary_service": primary,

--- a/scripts/confenge_outreach_pipeline/party_role.py
+++ b/scripts/confenge_outreach_pipeline/party_role.py
@@ -1,0 +1,149 @@
+"""Fail-closed projection of public-contract party roles for outbound."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+CONTRACTOR_ROLE_CONFIRMED = "CONTRACTOR_ROLE_CONFIRMED"
+PARTY_ROLE_CONFLICT = "PARTY_ROLE_CONFLICT"
+PARTY_ROLE_UNKNOWN = "UNKNOWN"
+PARTY_ROLE_POLICY_V1 = "contract-party-role.v1"
+
+
+def _digits(value: Any) -> str:
+    return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+
+def _cnpj14(value: Any) -> str:
+    value = _digits(value)
+    return value if len(value) == 14 else ""
+
+
+def project_contractor_role(
+    lead_cnpj: Any,
+    contracts: list[dict[str, Any]],
+    *,
+    source_run_id: str = "",
+    observed_at: str = "",
+) -> dict[str, Any]:
+    """Prove that the lead is supplier, never merely present in a contract."""
+    lead = _cnpj14(lead_cnpj)
+    valid: list[dict[str, str]] = []
+    root_only: list[dict[str, str]] = []
+    conflicts: list[dict[str, str]] = []
+    for contract in contracts:
+        if not isinstance(contract, dict):
+            continue
+        supplier = _cnpj14(
+            contract.get("supplier_cnpj14") or contract.get("fornecedor_cnpj") or contract.get("supplier_cnpj")
+        )
+        buyer = _cnpj14(contract.get("buyer_cnpj14") or contract.get("orgao_cnpj") or contract.get("buyer_cnpj"))
+        contract_id = str(contract.get("id") or contract.get("contrato_id") or "").strip()
+        supplier_role = str(contract.get("supplier_role") or "").upper().strip()
+        buyer_role = str(contract.get("buyer_role") or "").upper().strip()
+        fact = {
+            "contract_id": contract_id,
+            "supplier_cnpj14": supplier,
+            "buyer_cnpj14": buyer,
+            "supplier_role": supplier_role,
+            "buyer_role": buyer_role,
+        }
+        if lead and buyer and (lead == buyer or lead[:8] == buyer[:8]):
+            conflicts.append(fact)
+            continue
+        supplier_semantic = supplier_role in {
+            "CONTRATADA",
+            "FORNECEDORA",
+            "EXECUTORA",
+            "ADJUDICATARIA_CONTRATADA",
+            "ADJUDICATARIA",
+            "ADJUDICATÁRIA",
+            "ADJUDICATÁRIA/CONTRATADA",
+        }
+        buyer_semantic = buyer_role in {
+            "CONTRATANTE",
+            "ORGAO_CONTRATANTE",
+            "ÓRGÃO CONTRATANTE",
+            "ENTIDADE_PUBLICA_COMPRADORA",
+            "ENTIDADE PÚBLICA COMPRADORA",
+            "UNIDADE_GESTORA",
+            "UNIDADE GESTORA",
+            "ADMINISTRACAO_PUBLICA",
+            "ADMINISTRAÇÃO PÚBLICA",
+        }
+        if lead and supplier and buyer and supplier_semantic and buyer_semantic:
+            if lead == supplier and not (lead == buyer or lead[:8] == buyer[:8]):
+                valid.append(fact)
+            elif lead[:8] == supplier[:8] and not (lead == buyer or lead[:8] == buyer[:8]):
+                # A shared CNPJ root does not prove that a recipient or public
+                # contract of one establishment belongs to another. Keep the
+                # typed evidence for audit, but require a branch-specific link
+                # before delegated approval.
+                root_only.append(fact)
+
+    status = PARTY_ROLE_UNKNOWN
+    target_party_role = "UNKNOWN"
+    match_method = "NONE"
+    confidence = "UNKNOWN"
+    reason_codes = ["party_role_evidence_missing"]
+    facts: list[dict[str, str]] = []
+    if conflicts:
+        status = PARTY_ROLE_CONFLICT
+        target_party_role = "BUYER_CONFLICT"
+        match_method = (
+            "BUYER_EXACT_CNPJ14"
+            if any(lead == fact["buyer_cnpj14"] for fact in conflicts)
+            else "BUYER_CNPJ_ROOT"
+        )
+        confidence = "CONFLICT"
+        reason_codes = ["lead_matches_contracting_authority"]
+        facts = conflicts
+    elif valid:
+        status = CONTRACTOR_ROLE_CONFIRMED
+        target_party_role = "SUPPLIER"
+        match_method = "SUPPLIER_EXACT_CNPJ14"
+        confidence = "HIGH"
+        reason_codes = ["lead_matches_supplier", "lead_differs_from_buyer"]
+        facts = valid
+    elif root_only:
+        match_method = "SUPPLIER_CNPJ_ROOT"
+        confidence = "MEDIUM"
+        reason_codes = ["supplier_root_only_requires_specific_branch_evidence"]
+        facts = root_only
+
+    canonical = {
+        "lead_cnpj14": lead,
+        "status": status,
+        "target_party_role": target_party_role,
+        "role_match_method": match_method,
+        "confidence": confidence,
+        "policy_version": PARTY_ROLE_POLICY_V1,
+        "source_run_id": source_run_id,
+        "observed_at": observed_at,
+        "facts": sorted(facts, key=lambda item: json.dumps(item, sort_keys=True)),
+    }
+    digest = hashlib.sha256(
+        json.dumps(canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    supplier_cnpj14 = facts[0]["supplier_cnpj14"] if facts else ""
+    buyer_cnpj14 = facts[0]["buyer_cnpj14"] if facts else ""
+    return {
+        "status": status,
+        "target_party_role": target_party_role,
+        "policy_version": PARTY_ROLE_POLICY_V1,
+        "source": "extra-cli:v_contracts_canonical_v2",
+        "source_run_id": source_run_id,
+        "observed_at": observed_at,
+        "evidence_hash": digest,
+        "evidence_reference": f"extra-cli:v_contracts_canonical_v2:sha256:{digest}",
+        "evidence_ids": [fact["contract_id"] for fact in facts if fact["contract_id"]],
+        "reason_codes": reason_codes,
+        "supplier_cnpj14": supplier_cnpj14,
+        "supplier_identity_ref": f"cnpj:{supplier_cnpj14}" if supplier_cnpj14 else "",
+        "buyer_cnpj14": buyer_cnpj14,
+        "buyer_identity_ref": f"cnpj:{buyer_cnpj14}" if buyer_cnpj14 else "",
+        "role_match_method": match_method,
+        "confidence": confidence,
+    }

--- a/scripts/confenge_universe/aggregate.py
+++ b/scripts/confenge_universe/aggregate.py
@@ -69,6 +69,10 @@ def _safe_float(v: Any) -> float:
         return 0.0
 
 
+def _digits(value: Any) -> str:
+    return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+
 @dataclass
 class EstablishmentAgg:
     cnpj14: str
@@ -210,6 +214,12 @@ class EntityBucket:
                 self.object_snippets_pass.append(obj)
             sample = {
                 "contrato_id": row.get("contrato_id"),
+                "supplier_cnpj14": identity.cnpj14,
+                "supplier_cnpj_root": identity.cnpj_root,
+                "supplier_role": "CONTRATADA",
+                "buyer_cnpj14": _digits(row.get("orgao_cnpj")),
+                "buyer_cnpj_root": _digits(row.get("orgao_cnpj"))[:8],
+                "buyer_role": "CONTRATANTE",
                 "orgao_nome": row.get("orgao_nome"),
                 "objeto": obj,
                 "valor_total": valor if valor else None,

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.confenge_outreach_pipeline.party_role import project_contractor_role
 from scripts.confenge_target_fit.published import build_published_index_from_rows
 from scripts.warmbly_bridge import (
     DEFAULT_MAX_BYTES_PER_CHUNK,
@@ -202,6 +203,19 @@ def _normalize_authoritative_timestamps(leads: list[dict[str, Any]]) -> None:
         cnpj = str((lead.get("company") or {}).get("cnpj14") or "")
         for field in ("target_fit_source_watermark", "target_fit_computed_at"):
             lead[field] = _rfc3339_timestamp(lead.get(field), field=field, cnpj=cnpj)
+
+
+def _attach_contractor_roles(leads: list[dict[str, Any]], *, run_id: str, observed_at: str) -> None:
+    """Bind typed supplier/buyer truth at the canonical publication boundary."""
+    for lead in leads:
+        company = lead.get("company") if isinstance(lead.get("company"), dict) else {}
+        contracts = lead.get("contracts") if isinstance(lead.get("contracts"), list) else []
+        lead["contractor_role"] = project_contractor_role(
+            company.get("cnpj14"),
+            contracts,
+            source_run_id=run_id,
+            observed_at=observed_at,
+        )
 
 
 def _decision_order_key(lead: dict[str, Any]) -> tuple[datetime, datetime, str, str]:
@@ -420,6 +434,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         published_index=published_index,
         datalake_watermark=datalake_watermark,
     )
+    _attach_contractor_roles(leads, run_id=run_id, observed_at=datalake_watermark)
     _normalize_authoritative_timestamps(leads)
     leads.sort(key=_decision_order_key)
     if cfg.limit is not None:

--- a/scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
+++ b/scripts/warmbly_bridge/schemas/confenge.outreach.v1.json
@@ -59,6 +59,7 @@
         "messaging_context",
         "contacts",
         "contracts",
+        "contractor_role",
         "evidence",
         "commercial_state",
         "construction_universe_member",
@@ -136,6 +137,46 @@
         },
         "contracts": {
           "type": "array"
+        },
+        "contractor_role": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "target_party_role", "policy_version", "source", "source_run_id", "observed_at", "evidence_hash", "evidence_reference", "evidence_ids", "reason_codes", "supplier_cnpj14", "supplier_identity_ref", "buyer_cnpj14", "buyer_identity_ref", "role_match_method", "confidence"],
+          "properties": {
+            "status": { "type": "string", "enum": ["CONTRACTOR_ROLE_CONFIRMED", "PARTY_ROLE_CONFLICT", "UNKNOWN"] },
+            "target_party_role": { "type": "string", "enum": ["SUPPLIER", "BUYER_CONFLICT", "UNKNOWN"] },
+            "policy_version": { "const": "contract-party-role.v1" },
+            "source": { "type": "string", "minLength": 1 },
+            "source_run_id": { "type": "string", "minLength": 1 },
+            "observed_at": { "type": "string", "minLength": 1 },
+            "evidence_hash": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "evidence_reference": { "type": "string", "pattern": "^extra-cli:v_contracts_canonical_v2:sha256:[0-9a-f]{64}$" },
+            "evidence_ids": { "type": "array", "items": { "type": "string" } },
+            "reason_codes": { "type": "array", "items": { "type": "string" } },
+            "supplier_cnpj14": { "type": "string" },
+            "supplier_identity_ref": { "type": "string" },
+            "buyer_cnpj14": { "type": "string" },
+            "buyer_identity_ref": { "type": "string" },
+            "role_match_method": { "type": "string", "enum": ["SUPPLIER_EXACT_CNPJ14", "SUPPLIER_CNPJ_ROOT", "BUYER_EXACT_CNPJ14", "BUYER_CNPJ_ROOT", "NONE"] },
+            "confidence": { "type": "string", "enum": ["HIGH", "MEDIUM", "CONFLICT", "UNKNOWN"] }
+          },
+          "allOf": [
+            {
+              "if": { "properties": { "status": { "const": "CONTRACTOR_ROLE_CONFIRMED" } } },
+              "then": {
+                "properties": {
+                  "target_party_role": { "const": "SUPPLIER" },
+                  "supplier_cnpj14": { "pattern": "^[0-9]{14}$" },
+                  "supplier_identity_ref": { "pattern": "^cnpj:[0-9]{14}$" },
+                  "buyer_cnpj14": { "pattern": "^[0-9]{14}$" },
+                  "buyer_identity_ref": { "pattern": "^cnpj:[0-9]{14}$" },
+                  "role_match_method": { "const": "SUPPLIER_EXACT_CNPJ14" },
+                  "confidence": { "const": "HIGH" },
+                  "evidence_ids": { "minItems": 1 }
+                }
+              }
+            }
+          ]
         },
         "evidence": {
           "type": "array",

--- a/tests/confenge_outreach_pipeline/test_party_role.py
+++ b/tests/confenge_outreach_pipeline/test_party_role.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from scripts.confenge_outreach_pipeline.party_role import (
+    CONTRACTOR_ROLE_CONFIRMED,
+    PARTY_ROLE_CONFLICT,
+    PARTY_ROLE_UNKNOWN,
+    project_contractor_role,
+)
+
+
+def _contract(*, supplier: str, buyer: str) -> dict[str, str]:
+    return {
+        "id": "contract-1",
+        "supplier_cnpj14": supplier,
+        "supplier_role": "CONTRATADA",
+        "buyer_cnpj14": buyer,
+        "buyer_role": "CONTRATANTE",
+    }
+
+
+def test_supplier_root_without_branch_specific_evidence_stays_unknown() -> None:
+    result = project_contractor_role(
+        "11222333000225",
+        [_contract(supplier="11222333000144", buyer="99888777000166")],
+        source_run_id="run-1",
+        observed_at="2026-08-25T12:00:00Z",
+    )
+    assert result["status"] == PARTY_ROLE_UNKNOWN
+    assert result["target_party_role"] == "UNKNOWN"
+    assert result["role_match_method"] == "SUPPLIER_CNPJ_ROOT"
+    assert result["confidence"] == "MEDIUM"
+    assert result["reason_codes"] == ["supplier_root_only_requires_specific_branch_evidence"]
+    assert result["supplier_cnpj14"] == "11222333000144"
+    assert result["supplier_identity_ref"] == "cnpj:11222333000144"
+    assert result["buyer_cnpj14"] == "99888777000166"
+    assert result["buyer_identity_ref"] == "cnpj:99888777000166"
+    assert result["evidence_ids"] == ["contract-1"]
+    assert result["evidence_reference"].endswith(result["evidence_hash"])
+
+
+def test_contracting_authority_match_is_conflict_even_if_supplier_is_present() -> None:
+    result = project_contractor_role(
+        "11222333000144",
+        [_contract(supplier="99888777000166", buyer="11222333000144")],
+    )
+    assert result["status"] == PARTY_ROLE_CONFLICT
+    assert result["target_party_role"] == "BUYER_CONFLICT"
+    assert result["role_match_method"] == "BUYER_EXACT_CNPJ14"
+    assert result["confidence"] == "CONFLICT"
+    assert result["reason_codes"] == ["lead_matches_contracting_authority"]
+
+
+def test_unknown_is_never_promoted_to_contractor() -> None:
+    result = project_contractor_role(
+        "11222333000144",
+        [{"id": "contract-1", "supplier_role": "UNKNOWN", "buyer_role": "CONTRATANTE"}],
+    )
+    assert result["status"] == PARTY_ROLE_UNKNOWN
+    assert result["target_party_role"] == "UNKNOWN"
+    assert result["role_match_method"] == "NONE"
+
+
+def test_missing_role_labels_are_not_defaulted_to_contractor() -> None:
+    result = project_contractor_role(
+        "11222333000144",
+        [{"id": "contract-1", "supplier_cnpj14": "11222333000144", "buyer_cnpj14": "99888777000166"}],
+    )
+    assert result["status"] == PARTY_ROLE_UNKNOWN
+
+
+def test_exact_supplier_match_is_high_confidence() -> None:
+    result = project_contractor_role(
+        "11222333000144",
+        [_contract(supplier="11222333000144", buyer="99888777000166")],
+    )
+    assert result["status"] == CONTRACTOR_ROLE_CONFIRMED
+    assert result["role_match_method"] == "SUPPLIER_EXACT_CNPJ14"
+    assert result["confidence"] == "HIGH"
+
+
+def test_correct_contract_plus_conflicting_buyer_link_fails_closed() -> None:
+    correct = _contract(supplier="11222333000144", buyer="99888777000166")
+    conflict = {**_contract(supplier="88777666000155", buyer="11222333000144"), "id": "contract-2"}
+    result = project_contractor_role("11222333000144", [correct, conflict])
+    assert result["status"] == PARTY_ROLE_CONFLICT
+    assert result["target_party_role"] == "BUYER_CONFLICT"
+    assert result["evidence_ids"] == ["contract-2"]
+
+
+def test_same_cnpj_on_both_sides_is_conflict_not_supplier() -> None:
+    result = project_contractor_role(
+        "11222333000144",
+        [_contract(supplier="11222333000144", buyer="11222333000144")],
+    )
+    assert result["status"] == PARTY_ROLE_CONFLICT
+
+
+def test_role_labels_must_be_semantically_typed() -> None:
+    row = _contract(supplier="11222333000144", buyer="99888777000166")
+    row["supplier_role"] = "BUYER"
+    assert project_contractor_role("11222333000144", [row])["status"] == PARTY_ROLE_UNKNOWN
+
+
+def test_evidence_hash_is_deterministic() -> None:
+    contracts = [_contract(supplier="11222333000144", buyer="99888777000166")]
+    first = project_contractor_role("11222333000144", contracts, source_run_id="run-1")
+    second = project_contractor_role("11222333000144", list(reversed(contracts)), source_run_id="run-1")
+    assert first["evidence_hash"] == second["evidence_hash"]

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -720,6 +720,10 @@ def test_adapt_intelligence_and_contacts_join() -> None:
                     "data_fim": "2025-12-31",
                     "uf": "SC",
                     "orgao_nome": "Pref Joinville",
+                    "supplier_cnpj14": "11222333000181",
+                    "supplier_role": "CONTRATADA",
+                    "buyer_cnpj14": "83169623000110",
+                    "buyer_role": "ORGAO_CONTRATANTE",
                 }
             ],
         },
@@ -727,6 +731,7 @@ def test_adapt_intelligence_and_contacts_join() -> None:
     intel_in = universe_row_to_intelligence_input(universe, as_of="2026-08-01")
     assert intel_in["contracts"]
     assert intel_in["cnpj14"] == "11222333000181"
+    assert intel_in["contractor_role"]["status"] == "CONTRACTOR_ROLE_CONFIRMED"
 
     dossier = {
         "schema_id": "confenge-account-intelligence-v1",
@@ -762,8 +767,10 @@ def test_adapt_intelligence_and_contacts_join() -> None:
         "dominant_state": {"state": "NEW"},
         "generated_at": "2026-08-01T00:00:00Z",
         "as_of": "2026-08-01",
+        "_pipeline_contracts": intel_in["contracts"],
     }
     bridge_intel = intelligence_dossier_to_bridge_row(dossier)
+    assert bridge_intel["contractor_role"]["status"] == "CONTRACTOR_ROLE_CONFIRMED"
     # confenge.service.v1: warmbly service_code is canonical playbook code
     assert bridge_intel["offer"]["service_code"] == "MONITORAMENTO_CONTRATUAL"
     assert bridge_intel["offer"]["canonical_service_code"] == "MONITORAMENTO_CONTRATUAL"

--- a/tests/warmbly_bridge/test_export_contract.py
+++ b/tests/warmbly_bridge/test_export_contract.py
@@ -44,6 +44,12 @@ def _validate_against_schema_required(feed: dict[str, Any], schema: dict[str, An
         _assert_required(lead, lead_required, ctx=f"leads[{i}]")
         company_req = ((lead_def.get("properties") or {}).get("company") or {}).get("required") or []
         _assert_required(lead.get("company") or {}, company_req, ctx=f"leads[{i}].company")
+        role_schema = ((lead_def.get("properties") or {}).get("contractor_role") or {})
+        _assert_required(
+            lead.get("contractor_role") or {},
+            role_schema.get("required") or [],
+            ctx=f"leads[{i}].contractor_role",
+        )
         msg_req = ((lead_def.get("properties") or {}).get("messaging_context") or {}).get("required") or []
         _assert_required(
             lead.get("messaging_context") or {},
@@ -104,12 +110,32 @@ def test_feed_required_fields_and_schema(exported: Path, schemas_dir: Path) -> N
                 assert field in lead["messaging_context"]
             assert isinstance(lead["contacts"], list)
             assert isinstance(lead["contracts"], list)
+            assert lead["contractor_role"]["target_party_role"] in {
+                "SUPPLIER",
+                "BUYER_CONFLICT",
+                "UNKNOWN",
+            }
+            assert lead["contractor_role"]["source"] == "extra-cli:v_contracts_canonical_v2"
+            assert lead["contractor_role"]["source_run_id"] == feed["source"]["run_id"]
+            assert lead["contractor_role"]["evidence_hash"]
             assert isinstance(lead["evidence"], list)
             assert "rank" in lead["priority"]
             assert "score" in lead["priority"]
             assert "code" in lead["moment"] or "summary" in lead["moment"]
             assert "service_code" in lead["offer"] or "service_name" in lead["offer"]
             assert lead["commercial_state"]
+
+
+def test_confirmed_contractor_schema_requires_exact_branch_and_high_confidence(schemas_dir: Path) -> None:
+    schema = json.loads((schemas_dir / "confenge.outreach.v1.json").read_text(encoding="utf-8"))
+    role_schema = schema["$defs"]["lead"]["properties"]["contractor_role"]
+    confirmed = next(
+        rule["then"]["properties"]
+        for rule in role_schema["allOf"]
+        if rule["if"]["properties"]["status"].get("const") == "CONTRACTOR_ROLE_CONFIRMED"
+    )
+    assert confirmed["role_match_method"] == {"const": "SUPPLIER_EXACT_CNPJ14"}
+    assert confirmed["confidence"] == {"const": "HIGH"}
 
 
 def test_inferences_not_promoted_to_confirmed_fact(exported: Path) -> None:


### PR DESCRIPTION
## Resultado

Leva a separação canônica buyer × supplier até o contrato consumido pelo Warmbly. O feed agora inclui `contractor_role` tipado com supplier/buyer refs, método de match, confiança, reason codes, source/run e hash de evidência.

Somente match exato CNPJ14 de supplier confirma `CONTRACTOR_ROLE_CONFIRMED`; buyer, conflito, root-only e UNKNOWN falham fechados. O bridge recompõe essa verdade a partir das views canônicas e vincula o run/watermark real da exportação. O Warmbly não precisa reinterpretar PNCP bruto.

## Adversarial

Cobertura para supplier PASS; buyer FAIL; mesmo CNPJ em papéis múltiplos; role ausente; contrato correto com vínculo conflitante; schema/export e integração com pipeline.

## Validação

- testes focados party-role/pipeline/export: 40 passed
- generated-artifacts policy: PASS, 0 violações
- PR reviewability: PASS, 0 violações
- `git diff --check origin/main...HEAD`: passou

## Dependência e operação

Depende da autoridade versionada em tjsasakifln/Governance#148. Não publica nem declara saudável o feed live por si só; #468/#469 permanecem abertas até reconciliação do run corrente, freshness real e ingestão Warmbly comprovada. Nenhuma ontologia, fila, CRM ou base de leads paralela foi criada.

Refs #468, #469.