### PR TITLE
fix(test): make real-db suite isolated and fail-closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,9 @@ jobs:
       - name: Canonical full suite (migrations + seeds + pytest no marker exclusion)
         run: python -m scripts.ops.run_full_suite
 
+      - name: Canonical real_db twice (fresh DB, normal + reverse order)
+        run: python -m scripts.ops.run_full_suite --real-db-only --repeat 2
+
   # ============================================================================
   # RESILIENCE GATE — pre-VPS truth (fail-closed, no continue-on-error)
   # ============================================================================

--- a/DOD.md
+++ b/DOD.md
@@ -3213,3 +3213,8 @@ CI (PR #12):
   reason codes, run and snapshot in `contract_role_links`. An adversarial DB
   test prevents supplier-root inversion and four indexed EXPLAIN plans pass.
   Exact-HEAD CI and `main` are required.
+- [ ] The opt-in `real_db` suite is deterministic on a clean database. **#285
+  `VERIFIED` on branch:** the canonical runner creates a fresh database per run,
+  applies the complete migration ledger and required seeds fail-closed, rejects
+  fake connections and skips, and repeats in normal and reverse order. Exact-HEAD
+  CI and `main` are required before acceptance.

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ help:
 	@echo '── Testes ─────────────────────────────────────────────────────────'
 	@echo '  test           Roda testes (exceto slow) com cobertura'
 	@echo '  test-all       Roda todos os testes (inclui slow) com cobertura'
+	@echo '  test-real-db   Roda -m real_db 2x em DBs novos (normal + inversa)'
 	@echo '  resilient-smoke       Contrato/fail-closed/checkpoint/DLQ/chaos controlado'
 	@echo '  resilient-local-cycle Ciclo canônico local com fixtures (sem VPS/internet)'
 	@echo '  resilience-gate       Gate completo de prontidão técnica pré-VPS'
@@ -165,6 +166,12 @@ test-all:
 	@echo '==> [$(ENV)] Canonical full suite (no slow exclusion; isolated DSN required)'
 	@test -n "$${DATABASE_URL}$${LOCAL_DATALAKE_DSN}" || (echo 'DATABASE_URL or LOCAL_DATALAKE_DSN required for make test-all' && exit 2)
 	python -m scripts.ops.run_full_suite
+
+.PHONY: test-real-db
+test-real-db:
+	@echo '==> [$(ENV)] real_db isolado (2 execuções: ordem normal + inversa)'
+	@test -n "$${DATABASE_URL}$${LOCAL_DATALAKE_DSN}" || (echo 'DATABASE_URL or LOCAL_DATALAKE_DSN required for make test-real-db' && exit 2)
+	python -m scripts.ops.run_full_suite --real-db-only --repeat 2
 
 .PHONY: resilient-smoke
 resilient-smoke:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 **Path canônico:** `docs/DEVELOPMENT.md`  
 **Status:** canônico (DoD §32.1)  
-**Atualizado:** 2026-07-25  
+**Atualizado:** 2026-08-26
 **Precedência em conflito:** `DOD.md` → ADR vigente → código testado → evidência reproduzível.  
 **Contrato de entry-points:** `docs/canonical-entry-points.yaml`  
 **Onboarding / visão de produto:** `README.md`  
@@ -59,10 +59,15 @@ python3 -m scripts.ops.source_contract_tests --json
 #     é preflight acionável (DB_UNAVAILABLE / DB_REACHABLE_SCHEMA_MISSING), não skip.
 #   Sem opt-in: skip rápido com o reason code nomeado (nunca hang, nunca UndefinedTable tardio).
 #   Banco plenamente migrado: DB_READY e os testes reais executam.
-# Porta 5436 NÃO é exclusiva — o DSN canônico vence.
-export REQUIRE_REAL_DB=1
+# O entrypoint cria um banco local irmão por execução, aplica todas as migrations
+# e seeds obrigatórias, valida conexão/ledger/fixtures e executa a seleção duas
+# vezes: ordem normal e inversa. O usuário do DSN precisa de CREATEDB.
+# `psql` não é requisito: a administração usa o psycopg2 canônico.
 export LOCAL_DATALAKE_DSN="${LOCAL_DATALAKE_DSN:-postgresql://test:test@127.0.0.1:5433/extra_test}"
-python3 -m pytest tests/ -m real_db -q --tb=short
+python3 -m scripts.ops.run_full_suite --real-db-only --repeat 2
+
+# Diagnóstico equivalente dentro de um DSN isolado já migrado/semeado:
+# REQUIRE_REAL_DB=1 python3 -m pytest tests/ -m real_db -q --tb=short
 
 # Golden path (fail-closed — prova técnica de pipeline)
 python3 -m scripts.golden_path --dsn "$LOCAL_DATALAKE_DSN"

--- a/docs/architecture/adr/ADR-029-canonical-full-suite.md
+++ b/docs/architecture/adr/ADR-029-canonical-full-suite.md
@@ -16,9 +16,10 @@ gated to `workflow_dispatch` only without PostgreSQL.
 1. **Single executable definition:** `python -m scripts.ops.run_full_suite`
 2. **Shared by** local `make test-all` and CI job `Test All (full suite)`
 3. **Flags:** `pytest tests/ -m "" -o addopts=''` plus coverage thresholds
-4. **DB:** caller provisions disposable PostgreSQL 16 (pgvector image in CI);
-   entrypoint applies **all** versioned migrations (no hard-coded max) and
-   deterministic seeds (`db/seed/001_sc_entities.py`, `002_entity_aliases.py`)
+4. **DB:** caller provisions local PostgreSQL 16 (pgvector image in CI) with
+   `CREATEDB`; the entrypoint creates a disposable sibling database, applies
+   **all** versioned migrations (no hard-coded max), and loads deterministic
+   seeds (`db/seed/001_sc_entities.py`, `002_entity_aliases.py`)
 5. **Isolation env:** `REQUIRE_REAL_DB=1` and `RESILIENCE_REQUIRE_DB=1` so
    `tests/conftest.py` does not mock `psycopg2.connect`
 6. **CI triggers:** `pull_request` → `main`, `push` → `main`, `workflow_dispatch`
@@ -30,3 +31,22 @@ Default `make test` retains `-m "not slow"` for fast feedback.
 - Claims of FULL_SUITE_EXECUTED / “Suíte global completa verde” require this path
   (or proven equivalent) with exit 0, zero FAILED/ERROR/DESELECTED, and CI job success.
 - Live/external tests remain explicitly marked; they must not be used as operational proof.
+
+## Amendment — strict `real_db` convergence (#285, 2026-08-26)
+
+The same entrypoint owns the opt-in selection through
+`python -m scripts.ops.run_full_suite --real-db-only --repeat 2`:
+
+1. The supplied DSN must be local and its user must have `CREATEDB`; production
+   and soak database names are rejected.
+2. Every repetition creates a uniquely named empty sibling database, applies
+   every canonical migration and both deterministic seeds, validates the exact
+   migration ledger, seed cardinalities, and a real psycopg2 connection, then
+   drops the database even on failure.
+3. The first repetition uses collection order and the second reverses it. Any
+   skip from a `real_db` test while the opt-in is active is converted to failure.
+4. Administrative operations use psycopg2. `psql` is not a hidden local or CI
+   prerequisite; a missing Python driver fails preflight as
+   `REAL_DB_TOOLING_MISSING`.
+
+This is a mode of the canonical runner, not a second marker or fixture framework.

--- a/docs/ops/issue-285-real-db-handoff.md
+++ b/docs/ops/issue-285-real-db-handoff.md
@@ -1,0 +1,61 @@
+# Issue #285 — `real_db` reliability handoff
+
+**Status:** `VERIFIED` on branch; `ACCEPTED` requires exact-HEAD CI and merge to
+`main`.
+
+## Reproduce
+
+Provision a disposable local PostgreSQL 16+ instance with pgvector and a user
+that has `CREATEDB`, then run:
+
+```bash
+export LOCAL_DATALAKE_DSN=postgresql://test:test@127.0.0.1:5433/extra_test
+python3 -m scripts.ops.run_full_suite --real-db-only --repeat 2
+```
+
+The runner creates a new sibling database for each repetition, applies every
+canonical migration and both required seeds, validates the real connection and
+schema ledger, runs `REQUIRE_REAL_DB=1 pytest tests/ -m real_db`, and always
+drops the generated database. The second repetition reverses collection order.
+
+## Failure ledger
+
+| Baseline node/result on current `main` | Classification | Root cause and resolution | After |
+|---|---|---|---|
+| `TestSeedCoverage::test_all_secretarias_have_alias` failed | seed/fixture | Entity seed absent; strict seed bootstrap plus cardinality preflight | Pass |
+| `TestSeedCoverage::test_alias_count_matches_expected` failed | seed/fixture | Alias seed absent; both mandatory seeds now fail closed | Pass |
+| `test_dual_seed_and_bid_table_no_duplicate_keys` failed | seed/fixture | Idempotency test received an unseeded DB; canonical seeds now precede collection | Pass |
+| `test_clean_env_confirm_drop_runs` failed | tooling/psql | Hidden `psql` dependency replaced by required psycopg2 administration | Pass |
+| `test_linkage_pipeline_on_isolated_dsn` skipped | lifecycle / isolation | Module DSN and fixed-port gate bypassed the canonical DB; generated DB is accepted and data is owned/cleaned | Pass |
+| `test_population_stats_full_not_sample` skipped | seed/fixture / isolation | Campaign DB was assumed pre-restored; module now seeds deterministic material rows in the per-run DB | Pass |
+| `test_run_pack_end_to_end_real_path` skipped | seed/fixture / isolation | Same external campaign-state dependency; shared fixture now owns setup and cleanup | Pass |
+| Cross-module residual exposed during repair | leak de estado / order | Linkage/report rows contaminated later presence checks; producers clean their rows and clean-lake tests require the generated DB | 132 pass twice |
+
+No migration/schema drift, timezone/clock defect, or production-code defect was
+observed in the current-main residual. Those classes remain covered by the
+strict ledger, real-connection, and reverse-order preflights.
+
+Current-main revalidation before the fix collected 131 selected tests and
+reported **124 passed, 4 failed, 3 skipped**. The historical issue record
+reported 115 passed, 6 failed, and 1 error; the difference comes from changes
+already present on current `main`, not from hiding tests.
+
+Branch verification after the fix selected 132 tests. Both the normal-order and
+reverse-order runs reported **132 passed, 0 failed, 0 errors, 0 skipped**. Each
+run applied 103 migration files (104 exact ledger entries), loaded 2,085 entities
+and 459 active aliases, and verified a real psycopg2 connection before pytest.
+The canonical unfiltered runner was also exercised on a generated database and
+reported **6,035 passed, 139 optional skips, 0 failed, 0 errors**; those optional
+skips are not part of the `real_db` acceptance count.
+
+## Enforced invariants
+
+- no production/soak or non-local DSN;
+- no database reuse and no pre-existing schema;
+- no missing migration or checksum drift;
+- no missing entity or alias seed;
+- no fake/mock connection under opt-in;
+- no `real_db` skip after admission;
+- no `psql` requirement; missing psycopg2 is a named tooling failure.
+
+No refresh, feed, campaign, or production operation is part of this proof.

--- a/scripts/linkage/isolation.py
+++ b/scripts/linkage/isolation.py
@@ -32,6 +32,7 @@ FORBIDDEN_PATH_MARKERS = (
 # Allowed local isolated hosts/ports for this campaign
 ALLOWED_LOCAL_HOSTS = ("127.0.0.1", "localhost", "::1")
 PREFERRED_PORTS = (5438,)
+GENERATED_TEST_DB_PREFIX = "extra_real_db_"
 
 
 @dataclass
@@ -105,8 +106,9 @@ def check_dsn(dsn: str | None, *, require_isolated_port: bool = True) -> Isolati
     if host and host not in ALLOWED_LOCAL_HOSTS:
         hits.append(f"non_local_host:{host}")
 
-    if require_isolated_port and port is not None and port not in PREFERRED_PORTS:
-        # Campaign isolation: only preferred local RC ports are accepted.
+    generated_database = bool(db and db.startswith(GENERATED_TEST_DB_PREFIX))
+    if require_isolated_port and port is not None and port not in PREFERRED_PORTS and not generated_database:
+        # A unique database-per-run is stronger isolation than a fixed port.
         hits.append(f"port_not_isolated:{port}")
         reasons.append(f"port_{port}_not_preferred_5438")
 
@@ -120,11 +122,11 @@ def check_dsn(dsn: str | None, *, require_isolated_port: bool = True) -> Isolati
         and not policy_fail
         and bool(host)
         and host in ALLOWED_LOCAL_HOSTS
-        and (not require_isolated_port or port in PREFERRED_PORTS or port is None)
+        and (not require_isolated_port or port in PREFERRED_PORTS or port is None or generated_database)
     )
 
     if ok:
-        reasons.append("local_isolated_dsn")
+        reasons.append("local_database_per_run" if generated_database else "local_isolated_dsn")
     else:
         reasons.append("isolation_failed")
 

--- a/scripts/ops/golden_clean_env.py
+++ b/scripts/ops/golden_clean_env.py
@@ -1,19 +1,24 @@
 """Prove golden path on a freshly created empty database (DoD §12.1 clean env)."""
+
 from __future__ import annotations
 
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
+
+from scripts.testing.database_run import (
+    DatabaseRunError,
+    recreate_database,
+    require_psycopg2,
+)
 
 REPO = Path(__file__).resolve().parents[2]
-_PSQL = "psql"  # resolved from PATH in local/CI (not shell-expanded)
 
 
 def _parts(dsn: str) -> dict[str, str]:
@@ -28,72 +33,14 @@ def _parts(dsn: str) -> dict[str, str]:
     }
 
 
