### PR TITLE
fix(confenge): bind feed to immutable release SHA

### DIFF
--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -60,6 +60,7 @@ from scripts.confenge_universe import (
     DEFAULT_MANIFEST_NAME,
 )
 from scripts.confenge_universe.pipeline import run_universe_build
+from scripts.crawl.run_evidence import runtime_release_sha
 from scripts.decision_unit_intelligence import POLICY_VERSION as CONTACT_DISCOVERY_POLICY_VERSION
 from scripts.decision_unit_intelligence.controlled_email import dedupe_feed_contacts_by_mailbox
 from scripts.warmbly_bridge.export import ExportConfig, export_outreach
@@ -137,6 +138,8 @@ def _utcnow() -> str:
 def _git_sha() -> str:
     import shutil
 
+    if release_sha := runtime_release_sha():
+        return release_sha
     git_bin = shutil.which("git")
     if not git_bin:
         return "unknown"

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from scripts.confenge_outreach_pipeline.party_role import project_contractor_role
 from scripts.confenge_target_fit.published import build_published_index_from_rows
+from scripts.crawl.run_evidence import runtime_release_sha
 from scripts.warmbly_bridge import (
     DEFAULT_MAX_BYTES_PER_CHUNK,
     DEFAULT_MAX_LEADS_PER_CHUNK,
@@ -32,6 +33,8 @@ def _utcnow() -> str:
 def _git_sha() -> str:
     import shutil
 
+    if release_sha := runtime_release_sha():
+        return release_sha
     git_bin = shutil.which("git")
     if not git_bin:
         return "unknown"

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -880,3 +880,15 @@ def test_git_sha_is_resolved_from_runtime_checkout(monkeypatch) -> None:
     command = captured["command"]
     assert isinstance(command, list)
     assert command[1:3] == ["-C", str(runtime_root)]
+
+
+def test_git_sha_prefers_immutable_release_identity(monkeypatch) -> None:
+    release_sha = "a" * 40
+
+    def fail_git(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("git must not override immutable release identity")
+
+    monkeypatch.setattr(pipeline_module, "runtime_release_sha", lambda: release_sha)
+    monkeypatch.setattr(pipeline_module.subprocess, "check_output", fail_git)
+
+    assert pipeline_module._git_sha() == release_sha

--- a/tests/warmbly_bridge/test_export_contract.py
+++ b/tests/warmbly_bridge/test_export_contract.py
@@ -21,7 +21,20 @@ from scripts.warmbly_bridge import (
     REQUIRED_SOURCE_FIELDS,
     SCHEMA_OUTREACH,
 )
+from scripts.warmbly_bridge import export as export_module
 from scripts.warmbly_bridge.export import ExportConfig, export_outreach
+
+
+def test_export_git_sha_prefers_immutable_release_identity(monkeypatch) -> None:
+    release_sha = "b" * 40
+    monkeypatch.setattr(export_module, "runtime_release_sha", lambda: release_sha)
+    monkeypatch.setattr(
+        export_module.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: pytest.fail("git must not override immutable release identity"),
+    )
+
+    assert export_module._git_sha() == release_sha
 
 
 def _assert_required(obj: dict[str, Any], required: list[str] | tuple[str, ...], *, ctx: str) -> None:


### PR DESCRIPTION
## Objetivo

Preserva provenance no feed executado a partir de `/opt/extra-consultoria-releases/<sha>` sem `.git`: o pipeline e o exportador agora usam o contrato existente `runtime_release_sha()` antes do fallback Git.

## Prova

- testes adversariais garantem que Git não substitui a identidade do release;
- testes focados: 3 passed;
- ruff: PASS;
- nenhuma mudança em freshness, universo, scheduler ou transporte.

Dependência operacional: publicação corrente de extra-cli #468/#469.