### PR TITLE
feat(confenge): tornar o corte de release versionado e reprodutível

### DIFF
--- a/deploy/confenge/cut_release.sh
+++ b/deploy/confenge/cut_release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Materialise an immutable extra-cli release on the host and pin the CONFENGE
+# outbound chain to it.
+#
+# Releases used to be cut by hand, which is how three different SHAs ended up
+# running in one chain. This script is the versioned replacement:
+#
+#   * the tree comes from `git archive` at the exact SHA, so the live working
+#     checkout at /opt/extra-consultoria is never touched and no local
+#     modification can leak into a release;
+#   * the interpreter is copied from the release currently in use, so a deploy
+#     never depends on the network to rebuild an environment, and the copy is
+#     rejected if requirements.txt changed;
+#   * publication is an atomic rename of a fully-built staging directory;
+#   * the chain is pinned and verified through deploy/confenge/pin_release.py.
+#
+# Usage (as root on the host):  cut_release.sh <full-40-char-sha>
+set -euo pipefail
+
+SHA="${1:?full 40-character release SHA required}"
+[[ "$SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "CUT_RELEASE_ERROR: not a full SHA: $SHA" >&2; exit 1; }
+
+APP=/opt/extra-consultoria
+RELEASES=/opt/extra-consultoria-releases
+TARGET="$RELEASES/$SHA"
+STAGING="$RELEASES/.staging-$SHA.$$"
+
+if [ -d "$TARGET" ]; then
+  echo "CUT_RELEASE_SKIP: $SHA is already materialised"
+else
+  git -C "$APP" fetch --quiet origin
+  git -C "$APP" cat-file -e "$SHA^{commit}" 2>/dev/null || {
+    echo "CUT_RELEASE_ERROR: $SHA is not an object in $APP" >&2; exit 1; }
+
+  # The previous release supplies the interpreter. Refuse the copy if the
+  # dependency set moved: a stale venv is a silently wrong deploy.
+  PREV="$(ls -1dt "$RELEASES"/*/ 2>/dev/null | head -1 | sed 's:/*$::')"
+  [ -x "$PREV/.venv/bin/python" ] || { echo "CUT_RELEASE_ERROR: no usable previous venv" >&2; exit 1; }
+  PREV_SHA="$(basename "$PREV")"
+  if ! git -C "$APP" diff --quiet "$PREV_SHA" "$SHA" -- requirements.txt 2>/dev/null; then
+    echo "CUT_RELEASE_ERROR: requirements.txt changed between $PREV_SHA and $SHA; rebuild the venv explicitly" >&2
+    exit 1
+  fi
+
+  trap 'rm -rf "$STAGING"' EXIT
+  mkdir -p "$STAGING"
+  git -C "$APP" archive "$SHA" | tar -x -C "$STAGING"
+  cp -a "$PREV/.venv" "$STAGING/.venv"
+  # The venv records an absolute path; keep it pointing at a real interpreter.
+  "$STAGING/.venv/bin/python" -c "import sys; sys.exit(0)" || {
+    echo "CUT_RELEASE_ERROR: copied interpreter does not run" >&2; exit 1; }
+  PYTHONPATH="$STAGING" "$STAGING/.venv/bin/python" -c "
+import scripts.ops.confenge_feed_cycle as m
+import scripts.confenge_activation.publish as p
+import scripts.decision_unit_intelligence.batch_population as b
+assert hasattr(b, '_population_freshness'), 'release predates the population freshness fix'
+assert hasattr(p, 'producer_identity'), 'release predates the producer identity fix'
+print('CUT_RELEASE_IMPORT_OK')
+" || { echo "CUT_RELEASE_ERROR: staged release failed its import check" >&2; exit 1; }
+
+  chown -R root:root "$STAGING"
+  chmod -R a-w "$STAGING"
+  mv -T "$STAGING" "$TARGET"
+  trap - EXIT
+  echo "CUT_RELEASE_PUBLISHED: $TARGET"
+fi
+
+python3 "$TARGET/deploy/confenge/pin_release.py" "$SHA"

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -160,7 +160,12 @@ def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
             tmp.replace(target)
             written.append(str(target))
         _run(["systemctl", "daemon-reload"])
-        _run(["systemctl", "enable", *CHAIN_TIMERS, *CHAIN_ENABLED_SERVICES])
+        # --now, not just enable: enabling alone writes the wants/ symlink and
+        # leaves the timer unloaded until the next boot, which is precisely how
+        # the two safety-net timers came to be "enabled" and still absent from
+        # `systemctl list-timers`.
+        _run(["systemctl", "enable", "--now", *CHAIN_TIMERS])
+        _run(["systemctl", "enable", *CHAIN_ENABLED_SERVICES])
     return {
         "schema": "confenge.release_pin.v1",
         "release_sha": sha,
@@ -185,12 +190,19 @@ def verify(sha: str) -> dict[str, object]:
         state = _run(["systemctl", "is-enabled", unit], check=False).stdout.strip()
         if state != "enabled":
             disabled.append(f"{unit}={state or 'unknown'}")
+    # A timer that is enabled but not loaded fires nothing until the next boot.
+    inactive_timers: list[str] = []
+    for unit in CHAIN_TIMERS:
+        state = _run(["systemctl", "is-active", unit], check=False).stdout.strip()
+        if state != "active":
+            inactive_timers.append(f"{unit}={state or 'unknown'}")
     return {
         "schema": "confenge.release_pin_verification.v1",
         "release_sha": sha,
-        "ok": not drift and not disabled,
+        "ok": not drift and not disabled and not inactive_timers,
         "release_drift": drift,
         "not_enabled": disabled,
+        "timers_not_active": inactive_timers,
     }
 
 

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -147,8 +147,38 @@ def plan(sha: str) -> dict[str, str]:
     return rendered
 
 
+def foreign_execstart_dropins() -> dict[str, list[str]]:
+    """Find drop-ins other than ours that also override ExecStart.
+
+    The pinned drop-in sorts last and clears ExecStart before setting its own, so
+    any earlier drop-in that added an argument would be silently discarded. That
+    is not hypothetical: a hand-written 50-durable-checkpoint.conf carried
+    --checkpoint-dir, the pin dropped it, and the crawler died writing into the
+    read-only release. Whatever such a drop-in configures belongs in the
+    versioned unit file; until it moves there, refuse to pin.
+    """
+    found: dict[str, list[str]] = {}
+    for unit in CHAIN_UNITS:
+        directory = SYSTEMD_ROOT / f"{unit}.d"
+        if not directory.is_dir():
+            continue
+        offenders = [
+            path.name
+            for path in sorted(directory.glob("*.conf"))
+            if path.name != DROPIN_NAME and "ExecStart=" in path.read_text(encoding="utf-8")
+        ]
+        if offenders:
+            found[unit] = offenders
+    return found
+
+
 def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
     rendered = plan(sha)
+    if foreign := foreign_execstart_dropins():
+        raise PinError(
+            "drop-ins outside this tool also set ExecStart and would be discarded by the pin; "
+            f"move their configuration into deploy/systemd and remove them: {foreign}"
+        )
     written: list[str] = []
     if not dry_run:
         for unit, body in rendered.items():

--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -41,7 +41,13 @@ Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60
 # late arrivals/retificações, split by the runner into seven daily completion
 # units so mutable upstream pagination cannot invalidate the whole lookback.
 SuccessExitStatus=75
-ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.crawl.run_contracts_incremental --days 7
+# The checkpoint has to live outside the release tree: releases are immutable and
+# read-only, and a crawl that cannot write its checkpoint restarts from zero and
+# fails closed. This was a hand-written drop-in on the host, which is how a
+# release pin silently dropped it and the crawler died on PermissionError.
+ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.crawl.run_contracts_incremental \
+    --days 7 \
+    --checkpoint-dir /var/lib/extra-consultoria/checkpoints/contracts
 User=extra-consultoria
 Group=extra-consultoria
 TimeoutStartSec=150min

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -104,3 +104,45 @@ def test_timers_are_started_not_only_enabled():
     )
     assert '"enable", "--now", *CHAIN_TIMERS' in source
     assert '"timers_not_active"' in source, "verification must read back whether the timer is loaded"
+
+
+def test_pncp_checkpoint_dir_is_versioned_and_outside_the_release():
+    """A read-only release cannot hold a crawl checkpoint.
+
+    This lived in a hand-written host drop-in, so the release pin discarded it and
+    the crawler died with PermissionError writing inside the immutable tree.
+    """
+    unit = (UNIT_SOURCE / "pncp-contracts.service").read_text(encoding="utf-8")
+    assert "--checkpoint-dir /var/lib/extra-consultoria/checkpoints/contracts" in unit
+    body = render_dropin(unit, SHA)
+    exec_line = next(line for line in body.splitlines() if line.startswith("ExecStart=/"))
+    assert "--checkpoint-dir /var/lib/extra-consultoria/checkpoints/contracts" in exec_line
+    assert f"/opt/extra-consultoria-releases/{SHA}/data" not in exec_line
+    assert "--days 7" in exec_line
+
+
+def test_a_foreign_execstart_dropin_blocks_the_pin(tmp_path, monkeypatch):
+    import deploy.confenge.pin_release as pin
+
+    root = tmp_path / "systemd"
+    unit_dir = root / f"{CHAIN_UNITS[0]}.d"
+    unit_dir.mkdir(parents=True)
+    (unit_dir / "50-host-tweak.conf").write_text("[Service]\nExecStart=\nExecStart=/bin/true\n", encoding="utf-8")
+    (unit_dir / "90-immutable-release.conf").write_text("[Service]\nExecStart=/bin/true\n", encoding="utf-8")
+    monkeypatch.setattr(pin, "SYSTEMD_ROOT", root)
+
+    found = pin.foreign_execstart_dropins()
+    assert found == {CHAIN_UNITS[0]: ["50-host-tweak.conf"]}
+
+
+def test_our_own_dropin_is_not_reported_as_foreign(tmp_path, monkeypatch):
+    import deploy.confenge.pin_release as pin
+
+    root = tmp_path / "systemd"
+    for unit in CHAIN_UNITS:
+        unit_dir = root / f"{unit}.d"
+        unit_dir.mkdir(parents=True)
+        (unit_dir / "90-immutable-release.conf").write_text("[Service]\nExecStart=/bin/true\n", encoding="utf-8")
+    monkeypatch.setattr(pin, "SYSTEMD_ROOT", root)
+
+    assert pin.foreign_execstart_dropins() == {}

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -7,6 +7,8 @@ generated drop-ins stay derived from the versioned unit files.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from deploy.confenge.pin_release import (
@@ -89,3 +91,16 @@ def test_unknown_release_is_refused_before_touching_the_host():
 
 def test_long_running_worker_is_marked_for_reboot_persistence():
     assert "extra-confenge-target-fit-worker.service" in CHAIN_ENABLED_SERVICES
+
+
+def test_timers_are_started_not_only_enabled():
+    """`systemctl enable` alone leaves a timer unloaded until the next boot.
+
+    That is exactly how the contact-cycle and feed-cycle safety nets came to
+    report `enabled` while `systemctl list-timers` showed neither of them.
+    """
+    source = (Path(__file__).resolve().parents[1] / "deploy" / "confenge" / "pin_release.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"enable", "--now", *CHAIN_TIMERS' in source
+    assert '"timers_not_active"' in source, "verification must read back whether the timer is loaded"


### PR DESCRIPTION
Releases do extra-cli eram materializadas à mão. Foi assim que a cadeia outbound acabou rodando **três SHAs simultâneos**:

```
pncp-contracts.service                 → e25272e8
extra-contact-discovery-worker@.service→ e25272e8
extra-confenge-source-freshness-gate   → 652bb78f
extra-confenge-target-fit-reconcile    → 652bb78f
extra-confenge-contact-cycle           → 652bb78f
extra-confenge-feed-cycle              → 652bb78f
extra-confenge-target-fit-worker       → 623acdcd  (sem drop-in nenhum)
extra-confenge-target-fit-refresh      → 623acdcd  (sem drop-in nenhum)
```

`deploy/confenge/cut_release.sh` fecha isso junto com `pin_release.py` (#516):

- árvore vinda de `git archive` no SHA exato — o checkout vivo em `/opt/extra-consultoria` (que hoje está sujo, em `14c8b247`) nunca é tocado e nenhuma modificação local pode vazar para uma release;
- interpretador copiado da release em uso, com a cópia **recusada** se `requirements.txt` mudou entre as duas — venv defasado é deploy silenciosamente errado;
- import check no diretório de staging antes de publicar;
- publicação por rename atômico de um diretório já completo e read-only;
- pin + verificação da cadeia inteira no final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)