-def _dsn(parts: dict[str, str], dbname: str) -> str:
-    auth = parts["user"]
-    if parts["password"]:
-        auth = f"{parts['user']}:{parts['password']}"
-    return urlunparse(
-        (parts["scheme"], f"{auth}@{parts['host']}:{parts['port']}", f"/{dbname}", "", "", "")
-    )
-
-
-def _psql_env(parts: dict[str, str]) -> dict[str, str]:
-    env = os.environ.copy()
-    env["PGPASSWORD"] = parts["password"]
-    return env
-
-
-def _psql(parts: dict[str, str], dbname: str, sql: str) -> subprocess.CompletedProcess[str]:
-    # psql binary comes from PATH in local/CI; argv is fully controlled (shell=False).
-    argv = [
-        _PSQL,
-        "-h",
-        parts["host"],
-        "-p",
-        parts["port"],
-        "-U",
-        parts["user"],
-        "-d",
-        dbname,
-        "-v",
-        "ON_ERROR_STOP=1",
-        "-c",
-        sql,
-    ]
-    return subprocess.run(  # noqa: S603 — fixed argv, shell=False
-        argv,
-        env=_psql_env(parts),
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=60,
-    )
-
-
 def recreate_db(admin_dsn: str, clean_name: str) -> dict[str, Any]:
-    parts = _parts(admin_dsn)
-    # terminate + drop + create as separate autocommit statements
-    # clean_name / user come from controlled local tooling args, not external SQL input.
-    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", clean_name):
-        raise ValueError(f"invalid clean db name: {clean_name!r}")
-    user = parts["user"]
-    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", user):
-        raise ValueError(f"invalid db user: {user!r}")
-    # Identifiers validated via re.fullmatch above (safe literal interpolation for local tooling).
-    term_sql = f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{clean_name}' AND pid <> pg_backend_pid();"  # noqa: S608
-    drop_sql = f"DROP DATABASE IF EXISTS {clean_name};"  # noqa: S608
-    create_sql = f"CREATE DATABASE {clean_name} OWNER {user};"  # noqa: S608
-    term = _psql(parts, "postgres", term_sql)
-    drop = _psql(parts, "postgres", drop_sql)
-    create = _psql(parts, "postgres", create_sql)
+    """Recreate a local database using the required Python driver."""
+    dsn = recreate_database(admin_dsn, clean_name)
     return {
-        "term_exit": term.returncode,
-        "drop_exit": drop.returncode,
-        "drop_err": (drop.stderr or "")[-200:],
-        "create_exit": create.returncode,
-        "create_err": (create.stderr or "")[-200:],
-        "ok": create.returncode == 0,
-        "dsn": _dsn(parts, clean_name),
+        "backend": "psycopg2",
+        "psql_required": False,
+        "ok": True,
+        "dsn": dsn,
     }
 
 
@@ -121,17 +68,13 @@ def apply_migrations(dsn: str) -> dict[str, Any]:
     }
 
 
-
-
 def table_count(dsn: str) -> int:
     import psycopg2
 
     conn = psycopg2.connect(dsn, connect_timeout=5)
     try:
         with conn.cursor() as cur:
-            cur.execute(
-                "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'"
-            )
+            cur.execute("SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")
             return int(cur.fetchone()[0])
     finally:
         conn.close()
@@ -221,13 +164,31 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if not args.confirm_drop:
         print(
-            "REFUSING destructive DROP/CREATE without --confirm-drop "
-            f"(db={args.db_name}). Use --dry-run to preview.",
+            f"REFUSING destructive DROP/CREATE without --confirm-drop (db={args.db_name}). Use --dry-run to preview.",
             file=sys.stderr,
         )
         return 3
 
-    rec = recreate_db(args.admin_dsn, args.db_name)
+    try:
+        require_psycopg2()
+        report["steps"]["tooling"] = {
+            "ok": True,
+            "required": ["psycopg2"],
+            "psql_required": False,
+        }
+        rec = recreate_db(args.admin_dsn, args.db_name)
+    except DatabaseRunError as exc:
+        report["steps"]["tooling"] = {
+            "ok": False,
+            "required": ["psycopg2"],
+            "psql_required": False,
+            "error": str(exc),
+        }
+        report["ok"] = False
+        Path(args.report).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.report).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(report, indent=2))
+        return 2
     report["steps"]["recreate_db"] = rec
     if not rec["ok"]:
         Path(args.report).parent.mkdir(parents=True, exist_ok=True)
@@ -242,19 +203,28 @@ def main(argv: list[str] | None = None) -> int:
     # Prefer direct seed scripts for entities
     seed1 = subprocess.run(  # noqa: S603
         [sys.executable, str(REPO / "db" / "seed" / "001_sc_entities.py"), "--dsn", dsn],
-        cwd=str(REPO), env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
-        text=True, capture_output=True, check=False, timeout=180,
+        cwd=str(REPO),
+        env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
     )
     seed2 = subprocess.run(  # noqa: S603
         [sys.executable, str(REPO / "db" / "seed" / "002_entity_aliases.py"), "--dsn", dsn],
-        cwd=str(REPO), env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
-        text=True, capture_output=True, check=False, timeout=120,
+        cwd=str(REPO),
+        env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=120,
     )
     report["steps"]["seeds"] = {
         "entities_exit": seed1.returncode,
         "aliases_exit": seed2.returncode,
-        "ok": seed1.returncode == 0,
+        "ok": seed1.returncode == 0 and seed2.returncode == 0,
         "entities_tail": (seed1.stdout or seed1.stderr or "")[-400:],
+        "aliases_tail": (seed2.stdout or seed2.stderr or "")[-400:],
     }
     try:
         n = table_count(dsn)
@@ -269,12 +239,18 @@ def main(argv: list[str] | None = None) -> int:
     report["steps"]["ledger_path"] = str(ledger)
     parts = _parts(dsn)
     report["clean_dsn_hint"] = f"{parts['host']}:{parts['port']}/{args.db_name}"
