### PR TITLE
feat(confenge): cascade contemporary outreach refresh (#468)

### DIFF
--- a/.ai/story-468-validation.json
+++ b/.ai/story-468-validation.json
@@ -1,0 +1,27 @@
+{
+  "story": "docs/stories/story-468-contemporary-outreach-refresh-cascade.md",
+  "validated_at": "2026-08-26",
+  "validator": "Pax (@po)",
+  "mode": "YOLO",
+  "project_type": "brownfield-no-ui",
+  "verdict": "GO",
+  "implementation_readiness_score": 10,
+  "confidence": "high",
+  "critical_issues": [],
+  "should_fix": [],
+  "nice_to_have": [],
+  "template_compliance": "PASS",
+  "executor_assignment": "PASS: @dev != @architect; integration implementation with independent architecture gate",
+  "acceptance_criteria": "PASS: nine measurable criteria mapped to three ordered tasks",
+  "testing": "PASS: freshness exits, graph, systemd validation, focused regressions and canonical gates are explicit",
+  "security": "PASS: no secrets/PII, no Warmbly mutation and no commercial scheduling authority",
+  "rollback": "PASS: remove graph edges/gate without deleting durable state or current release",
+  "anti_hallucination": "PASS: referenced paths and behavioral claims verified in the checkout; founder checkpoint linked",
+  "code_intelligence": "SKIPPED_UNAVAILABLE",
+  "coderabbit": "PASS: type, agents, three quality gates, light self-healing and focus areas present",
+  "skipped_sections": [
+    "greenfield scaffolding",
+    "UI/UX"
+  ],
+  "status_transition": "Draft -> Ready"
+}

--- a/deploy/systemd/extra-confenge-contact-cycle.service
+++ b/deploy/systemd/extra-confenge-contact-cycle.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Extra Consultoria — continuously reconcile TARGET_CONFIRMED contact routes
-After=network-online.target postgresql.service extra-confenge-target-fit-refresh.service
+After=network-online.target postgresql.service extra-confenge-target-fit-refresh.service extra-confenge-target-fit-reconcile.service
 Wants=network-online.target
 Requires=postgresql.service
 OnFailure=extra-onfailure@%n.service
+OnSuccess=extra-confenge-feed-cycle.service
 
 [Service]
 Type=oneshot

--- a/deploy/systemd/extra-confenge-feed-cycle.service
+++ b/deploy/systemd/extra-confenge-feed-cycle.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Extra Consultoria — build and atomically publish CONFENGE outreach feed
-After=network-online.target postgresql.service extra-confenge-target-fit-refresh.service
+After=network-online.target postgresql.service extra-confenge-target-fit-refresh.service extra-confenge-contact-cycle.service
 Wants=network-online.target
 Requires=postgresql.service
 OnFailure=extra-onfailure@%n.service

--- a/deploy/systemd/extra-confenge-source-freshness-gate.service
+++ b/deploy/systemd/extra-confenge-source-freshness-gate.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Extra Consultoria — gate contemporary PNCP source before CONFENGE refresh
+Documentation=file:/opt/extra-consultoria/docs/ops/confenge-outreach-pipeline.md
+After=pncp-contracts.service postgresql.service
+Requires=postgresql.service
+OnFailure=extra-onfailure@%n.service
+OnSuccess=extra-confenge-target-fit-reconcile.service
+
+[Service]
+Type=oneshot
+User=extra-consultoria
+Group=extra-consultoria
+WorkingDirectory=/opt/extra-consultoria
+Environment=PYTHONPATH=/opt/extra-consultoria
+EnvironmentFile=/opt/extra-consultoria/.env
+ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.ops.pncp_contract_freshness --live --health
+TimeoutStartSec=30m
+UMask=0077
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=extra-confenge-source-freshness-gate
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/extra-confenge-target-fit-reconcile.service
+++ b/deploy/systemd/extra-confenge-target-fit-reconcile.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=Extra Consultoria — CONFENGE target-fit national reconciliation
 Documentation=file:/opt/extra-consultoria/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
-After=network-online.target postgresql.service
+After=network-online.target postgresql.service extra-confenge-source-freshness-gate.service
 Wants=network-online.target
+OnFailure=extra-onfailure@%n.service
+OnSuccess=extra-confenge-contact-cycle.service
 
 [Service]
 Type=oneshot

--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -6,6 +6,10 @@ Description=PNCP Contracts Crawler — Extra Consultoria
 After=network-online.target
 Wants=network-online.target
 OnFailure=extra-onfailure@%n.service
+# SuccessExitStatus=75 below is intentionally considered successful by
+# systemd. Never point this unit directly at target-fit: the dedicated gate
+# re-evaluates the semantic source contract and blocks 75/partial/stale/error.
+OnSuccess=extra-confenge-source-freshness-gate.service
 
 [Service]
 Type=oneshot

--- a/docs/ops/confenge-activation-planner.md
+++ b/docs/ops/confenge-activation-planner.md
@@ -82,7 +82,18 @@ python -m scripts.ops.confenge_feed_cycle \
   --max-age-hours 24
 ```
 
-Install and enable `extra-confenge-feed-cycle.timer` (12-hour cadence, at 01:20 and 13:20 local time) and `extra-confenge-feed-monitor.timer` (hourly validation). The feed schedule deliberately starts after the PNCP 00:00/12:00 source windows have time to close; an in-flight source window remains a fail-closed publication blocker. Configure the non-secret paths from `deploy/systemd/confenge-feed.env.example`. The service account needs write access to `/var/lib/extra-consultoria` and the publication root. Warmbly reads the manifest from the HTTP document root that mounts the atomic `current` release; the `current` symlink changes only after the full manifest, every chunk hash, full target-fit coverage, PNCP freshness and both feed timestamps pass validation.
+Production refresh is driven by the canonical `pncp-contracts.timer` and the
+fail-closed service cascade documented in
+[`confenge-outreach-pipeline.md`](./confenge-outreach-pipeline.md#continuous-production-refresh).
+Do not enable the independent target-fit/contact/feed timers as a substitute:
+their clocks can invert the required source → target-fit → contacts → feed
+order. Keep `extra-confenge-feed-monitor.timer` enabled for hourly readback.
+Configure the non-secret paths from `deploy/systemd/confenge-feed.env.example`.
+The service account needs write access to `/var/lib/extra-consultoria` and the
+publication root. Warmbly reads the manifest from the HTTP document root that
+mounts the atomic `current` release; the `current` symlink changes only after
+the full manifest, every chunk hash, full target-fit coverage, PNCP freshness
+and both feed timestamps pass validation.
 
 The durable state is `/var/lib/extra-consultoria/confenge-feed/publication-state.json`. It preserves the last successful publication while recording the latest generation and monitor result, duration, snapshot, watermark, lead/contact totals, deltas, route classes and provenance sources. Alerts append to `/var/lib/extra-consultoria/alerts/confenge-feed.jsonl` and trigger the normal systemd `OnFailure` path.
 

--- a/docs/ops/confenge-outreach-pipeline.md
+++ b/docs/ops/confenge-outreach-pipeline.md
@@ -85,6 +85,70 @@ intelligence. Every account in the authoritative `TARGET_CONFIRMED` snapshot is
 processed for service, public factual context and message spine before the
 complete decision feed is exported. Smoke/sample mode remains bounded.
 
+## Continuous production refresh
+
+The production data path is one fail-closed systemd cascade:
+
+```text
+pncp-contracts.service
+  --OnSuccess--> extra-confenge-source-freshness-gate.service
+  --OnSuccess--> extra-confenge-target-fit-reconcile.service
+  --OnSuccess--> extra-confenge-contact-cycle.service
+  --OnSuccess--> extra-confenge-feed-cycle.service
+```
+
+The source gate runs `scripts.ops.pncp_contract_freshness --live --health` and
+advances only on `PNCP_CONTRACT_FRESHNESS/1.0` status `FRESH` (exit 0). This is
+required because source writer contention exits 75 and is intentionally listed
+in `SuccessExitStatus` for systemd alert hygiene; semantically it remains
+`LOCK_BUSY_NO_CLOSE` and cannot trigger target-fit. A prior successful close
+also cannot certify a newer unclosed source invocation.
+
+Every stage is a oneshot. `OnSuccess` is the only forward edge and `OnFailure`
+alerts without starting the successor. Existing per-stage locks prevent two
+writers; the publisher independently requires the exact current source run,
+membership hash, complete terminal contact coverage and max-age before its
+atomic `current` swap. A failed, partial, stale or identical-semantic build
+therefore leaves the previous release untouched. The feed monitor remains an
+independent hourly readback.
+
+Only `pncp-contracts.timer` needs to be enabled to drive this graph. The legacy
+independent target-fit/contact/feed timers are not prerequisites and should
+remain disabled to avoid inverted cadence. This graph refreshes data; it does
+not schedule email, create a commercial queue, approve outreach or mutate
+Warmbly.
+
+Install/upgrade the five services from the exact deployed release, then verify
+before observing a live cycle:
+
+```bash
+sudo cp deploy/systemd/{pncp-contracts,extra-confenge-source-freshness-gate,extra-confenge-target-fit-reconcile,extra-confenge-contact-cycle,extra-confenge-feed-cycle}.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemd-analyze verify \
+  pncp-contracts.service \
+  extra-confenge-source-freshness-gate.service \
+  extra-confenge-target-fit-reconcile.service \
+  extra-confenge-contact-cycle.service \
+  extra-confenge-feed-cycle.service
+sudo systemctl show pncp-contracts.service \
+  extra-confenge-source-freshness-gate.service \
+  extra-confenge-target-fit-reconcile.service \
+  extra-confenge-contact-cycle.service \
+  extra-confenge-feed-cycle.service \
+  -p Id -p OnSuccess -p OnFailure -p FragmentPath
+```
+
+Observe the exact invocation chain with `systemctl show ... -p InvocationID -p
+Result -p ExecMainStatus -p ExecMainStartTimestamp -p ExecMainExitTimestamp`
+and each unit's journal. The gate journal contains the versioned freshness JSON;
+the feed cycle state and publication manifest contain the source run/hash and
+promotion outcome.
+
+Rollback is non-destructive: restore the prior five unit files (or remove only
+the four added `OnSuccess` edges and the gate unit), run `daemon-reload`, and
+leave `current`, release directories and durable state untouched. A rollback
+does not authorize running the independent downstream timers.
+
 ## Outputs
 
 ```text

--- a/docs/stories/story-468-contemporary-outreach-refresh-cascade.md
+++ b/docs/stories/story-468-contemporary-outreach-refresh-cascade.md
@@ -1,0 +1,210 @@
+# Story #468: Cascata contemporânea do feed autoritativo CONFENGE
+
+## Status
+
+**InProgress**
+
+## Executor Assignment
+
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools: ["pytest", "systemd-analyze", "dod_controller", "coderabbit"]
+
+## Story
+
+**Como** founder responsável pela ativação do outbound da CONFENGE,
+**quero** que cada fechamento contemporâneo e completo da fonte dispare, em ordem, a reconciliação target-fit, a descoberta de contato e a publicação atômica,
+**para que** o reservoir do Warmbly seja abastecido continuamente pelo mesmo run/hash sem transformar o `extra-cli` em scheduler comercial.
+
+## Contexto e autoridade
+
+- Origem P0: [extra-cli #468](https://github.com/tjsasakifln/extra-cli/issues/468), complementada por #469 e #381.
+- O founder revogou contemporaneamente o freeze operacional anterior e autorizou ativação e abastecimento contínuo. O checkpoint foi registrado em [#468](https://github.com/tjsasakifln/extra-cli/issues/468#issuecomment-5425203178), deve preceder a primeira publicação live e não relaxa nenhum guard fail-closed.
+- O código e os contratos de publicação foram entregues no PR #511. O residual desta story é operacional: hoje os serviços de source, target-fit, contato e feed possuem cadências independentes ou timers desabilitados, de modo que um source run completo não conduz deterministicamente os estágios seguintes.
+- A cascata é agendamento de pipeline de dados. Não cria fila comercial, scheduler de e-mail, CRM, approval, outcome store ou envio.
+
+## Scope
+
+**IN:** dependências systemd entre os quatro estágios já existentes, um gate que reutiliza o contrato de freshness vigente, testes do grafo, runbook, deploy e prova live.
+
+**OUT:** thresholds, nova fonte/consumer, fila ou cadência de e-mail, CRM, approval, outcomes, composer, cohort, Warmbly mutável e compra/guess de contatos.
+
+## Dependencies and sizing
+
+- Pré-requisitos já entregues: PR #511 no `main`, freshness PNCP versionada, reconcile target-fit, contact cycle, publisher atômico e consumer Warmbly existente.
+- Dependência externa live: disponibilidade e fechamento completo do PNCP. Indisponibilidade bloqueia publicação, não implementação/deploy da cascata.
+- T-shirt size: **M**. O diff é pequeno, mas o risco operacional é P0 e exige deploy exato, rollback e observação live.
+
+## Risks and mitigations
+
+- `exit 75` parecer sucesso ao systemd: mitigado pelo gate semântico separado, que exige `FRESH`/0.
+- Overlap de ciclos: mitigado pelos locks existentes, validação de mesma membership/run no publisher e recuperação no próximo source slot; nenhum resultado divergente promove.
+- Loop ou bypass entre units: mitigado por grafo linear sem `OnSuccess` no feed e teste estático do conjunto exato de arestas.
+- Fonte externa indisponível: último feed válido permanece servido e a issue recebe blocker factual; nenhum timestamp é renovado.
+
+## Acceptance Criteria
+
+1. O término bem-sucedido de `pncp-contracts.service` aciona um gate dedicado que avalia o contrato live `PNCP_CONTRACT_FRESHNESS/1.0`; somente `FRESH`/exit 0 prossegue. `LOCK_BUSY`/75, `DEGRADED`, `STALE`, `UNKNOWN`, partial e error interrompem a cascata.
+2. O gate aprovado aciona `extra-confenge-target-fit-reconcile.service`; somente o sucesso real da reconciliação aciona `extra-confenge-contact-cycle.service`, e somente o sucesso real do ciclo de contatos aciona `extra-confenge-feed-cycle.service`.
+3. Falha em qualquer estágio não aciona o sucessor, não altera o symlink `current` e preserva o último feed válido. Os `OnFailure` existentes continuam ativos e o reconcile/gate ganham alerta explícito.
+4. O encadeamento não depende dos timers independentes de target-fit, contato ou feed e não habilita nenhum deles. O único disparador recorrente necessário é o timer canônico da fonte; o monitor do feed permanece independente.
+5. Reexecução é segura: os locks existentes evitam writers concorrentes; membership/run/hash continuam reproduzíveis; snapshot sem mudança semântica continua recusado como `SAME_SNAPSHOT_NOT_FRESHNESS` e não toca `generated_at`.
+6. Testes estáticos verificam grafo, gate e ausência de bypass; teste funcional do contrato comprova exits 0/1/2 e que exit 75 nunca promove. Todas as units alteradas passam por validação do repositório e `systemd-analyze verify` no ambiente disponível.
+7. O runbook documenta o grafo, os estados que interrompem a cascata, instalação, observabilidade, rollback e a separação explícita entre refresh de dados e scheduling comercial.
+8. Deploy usa o SHA exato com CI verde. Em produção, um source run contemporâneo completo deve atravessar a cascata ou ser executado manualmente na mesma ordem; a publicação só fecha #468 com `coverage_complete=true`, terminais exaustivos e prova Warmbly do mesmo `source_run_id`/`source_snapshot_hash`.
+9. Os updates de #468/#469/#381 reportam números LIVE e hashes do run publicado. Se a fonte real não permitir 1.000 contas com recipient atribuível, o máximo real e a decomposição nominal do gargalo são publicados sem fabricar volume.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — Codificar o grafo fail-closed (AC: 1–5)
+  - [x] Adicionar unit oneshot de freshness gate que executa o contrato live com `--health`.
+  - [x] Encadear source → gate → target-fit reconcile → contact cycle → feed cycle por `OnSuccess`.
+  - [x] Preservar locks, `OnFailure`, usuários, environment files e limites atuais.
+- [ ] Task 2 — Provar o contrato operacional (AC: 5–7)
+  - [x] Adicionar testes do grafo, do comando do gate e dos bloqueios `DEGRADED`/`STALE`/75.
+  - [ ] Rodar testes focados, validator systemd e `systemd-analyze verify`.
+  - [x] Atualizar o runbook com instalação, health, journals e rollback.
+- [ ] Task 3 — PR, deploy e prova live (AC: 8–9)
+  - [ ] Rodar gates de reviewability, CI e review; mergear e implantar somente o HEAD exato.
+  - [ ] Observar ou iniciar o source run contemporâneo sem contornar a fonte; avançar apenas com `FRESH` e cobertura completa.
+  - [ ] Publicar atomicamente, provar readback do Warmbly no mesmo run/hash e atualizar #468/#469/#381.
+
+## Dev Notes
+
+### Contratos e decisões
+
+- `SuccessExitStatus=75` em `pncp-contracts.service` representa contenção esperada do writer para o systemd, mas o contrato de freshness o classifica explicitamente como não `FRESH`. Por isso o source não pode apontar diretamente para target-fit. [Source: `deploy/systemd/pncp-contracts.service`; `scripts/ops/pncp_contract_freshness.py`]
+- `python -m scripts.ops.pncp_contract_freshness --live --health` retorna 0 apenas para `FRESH`, 1 para `DEGRADED` e 2 para `STALE`/`UNKNOWN`. Esse contrato existente é o gate, sem nova segunda verdade. [Source: `scripts/ops/pncp_contract_freshness.py`; `tests/test_pncp_contract_freshness.py`]
+- `OnSuccess=` é uma dependência de transição entre oneshots, não um timer. Cada serviço mantém seu próprio lock e somente saída bem-sucedida aciona o sucessor.
+- O publisher já valida fonte, membership exata, cobertura terminal, hashes, max age e promoção atômica; snapshot semanticamente idêntico não renova freshness. [Source: `scripts/ops/confenge_feed_cycle.py`; `scripts/confenge_activation/publish.py`]
+
+### Relevant source tree
+
+- Units: `deploy/systemd/{pncp-contracts,extra-confenge-target-fit-reconcile,extra-confenge-contact-cycle,extra-confenge-feed-cycle}.service`
+- Freshness: `scripts/ops/pncp_contract_freshness.py`
+- Tests: `tests/test_pncp_contract_freshness.py`, `tests/confenge_target_fit/test_cli_and_invariants.py`, `tests/test_confenge_contact_cycle.py`, `tests/test_confenge_feed_publication.py`, `tests/test_local_resilience.py`
+- Runbooks: `docs/ops/confenge-outreach-pipeline.md`, `docs/ops/confenge-activation-planner.md`
+
+### Operational safeguards
+
+- Nenhuma alteração de threshold, `skip`, `xfail`, mock irreal ou promoção de estado incompleto.
+- Nenhum dado live, PII, dump, log ou secret entra no Git; evidence pack pesado permanece como artifact/host protegido.
+- A primeira onda é instalação + validação das units; a cascata só é observada live depois de CI/merge/deploy do SHA exato.
+- Rollback remove os `OnSuccess` adicionados e a unit de gate, recarrega o daemon e mantém o último `current` válido; não apaga releases nem estado durável.
+
+## Testing
+
+- Focado: `python3 -m pytest tests/test_confenge_outreach_refresh_cascade.py tests/test_pncp_contract_freshness.py -q --tb=short`
+- Systemd: `python3 -m scripts.ops.validate_systemd` e `systemd-analyze verify` das cinco units.
+- Regressão do raio: target-fit, contact cycle, feed publication e outreach pipeline.
+- Gates canônicos: suíte completa, golden path com DSN explícito e policies fail-closed de PR.
+
+## 🤖 CodeRabbit Integration
+
+### Story Type Analysis
+
+**Primary Type:** Integration
+
+**Secondary Type(s):** Deployment
+
+**Complexity:** Medium — mudança pequena de units com impacto operacional P0.
+
+### Specialized Agent Assignment
+
+**Primary Agents:**
+
+- @dev — implementação, testes e pre-commit.
+- @github-devops — PR, instalação das units e deploy do SHA exato.
+
+**Supporting Agents:**
+
+- @architect — gate independente do grafo e do raio arquitetural.
+- @qa — verificação dos ACs, regressões e evidência live.
+
+### Quality Gate Tasks
+
+- [ ] Pre-Commit (@dev): review do diff exato; se o CLI local não existir, registrar ausência sem falso-verde.
+- [ ] Pre-PR (@github-devops): generated-artifacts policy, reviewability e CI no HEAD.
+- [ ] Pre-Deployment (@github-devops): `systemd-analyze verify`, daemon-reload, status do grafo e rollback explícito.
+
+### Self-Healing Configuration
+
+**Expected Self-Healing:**
+
+- Primary Agent: @dev (light mode)
+- Max Iterations: 2
+- Timeout: 15 minutes
+- Severity Filter: CRITICAL only
+
+**Predicted Behavior:**
+
+- CRITICAL: corrigir até duas iterações e parar se persistir.
+- HIGH: documentar para o quality gate; não reduzir guard nem ocultar falha.
+
+### CodeRabbit Focus Areas
+
+**Primary Focus:**
+
+- Bypass por `SuccessExitStatus=75`, partial/stale/error ou falha silenciosa.
+- Loops/deadlocks de `OnSuccess`, concorrência de locks e preservação do último feed válido.
+
+**Secondary Focus:**
+
+- Nenhum secret ou path mutável incorporado ao artefato.
+- Nenhum acoplamento a scheduling comercial ou mutação do Warmbly.
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---|---|---|
+| 2026-08-26 | 0.1.0 | Draft P0 do residual de abastecimento contínuo do #468 | River (@sm) |
+| 2026-08-26 | 0.1.1 | Validated GO (10/10) — Status: Draft → Ready | Pax (@po) |
+| 2026-08-26 | 0.2.0 | Desenvolvimento iniciado — Status: Ready → InProgress | Dex (@dev) |
+| 2026-08-26 | 0.2.1 | Grafo, gate causal, testes e runbook implementados; host/live permanecem abertos | Dex (@dev) |
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex (Dex / @dev)
+
+### Debug Log References
+
+- Focados: `40 passed` em 1,00s.
+- Regressão integrada: `110 passed, 1 skipped`; o caso condicionado a PostgreSQL foi reexecutado com `REQUIRE_REAL_DB=1` e passou.
+- Suíte canônica: `5928 passed, 240 skipped, 11 deselected` em 1466,09s.
+- Source contracts offline: `17/17` verdes.
+- Golden path real local: `PARTIAL`, exit 2; PNCP 2×720s timeout, PCP 141 fetched/135 inserted, ComprasGov `success_zero`; freshness bloqueou `pncp, contracts`.
+- `scripts.ops.validate_systemd`, Ruff e `git diff --check`: verdes. `systemd-analyze verify` fica aberto para o host com `/opt`/PostgreSQL reais.
+- CodeRabbit local: CLI atual exigiu autenticação interativa por navegador e foi encerrado sem resultado; review não foi declarado verde.
+
+### Completion Notes List
+
+- A cascata usa somente `OnSuccess` entre oneshots existentes e termina no feed; não existe timer/componente comercial novo.
+- `pncp_contract_freshness` agora impede que uma tentativa mais nova sem fechamento reutilize a freshness de um fechamento anterior.
+- Stale/partial/error/75 interrompem antes de target-fit; falhas posteriores interrompem o sucessor; o publisher continua responsável por coverage, hash e troca atômica.
+- O host Debian 13 usa systemd 257, compatível com `OnSuccess`; instalação e verificação do fragmento aguardam merge/CI no SHA exato.
+- A indisponibilidade PNCP permanece blocker factual para source run contemporâneo e publicação, sem alteração de threshold ou reuso do feed antigo.
+
+### File List
+
+- `.ai/story-468-validation.json`
+- `deploy/systemd/extra-confenge-source-freshness-gate.service`
+- `deploy/systemd/pncp-contracts.service`
+- `deploy/systemd/extra-confenge-target-fit-reconcile.service`
+- `deploy/systemd/extra-confenge-contact-cycle.service`
+- `deploy/systemd/extra-confenge-feed-cycle.service`
+- `docs/ops/confenge-activation-planner.md`
+- `docs/ops/confenge-outreach-pipeline.md`
+- `docs/stories/story-468-contemporary-outreach-refresh-cascade.md`
+- `scripts/ops/pncp_contract_freshness.py`
+- `tests/test_confenge_outreach_refresh_cascade.py`
+- `tests/test_pncp_contract_freshness.py`
+
+## QA Results
+
+Architect gate: **PASS WITH CONCERNS**, sem CRITICAL/HIGH. O grafo, causalidade,
+fail-closed e raio foram aprovados. Concern MEDIUM: ciclos downstream muito
+longos podem sobrepor slots de 4h; locks e hashes bloqueiam promoção divergente,
+mas duração deve ser observada live. `systemd-analyze verify` no host e review
+CodeRabbit autenticado permanecem gates antes do live.

--- a/scripts/ops/pncp_contract_freshness.py
+++ b/scripts/ops/pncp_contract_freshness.py
@@ -955,8 +955,12 @@ def build_contract(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     if not cadence.get("timezone_explicit", bool(cadence.get("timezone"))):
         extra_reasons.append(REASON_TIMER_TIMEZONE_AMBIGUOUS)
 
-    if not closed and last_run_at is not None:
+    # A previously closed window cannot certify a newer source invocation. This
+    # matters for the systemd refresh cascade: a stopped/crashed attempt must
+    # not reuse a still-young prior close to trigger target-fit and publication.
+    if last_run_at is not None and (closed_at is None or last_run_at > closed_at):
         extra_reasons.append(REASON_UNCLOSED_CURRENT_WINDOW)
+        material_incomplete = True
 
     backup = dict(snapshot.get("backup") or {})
     backup_reason = classify_backup(

--- a/tests/test_confenge_outreach_refresh_cascade.py
+++ b/tests/test_confenge_outreach_refresh_cascade.py
@@ -1,0 +1,80 @@
+"""Fail-closed systemd graph for the contemporary CONFENGE data refresh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UNIT_DIR = ROOT / "deploy" / "systemd"
+
+SOURCE = "pncp-contracts.service"
+GATE = "extra-confenge-source-freshness-gate.service"
+TARGET = "extra-confenge-target-fit-reconcile.service"
+CONTACT = "extra-confenge-contact-cycle.service"
+FEED = "extra-confenge-feed-cycle.service"
+
+
+def _unit(name: str) -> str:
+    return (UNIT_DIR / name).read_text(encoding="utf-8")
+
+
+def _unit_section(text: str) -> str:
+    return text.split("[Unit]", 1)[1].split("[Service]", 1)[0]
+
+
+def _on_success(name: str) -> list[str]:
+    values: list[str] = []
+    for line in _unit_section(_unit(name)).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("OnSuccess="):
+            values.extend(stripped.split("=", 1)[1].split())
+    return values
+
+
+def test_refresh_graph_is_exact_linear_and_acyclic() -> None:
+    graph = {
+        SOURCE: _on_success(SOURCE),
+        GATE: _on_success(GATE),
+        TARGET: _on_success(TARGET),
+        CONTACT: _on_success(CONTACT),
+        FEED: _on_success(FEED),
+    }
+
+    assert graph == {
+        SOURCE: [GATE],
+        GATE: [TARGET],
+        TARGET: [CONTACT],
+        CONTACT: [FEED],
+        FEED: [],
+    }
+    assert all((UNIT_DIR / successor).is_file() for values in graph.values() for successor in values)
+
+
+def test_source_never_bypasses_the_semantic_freshness_gate() -> None:
+    source = _unit(SOURCE)
+    gate = _unit(GATE)
+
+    assert "SuccessExitStatus=75" in source
+    assert f"OnSuccess={GATE}" in _unit_section(source)
+    assert f"OnSuccess={TARGET}" not in _unit_section(source)
+    assert (
+        "ExecStart=/opt/extra-consultoria/.venv/bin/python "
+        "-m scripts.ops.pncp_contract_freshness --live --health"
+    ) in gate
+    assert "SuccessExitStatus=" not in gate
+
+
+def test_each_promoting_stage_alerts_and_only_success_can_advance() -> None:
+    for name in (SOURCE, GATE, TARGET, CONTACT, FEED):
+        text = _unit(name)
+        assert "Type=oneshot" in text
+        assert "OnFailure=extra-onfailure@%n.service" in _unit_section(text)
+
+    assert "OnSuccess=" not in _unit_section(_unit(FEED))
+
+
+def test_refresh_cascade_does_not_create_or_enable_a_commercial_timer() -> None:
+    timer_names = {path.name for path in UNIT_DIR.glob("*.timer")}
+
+    assert "extra-confenge-source-freshness-gate.timer" not in timer_names
+    assert all("commercial" not in name for name in timer_names if "confenge" in name)

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -42,6 +42,7 @@ from scripts.ops.pncp_contract_freshness import (
     REASON_STALE_CHECKPOINT,
     REASON_TIMER_ACTIVE_NOT_PROOF,
     REASON_TIMER_DELAYED,
+    REASON_UNCLOSED_CURRENT_WINDOW,
     REASON_WINDOW_EMPTY_COMPLETE,
     REASON_WINDOW_EMPTY_INCOMPLETE,
     REASON_WINDOW_INCOMPLETE,
@@ -977,6 +978,29 @@ def test_lock_busy_exit_75_is_not_fresh_or_closed_window() -> None:
     )
     assert artifact["status"] != "FRESH"
     assert REASON_LOCK_BUSY_NO_CLOSE in artifact["reason_codes"]
+    assert health_exit(artifact["status"]) != 0
+
+
+def test_newer_unclosed_attempt_cannot_reuse_previous_fresh_close() -> None:
+    artifact = build_contract(
+        _snapshot(
+            windows=[_closed_window(closed_at="2026-08-20T12:00:00Z")],
+            timer={
+                "active": True,
+                "last_run_at": "2026-08-20T12:10:00Z",
+                "next_run_at": "2026-08-20T16:00:00Z",
+                "last_exec_status": 0,
+                "last_result": "success",
+                "on_calendar": "*-*-* 00,04,08,12,16,20:00:00 America/Sao_Paulo",
+            },
+            as_of="2026-08-20T12:30:00Z",
+        )
+    )
+
+    assert artifact["source_observed_at"] == "2026-08-20T12:00:00Z"
+    assert artifact["status"] == "STALE"
+    assert REASON_UNCLOSED_CURRENT_WINDOW in artifact["reason_codes"]
+    assert REASON_WINDOW_INCOMPLETE in artifact["reason_codes"]
     assert health_exit(artifact["status"]) != 0
 
 


### PR DESCRIPTION
## Summary

- add a semantic PNCP freshness gate before target-fit
- chain source -> gate -> target-fit -> contacts -> atomic feed with OnSuccess only
- prevent a newer unclosed source invocation from reusing an earlier fresh close
- document install, observability, rollback, and the explicit absence of commercial scheduling

## Evidence

- focused: 40 passed
- integrated radius: 110 passed; the conditioned PostgreSQL case passed separately with REQUIRE_REAL_DB=1
- canonical suite: 5928 passed, 240 skipped, 11 deselected
- source contracts: 17/17 passed
- static systemd validator, Ruff, diff check, generated-artifact policy, and reviewability: passed
- architect gate: PASS WITH CONCERNS, no CRITICAL/HIGH
- CodeRabbit local review did not run because the installed CLI required interactive browser authentication; PR integration remains authoritative

## Live truth

The local golden path ended PARTIAL/exit 2 after PNCP timed out twice at 720s. PCP fetched 141 and ComprasGov returned success_zero; freshness correctly blocked pncp/contracts. This PR does not claim a contemporary publication. After exact-HEAD CI and merge, deploy the five units, run systemd-analyze verify on ec-prod, and advance only when PNCP is FRESH.

Refs #468
Refs #469
Refs #381