### PR TITLE
fix(confenge): mover só o código para a release, não o diretório de trabalho

### DIFF
--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -67,7 +67,20 @@ CHAIN_TIMERS = (
 # Long-running workers that must come back after a reboot.
 CHAIN_ENABLED_SERVICES = ("extra-confenge-target-fit-worker.service",)
 
-PINNED_DIRECTIVES = ("WorkingDirectory=", "Environment=PYTHONPATH=", "ExecStart=")
+# Only code locations move to the immutable release. WorkingDirectory stays
+# where the unit authored it, because releases are read-only and several jobs
+# write evidence through paths relative to their working directory: pinning the
+# cwd into the release made the PNCP crawler die on
+# PermissionError: 'output/contracts/incremental-latest.json' after a window it
+# had already crawled successfully.
+PINNED_DIRECTIVES = ("Environment=PYTHONPATH=", "ExecStart=")
+PRESERVED_DIRECTIVES = ("WorkingDirectory=",)
+
+# With the working directory outside the release, Python would otherwise prepend
+# that directory to sys.path and let the checkout at /opt/extra-consultoria
+# shadow the release's own `scripts` package. -P is what makes the pin actually
+# bind the code it claims to bind.
+ISOLATED_INTERPRETER_FLAG = "-P"
 
 
 class PinError(RuntimeError):
@@ -90,17 +103,31 @@ def _logical_lines(text: str) -> list[str]:
     return lines
 
 
+def _isolate_interpreter(exec_start: str, release: str) -> str:
+    """Insert -P after the release interpreter so cwd cannot shadow the release."""
+    interpreter = f"{release}/.venv/bin/python"
+    if interpreter not in exec_start:
+        raise PinError(f"pinned ExecStart does not invoke the release interpreter: {exec_start}")
+    head, _, tail = exec_start.partition(interpreter)
+    if tail.lstrip().startswith(ISOLATED_INTERPRETER_FLAG + " "):
+        return exec_start
+    return f"{head}{interpreter} {ISOLATED_INTERPRETER_FLAG}{tail}"
+
+
 def render_dropin(unit_text: str, sha: str) -> str:
     """Build the drop-in that re-points one unit at an immutable release."""
     release = f"{RELEASE_ROOT}/{sha}"
     directives: list[str] = []
     exec_start: str | None = None
     for line in _logical_lines(unit_text):
-        if not any(line.startswith(prefix) for prefix in PINNED_DIRECTIVES):
+        if line.startswith(PRESERVED_DIRECTIVES):
+            directives.append(line)
+            continue
+        if not line.startswith(PINNED_DIRECTIVES):
             continue
         rewritten = line.replace(CANONICAL_PREFIX, release)
         if line.startswith("ExecStart="):
-            exec_start = rewritten
+            exec_start = _isolate_interpreter(rewritten, release)
         else:
             directives.append(rewritten)
     if exec_start is None:

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -46,16 +46,46 @@ def test_the_canonical_chain_order_is_covered():
         assert unit in CHAIN_UNITS
 
 
-def test_rendered_dropin_repoints_every_path_at_the_release():
+def test_rendered_dropin_repoints_code_at_the_release():
     unit = (UNIT_SOURCE / "extra-confenge-feed-cycle.service").read_text(encoding="utf-8")
     body = render_dropin(unit, SHA)
     assert f"/opt/extra-consultoria-releases/{SHA}/.venv/bin/python" in body
     assert f"Environment=EXTRA_DEPLOYED_SHA={SHA}" in body
     assert "ExecStart=\n" in body, "inherited ExecStart must be cleared before appending"
     for line in body.splitlines():
-        if line.startswith(("WorkingDirectory=", "Environment=PYTHONPATH=", "ExecStart=/")):
+        if line.startswith(("Environment=PYTHONPATH=", "ExecStart=/")):
             assert f"{CANONICAL_PREFIX}-releases/{SHA}" in line
-            assert not line.replace(f"{CANONICAL_PREFIX}-releases/{SHA}", "").count(CANONICAL_PREFIX)
+
+
+def test_working_directory_stays_outside_the_read_only_release():
+    """Releases are read-only; several jobs write evidence via relative paths.
+
+    Pinning the cwd into the release killed the PNCP crawler with
+    PermissionError: 'output/contracts/incremental-latest.json' *after* it had
+    already crawled a window successfully.
+    """
+    for unit_name in ("pncp-contracts.service", "extra-confenge-feed-cycle.service"):
+        unit = (UNIT_SOURCE / unit_name).read_text(encoding="utf-8")
+        body = render_dropin(unit, SHA)
+        workdirs = [line for line in body.splitlines() if line.startswith("WorkingDirectory=")]
+        assert workdirs == [f"WorkingDirectory={CANONICAL_PREFIX}"], f"{unit_name}: {workdirs}"
+
+
+def test_pinned_interpreter_is_isolated_from_the_working_directory():
+    """Without -P, cwd is prepended to sys.path and the checkout at
+    /opt/extra-consultoria shadows the release's own `scripts` package — so the
+    pin would bind a release it never actually ran."""
+    unit = (UNIT_SOURCE / "extra-confenge-feed-cycle.service").read_text(encoding="utf-8")
+    body = render_dropin(unit, SHA)
+    exec_line = next(line for line in body.splitlines() if line.startswith("ExecStart=/"))
+    assert f"/opt/extra-consultoria-releases/{SHA}/.venv/bin/python -P " in exec_line
+
+
+def test_isolation_flag_is_not_duplicated():
+    unit = (UNIT_SOURCE / "extra-confenge-feed-cycle.service").read_text(encoding="utf-8")
+    once = render_dropin(unit, SHA)
+    exec_line = next(line for line in once.splitlines() if line.startswith("ExecStart=/"))
+    assert exec_line.count(" -P ") == 1
 
 
 def test_multi_line_execstart_is_joined_not_truncated():


### PR DESCRIPTION
Segunda ocorrência da mesma classe de erro do pin, encontrada em produção.

O pin reescrevia `WorkingDirectory` para dentro da release. Releases são **read-only** e vários jobs escrevem evidência por caminho relativo:

```
Aug 27 10:06:47 Window 20260820_20260820 completed pages=24 transformed=11646
Aug 27 10:06:47 PermissionError: [Errno 13] Permission denied:
                'output/contracts/incremental-latest.json'
```

A janela inteira foi varrida com sucesso e descartada no último write.

O drop-in escrito à mão que o pin substituiu mantinha `WorkingDirectory=/opt/extra-consultoria` exatamente por isso — e mantinha `-P` também. Com o cwd fora da release, o Python prependa esse diretório a `sys.path`, e o checkout em `/opt/extra-consultoria` (hoje sujo, em `14c8b247`, três releases atrás) sombreia o pacote `scripts` da release. Sem `-P` o pin *bindaria uma release que nunca executou*.

A regra passa a ser explícita: o pin move **código** (interpretador, PYTHONPATH) e preserva **dados** (WorkingDirectory), emitindo `-P` para que a separação seja real.

Testes cobrem as duas metades: o cwd continua fora da release, e o interpretador sai isolado (sem duplicar a flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)