-    report["ok"] = bool(rec["ok"] and mig.get("ok") and report["steps"].get("seeds",{}).get("ok") and n >= 5 and gp["ok"])
+    report["ok"] = bool(
+        rec["ok"] and mig.get("ok") and report["steps"].get("seeds", {}).get("ok") and n >= 5 and gp["ok"]
+    )
     report["limitations"] = [
         "vector extension optional (014 skipped if unavailable)",
         "clean env proof: empty DB → migrations → golden_path (--skip-freshness --allow-zero); sources may be zero on empty net",
         "Live crawl can be re-run after clean bootstrap with data sources",
     ]
+    report["tooling"] = {
+        "database_admin": "psycopg2",
+        "psql_required": False,
+    }
     report["claims"] = {
         "allowed": [
             "Golden path executed on freshly created empty database",
@@ -284,9 +260,7 @@ def main(argv: list[str] | None = None) -> int:
     }
 
     Path(args.report).parent.mkdir(parents=True, exist_ok=True)
-    Path(args.report).write_text(
-        json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-    )
+    Path(args.report).write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     print(json.dumps({k: report[k] for k in ("ok", "clean_dsn_hint", "steps")}, indent=2, default=str)[:3500])
     return 0 if report["ok"] else 1
 

--- a/scripts/ops/run_full_suite.py
+++ b/scripts/ops/run_full_suite.py
@@ -24,8 +24,24 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
+
+from scripts.ops.apply_migrations import file_checksum, list_migrations, version_key
+from scripts.testing.database_run import (
+    assert_generated_database_connection,
+    isolated_database,
+)
+from scripts.testing.real_db_guard import connection_kind
 
 REPO = Path(__file__).resolve().parents[2]
+MIGRATIONS = REPO / "db" / "migrations"
+REQUIRED_SEEDS = (
+    "db/seed/001_sc_entities.py",
+    "db/seed/002_entity_aliases.py",
+)
+MIGRATION_INTERNAL_LEDGER_ENTRIES = {
+    "021": ("coverage-2.4_entity_coverage_rebuild", "sha256=coverage-2-4-manual"),
+}
 
 
 def _dsn() -> str:
@@ -60,14 +76,10 @@ def apply_seeds(dsn: str) -> None:
     env = os.environ.copy()
     env["DATABASE_URL"] = dsn
     env["LOCAL_DATALAKE_DSN"] = dsn
-    for rel in (
-        "db/seed/001_sc_entities.py",
-        "db/seed/002_entity_aliases.py",
-    ):
+    for rel in REQUIRED_SEEDS:
         path = REPO / rel
         if not path.is_file():
-            print(f"WARNING: seed missing {rel}", flush=True)
-            continue
+            raise FileNotFoundError(f"REAL_DB_SEED_MISSING: {rel}")
         print(f"==> seed: {rel}", flush=True)
         # Trusted argv: sys.executable + in-repo seed script path.
         subprocess.check_call(  # noqa: S603
@@ -75,20 +87,86 @@ def apply_seeds(dsn: str) -> None:
         )
 
 
-def run_pytest(extra: list[str]) -> int:
+def _expected_migration_ledger() -> dict[str, tuple[str, str]]:
+    expected = {version_key(path): (path.name, file_checksum(path)) for path in list_migrations(MIGRATIONS)}
+    expected.update(MIGRATION_INTERNAL_LEDGER_ENTRIES)
+    return expected
+
+
+def compare_migration_ledger(
+    expected: dict[str, tuple[str, str]],
+    actual: dict[str, tuple[str, str]],
+) -> None:
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+    drifted = sorted(key for key in expected.keys() & actual.keys() if expected[key] != actual[key])
+    if missing or extra or drifted:
+        raise RuntimeError(f"REAL_DB_SCHEMA_DRIFT: missing={missing} extra={extra} drifted={drifted}")
+
+
+def validate_real_db_contract(dsn: str) -> dict[str, Any]:
+    """Fail closed on fake connection, migration drift, or missing suite seeds."""
+    import psycopg2
+
+    conn = psycopg2.connect(dsn, connect_timeout=5)
+    kind = connection_kind(conn)
+    if kind != "psycopg2":
+        conn.close()
+        raise RuntimeError(f"REAL_DB_FAKE_CONNECTION: expected psycopg2, got {kind}")
+    try:
+        database = assert_generated_database_connection(conn)
+        with conn.cursor() as cur:
+            cur.execute("SELECT version, name, checksum FROM public._migrations")
+            actual = {str(row[0]): (str(row[1]), str(row[2])) for row in cur.fetchall()}
+            compare_migration_ledger(_expected_migration_ledger(), actual)
+            cur.execute("SELECT count(*) FROM sc_public_entities")
+            entity_count = int(cur.fetchone()[0])
+            cur.execute("SELECT count(*) FROM entity_aliases WHERE is_active")
+            alias_count = int(cur.fetchone()[0])
+    finally:
+        conn.close()
+    if entity_count < 2085 or alias_count < 359:
+        raise RuntimeError(f"REAL_DB_SEED_MISSING: sc_public_entities={entity_count} entity_aliases={alias_count}")
+    return {
+        "connection_kind": kind,
+        "database": database,
+        "migration_count": len(actual),
+        "entity_count": entity_count,
+        "alias_count": alias_count,
+    }
+
+
+def run_pytest(
+    extra: list[str],
+    *,
+    marker: str = "",
+    dsn: str | None = None,
+    order: str = "normal",
+) -> int:
     env = os.environ.copy()
+    if dsn:
+        for key in (
+            "DATABASE_URL",
+            "LOCAL_DATALAKE_DSN",
+            "TEST_DSN",
+            "NATIONAL_INTEL_DSN",
+            "CAMPAIGN_TEST_DSN",
+            "LINKAGE_TEST_DSN",
+        ):
+            env[key] = dsn
     # Real PG for integration/database tests; never use operator personal DSN defaults.
     env["REQUIRE_REAL_DB"] = "1"
     env["RESILIENCE_REQUIRE_DB"] = "1"
     env.setdefault("RESILIENCE_ENV", "test")
     env.setdefault("CI", "true")
+    env["REAL_DB_TEST_ORDER"] = order
     cmd = [
         sys.executable,
         "-m",
         "pytest",
         "tests/",
         "-m",
-        "",
+        marker,
         "-o",
         "addopts=",
         "--cov=scripts",
@@ -101,11 +179,36 @@ def run_pytest(extra: list[str]) -> int:
     print("==> pytest:", " ".join(cmd), flush=True)
     print(
         "==> env: REQUIRE_REAL_DB=1 RESILIENCE_REQUIRE_DB=1 "
+        f"marker={marker or '<all>'} order={order} "
         f"DATABASE_URL set={bool(env.get('DATABASE_URL'))}",
         flush=True,
     )
     # Trusted argv: sys.executable + fixed pytest module path/flags.
     return subprocess.call(cmd, cwd=REPO, env=env)  # noqa: S603
+
+
+def run_real_db_repeated(admin_dsn: str, *, repeat: int, extra: list[str]) -> int:
+    """Run the complete real_db selection on a new database each time."""
+    for index in range(repeat):
+        order = "normal" if index == 0 else "reverse"
+        with isolated_database(admin_dsn) as database:
+            print(
+                f"==> real_db run {index + 1}/{repeat}: database={database.name} order={order}",
+                flush=True,
+            )
+            apply_all_migrations(database.dsn)
+            apply_seeds(database.dsn)
+            contract = validate_real_db_contract(database.dsn)
+            print(f"==> real_db preflight: {contract}", flush=True)
+            result = run_pytest(
+                extra,
+                marker="real_db",
+                dsn=database.dsn,
+                order=order,
+            )
+            if result != 0:
+                return result
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -121,22 +224,52 @@ def main(argv: list[str] | None = None) -> int:
         help="Skip sc_public_entities / entity_aliases seed scripts",
     )
     parser.add_argument(
+        "--real-db-only",
+        action="store_true",
+        help="Run only -m real_db on a generated database-per-run",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="Number of isolated real_db executions (run 2+ reverses collection order)",
+    )
+    parser.add_argument(
         "pytest_args",
         nargs="*",
         help="Extra args forwarded to pytest after the canonical flags",
     )
     args = parser.parse_args(argv)
+    if args.repeat < 1:
+        parser.error("--repeat must be >= 1")
+    if args.repeat != 1 and not args.real_db_only:
+        parser.error("--repeat is supported only with --real-db-only")
 
     dsn = _dsn()
-    os.environ.setdefault("DATABASE_URL", dsn)
-    os.environ.setdefault("LOCAL_DATALAKE_DSN", dsn)
+    if args.real_db_only:
+        if args.skip_migrations or args.skip_seeds:
+            parser.error("--real-db-only is fail-closed; skip flags are not allowed")
+        return run_real_db_repeated(dsn, repeat=args.repeat, extra=list(args.pytest_args))
 
-    if not args.skip_migrations:
-        apply_all_migrations(dsn)
-    if not args.skip_seeds:
-        apply_seeds(dsn)
+    if args.skip_migrations or args.skip_seeds:
+        # Diagnostic resume mode: the caller owns and names an already-isolated DB.
+        os.environ.setdefault("DATABASE_URL", dsn)
+        os.environ.setdefault("LOCAL_DATALAKE_DSN", dsn)
+        if not args.skip_migrations:
+            apply_all_migrations(dsn)
+        if not args.skip_seeds:
+            apply_seeds(dsn)
+        return run_pytest(list(args.pytest_args), dsn=dsn)
 
-    return run_pytest(list(args.pytest_args))
+    # Canonical full-suite runs also start empty. The supplied DSN is an admin
+    # endpoint only; test code never receives or mutates that database.
+    with isolated_database(dsn) as database:
+        print(f"==> full-suite database={database.name}", flush=True)
+        apply_all_migrations(database.dsn)
+        apply_seeds(database.dsn)
+        contract = validate_real_db_contract(database.dsn)
+        print(f"==> full-suite preflight: {contract}", flush=True)
+        return run_pytest(list(args.pytest_args), dsn=database.dsn)
 
 
 if __name__ == "__main__":

--- a/scripts/testing/database_run.py
+++ b/scripts/testing/database_run.py
@@ -1,0 +1,207 @@
+"""Disposable PostgreSQL databases for deterministic test-suite runs.
+
+The caller supplies a local PostgreSQL DSN with ``CREATEDB`` privilege.  This
+module creates a sibling database with a generated name, verifies that it is
+empty, and drops it after the run.  Administrative operations use psycopg2;
+``psql`` is deliberately not a hidden runtime dependency.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+LOCAL_DATABASE_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+REAL_DB_NAME_PREFIX = "extra_real_db_"
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_FORBIDDEN_DATABASE_MARKERS = ("prod", "production", "soak")
+
+
+class DatabaseRunError(RuntimeError):
+    """Fail-closed configuration or lifecycle error for a test database."""
+
+
+def require_psycopg2(
+    importer: Callable[[str], Any] = importlib.import_module,
+) -> Any:
+    """Return the required PostgreSQL driver or raise a named tooling error."""
+    try:
+        return importer("psycopg2")
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise DatabaseRunError("REAL_DB_TOOLING_MISSING: psycopg2 is required; psql is not required") from exc
+
+
+def validate_database_name(name: str, *, required_prefix: str | None = None) -> str:
+    if not _SAFE_IDENTIFIER.fullmatch(name):
+        raise DatabaseRunError(f"REAL_DB_INVALID_DATABASE_NAME: {name!r}")
+    lowered = name.lower()
+    if lowered in {"postgres", "template0", "template1"} or any(
+        marker in lowered for marker in _FORBIDDEN_DATABASE_MARKERS
+    ):
+        raise DatabaseRunError(f"REAL_DB_FORBIDDEN_DATABASE_NAME: {name!r}")
+    if required_prefix and not name.startswith(required_prefix):
+        raise DatabaseRunError(f"REAL_DB_UNSAFE_DATABASE_NAME: expected prefix {required_prefix!r}")
+    return name
+
+
+def validate_local_admin_dsn(dsn: str) -> str:
+    parsed = urlparse(dsn)
+    if parsed.scheme not in {"postgres", "postgresql"}:
+        raise DatabaseRunError("REAL_DB_INVALID_DSN: PostgreSQL URL required")
+    host = parsed.hostname or ""
+    if host not in LOCAL_DATABASE_HOSTS:
+        raise DatabaseRunError(f"REAL_DB_ISOLATION_FAIL: local PostgreSQL required, got host={host or 'missing'}")
+    database = (parsed.path or "").lstrip("/")
+    if any(marker in database.lower() for marker in _FORBIDDEN_DATABASE_MARKERS):
+        raise DatabaseRunError("REAL_DB_ISOLATION_FAIL: production/soak database refused")
+    return dsn
+
+
+def dsn_with_database(dsn: str, database: str) -> str:
+    validate_database_name(database)
+    parsed = urlparse(dsn)
+    return urlunparse(parsed._replace(path=f"/{database}"))
+
+
+def generated_database_name() -> str:
+    return f"{REAL_DB_NAME_PREFIX}{os.getpid()}_{uuid.uuid4().hex[:10]}"
+
+
+def assert_initially_empty(table_count: int, view_count: int) -> None:
+    if table_count != 0 or view_count != 0:
+        raise DatabaseRunError(
+            f"REAL_DB_DIRTY_REUSE: newly created database is not empty (tables={table_count}, views={view_count})"
+        )
+
+
+def assert_generated_database_connection(conn: Any) -> str:
+    """Refuse destructive test setup unless the connection is per-run isolated."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT current_database()")
+        database = str(cur.fetchone()[0])
+    validate_database_name(database, required_prefix=REAL_DB_NAME_PREFIX)
+    return database
+
+
+def _admin_connection(admin_dsn: str, *, connector: Callable[..., Any] | None = None) -> Any:
+    validate_local_admin_dsn(admin_dsn)
+    connect = connector or require_psycopg2().connect
+    parsed = urlparse(admin_dsn)
+    postgres_dsn = urlunparse(parsed._replace(path="/postgres"))
+    conn = connect(postgres_dsn, connect_timeout=5)
+    conn.autocommit = True
+    return conn
+
+
+def create_database(
+    admin_dsn: str,
+    database: str,
+    *,
+    connector: Callable[..., Any] | None = None,
+) -> str:
+    """Create a local database and return its DSN; never reuse an existing DB."""
+    validate_database_name(database)
+    require_psycopg2()
+    from psycopg2 import sql
+
+    conn = _admin_connection(admin_dsn, connector=connector)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (database,))
+            if cur.fetchone() is not None:
+                raise DatabaseRunError(f"REAL_DB_DIRTY_REUSE: database already exists: {database}")
+            cur.execute("SELECT current_user")
+            owner = str(cur.fetchone()[0])
+            cur.execute(
+                sql.SQL("CREATE DATABASE {} OWNER {}").format(
+                    sql.Identifier(database),
+                    sql.Identifier(owner),
+                )
+            )
+    finally:
+        conn.close()
+    target = dsn_with_database(admin_dsn, database)
+    assert_database_empty(target, connector=connector)
+    return target
+
+
+def recreate_database(
+    admin_dsn: str,
+    database: str,
+    *,
+    connector: Callable[..., Any] | None = None,
+) -> str:
+    """Drop and recreate an explicitly confirmed local database."""
+    validate_database_name(database)
+    drop_database(admin_dsn, database, connector=connector, missing_ok=True)
+    return create_database(admin_dsn, database, connector=connector)
+
+
+def drop_database(
+    admin_dsn: str,
+    database: str,
+    *,
+    connector: Callable[..., Any] | None = None,
+    missing_ok: bool = True,
+) -> None:
+    validate_database_name(database)
+    require_psycopg2()
+    from psycopg2 import sql
+
+    conn = _admin_connection(admin_dsn, connector=connector)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = %s AND pid <> pg_backend_pid()",
+                (database,),
+            )
+            clause = "DROP DATABASE IF EXISTS {}" if missing_ok else "DROP DATABASE {}"
+            cur.execute(sql.SQL(clause).format(sql.Identifier(database)))
+    finally:
+        conn.close()
+
+
+def assert_database_empty(
+    dsn: str,
+    *,
+    connector: Callable[..., Any] | None = None,
+) -> None:
+    connect = connector or require_psycopg2().connect
+    conn = connect(dsn, connect_timeout=5)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM information_schema.tables "
+                "WHERE table_schema = 'public' AND table_type = 'BASE TABLE'"
+            )
+            table_count = int(cur.fetchone()[0])
+            cur.execute("SELECT count(*) FROM information_schema.views WHERE table_schema = 'public'")
+            view_count = int(cur.fetchone()[0])
+    finally:
+        conn.close()
+    assert_initially_empty(table_count, view_count)
+
+
+@dataclass(frozen=True)
+class IsolatedDatabase:
+    name: str
+    dsn: str
+
+
+@contextmanager
+def isolated_database(admin_dsn: str) -> Iterator[IsolatedDatabase]:
+    """Create and always tear down a generated database-per-run."""
+    name = generated_database_name()
+    validate_database_name(name, required_prefix=REAL_DB_NAME_PREFIX)
+    dsn = create_database(admin_dsn, name)
+    try:
+        yield IsolatedDatabase(name=name, dsn=dsn)
+    finally:
+        drop_database(admin_dsn, name)

--- a/scripts/testing/real_db_guard.py
+++ b/scripts/testing/real_db_guard.py
@@ -25,9 +25,9 @@ from urllib.parse import urlparse
 Strategy = Literal["real", "skip", "config_error", "mock"]
 AdmissionState = Literal["DB_UNAVAILABLE", "DB_REACHABLE_SCHEMA_MISSING", "DB_READY"]
 
-DB_UNAVAILABLE = "DB_UNAVAILABLE"
-DB_REACHABLE_SCHEMA_MISSING = "DB_REACHABLE_SCHEMA_MISSING"
-DB_READY = "DB_READY"
+DB_UNAVAILABLE: Literal["DB_UNAVAILABLE"] = "DB_UNAVAILABLE"
+DB_REACHABLE_SCHEMA_MISSING: Literal["DB_REACHABLE_SCHEMA_MISSING"] = "DB_REACHABLE_SCHEMA_MISSING"
+DB_READY: Literal["DB_READY"] = "DB_READY"
 
 CONNECT_TIMEOUT_SECONDS = 2
 
@@ -58,6 +58,11 @@ def explicit_dsn_provided() -> bool:
 
 def require_real_db() -> bool:
     return env_flag("REQUIRE_REAL_DB")
+
+
+def real_db_skip_is_forbidden(*, marked_real_db: bool, require_real: bool) -> bool:
+    """Opted-in real_db items must execute or fail; skip is never success."""
+    return marked_real_db and require_real
 
 
 def dsn_host_for_logs(dsn: str) -> str:
@@ -168,7 +173,7 @@ class AdmissionResult:
         return self.state == DB_READY
 
 
-def _existing_relations(conn: object, *, kind: str, names: tuple[str, ...]) -> set[str]:
+def _existing_relations(conn: Any, *, kind: str, names: tuple[str, ...]) -> set[str]:
     if not names:
         return set()
     table_type = "BASE TABLE" if kind == "table" else "VIEW"
@@ -177,7 +182,7 @@ def _existing_relations(conn: object, *, kind: str, names: tuple[str, ...]) -> s
         "SELECT table_name FROM information_schema.tables "
         "WHERE table_schema = 'public' AND table_type = %s AND table_name = %s"
     )
-    cursor = conn.cursor()  # type: ignore[union-attr]
+    cursor = conn.cursor()
     try:
         with cursor:
             for name in names:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,31 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Second canonical real_db run reverses order to expose module coupling."""
+    order = os.getenv("REAL_DB_TEST_ORDER", "normal").strip().lower()
+    if order == "reverse" and "real_db" in (config.option.markexpr or ""):
+        items.reverse()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+    """A selected real_db item cannot silently skip after explicit opt-in."""
+    outcome = yield
+    report = outcome.get_result()
+    from scripts.testing.real_db_guard import real_db_skip_is_forbidden
+
+    if report.skipped and real_db_skip_is_forbidden(
+        marked_real_db=item.get_closest_marker("real_db") is not None,
+        require_real=os.getenv("REQUIRE_REAL_DB", "").lower() in {"1", "true", "yes"},
+    ):
+        report.outcome = "failed"
+        report.longrepr = (
+            f"REAL_DB_SKIP_FORBIDDEN: {item.nodeid} skipped during {report.when}; "
+            "REQUIRE_REAL_DB=1 requires execution or a named failure"
+        )
+
+
 @pytest.fixture(autouse=True)
 def _mock_psycopg2_connect(request):
     """Mock psycopg2.connect to prevent real PostgreSQL calls in tests.
@@ -67,9 +92,7 @@ def _mock_psycopg2_connect(request):
         return
 
     # Pre-VPS resilience vertical slice / DB-marked tests with explicit env.
-    if request.node.get_closest_marker("database") is not None and (
-        require_resilience_db or require_real
-    ):
+    if request.node.get_closest_marker("database") is not None and (require_resilience_db or require_real):
         yield
         return
 
@@ -84,9 +107,7 @@ def _mock_psycopg2_connect(request):
     )
 
     filename = path_parts[-1] if path_parts else ""
-    consults_pg = request.node.get_closest_marker("real_db") is not None or (
-        filename in CANONICAL_REAL_SUITES
-    )
+    consults_pg = request.node.get_closest_marker("real_db") is not None or (filename in CANONICAL_REAL_SUITES)
     if consults_pg:
         from scripts.testing.real_db_guard import admit_real_db_or_raise
 

--- a/tests/test_canonical_entity_linkage.py
+++ b/tests/test_canonical_entity_linkage.py
@@ -134,6 +134,11 @@ class TestIsolation:
         assert chk.ok is False
         assert any("port_not_isolated" in h for h in chk.forbidden_hits)
 
+    def test_database_per_run_is_isolated_on_caller_port(self):
+        chk = check_dsn("postgresql://test:test@127.0.0.1:5432/extra_real_db_123_deadbeef")
+        assert chk.ok is True
+        assert "local_database_per_run" in chk.reasons
+
     def test_blocks_ec_prod(self):
         chk = check_dsn("postgresql://u:p@ec-prod.example:5432/extra")
         assert chk.ok is False
@@ -209,35 +214,102 @@ class TestShippedEntryPoints:
 
 @pytest.mark.real_db
 def test_linkage_pipeline_on_isolated_dsn():
-    dsn = os.environ.get("LINKAGE_TEST_DSN")
-    if not dsn:
-        pytest.skip("LINKAGE_TEST_DSN not set")
+    from scripts.testing.real_db_guard import canonical_dsn
+
+    dsn = canonical_dsn()
     from scripts.linkage.isolation import check_dsn
     from scripts.linkage.pipeline import connect, run_linkage
 
     chk = check_dsn(dsn)
     if not chk.ok:
-        pytest.skip(f"DSN not isolated: {chk.as_dict()}")
-    conn = connect(dsn)
-    try:
-        with conn.cursor() as cur:
-            cur.execute("SELECT to_regclass('public.entity_linkage_runs') AS t")
-            row = cur.fetchone()
-            reg = row["t"] if isinstance(row, dict) else row[0]
-            if reg is None:
-                pytest.skip("migration 061 not applied")
-            cur.execute("SELECT count(*) AS n FROM opportunity_intel WHERE is_active")
-            row = cur.fetchone()
-            n = int(row["n"] if isinstance(row, dict) else row[0])
-            if n == 0:
-                pytest.skip("no opportunities seeded")
-    finally:
-        conn.close()
+        pytest.fail(f"REAL_DB_ISOLATION_FAIL: {chk.as_dict()}")
 
-    res = run_linkage(dsn, run_id="test-pytest-linkage", contract_limit_per_opp=10, max_opportunities=3)
-    assert res.status == "completed"
-    assert res.production_touched is False
-    assert res.metrics["organ_links"]["total"] >= 1
-    # unresolved stay in denominator
-    assert res.metrics["organ_links"]["unresolved_in_denominator"] is True
-    assert res.metrics["organ_links"]["hard_cases_excluded"] is False
+    def cleanup() -> None:
+        cleanup_conn = connect(dsn)
+        try:
+            with cleanup_conn.cursor() as cur:
+                cur.execute("DELETE FROM entity_linkage_review_queue WHERE run_id = 'test-pytest-linkage'")
+                cur.execute("DELETE FROM canonical_entity_aliases WHERE run_id = 'test-pytest-linkage'")
+                cur.execute("DELETE FROM entity_linkage_runs WHERE run_id = 'test-pytest-linkage'")
+                cur.execute(
+                    "DELETE FROM opportunity_intel WHERE source = 'real_db_test' AND source_id = 'REALDB-LINK-O-001'"
+                )
+                cur.execute("DELETE FROM pncp_supplier_contracts WHERE contrato_id = 'REALDB-LINK-C-001'")
+                cur.execute("DELETE FROM canonical_organs WHERE first_seen_run_id = 'test-pytest-linkage'")
+                cur.execute("DELETE FROM canonical_suppliers WHERE first_seen_run_id = 'test-pytest-linkage'")
+            cleanup_conn.commit()
+        finally:
+            cleanup_conn.close()
+
+    cleanup()
+    try:
+        conn = connect(dsn)
+        try:
+            from psycopg2.extras import Json
+
+            with conn.cursor() as cur:
+                cur.execute("SELECT to_regclass('public.entity_linkage_runs') AS t")
+                row = cur.fetchone()
+                reg = row["t"] if isinstance(row, dict) else row[0]
+                if reg is None:
+                    pytest.fail("REAL_DB_SCHEMA_DRIFT: migration 061 not applied")
+                organ_cnpj = _make_cnpj("123456780001")
+                supplier_cnpj = _make_cnpj("987654320001")
+                cur.execute(
+                    "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                    (
+                        Json(
+                            [
+                                {
+                                    "contrato_id": "REALDB-LINK-C-001",
+                                    "orgao_cnpj": organ_cnpj,
+                                    "orgao_nome": "Orgao Linkage",
+                                    "fornecedor_cnpj": supplier_cnpj,
+                                    "fornecedor_nome": "Fornecedor Linkage",
+                                    "supplier_id_type": "CNPJ",
+                                    "supplier_identifier": supplier_cnpj,
+                                    "supplier_country": "BR",
+                                    "objeto_contrato": "reforma predial",
+                                    "valor_total": "125000",
+                                    "data_publicacao": "2026-01-15",
+                                    "uf": "SC",
+                                    "municipio": "Florianopolis",
+                                    "source": "real_db_test",
+                                    "source_id": "REALDB-LINK-C-001",
+                                }
+                            ]
+                        ),
+                    ),
+                )
+                cur.execute(
+                    """
+                    INSERT INTO opportunity_intel (
+                        source, source_id, content_hash, numero_controle_pncp,
+                        orgao_cnpj, orgao_nome, uf, municipio, objeto,
+                        status_canonico, is_active, ranking
+                    ) VALUES (
+                        'real_db_test', 'REALDB-LINK-O-001', %s,
+                        'REALDB-LINK-O-001', %s, 'Orgao Linkage', 'SC',
+                        'Florianopolis', 'reforma predial', 'open', TRUE, 'REVIEW'
+                    ) ON CONFLICT DO NOTHING
+                    """,
+                    ("f" * 64, organ_cnpj),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        res = run_linkage(
+            dsn,
+            run_id="test-pytest-linkage",
+            contract_limit_per_opp=10,
+            max_opportunities=3,
+        )
+        assert res.status == "completed"
+        assert res.production_touched is False
+        assert res.metrics["organ_links"]["total"] >= 1
+        # unresolved stay in denominator
+        assert res.metrics["organ_links"]["unresolved_in_denominator"] is True
+        assert res.metrics["organ_links"]["hard_cases_excluded"] is False
+    finally:
+        cleanup()

--- a/tests/test_cmi_item_proofs.py
+++ b/tests/test_cmi_item_proofs.py
@@ -1,8 +1,8 @@
 """Tests for per-item CMI proof runner."""
+
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 import pytest
 
@@ -11,7 +11,6 @@ from scripts.ops import contract_market_intelligence as cmi
 
 DSN = os.environ.get("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
 REQUIRE = os.environ.get("REQUIRE_REAL_DB", "").lower() in {"1", "true", "yes"}
-PKG = Path("artifacts/campaigns/CONTRACT-MARKET-INTELLIGENCE-ACCEPT-01/final-package")
 
 
 def test_all_aliases_registered():
@@ -28,13 +27,15 @@ def test_unit_value_and_win_rate_gates():
 
 @pytest.mark.real_db
 @pytest.mark.skipif(not REQUIRE, reason="REQUIRE_REAL_DB")
-def test_all_item_proofs_against_package():
+def test_all_item_proofs_against_package(tmp_path, monkeypatch: pytest.MonkeyPatch):
     # Always regenerate package so Excel and material rows exist in CI.
-    cmi.run_package(DSN, PKG, seed_if_empty=True)
+    package = tmp_path / "final-package"
+    monkeypatch.setattr(proofs, "PACKAGE_DIR", package)
+    cmi.run_package(DSN, package, seed_if_empty=True)
     try:
         out = proofs.run_all()
         assert out["ok"] is True, out.get("failed")
         assert len(out["passed"]) == 47
-        assert (PKG / "executive-review.xlsx").is_file()
+        assert (package / "executive-review.xlsx").is_file()
     finally:
         cmi.cleanup_cmi_fixture(DSN)

--- a/tests/test_contracts_entity_evidence.py
+++ b/tests/test_contracts_entity_evidence.py
@@ -91,12 +91,15 @@ def test_complete_checkpoint_allows_success_zero(tmp_path: Path) -> None:
     path = _valid_multi_window_proof(tmp_path, planned=3, completed=3, pages=40)
     proof = load_checkpoint_window_proof(path)
     assert proof.valid is True
-    assert assert_success_zero_proof(
-        window_complete=True,
-        proof=proof,
-        pages_processed=proof.pages_processed,
-        pages_expected=proof.pages_expected,
-    ) == []
+    assert (
+        assert_success_zero_proof(
+            window_complete=True,
+            proof=proof,
+            pages_processed=proof.pages_processed,
+            pages_expected=proof.pages_expected,
+        )
+        == []
+    )
 
 
 def test_project_refuses_success_zero_without_proof() -> None:
@@ -167,9 +170,7 @@ def test_project_dry_run_without_write(monkeypatch: pytest.MonkeyPatch) -> None:
         seed_path=resolve_default_seed_path(),
     )
     assert report.dry_run is True
-    assert report.applicable_count == len(
-        load_canonical_universe(seed_path=resolve_default_seed_path()).included
-    )
+    assert report.applicable_count == len(load_canonical_universe(seed_path=resolve_default_seed_path()).included)
     assert report.success_zero == 0  # only_with_data + incomplete window
     assert report.written_rows == 0 or report.dry_run
 
@@ -180,24 +181,18 @@ def test_project_success_with_data_and_dual_mapping() -> None:
 
     Requires: REQUIRE_REAL_DB=1 and LOCAL_DATALAKE_DSN (conftest mocks psycopg2 otherwise).
     """
-    import os
+    from scripts.testing.database_run import assert_generated_database_connection
+    from scripts.testing.real_db_guard import admit_ready_connection
 
-    if os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"}:
-        pytest.skip("REQUIRE_REAL_DB=1 required for real PostgreSQL evidence projection")
-    pytest.importorskip("psycopg2")
-    import psycopg2
-
-    dsn = os.environ.get("LOCAL_DATALAKE_DSN") or os.environ.get("TEST_DSN")
-    if not dsn:
-        pytest.skip("LOCAL_DATALAKE_DSN not set")
-    try:
-        conn = psycopg2.connect(dsn)
-    except Exception as exc:  # pragma: no cover
-        pytest.skip(f"postgres unavailable: {exc}")
+    conn, _dsn = admit_ready_connection(
+        required_tables=("coverage_evidence", "pncp_supplier_contracts"),
+        context="contracts_entity_evidence",
+    )
 
     try:
+        assert_generated_database_connection(conn)
         cur = conn.cursor()
-        cur.execute("TRUNCATE coverage_evidence RESTART IDENTITY")
+        cur.execute("TRUNCATE coverage_evidence, pncp_supplier_contracts RESTART IDENTITY CASCADE")
         conn.commit()
         start, end = default_backfill_window()
         # Synthetic multi-window proof is allowed only for mapping tests (real_db),
@@ -247,7 +242,7 @@ def test_project_success_with_data_and_dual_mapping() -> None:
         assert hc.covered_numerator == hc.applicable_denominator
         assert hc.coverage_gate_pass is True
         # Cleanup so local ops DB is not left claiming operational PASS without live crawl
-        cur.execute("TRUNCATE coverage_evidence RESTART IDENTITY")
+        cur.execute("TRUNCATE coverage_evidence, pncp_supplier_contracts RESTART IDENTITY CASCADE")
         conn.commit()
     finally:
         conn.close()

--- a/tests/test_golden_clean_env.py
+++ b/tests/test_golden_clean_env.py
@@ -1,10 +1,12 @@
 """DoD §12.1 — golden path can run in a clean environment."""
+
 from __future__ import annotations
 
 import json
 import os
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 import pytest
@@ -39,9 +41,7 @@ def test_clean_env_dry_run() -> None:
 
 def test_clean_env_refuses_without_confirm() -> None:
     env = os.environ.copy()
-    env["LOCAL_DATALAKE_DSN"] = env.get(
-        "LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test"
-    )
+    env["LOCAL_DATALAKE_DSN"] = env.get("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
     r = subprocess.run(
         [sys.executable, "-m", "scripts.ops.golden_clean_env", "--db-name", "extra_clean_refuse"],
         cwd=REPO,
@@ -57,38 +57,44 @@ def test_clean_env_refuses_without_confirm() -> None:
 
 @pytest.mark.real_db
 def test_clean_env_confirm_drop_runs(tmp_path: Path) -> None:
-    dsn = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
-    try:
-        import psycopg2
+    from scripts.testing.database_run import drop_database
+    from scripts.testing.real_db_guard import canonical_dsn
 
-        psycopg2.connect(dsn, connect_timeout=3).close()
-    except Exception:
-        pytest.skip("no admin DB")
+    dsn = canonical_dsn()
+    clean_name = f"extra_clean_pytest_{uuid.uuid4().hex[:10]}"
     report = tmp_path / "clean-env-report.json"
-    r = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "scripts.ops.golden_clean_env",
-            "--confirm-drop",
-            "--db-name",
-            "extra_clean_pytest",
-            "--admin-dsn",
-            dsn,
-            "--report",
-            str(report),
-        ],
-        cwd=REPO,
-        env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
-        capture_output=True,
-        text=True,
-        timeout=600,
-        check=False,
-    )
-    assert report.is_file(), (r.stdout, r.stderr)
-    data = json.loads(report.read_text(encoding="utf-8"))
-    assert data.get("steps", {}).get("recreate_db", {}).get("ok") is True
-    assert data.get("steps", {}).get("migrations", {}).get("ok") is True
-    assert int(data.get("steps", {}).get("public_tables") or 0) >= 5
-    assert data.get("ok") is True, data
-    assert r.returncode == 0
+    try:
+        r = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.ops.golden_clean_env",
+                "--confirm-drop",
+                "--db-name",
+                clean_name,
+                "--admin-dsn",
+                dsn,
+                "--report",
+                str(report),
+            ],
+            cwd=REPO,
+            env={**os.environ, "LOCAL_DATALAKE_DSN": dsn},
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+        assert report.is_file(), (r.stdout, r.stderr)
+        data = json.loads(report.read_text(encoding="utf-8"))
+        assert data.get("steps", {}).get("tooling") == {
+            "ok": True,
+            "required": ["psycopg2"],
+            "psql_required": False,
+        }
+        assert data.get("steps", {}).get("recreate_db", {}).get("ok") is True
+        assert data.get("steps", {}).get("migrations", {}).get("ok") is True
+        assert int(data.get("steps", {}).get("public_tables") or 0) >= 5
+        assert data.get("ok") is True, data
+        assert r.returncode == 0
+    finally:
+        drop_database(dsn, clean_name)

--- a/tests/test_golden_path_contratos_report.py
+++ b/tests/test_golden_path_contratos_report.py
@@ -38,7 +38,7 @@ def test_write_contratos_report_domain_file(tmp_path: Path) -> None:
     except Exception:
         pytest.skip("no test-db")
 
-    # Ensure table exists; seed one synthetic contract if empty
+    # Ensure the canonical table exists. Header-only output is valid on a clean DB.
     try:
         import psycopg2
 
@@ -54,25 +54,6 @@ def test_write_contratos_report_domain_file(tmp_path: Path) -> None:
             )
             if not cur.fetchone()[0]:
                 pytest.skip("pncp_supplier_contracts missing")
-            cur.execute("SELECT count(*) FROM pncp_supplier_contracts WHERE COALESCE(is_active,true)")
-            n = int(cur.fetchone()[0])
-            if n == 0:
-                # Best-effort seed; if columns differ, report still writes header-only honestly
-                try:
-                    cur.execute(
-                        """
-                        INSERT INTO pncp_supplier_contracts (
-                          orgao_cnpj, orgao_nome, fornecedor_cnpj, fornecedor_nome,
-                          valor_total, is_active
-                        ) VALUES (
-                          '00000000000191', 'Orgao Teste', '11111111000191', 'Fornecedor Teste',
-                          1000.0, true
-                        )
-                        """
-                    )
-                    conn.commit()
-                except Exception:
-                    conn.rollback()
         conn.close()
     except Exception as exc:
         pytest.skip(f"cannot inspect contracts table: {exc}")

--- a/tests/test_golden_path_coverage.py
+++ b/tests/test_golden_path_coverage.py
@@ -13,16 +13,21 @@ from scripts.golden_path import run_coverage_calculation
 
 
 def _require_real_db() -> str:
-    """Opt-in real PostgreSQL (conftest mocks psycopg2 otherwise)."""
-    if os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"}:
-        pytest.skip("REQUIRE_REAL_DB=1 required for live dual coverage")
-    dsn = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
-    try:
-        import psycopg2
+    """Prepare the generated per-run database for a clean-lake measurement."""
+    from scripts.testing.database_run import assert_generated_database_connection
+    from scripts.testing.real_db_guard import admit_ready_connection
 
-        psycopg2.connect(dsn, connect_timeout=3).close()
-    except Exception:
-        pytest.skip("no local test-db")
+    conn, dsn = admit_ready_connection(
+        required_tables=("coverage_evidence", "pncp_raw_bids", "pncp_supplier_contracts"),
+        context="golden_path_coverage",
+    )
+    try:
+        assert_generated_database_connection(conn)
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE coverage_evidence, pncp_raw_bids, pncp_supplier_contracts RESTART IDENTITY CASCADE")
+        conn.commit()
+    finally:
+        conn.close()
     return dsn
 
 

--- a/tests/test_golden_path_idempotency.py
+++ b/tests/test_golden_path_idempotency.py
@@ -53,9 +53,19 @@ def test_dual_snapshot_stable_ids_sha() -> None:
     )
     try:
         with conn.cursor() as cur:
-            cur.execute("SELECT count(*) FROM pncp_raw_bids")
-            if int(cur.fetchone()[0]) == 0:
-                pytest.skip("no bids")
+            cur.execute(
+                """
+                INSERT INTO pncp_raw_bids (
+                    pncp_id, objeto_compra, uf, source, content_hash,
+                    is_active, synthetic_id
+                ) VALUES (
+                    'REALDB-IDEMPOTENCY-001', 'idempotency deterministic seed',
+                    'SC', 'real_db_test', %s, TRUE, TRUE
+                ) ON CONFLICT (pncp_id) DO UPDATE SET is_active = TRUE
+                """,
+                ("d" * 64,),
+            )
+        conn.commit()
     finally:
         conn.close()
 

--- a/tests/test_golden_path_snapshot.py
+++ b/tests/test_golden_path_snapshot.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -13,6 +12,33 @@ import pytest
 from scripts.golden_path import run_snapshot_reconciliation
 
 pytestmark = pytest.mark.real_db
+
+
+def _dsn_with_bid() -> str:
+    from scripts.testing.real_db_guard import admit_ready_connection
+
+    conn, dsn = admit_ready_connection(
+        required_tables=("pncp_raw_bids",),
+        context="golden_path_snapshot",
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO pncp_raw_bids (
+                    pncp_id, objeto_compra, uf, source, content_hash,
+                    is_active, synthetic_id
+                ) VALUES (
+                    'REALDB-SNAPSHOT-001', 'snapshot deterministic seed', 'SC',
+                    'real_db_test', %s, TRUE, TRUE
+                ) ON CONFLICT (pncp_id) DO UPDATE SET is_active = TRUE
+                """,
+                ("e" * 64,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return dsn
 
 
 def test_help_documents_execute_snapshot_only() -> None:
@@ -28,19 +54,7 @@ def test_help_documents_execute_snapshot_only() -> None:
 
 
 def test_snapshot_baseline_then_stable(tmp_path: Path) -> None:
-    dsn = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
-    try:
-        import psycopg2
-
-        conn = psycopg2.connect(dsn, connect_timeout=3)
-        with conn.cursor() as cur:
-            cur.execute("SELECT count(*) FROM pncp_raw_bids")
-            n = int(cur.fetchone()[0])
-        conn.close()
-        if n == 0:
-            pytest.skip("pncp_raw_bids empty — run crawl first")
-    except Exception:
-        pytest.skip("no local test-db")
+    dsn = _dsn_with_bid()
 
     snap_dir = tmp_path / "snapshots"
     r1 = run_snapshot_reconciliation(dsn, snapshot_dir=snap_dir)
@@ -59,19 +73,7 @@ def test_snapshot_baseline_then_stable(tmp_path: Path) -> None:
 
 
 def test_snapshot_detects_removed_id(tmp_path: Path) -> None:
-    dsn = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
-    try:
-        import psycopg2
-
-        conn = psycopg2.connect(dsn, connect_timeout=3)
-        with conn.cursor() as cur:
-            cur.execute("SELECT count(*) FROM pncp_raw_bids")
-            n = int(cur.fetchone()[0])
-        conn.close()
-        if n == 0:
-            pytest.skip("pncp_raw_bids empty — run crawl first")
-    except Exception:
-        pytest.skip("no local test-db")
+    dsn = _dsn_with_bid()
 
     snap_dir = tmp_path / "snap2"
     r1 = run_snapshot_reconciliation(dsn, snapshot_dir=snap_dir)

--- a/tests/test_live_consulting_pack.py
+++ b/tests/test_live_consulting_pack.py
@@ -3,11 +3,11 @@
 Unit tests drive shipped functions. Isolation and schema collision are
 structural. Full population path runs when CAMPAIGN_TEST_DSN has data.
 """
+
 from __future__ import annotations
 
 import inspect
 import json
-import os
 from datetime import date
 from pathlib import Path
 
@@ -16,10 +16,93 @@ import pytest
 from scripts.ops import live_consulting_pack as lcp
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-CAMPAIGN_DSN = os.getenv(
-    "CAMPAIGN_TEST_DSN",
-    "postgresql://test:test@127.0.0.1:5436/extra_live_pack_rc",
-)
+
+
+def _make_cnpj(base12: str) -> str:
+    weights1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+    weights2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+
+    def digit(value: str, weights: list[int]) -> str:
+        remainder = sum(int(n) * w for n, w in zip(value, weights, strict=True)) % 11
+        return str(0 if remainder < 2 else 11 - remainder)
+
+    first = base12 + digit(base12, weights1)
+    return first + digit(first, weights2)
+
+
+@pytest.fixture(scope="module")
+def populated_campaign_dsn() -> str:
+    """Seed a material deterministic population on the real isolated DB."""
+    from psycopg2.extras import Json
+
+    from scripts.testing.real_db_guard import admit_ready_connection, canonical_dsn
+
+    dsn = canonical_dsn()
+    conn, _ = admit_ready_connection(
+        dsn=dsn,
+        required_tables=("pncp_supplier_contracts",),
+        context="live_consulting_pack",
+    )
+    lcp.assert_isolation(dsn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT cnpj_8, razao_social, municipio
+                FROM sc_public_entities
+                WHERE raio_200km IS TRUE AND is_active IS TRUE
+                ORDER BY cnpj_8
+                LIMIT 12
+                """
+            )
+            organs = cur.fetchall()
+            assert len(organs) == 12
+            records = []
+            engineering_objects = (
+                "reforma predial e obra de engenharia",
+                "pavimentacao asfaltica de via publica",
+                "drenagem pluvial urbana",
+                "construcao de escola municipal",
+            )
+            for index in range(120):
+                supplier = _make_cnpj(f"{20000000 + (index % 20):08d}0001")
+                organ_row = organs[index % len(organs)]
+                organ = _make_cnpj(f"{organ_row[0]}0001")
+                records.append(
+                    {
+                        "contrato_id": f"REALDB-LCP-{index:03d}",
+                        "orgao_cnpj": organ,
+                        "orgao_nome": organ_row[1],
+                        "fornecedor_cnpj": supplier,
+                        "fornecedor_nome": f"Fornecedor Engenharia {index % 20:02d}",
+                        "supplier_id_type": "CNPJ",
+                        "supplier_identifier": supplier,
+                        "supplier_country": "BR",
+                        "objeto_contrato": engineering_objects[(index // 12) % 4],
+                        "valor_total": str(100000 + index * 1000),
+                        "data_inicio": "2025-01-15",
+                        "data_fim": "2027-01-15",
+                        "data_publicacao": "2025-01-10",
+                        "data_assinatura": "2025-01-15",
+                        "uf": "SC",
+                        "municipio": organ_row[2] or "Florianopolis",
+                        "source": "lcp_real_db_test",
+                        "source_id": f"REALDB-LCP-{index:03d}",
+                    }
+                )
+            cur.execute("DELETE FROM pncp_supplier_contracts WHERE source = 'lcp_real_db_test'")
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (Json(records),),
+            )
+            assert len(cur.fetchall()) == 120
+        conn.commit()
+        yield dsn
+    finally:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM pncp_supplier_contracts WHERE source = 'lcp_real_db_test'")
+        conn.commit()
+        conn.close()
 
 
 def test_mask_dsn_hides_password() -> None:
@@ -84,29 +167,9 @@ def test_national_intel_is_internal_engine() -> None:
     assert callable(competitors.run_competitors)
 
 
-def _db_has_contracts(dsn: str) -> int:
-    try:
-        conn = lcp.connect(dsn)
-        try:
-            n = lcp.scalar(
-                conn,
-                "SELECT COUNT(*) FROM pncp_supplier_contracts WHERE COALESCE(is_active,TRUE)",
-            )
-            return int(n or 0)
-        finally:
-            conn.close()
-    except Exception:
-        return 0
-
-
 @pytest.mark.real_db
-@pytest.mark.skipif(
-    _db_has_contracts(CAMPAIGN_DSN) < 100
-    or os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"},
-    reason="isolated campaign DB not restored or REQUIRE_REAL_DB not set",
-)
-def test_population_stats_full_not_sample(tmp_path: Path) -> None:
-    conn = lcp.connect(CAMPAIGN_DSN)
+def test_population_stats_full_not_sample(populated_campaign_dsn: str, tmp_path: Path) -> None:
+    conn = lcp.connect(populated_campaign_dsn)
     try:
         pop = lcp.population_stats(conn, uf="SC")
     finally:
@@ -117,16 +180,11 @@ def test_population_stats_full_not_sample(tmp_path: Path) -> None:
 
 
 @pytest.mark.real_db
-@pytest.mark.skipif(
-    _db_has_contracts(CAMPAIGN_DSN) < 100
-    or os.getenv("REQUIRE_REAL_DB", "").lower() not in {"1", "true", "yes"},
-    reason="isolated campaign DB not restored or REQUIRE_REAL_DB not set",
-)
-def test_run_pack_end_to_end_real_path(tmp_path: Path) -> None:
+def test_run_pack_end_to_end_real_path(populated_campaign_dsn: str, tmp_path: Path) -> None:
     """Drive shipped run_pack on isolated DSN — not fixtures as universe."""
     out = tmp_path / "pack"
     pack = lcp.run_pack(
-        dsn=CAMPAIGN_DSN,
+        dsn=populated_campaign_dsn,
         out_dir=out,
         uf="SC",
         export_limit=50,
@@ -136,7 +194,7 @@ def test_run_pack_end_to_end_real_path(tmp_path: Path) -> None:
     assert pack["production_touched"] is False
     assert pack["reconcile"]["status"] == "PASS"
     assert pack["population"]["eligible_population"] >= 100
-    assert pack["deliverable_a"]["status"] in {"OK", "PARTIAL"}
+    assert pack["deliverable_a"]["status"] in {"OK", "PARTIAL"}, pack["deliverable_a"]
     assert pack["deliverable_a"]["n_rows"] >= 1
     # B: OK with >=15 or honest INSUFFICIENT
     assert pack["deliverable_b"]["status"] in {"OK", "INSUFFICIENT", "PARTIAL"}
@@ -153,6 +211,4 @@ def test_run_pack_end_to_end_real_path(tmp_path: Path) -> None:
 
 def test_cli_verify_isolation_exit_codes() -> None:
     assert lcp.main(["verify-isolation", "--dsn", "postgresql://t:t@127.0.0.1:5436/x"]) == 0
-    assert (
-        lcp.main(["verify-isolation", "--dsn", "postgresql://t:t@ec-prod:5432/x"]) == 2
-    )
+    assert lcp.main(["verify-isolation", "--dsn", "postgresql://t:t@ec-prod:5432/x"]) == 2

--- a/tests/test_presence_pg_real.py
+++ b/tests/test_presence_pg_real.py
@@ -6,7 +6,6 @@ No handcrafted PresenceLoadResult as the unit under test; no ``or True``.
 
 from __future__ import annotations
 
-import os
 import uuid
 
 import pytest
@@ -24,24 +23,20 @@ from scripts.lib.universe import CanonicalEntity, CanonicalUniverse
 
 pytestmark = pytest.mark.real_db
 
-DSN = os.getenv("LOCAL_DATALAKE_DSN", "postgresql://test:test@127.0.0.1:5433/extra_test")
-
 
 def _conn():
-    import psycopg2
+    from scripts.testing.real_db_guard import admit_ready_connection
 
-    try:
-        return psycopg2.connect(DSN, connect_timeout=5)
-    except Exception as exc:  # noqa: BLE001
-        pytest.skip(f"no postgres: {exc}")
+    conn, _ = admit_ready_connection(
+        required_tables=("pncp_raw_bids",),
+        context="presence_pg_real",
+    )
+    return conn
 
 
 def _require_real() -> None:
-    try:
-        c = _conn()
-        c.close()
-    except Exception:
-        pytest.skip("DB unreachable")
+    c = _conn()
+    c.close()
 
 
 def _entity() -> CanonicalEntity:
@@ -75,8 +70,7 @@ def test_pg_measured_rows_or_no_rows_via_loader() -> None:
             WHERE table_schema='public' AND table_name='pncp_raw_bids'
             """
         )
-        if not cur.fetchone():
-            pytest.skip("pncp_raw_bids absent")
+        assert cur.fetchone(), "REAL_DB_SCHEMA_DRIFT: pncp_raw_bids absent"
         cur.close()
         pres = load_data_presence(conn, CAP_OPEN_TENDERS, {}, set())
         assert pres.status != "table_absent"

--- a/tests/test_real_db_run_contract.py
+++ b/tests/test_real_db_run_contract.py
@@ -1,0 +1,92 @@
+"""Regression contract for issue #285 real_db lifecycle and preflight."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.ops import run_full_suite
+from scripts.testing.database_run import (
+    REAL_DB_NAME_PREFIX,
+    DatabaseRunError,
+    assert_generated_database_connection,
+    assert_initially_empty,
+    generated_database_name,
+    require_psycopg2,
+    validate_local_admin_dsn,
+)
+from scripts.testing.real_db_guard import (
+    canonical_dsn,
+    real_db_skip_is_forbidden,
+)
+
+
+def test_generated_database_names_are_unique_and_safe() -> None:
+    first = generated_database_name()
+    second = generated_database_name()
+    assert first.startswith(REAL_DB_NAME_PREFIX)
+    assert second.startswith(REAL_DB_NAME_PREFIX)
+    assert first != second
+
+
+def test_dirty_database_reuse_fails_closed() -> None:
+    assert_initially_empty(0, 0)
+    with pytest.raises(DatabaseRunError, match="REAL_DB_DIRTY_REUSE"):
+        assert_initially_empty(1, 0)
+    with pytest.raises(DatabaseRunError, match="REAL_DB_DIRTY_REUSE"):
+        assert_initially_empty(0, 1)
+
+
+def test_destructive_setup_rejects_non_generated_database() -> None:
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value.fetchone.return_value = ("extra_test",)
+    with pytest.raises(DatabaseRunError, match="REAL_DB_UNSAFE_DATABASE_NAME"):
+        assert_generated_database_connection(conn)
+
+
+def test_required_postgres_tooling_disappearance_is_named() -> None:
+    def missing(_name: str):
+        raise ModuleNotFoundError("driver removed")
+
+    with pytest.raises(DatabaseRunError, match="REAL_DB_TOOLING_MISSING"):
+        require_psycopg2(missing)
+
+
+def test_admin_dsn_refuses_nonlocal_or_production() -> None:
+    with pytest.raises(DatabaseRunError, match="REAL_DB_ISOLATION_FAIL"):
+        validate_local_admin_dsn("postgresql://u:p@db.example.com:5432/test")
+    with pytest.raises(DatabaseRunError, match="REAL_DB_ISOLATION_FAIL"):
+        validate_local_admin_dsn("postgresql://u:p@127.0.0.1:5432/extra_prod")
+
+
+def test_migration_ledger_missing_or_drifted_fails() -> None:
+    expected = {"001": ("001_a.sql", "sha256=aaa")}
+    with pytest.raises(RuntimeError, match="REAL_DB_SCHEMA_DRIFT"):
+        run_full_suite.compare_migration_ledger(expected, {})
+    with pytest.raises(RuntimeError, match="REAL_DB_SCHEMA_DRIFT"):
+        run_full_suite.compare_migration_ledger(expected, {"001": ("001_a.sql", "sha256=bbb")})
+    run_full_suite.compare_migration_ledger(expected, expected.copy())
+
+
+def test_missing_mandatory_seed_is_not_a_warning(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(run_full_suite, "REPO", tmp_path)
+    with pytest.raises(FileNotFoundError, match="REAL_DB_SEED_MISSING"):
+        run_full_suite.apply_seeds("postgresql://unused")
+
+
+def test_opted_in_real_db_skip_is_forbidden() -> None:
+    assert real_db_skip_is_forbidden(marked_real_db=True, require_real=True)
+    assert not real_db_skip_is_forbidden(marked_real_db=True, require_real=False)
+    assert not real_db_skip_is_forbidden(marked_real_db=False, require_real=True)
+
+
+@pytest.mark.real_db
+def test_runtime_contract_uses_fresh_migrated_seeded_real_connection() -> None:
+    contract = run_full_suite.validate_real_db_contract(canonical_dsn())
+    assert contract["connection_kind"] == "psycopg2"
+    assert contract["database"].startswith(REAL_DB_NAME_PREFIX)
+    assert contract["migration_count"] == len(run_full_suite._expected_migration_ledger())
+    assert contract["entity_count"] >= 2085
+    assert contract["alias_count"] >= 359


### PR DESCRIPTION
## Summary

- adds a strict `--real-db-only --repeat 2` mode to the ADR-029 runner;
- creates and drops a fresh local PostgreSQL database per run, applies all 103 migration files, validates the exact 104-row ledger, and loads both mandatory seeds fail-closed;
- routes every database env key to the generated DSN, rejects fake connections and opted-in skips, and repeats in reverse collection order;
- replaces the hidden host `psql` dependency in clean-env with the required psycopg2 driver;
- makes linkage, coverage, snapshot, reporting, CMI, and live-pack real-DB scenarios own deterministic data and avoid cross-module residue;
- documents and runs the canonical two-pass gate in local tooling and CI.

Closes #285.

## Current-main baseline → branch

| Baseline result | Cause | Branch result |
|---|---|---|
| 2 entity/alias failures | mandatory seeds absent | pass; 2,085 entities / 459 aliases preflighted |
| 1 idempotency failure | seed absent | pass |
| 1 clean-env error | host `psql` absent | pass without `psql` |
| 1 linkage skip | module DSN/fixed-port isolation | pass on generated DB |
| 2 live-pack skips | externally restored campaign DB assumed | pass with deterministic module-owned rows |
| shared-state residual exposed during repair | synthetic linkage/report rows leaked into coverage presence | producers clean up and reverse-order run passes |

Current `main`: **124 passed, 4 failed, 3 skipped** (131 selected).

This branch, normal order: **132 passed, 0 failed, 0 errors, 0 skipped**.

This branch, reverse order on a second fresh DB: **132 passed, 0 failed, 0 errors, 0 skipped**.

## Reproduce

```bash
export LOCAL_DATALAKE_DSN=postgresql://test:test@127.0.0.1:5433/extra_test
python3 -m scripts.ops.run_full_suite --real-db-only --repeat 2
```

The DSN must be local and its user must have `CREATEDB`. The supplied database is not mutated; it is used only to create generated sibling databases. Production/soak and non-local DSNs are refused.

## Verification

- `python -m scripts.ops.run_full_suite --real-db-only --repeat 2` — 132 passed twice, zero skip
- `python -m scripts.ops.run_full_suite` — 6,035 passed, 139 optional skips, zero failed/errors
- `ruff check .` — pass
- `mypy --follow-imports=skip <5 touched production modules>` — pass
- `python -m scripts.ops.source_contract_tests --json` — 17/17 pass
- focused admission/lifecycle regressions — 26 passed
- generated-artifacts policy — pass (23 files, zero violations)
- PR reviewability policy — pass (23 files, 1,303 textual lines)

No refresh, feed, campaign, production database, threshold reduction, `xfail`, or new marker/fixture framework was used. The global DOD audit still reports pre-existing proof debt; this PR adds a `VERIFIED` unchecked #285 entry and does not promote it to `ACCEPTED` before exact-HEAD CI and merge.
