### PR TITLE
fix(confenge): harden producer feed and immutable release

### DIFF
--- a/deploy/confenge/cut_release.sh
+++ b/deploy/confenge/cut_release.sh
@@ -34,7 +34,12 @@ else
 
   # The previous release supplies the interpreter. Refuse the copy if the
   # dependency set moved: a stale venv is a silently wrong deploy.
-  PREV="$(ls -1dt "$RELEASES"/*/ 2>/dev/null | head -1 | sed 's:/*$::')"
+  [ -d "$RELEASES" ] || { echo "CUT_RELEASE_ERROR: release root is missing: $RELEASES" >&2; exit 1; }
+  PREV="$(
+    find "$RELEASES" -regextype posix-extended -mindepth 1 -maxdepth 1 -type d \
+      -regex "$RELEASES/[0-9a-f]{40}" -printf '%T@ %p\n' \
+      | sort -nr | sed -n '1{s/^[^ ]* //;p;}'
+  )"
   [ -x "$PREV/.venv/bin/python" ] || { echo "CUT_RELEASE_ERROR: no usable previous venv" >&2; exit 1; }
   PREV_SHA="$(basename "$PREV")"
   if ! git -C "$APP" diff --quiet "$PREV_SHA" "$SHA" -- requirements.txt 2>/dev/null; then
@@ -47,9 +52,9 @@ else
   git -C "$APP" archive "$SHA" | tar -x -C "$STAGING"
   cp -a "$PREV/.venv" "$STAGING/.venv"
   # The venv records an absolute path; keep it pointing at a real interpreter.
-  "$STAGING/.venv/bin/python" -c "import sys; sys.exit(0)" || {
+  PYTHONDONTWRITEBYTECODE=1 "$STAGING/.venv/bin/python" -P -c "import sys; sys.exit(0)" || {
     echo "CUT_RELEASE_ERROR: copied interpreter does not run" >&2; exit 1; }
-  PYTHONPATH="$STAGING" "$STAGING/.venv/bin/python" -c "
+  PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$STAGING" "$STAGING/.venv/bin/python" -P -c "
 import scripts.ops.confenge_feed_cycle as m
 import scripts.confenge_activation.publish as p
 import scripts.decision_unit_intelligence.batch_population as b
@@ -65,4 +70,29 @@ print('CUT_RELEASE_IMPORT_OK')
   echo "CUT_RELEASE_PUBLISHED: $TARGET"
 fi
 
-python3 "$TARGET/deploy/confenge/pin_release.py" "$SHA"
+# Existing targets are never trusted merely because their directory name is a
+# SHA. Refuse writable or non-root-owned material and re-bind the critical
+# release/publisher files to the exact Git objects before pinning systemd.
+if find "$TARGET" -xdev \( -type f -o -type d \) -perm /222 -print -quit | grep -q .; then
+  echo "CUT_RELEASE_ERROR: release is writable: $TARGET" >&2
+  exit 1
+fi
+if find "$TARGET" -xdev \( ! -user root -o ! -group root \) -print -quit | grep -q .; then
+  echo "CUT_RELEASE_ERROR: release is not root-owned: $TARGET" >&2
+  exit 1
+fi
+for CRITICAL_PATH in \
+  deploy/confenge/cut_release.sh \
+  deploy/confenge/pin_release.py \
+  scripts/confenge_activation/publish.py \
+  scripts/decision_unit_intelligence/batch_population.py \
+  scripts/ops/confenge_feed_cycle.py \
+  scripts/warmbly_bridge/export.py
+do
+  [ -f "$TARGET/$CRITICAL_PATH" ] || {
+    echo "CUT_RELEASE_ERROR: release is missing $CRITICAL_PATH" >&2; exit 1; }
+  git -C "$APP" show "$SHA:$CRITICAL_PATH" | cmp -s - "$TARGET/$CRITICAL_PATH" || {
+    echo "CUT_RELEASE_ERROR: release file does not match $SHA: $CRITICAL_PATH" >&2; exit 1; }
+done
+
+PYTHONDONTWRITEBYTECODE=1 python3 -P "$TARGET/deploy/confenge/pin_release.py" "$SHA"

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -16,8 +16,10 @@ exactly the unversioned manual configuration this repository must not depend on.
 
 This tool derives each drop-in mechanically from the versioned unit files in
 ``deploy/systemd`` by rewriting the ``/opt/extra-consultoria`` prefix to the
-requested immutable release, applies the whole set atomically-or-not-at-all, and
-enables the safety-net timers so a failed chain still retries on its own.
+requested immutable release, applies the whole set atomically-or-not-at-all,
+and keeps only the source timer plus the independent feed monitor scheduled.
+The downstream data stages advance through ``OnSuccess`` and do not own a
+second cadence.
 """
 
 from __future__ import annotations
@@ -53,15 +55,21 @@ CHAIN_UNITS = (
 )
 
 # Timers that must survive a reboot for the chain to run without an operator.
-# The OnSuccess chain is the primary path; these are the recovery net for a
-# failed or missed link. Concurrency is already guarded by flock in the units.
+# Only the source starts a data cycle; the monitor observes publication health
+# without advancing the pipeline.
 CHAIN_TIMERS = (
     "pncp-contracts.timer",
+    "extra-confenge-feed-monitor.timer",
+)
+
+# These legacy independent cadences bypass the source-triggered cascade. Merely
+# omitting ``enable`` is insufficient because an older pin may have left them
+# enabled and active on the host.
+CHAIN_DISABLED_TIMERS = (
     "extra-confenge-target-fit-reconcile.timer",
     "extra-confenge-target-fit-refresh.timer",
     "extra-confenge-contact-cycle.timer",
     "extra-confenge-feed-cycle.timer",
-    "extra-confenge-feed-monitor.timer",
 )
 
 # Long-running workers that must come back after a reboot.
@@ -142,6 +150,10 @@ def render_dropin(unit_text: str, sha: str) -> str:
         *directives,
         f"Environment=EXTRA_DEPLOYED_SHA={sha}",
         f"Environment=EXTRA_CODE_SHA={sha}",
+        # A root-run diagnostic can bypass 0555 and recreate __pycache__ in an
+        # otherwise immutable release. Suppress bytecode for every pinned
+        # process; the venv remains the only mutable interpreter input.
+        "Environment=PYTHONDONTWRITEBYTECODE=1",
         # Clear the inherited ExecStart before appending the pinned one.
         "ExecStart=",
         exec_start,
@@ -217,17 +229,17 @@ def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
             tmp.replace(target)
             written.append(str(target))
         _run(["systemctl", "daemon-reload"])
-        # --now, not just enable: enabling alone writes the wants/ symlink and
-        # leaves the timer unloaded until the next boot, which is precisely how
-        # the two safety-net timers came to be "enabled" and still absent from
-        # `systemctl list-timers`.
+        # --now is required for both the source trigger and independent monitor;
+        # enabling alone would defer them until the next boot.
         _run(["systemctl", "enable", "--now", *CHAIN_TIMERS])
+        _run(["systemctl", "disable", "--now", *CHAIN_DISABLED_TIMERS])
         _run(["systemctl", "enable", *CHAIN_ENABLED_SERVICES])
     return {
         "schema": "confenge.release_pin.v1",
         "release_sha": sha,
         "units_pinned": list(rendered),
         "timers_enabled": list(CHAIN_TIMERS),
+        "timers_disabled": list(CHAIN_DISABLED_TIMERS),
         "services_enabled": list(CHAIN_ENABLED_SERVICES),
         "dropins_written": written,
         "dry_run": dry_run,
@@ -237,11 +249,44 @@ def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
 def verify(sha: str) -> dict[str, object]:
     """Read back what systemd actually resolved, not what we intended to write."""
     drift: list[dict[str, str]] = []
+    unsafe_python_path: list[dict[str, str]] = []
+    bytecode_writes_enabled: list[dict[str, str]] = []
+    working_directory_drift: list[dict[str, str]] = []
+    working_directory_not_writable: list[dict[str, str]] = []
+    release = f"{RELEASE_ROOT}/{sha}"
     for unit in CHAIN_UNITS:
         result = _run(["systemctl", "show", unit, "-p", "ExecStart", "--value"], check=False)
         resolved = (result.stdout or "").strip()
-        if f"{RELEASE_ROOT}/{sha}" not in resolved:
+        if release not in resolved:
             drift.append({"unit": unit, "resolved": resolved[:400]})
+        interpreter = f"{release}/.venv/bin/python"
+        if interpreter not in resolved or re.search(r"(?:^|\s)-P(?:\s|$)", resolved) is None:
+            unsafe_python_path.append({"unit": unit, "resolved": resolved[:400]})
+
+        environment = (
+            _run(["systemctl", "show", unit, "-p", "Environment", "--value"], check=False).stdout or ""
+        ).strip()
+        if f"PYTHONPATH={release}" not in environment:
+            drift.append({"unit": unit, "resolved": environment[:400]})
+        if "PYTHONDONTWRITEBYTECODE=1" not in environment:
+            bytecode_writes_enabled.append({"unit": unit, "resolved": environment[:400]})
+
+        working_directory = (
+            _run(["systemctl", "show", unit, "-p", "WorkingDirectory", "--value"], check=False).stdout or ""
+        ).strip()
+        user = (_run(["systemctl", "show", unit, "-p", "User", "--value"], check=False).stdout or "").strip()
+        if not working_directory or working_directory == release or working_directory.startswith(f"{release}/"):
+            working_directory_drift.append({"unit": unit, "working_directory": working_directory or "MISSING"})
+        else:
+            writable_probe = (
+                ["test", "-w", working_directory]
+                if user in {"", "root"}
+                else ["runuser", "-u", user, "--", "test", "-w", working_directory]
+            )
+            if _run(writable_probe, check=False).returncode != 0:
+                working_directory_not_writable.append(
+                    {"unit": unit, "user": user or "root", "working_directory": working_directory}
+                )
     disabled: list[str] = []
     for unit in (*CHAIN_TIMERS, *CHAIN_ENABLED_SERVICES):
         state = _run(["systemctl", "is-enabled", unit], check=False).stdout.strip()
@@ -253,13 +298,37 @@ def verify(sha: str) -> dict[str, object]:
         state = _run(["systemctl", "is-active", unit], check=False).stdout.strip()
         if state != "active":
             inactive_timers.append(f"{unit}={state or 'unknown'}")
+    independently_scheduled: list[str] = []
+    for unit in CHAIN_DISABLED_TIMERS:
+        enabled = _run(["systemctl", "is-enabled", unit], check=False).stdout.strip()
+        active = _run(["systemctl", "is-active", unit], check=False).stdout.strip()
+        if enabled not in {"disabled", "masked"} or active != "inactive":
+            independently_scheduled.append(
+                f"{unit}=enabled:{enabled or 'unknown'},active:{active or 'unknown'}"
+            )
     return {
         "schema": "confenge.release_pin_verification.v1",
         "release_sha": sha,
-        "ok": not drift and not disabled and not inactive_timers,
+        "ok": not any(
+            (
+                drift,
+                unsafe_python_path,
+                bytecode_writes_enabled,
+                working_directory_drift,
+                working_directory_not_writable,
+                disabled,
+                inactive_timers,
+                independently_scheduled,
+            )
+        ),
         "release_drift": drift,
+        "unsafe_python_path": unsafe_python_path,
+        "bytecode_writes_enabled": bytecode_writes_enabled,
+        "working_directory_drift": working_directory_drift,
+        "working_directory_not_writable": working_directory_not_writable,
         "not_enabled": disabled,
         "timers_not_active": inactive_timers,
+        "downstream_timers_scheduled": independently_scheduled,
     }
 
 

--- a/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/verification-2026-08-27.json
+++ b/docs/ops/campaigns/CONFENGE-AUTHORITATIVE-OUTREACH-FEED-01/verification-2026-08-27.json
@@ -1,0 +1,137 @@
+{
+  "schema": "confenge.authoritative-outreach-feed-verification.v3",
+  "issue": 468,
+  "observed_at": "2026-08-27T16:08:40Z",
+  "campaign_branch": "campaign/producer-feed-release-20260827",
+  "status": {
+    "producer_candidate": "GO:PRODUCER_FEED",
+    "live": "DEGRADED:SOURCE_STALE",
+    "blocker": "PNCP_CONTRACT_FRESHNESS/1.0:STALE:UNCLOSED_CURRENT_WINDOW,WINDOW_INCOMPLETE,LAG_ABOVE_HARD_GUARDRAIL"
+  },
+  "git": {
+    "origin_main_sha_at_start_and_revalidation": "c02aad71259f13d2f019939442a1bca469344760",
+    "candidate_implementation_sha": "db44233d2b2fb0b03efc0ae4b7f4629b7e053692"
+  },
+  "live_release": {
+    "effective_sha": "c02aad71259f13d2f019939442a1bca469344760",
+    "chain_unit_count": 8,
+    "all_effective_execstart_paths_match_sha": true,
+    "all_effective_pythonpaths_match_sha": true,
+    "all_effective_python_commands_use_safe_path": true,
+    "working_directory": "/opt/extra-consultoria",
+    "working_directory_writable_by_service_user": true,
+    "operational_checkout_head": "14c8b2473c4e52566a7fed96c45057bd3214a2fe",
+    "operational_checkout_is_executed": false,
+    "release_integrity_after_live_cache_cleanup": {
+      "owner": "root:root",
+      "root_mode": "0555",
+      "tracked_regular_files_compared_to_git_archive": 9141,
+      "missing": 0,
+      "content_mismatch": 0,
+      "executable_bit_mismatch": 0,
+      "symlink_mismatch": 0,
+      "extras_outside_venv": 0,
+      "writable_paths": 0,
+      "non_root_owned_paths": 0
+    },
+    "live_repair": {
+      "removed_untracked_bytecode_cache_paths": true,
+      "recoverability": "Python bytecode cache only; source and venv were unchanged",
+      "future_prevention_in_candidate": "PYTHONDONTWRITEBYTECODE=1 is injected and verified by the release pin"
+    },
+    "timer_drift_at_observation": {
+      "source_and_monitor_expected_active": true,
+      "independent_downstream_timers_still_active_on_live_sha": true,
+      "candidate_pin_disables_and_verifies_downstream_timers": true
+    }
+  },
+  "source_freshness": {
+    "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+    "status": "STALE",
+    "reason_codes": [
+      "UNCLOSED_CURRENT_WINDOW",
+      "WINDOW_INCOMPLETE",
+      "LAG_ABOVE_HARD_GUARDRAIL"
+    ],
+    "as_of": "2026-08-27T16:01:22.329537Z",
+    "latest_successful_closed_window": "20260820_20260820",
+    "current_lag_hours": 184.02286931583333,
+    "last_source_attempt_at": "2026-08-27T15:00:21Z",
+    "last_source_attempt_result": "exit-code",
+    "nominal_last_error": "PNCP page read timed out",
+    "gate_exec_status": 2,
+    "downstream_started_by_gate": false
+  },
+  "current_publication": {
+    "status": "LAST_CURRENT_PRESERVED_BUT_UNHEALTHY",
+    "producer_repo_sha": "e25272e83026b3569799aed8b57490054242d4ec",
+    "run_id": "run-25d918a5801fa976",
+    "snapshot_hash": "1c507558ec0e803bd2344d565f5adcb541375778b1b247b47e152470f024402a",
+    "generated_at": "2026-08-27T02:02:34Z",
+    "derived_lead_count": 406076,
+    "derived_chunk_count": 8125,
+    "derived_total_chunk_bytes": 1462954986,
+    "derived_unique_all_roots": 405894,
+    "derived_target_confirmed_unique_roots": 8653,
+    "derived_target_membership_hash": "7a08b8969b6e4ca9b68f9dd845abfcf9b73609058d91aad332e1aa11220d5880",
+    "declared_target_membership_hash_matches": true,
+    "chunk_hash_mismatches": 0,
+    "deactivation_count": 0,
+    "feed_scope_attestation": null,
+    "population_as_of": "2026-08-26T05:37:53.901406+02:00",
+    "population_as_of_source": null,
+    "population_publication_ready": null,
+    "monitor_status": "UNHEALTHY",
+    "monitor_error": "authoritative PNCP freshness expired before publication",
+    "consumer_readback": "current manifest rejected because it exceeds the safe chunk ceiling; prior applied authority remains unchanged"
+  },
+  "staged_membership_candidate": {
+    "status": "STAGED_NOT_PROMOTED",
+    "producer_repo_sha": "652bb78f2b811a202795afd16f01d5b088920602",
+    "module_version": "1.2.0",
+    "run_id": "run-f0e0e7aba9fcae1f",
+    "snapshot_hash": "ef25065736e83833c4afeb208a8913433bdad7918b744bb87385d370b05ac22d",
+    "generated_at": "2026-08-27T10:01:25Z",
+    "feed_scope": "TARGET_CONFIRMED_MEMBERSHIP",
+    "derived_lead_count": 8653,
+    "derived_unique_root_count": 8653,
+    "derived_chunk_count": 298,
+    "derived_total_chunk_bytes": 149599394,
+    "decision_universe_count": 406583,
+    "withheld_decision_count": 397930,
+    "derived_membership_hash": "7a08b8969b6e4ca9b68f9dd845abfcf9b73609058d91aad332e1aa11220d5880",
+    "declared_membership_hash_matches": true,
+    "chunk_hash_mismatches": 0,
+    "deactivation_count": 0
+  },
+  "candidate_contract": {
+    "publication_ready_requires_exact_numeric_coverage_ratio": 1.0,
+    "population_as_of_requires_full_reconcile_attestation": true,
+    "wire_scope": "TARGET_CONFIRMED_MEMBERSHIP",
+    "unique_identity_key": "cnpj_root8",
+    "membership_hash_reproduced_from_shipped_roots": true,
+    "membership_drops_require_explicit_deactivation": true,
+    "representative_branch_flip_is_not_a_deactivation": true,
+    "same_snapshot_new_output_semantics_promote": true,
+    "same_snapshot_same_semantics_replay_without_freshness": true,
+    "partial_stale_error_preserve_last_current": true,
+    "atomic_current_swap_failure_preserves_last_current": true,
+    "lead_chunk_and_byte_counts_are_derived": true,
+    "consumer_limits_fail_closed_without_truncation": true
+  },
+  "verification": {
+    "impacted_tests": "179 passed",
+    "release_pin_tests": "25 passed",
+    "ruff": "pass",
+    "shellcheck": "pass",
+    "systemd_validation": "pass",
+    "generated_artifacts_policy": "pass",
+    "pr_reviewability_policy": "pass",
+    "coderabbit_local": "unavailable_signed_out",
+    "smtp_or_provider_mutation": false
+  },
+  "governance_handoff": {
+    "owner_required": "DOD/ADR owner",
+    "conflict": "DOD.md:490 and proposed ADR-035 still describe the full decision universe as the Warmbly wire artifact; the current producer contract ships only TARGET_CONFIRMED membership while retaining full-universe accounting"
+  }
+}

--- a/scripts/confenge_activation/publish.py
+++ b/scripts/confenge_activation/publish.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import shutil
 import tempfile
@@ -26,7 +27,10 @@ FEED_SCOPE = "TARGET_CONFIRMED_MEMBERSHIP"
 # fail-closed publication refusal, never a truncation.
 CONSUMER_MAX_LEADS = 100_000
 CONSUMER_MAX_CHUNKS = 1_000
+CONSUMER_MAX_BYTES_PER_CHUNK = 512_000
+CONSUMER_MAX_STAGED_BYTES = 1_073_741_824
 DEACTIVATION_STATES = frozenset({"RESEARCH_REQUIRED", "SUPPRESSED", "WATCH"})
+MEMBERSHIP_DROP_REASON = "TARGET_CONFIRMED_MEMBERSHIP_DROPPED"
 DEFAULT_MAX_AGE_HOURS = 24.0
 DEFAULT_STATE_PATH = Path("/var/lib/extra-consultoria/confenge-feed/publication-state.json")
 DEFAULT_ALERT_LEDGER = Path("/var/lib/extra-consultoria/alerts/confenge-feed.jsonl")
@@ -76,23 +80,30 @@ def _assert_publication_ready_population(contact_projection: dict) -> None:
 
     The reconciler accepts coverage >= 0.995 as usable operational state; the
     outreach feed does not. A PARTIAL population never becomes a commercial feed
-    merely because it exceeds the reconcile threshold. Projections that predate
-    this provenance field are accepted only when they also carry no coverage
-    ratio to contradict, and a ratio below 1.0 is always refused.
+    merely because it exceeds the reconcile threshold. Both the explicit
+    attestation and its measured ratio are mandatory: silently accepting a
+    legacy projection with neither field recreates the exact false-green this
+    gate exists to prevent.
     """
     ready = contact_projection.get("population_publication_ready")
     ratio = contact_projection.get("population_coverage_ratio")
-    if ratio is not None:
-        try:
-            ratio_value = float(ratio)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("authoritative contact projection coverage ratio is invalid") from exc
-        if ratio_value + 1e-12 < 1.0:
-            raise ValueError(
-                "authoritative target-fit population is not publication ready: "
-                f"coverage_ratio={ratio_value} < 1.0 (RECONCILE_ACCEPTABLE is not PUBLICATION_READY)"
-            )
     if ready is False:
+        raise ValueError(
+            "authoritative target-fit population is not publication ready: "
+            "the national reconcile did not attest complete coverage"
+        )
+    if isinstance(ratio, bool) or not isinstance(ratio, (int, float)):
+        raise ValueError("authoritative contact projection coverage ratio is missing or invalid")
+    try:
+        ratio_value = float(ratio)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("authoritative contact projection coverage ratio is missing or invalid") from exc
+    if not math.isfinite(ratio_value) or abs(ratio_value - 1.0) > 1e-12:
+        raise ValueError(
+            "authoritative target-fit population is not publication ready: "
+            f"coverage_ratio={ratio_value} != 1.0 (RECONCILE_ACCEPTABLE is not PUBLICATION_READY)"
+        )
+    if ready is not True:
         raise ValueError(
             "authoritative target-fit population is not publication ready: "
             "the national reconcile did not attest complete coverage"
@@ -140,6 +151,53 @@ def _read_state(path: Path) -> dict[str, Any]:
         return _read_json(path)
     except (OSError, ValueError, json.JSONDecodeError):
         return {}
+
+
+def _published_target_roots(directory: Path, manifest: dict[str, Any]) -> set[str]:
+    """Read the TARGET_CONFIRMED root membership actually carried by chunks."""
+    roots: set[str] = set()
+    chunks = manifest.get("chunks") if isinstance(manifest.get("chunks"), list) else []
+    for chunk in chunks:
+        if not isinstance(chunk, dict):
+            raise ValueError("publication membership chunk is not an object")
+        name = str(chunk.get("file") or "").strip()
+        if not name or Path(name).name != name:
+            raise ValueError("publication membership chunk name is unsafe")
+        payload = _read_json(directory / name)
+        for lead in payload.get("leads") or []:
+            if not isinstance(lead, dict) or str(lead.get("target_fit_class") or "") != "TARGET_CONFIRMED":
+                continue
+            cnpj = "".join(char for char in str((lead.get("company") or {}).get("cnpj14") or "") if char.isdigit())
+            if len(cnpj) != 14:
+                raise ValueError("publication membership contains an invalid CNPJ14")
+            root = cnpj[:8]
+            roots.add(root)
+    return roots
+
+
+def _assert_membership_deactivation_delta(
+    prior_dir: Path,
+    prior_manifest: dict[str, Any],
+    build_dir: Path,
+    manifest: dict[str, Any],
+) -> None:
+    """Every root that leaves current must travel as one explicit revocation."""
+    prior_roots = _published_target_roots(prior_dir, prior_manifest)
+    next_roots = _published_target_roots(build_dir, manifest)
+    expected = prior_roots - next_roots
+    declared: set[str] = set()
+    for entry in manifest.get("deactivations") or []:
+        if not isinstance(entry, dict) or MEMBERSHIP_DROP_REASON not in (entry.get("reason_codes") or []):
+            continue
+        cnpj = "".join(char for char in str(entry.get("cnpj14") or "") if char.isdigit())
+        if len(cnpj) != 14:
+            raise ValueError("membership-drop deactivation has an invalid CNPJ14")
+        declared.add(cnpj[:8])
+    if declared != expected:
+        raise ValueError(
+            "membership-drop deactivations do not close the current-to-next delta: "
+            f"expected={len(expected)} declared={len(declared)}"
+        )
 
 
 def _append_alert(path: Path, *, reason: str, detail: dict[str, Any]) -> None:
@@ -247,6 +305,44 @@ def producer_identity(manifest: dict[str, Any]) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def publication_semantic_hash(manifest: dict[str, Any]) -> str:
+    """Clock-free identity of the consumer-visible publication semantics.
+
+    The source snapshot deliberately excludes an externally supplied
+    deactivation delta. Producer identity captures code/policy meaning, but it
+    also cannot see that wire delta. Replaying solely on those two identities
+    therefore discarded a newly required revocation. Normalize the output
+    semantics that can change independently of the input files; operational
+    timestamps remain excluded so a true replay stays a replay.
+    """
+    membership = manifest.get("authoritative_target_membership")
+    membership = membership if isinstance(membership, dict) else {}
+    scope = manifest.get("authoritative_feed_scope")
+    scope = scope if isinstance(scope, dict) else {}
+    normalized_deactivations: list[dict[str, Any]] = []
+    for entry in manifest.get("deactivations") or []:
+        if not isinstance(entry, dict):
+            continue
+        normalized_deactivations.append(
+            {key: value for key, value in entry.items() if key not in {"evaluated_at"}}
+        )
+    normalized_deactivations.sort(
+        key=lambda row: (str(row.get("cnpj14") or "")[:8], json.dumps(row, sort_keys=True, default=str))
+    )
+    source = manifest.get("source") if isinstance(manifest.get("source"), dict) else {}
+    semantics = {
+        "producer_identity": producer_identity(manifest),
+        "snapshot_hash": source.get("snapshot_hash"),
+        "feed_scope": scope.get("scope") or manifest.get("feed_scope") or FEED_SCOPE,
+        "identity_key": scope.get("identity_key"),
+        "membership_hash": membership.get("membership_hash"),
+        "lead_count": manifest.get("lead_count"),
+        "deactivations": normalized_deactivations,
+    }
+    encoded = json.dumps(semantics, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
 def _validate_authoritative_manifest(
     build_dir: Path,
     manifest: dict[str, Any],
@@ -310,8 +406,8 @@ def _validate_authoritative_manifest(
     if int(manifest.get("chunk_count") or -1) != len(chunks):
         raise ValueError("manifest chunk_count does not match chunks")
     declared_lead_count = int(manifest.get("lead_count", -1))
-    if declared_lead_count < 1:
-        raise ValueError("authoritative feed must ship at least one TARGET_CONFIRMED lead")
+    if declared_lead_count < 0:
+        raise ValueError("authoritative feed lead_count cannot be negative")
     if declared_lead_count > CONSUMER_MAX_LEADS:
         raise ValueError(
             "authoritative feed exceeds the consumer lead ceiling; refusing to publish a feed that "
@@ -322,7 +418,11 @@ def _validate_authoritative_manifest(
             "authoritative feed exceeds the consumer chunk ceiling; refusing to publish a feed that "
             f"cannot be imported: chunk_count={len(chunks)} max={CONSUMER_MAX_CHUNKS}"
         )
+    declared_chunk_byte_ceiling = int(manifest.get("max_bytes_per_chunk", -1))
+    if not 1024 <= declared_chunk_byte_ceiling <= CONSUMER_MAX_BYTES_PER_CHUNK:
+        raise ValueError("manifest max_bytes_per_chunk is missing or exceeds the consumer ceiling")
     total_leads = 0
+    total_chunk_bytes = 0
     accounts_with_contacts = 0
     accounts_with_preferred_route = 0
     target_accounts_with_preferred_route = 0
@@ -348,6 +448,15 @@ def _validate_authoritative_manifest(
         expected_hash = str(chunk.get("content_hash") or "").strip()
         if not expected_hash or actual_hash != expected_hash:
             raise ValueError(f"chunk hash mismatch for {filename}: {actual_hash} != {expected_hash or 'MISSING'}")
+        actual_bytes = chunk_path.stat().st_size
+        if actual_bytes > declared_chunk_byte_ceiling:
+            raise ValueError(
+                f"chunk {filename} exceeds the declared byte ceiling: "
+                f"bytes={actual_bytes} max={declared_chunk_byte_ceiling}"
+            )
+        if int(chunk.get("byte_count", -1)) != actual_bytes:
+            raise ValueError(f"manifest chunk byte_count mismatch for {filename}")
+        total_chunk_bytes += actual_bytes
         payload = _read_json(chunk_path)
         payload_source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
         if payload.get("schema_version") != FEED_SCHEMA:
@@ -410,6 +519,13 @@ def _validate_authoritative_manifest(
                 provenance_sources[source_name] = provenance_sources.get(source_name, 0) + 1
     if total_leads != declared_lead_count:
         raise ValueError("manifest lead_count does not match chunk payloads")
+    if total_chunk_bytes > CONSUMER_MAX_STAGED_BYTES:
+        raise ValueError(
+            "authoritative feed exceeds the consumer staged-byte ceiling; "
+            f"bytes={total_chunk_bytes} max={CONSUMER_MAX_STAGED_BYTES}"
+        )
+    if int(manifest.get("total_chunk_bytes", -1)) != total_chunk_bytes:
+        raise ValueError("manifest total_chunk_bytes does not match chunk files")
     if len(target_member_cnpjs) != total_leads:
         raise ValueError("published feed contains a lead that is not TARGET_CONFIRMED")
 
@@ -429,6 +545,8 @@ def _validate_authoritative_manifest(
     declared_universe_count = int(authority.get("declared_universe_count", -1))
     if full_decision_count < total_leads:
         raise ValueError("authoritative decision universe cannot be smaller than the published feed")
+    if full_decision_count < 1:
+        raise ValueError("authoritative decision universe cannot be empty")
     if int(feed_scope.get("decision_universe_count", -1)) != full_decision_count:
         raise ValueError("authoritative feed scope decision_universe_count does not match the decision universe")
     if full_decision_count != universe_count or full_decision_count != declared_universe_count:
@@ -466,7 +584,7 @@ def _validate_authoritative_manifest(
         raise ValueError("authoritative TARGET_CONFIRMED source_member_count mismatch")
     if target_membership.get("target_fit_class") != "TARGET_CONFIRMED":
         raise ValueError("authoritative target membership class must be TARGET_CONFIRMED")
-    if not target_membership.get("target_fit_policy_versions"):
+    if total_leads and not target_membership.get("target_fit_policy_versions"):
         raise ValueError("authoritative target membership policy versions are required")
     if target_membership.get("target_party_role_distribution") != dict(sorted(target_role_distribution.items())):
         raise ValueError("authoritative TARGET_CONFIRMED party role distribution mismatch")
@@ -493,6 +611,8 @@ def _validate_authoritative_manifest(
         "generated_at",
         "population_hash",
         "population_as_of",
+        "population_as_of_source",
+        "population_verified_at",
         "projection_hash",
         "controlled_email_policy_version",
         "discovery_policy_version",
@@ -509,6 +629,14 @@ def _validate_authoritative_manifest(
     contact_population_as_of = _parse_timestamp(
         contact_projection.get("population_as_of"), field="authoritative_contact_projection.population_as_of"
     )
+    contact_population_verified_at = _parse_timestamp(
+        contact_projection.get("population_verified_at"),
+        field="authoritative_contact_projection.population_verified_at",
+    )
+    if contact_projection.get("population_as_of_source") != "target_fit_full_reconcile":
+        raise ValueError("authoritative contact population freshness must come from a full reconcile")
+    if contact_population_as_of != contact_population_verified_at:
+        raise ValueError("authoritative contact population_as_of must equal its full reconcile attestation")
     if contact_generated > now + timedelta(minutes=5) or contact_population_as_of > now + timedelta(minutes=5):
         raise ValueError("authoritative contact projection timestamp is in the future")
     if max(0.0, (now - contact_generated).total_seconds() / 3600) > max_age_hours:
@@ -581,19 +709,20 @@ def _validate_authoritative_manifest(
     deactivations = deactivations if isinstance(deactivations, list) else []
     if int(manifest.get("deactivation_count", -1)) != len(deactivations):
         raise ValueError("manifest deactivation_count does not match deactivations")
-    published_cnpjs = set(target_member_cnpjs)
-    seen_deactivations: set[str] = set()
+    published_roots = {cnpj[:8] for cnpj in target_member_cnpjs}
+    seen_deactivation_roots: set[str] = set()
     for entry in deactivations:
         if not isinstance(entry, dict):
             raise ValueError("manifest deactivation is not an object")
         cnpj = "".join(char for char in str(entry.get("cnpj14") or "") if char.isdigit())
         if len(cnpj) != 14:
             raise ValueError("manifest deactivation has an invalid cnpj14")
-        if cnpj in seen_deactivations:
-            raise ValueError(f"manifest deactivates {cnpj} more than once")
-        seen_deactivations.add(cnpj)
-        if cnpj in published_cnpjs:
-            raise ValueError(f"manifest both publishes and deactivates {cnpj}")
+        root = cnpj[:8]
+        if root in seen_deactivation_roots:
+            raise ValueError(f"manifest deactivates cnpj_root8 {root} more than once")
+        seen_deactivation_roots.add(root)
+        if root in published_roots:
+            raise ValueError(f"manifest both publishes and deactivates cnpj_root8 {root}")
         state = str(entry.get("to_state") or "").strip().upper()
         if state not in DEACTIVATION_STATES:
             raise ValueError(f"manifest deactivation has an unsupported to_state: {state or 'MISSING'}")
@@ -602,12 +731,14 @@ def _validate_authoritative_manifest(
         "run_id": run_id,
         "snapshot_hash": snapshot_hash,
         "producer_identity": producer_identity(manifest),
+        "publication_semantic_hash": publication_semantic_hash(manifest),
         "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
         "datalake_watermark": watermark.isoformat().replace("+00:00", "Z"),
         "generated_age_hours": round(generated_age, 6),
         "watermark_age_hours": round(watermark_age, 6),
         "lead_count": total_leads,
         "chunk_count": len(chunks),
+        "total_chunk_bytes": total_chunk_bytes,
         "decision_universe_count": full_decision_count,
         "withheld_decision_count": full_decision_count - total_leads,
         "feed_scope": FEED_SCOPE,
@@ -689,15 +820,33 @@ def atomic_publish_directory(
             prior = _read_json(current / "manifest.json")
         except (OSError, ValueError, json.JSONDecodeError):
             prior = {}
+        try:
+            _assert_membership_deactivation_delta(current, prior, build_dir, manifest)
+        except Exception as exc:
+            detail = {"build_dir": str(build_dir), "error": str(exc)}
+            _append_alert(alert_ledger, reason="PUBLICATION_REFUSED", detail=detail)
+            state = _read_state(state_path)
+            _atomic_json(
+                state_path,
+                {
+                    **state,
+                    "schema_id": "confenge.feed_publication_state.v1",
+                    "last_attempt_at": clock.isoformat().replace("+00:00", "Z"),
+                    "last_status": "REFUSED",
+                    **detail,
+                },
+            )
+            raise
         prior_source = prior.get("source") if isinstance(prior.get("source"), dict) else {}
         same_inputs = str(prior_source.get("snapshot_hash") or "") == metrics["snapshot_hash"]
-        same_semantics = producer_identity(prior) == metrics["producer_identity"]
+        same_semantics = publication_semantic_hash(prior) == metrics["publication_semantic_hash"]
         if same_inputs and same_semantics:
             result = {
                 "ok": False,
                 "skipped_same": True,
                 "reason": "SAME_SNAPSHOT_NOT_FRESHNESS",
                 "prior_producer_identity": producer_identity(prior),
+                "prior_publication_semantic_hash": publication_semantic_hash(prior),
                 "publish_dir": str(publish_dir.resolve()),
                 "current": str(current.resolve()),
                 **metrics,
@@ -717,11 +866,10 @@ def atomic_publish_directory(
             )
             return result
 
-    # The immutable release name carries the full build identity: inputs and the
-    # producer semantics that interpreted them. Naming it by inputs alone made a
-    # semantics-only rebuild collide with the release it was meant to supersede.
+    # The immutable release name carries the full consumer-visible identity.
+    # Producer identity alone misses wire deltas such as deactivations.
     release_dir = releases / (
-        f"{run_id}-{str(metrics['snapshot_hash'])[:12]}-{str(metrics['producer_identity'])[:8]}"
+        f"{run_id}-{str(metrics['snapshot_hash'])[:12]}-{str(metrics['publication_semantic_hash'])[:12]}"
     )
     if release_dir.exists():
         raise FileExistsError(f"immutable feed release already exists: {release_dir}")
@@ -752,7 +900,14 @@ def atomic_publish_directory(
     # Relative symlink for portability
     rel_target = Path("releases") / release_dir.name
     link_tmp.symlink_to(rel_target, target_is_directory=True)
-    os.replace(str(link_tmp), str(current))
+    try:
+        os.replace(str(link_tmp), str(current))
+    except Exception:
+        link_tmp.unlink(missing_ok=True)
+        # A release that was never made current is safe to discard. Leaving it
+        # behind would make an identical retry collide with FileExistsError.
+        shutil.rmtree(release_dir, ignore_errors=True)
+        raise
     _fsync_dir(publish_dir)
 
     state = _read_state(state_path)

--- a/scripts/decision_unit_intelligence/batch_population.py
+++ b/scripts/decision_unit_intelligence/batch_population.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections import Counter
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from scripts.confenge_contact_resolution.continuous_from_target_fit import (
@@ -87,7 +88,16 @@ def _population_freshness(
     attestation is PUBLICATION_READY; anything weaker falls back to
     max(computed_at), which keeps the downstream staleness gate fail-closed.
     """
-    computed_max = computed[-1] if computed else None
+    def parsed(value: str) -> datetime:
+        try:
+            stamp = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"invalid target-fit population timestamp: {value!r}") from exc
+        if stamp.tzinfo is None:
+            raise ValueError(f"target-fit population timestamp must include a timezone: {value!r}")
+        return stamp.astimezone(UTC)
+
+    computed_max = max(computed, key=parsed) if computed else None
     attestation = coverage_attestation or {}
     verified_at = str(
         attestation.get("last_full_reconcile_completed_at")
@@ -102,13 +112,12 @@ def _population_freshness(
             "population_coverage_ratio": attestation.get("coverage_ratio"),
             "population_publication_ready": bool(attestation) and publication_ready(attestation),
         }
-    # Never let the attestation move freshness backwards past observed evidence.
-    resolved = verified_at if not computed_max or verified_at >= computed_max else computed_max
+    parsed(verified_at)
     return {
-        "population_as_of": resolved,
-        "population_as_of_source": (
-            "target_fit_full_reconcile" if resolved == verified_at else "target_fit_computed_at_max"
-        ),
+        # A single recently changed row cannot refresh the whole population.
+        # Only the complete reconcile attests that denominator.
+        "population_as_of": verified_at,
+        "population_as_of_source": "target_fit_full_reconcile",
         "population_verified_at": verified_at,
         "population_coverage_ratio": attestation.get("coverage_ratio"),
         "population_publication_ready": True,

--- a/scripts/warmbly_bridge/__init__.py
+++ b/scripts/warmbly_bridge/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 SCHEMA_OUTREACH = "confenge.outreach.v1"
 SCHEMA_OUTCOME = "confenge.outcome.v1"
-MODULE_VERSION = "1.2.0"
+MODULE_VERSION = "1.2.1"
 DEFAULT_SYSTEM = "extra-cli"
 DEFAULT_PROFILE_ID = "confenge"
 DEFAULT_PROFILE_VERSION = "2.0.0"

--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import subprocess
 from collections import Counter
 from dataclasses import dataclass
@@ -54,6 +55,8 @@ FEED_MEMBERSHIP_FILENAME = "membership.json"
 # the run so a human reconciles the population.
 CONSUMER_MAX_LEADS = 100_000
 CONSUMER_MAX_CHUNKS = 1_000
+CONSUMER_MAX_BYTES_PER_CHUNK = 512_000
+CONSUMER_MAX_STAGED_BYTES = 1_073_741_824
 
 # Warmbly rejects a deactivation targeting ACTIONABLE_NOW.
 DEACTIVATION_STATES = ("RESEARCH_REQUIRED", "SUPPRESSED", "WATCH")
@@ -193,6 +196,11 @@ def validate_inputs(cfg: ExportConfig) -> None:
         raise InputError("--max-leads-per-chunk must be >= 1")
     if cfg.max_bytes_per_chunk < 1024:
         raise InputError("--max-bytes-per-chunk must be >= 1024")
+    if cfg.max_bytes_per_chunk > CONSUMER_MAX_BYTES_PER_CHUNK:
+        raise InputError(
+            "--max-bytes-per-chunk exceeds the consumer ceiling: "
+            f"configured={cfg.max_bytes_per_chunk} max={CONSUMER_MAX_BYTES_PER_CHUNK}"
+        )
     if cfg.expected_universe_count is not None and cfg.expected_universe_count < 1:
         raise InputError("--expected-universe-count must be >= 1")
     freshness = cfg.authoritative_source_freshness or {}
@@ -432,6 +440,38 @@ def _authoritative_contact_projection(
         raise InputError("contact projection terminal coverage is incomplete")
     if report.get("membership_contract_matches_population") is not True:
         raise InputError("contact projection membership does not match its population contract")
+    raw_population_coverage_ratio = report.get("population_coverage_ratio")
+    if isinstance(raw_population_coverage_ratio, bool) or not isinstance(
+        raw_population_coverage_ratio, (int, float)
+    ):
+        raise InputError("contact projection population_coverage_ratio is missing or invalid")
+    try:
+        population_coverage_ratio = float(raw_population_coverage_ratio)
+    except (TypeError, ValueError) as exc:
+        raise InputError("contact projection population_coverage_ratio is missing or invalid") from exc
+    if (
+        report.get("population_publication_ready") is not True
+        or not math.isfinite(population_coverage_ratio)
+        or abs(population_coverage_ratio - 1.0) > 1e-12
+    ):
+        raise InputError(
+            "contact projection population is not PUBLICATION_READY: "
+            f"coverage_ratio={population_coverage_ratio}"
+        )
+    if report.get("population_as_of_source") != "target_fit_full_reconcile":
+        raise InputError("contact projection population freshness is not bound to a full reconcile")
+    verified_at = _parse_timestamp(
+        report.get("population_verified_at"),
+        field="contact_projection.population_verified_at",
+        cnpj="authoritative-projection",
+    )
+    population_as_of = _parse_timestamp(
+        report.get("population_as_of"),
+        field="contact_projection.population_as_of",
+        cnpj="authoritative-projection",
+    )
+    if verified_at != population_as_of:
+        raise InputError("contact projection population_as_of does not equal its full reconcile attestation")
     if int(report.get("population_count") or -1) != int(target_membership["population_count"]):
         raise InputError("contact projection population_count does not match TARGET_CONFIRMED membership")
     if int(report.get("membership_count") or -1) != int(target_membership["population_count"]):
@@ -502,6 +542,10 @@ def _authoritative_contact_projection(
         "population_count": int(report["population_count"]),
         "population_hash": report.get("population_hash"),
         "population_as_of": report.get("population_as_of"),
+        "population_as_of_source": report.get("population_as_of_source"),
+        "population_verified_at": report.get("population_verified_at"),
+        "population_coverage_ratio": population_coverage_ratio,
+        "population_publication_ready": True,
         "membership_schema_version": report.get("membership_schema_version"),
         "membership_identity_key": report.get("membership_identity_key"),
         "membership_count": int(report["membership_count"]),
@@ -888,7 +932,7 @@ def _assert_feed_membership(
     }
 
 
-def _assert_consumer_ceilings(*, lead_count: int, chunk_count: int) -> None:
+def _assert_consumer_ceilings(*, lead_count: int, chunk_count: int, staged_bytes: int | None = None) -> None:
     """Refuse to publish a feed the consumer contract cannot import.
 
     Truncating would silently drop authorized companies, so the run aborts and a
@@ -904,12 +948,45 @@ def _assert_consumer_ceilings(*, lead_count: int, chunk_count: int) -> None:
             "TARGET_CONFIRMED feed exceeds the consumer chunk ceiling; refusing to truncate: "
             f"chunk_count={chunk_count} max={CONSUMER_MAX_CHUNKS}"
         )
+    if staged_bytes is not None and staged_bytes > CONSUMER_MAX_STAGED_BYTES:
+        raise InputError(
+            "TARGET_CONFIRMED feed exceeds the consumer staged-byte ceiling; refusing to truncate: "
+            f"staged_bytes={staged_bytes} max={CONSUMER_MAX_STAGED_BYTES}"
+        )
 
 
-def _load_previous_feed_membership(previous_feed_dir: Path | None) -> tuple[set[str], str]:
-    """Return the CNPJ14s the previous published release actually shipped."""
+def _members_by_root(
+    cnpjs: list[str],
+    *,
+    source: str,
+    allow_legacy_branch_duplicates: bool = False,
+) -> dict[str, str]:
+    """Index one representative CNPJ14 per canonical membership root."""
+    by_root: dict[str, str] = {}
+    for raw in cnpjs:
+        cnpj = normalize_cnpj14(str(raw or ""))
+        if not cnpj:
+            raise InputError(f"{source} contains a non-canonical CNPJ14")
+        root = cnpj[:8]
+        prior = by_root.get(root)
+        if prior is not None and prior != cnpj:
+            if not allow_legacy_branch_duplicates:
+                raise InputError(f"{source} repeats cnpj_root8 {root} with multiple representatives")
+            # The pre-roster wire format shipped the whole decision universe,
+            # so two establishments from one company can both appear as
+            # TARGET_CONFIRMED. This compatibility path is used only while
+            # migrating that legacy current. Elect the same stable
+            # representative regardless of chunk/input ordering.
+            by_root[root] = min(prior, cnpj)
+            continue
+        by_root[root] = cnpj
+    return by_root
+
+
+def _load_previous_feed_membership(previous_feed_dir: Path | None) -> tuple[dict[str, str], str]:
+    """Return the previous release membership keyed by canonical CNPJ root."""
     if previous_feed_dir is None:
-        return set(), "UNKNOWN"
+        return {}, "UNKNOWN"
     directory = Path(previous_feed_dir)
     if not directory.is_dir():
         raise InputError(f"--previous-feed-dir is not a readable directory: {directory}")
@@ -924,15 +1001,27 @@ def _load_previous_feed_membership(previous_feed_dir: Path | None) -> tuple[set[
         members = payload.get("members")
         if not isinstance(members, list):
             raise InputError("previous feed membership roster has no members array")
-        previous: set[str] = set()
+        cnpjs: list[str] = []
         for member in members:
-            raw = member.get("cnpj14") if isinstance(member, dict) else member
-            cnpj = normalize_cnpj14(str(raw or ""))
-            if not cnpj:
-                raise InputError("previous feed membership roster contains a non-canonical CNPJ14")
-            previous.add(cnpj)
-        if len(previous) != int(payload.get("population_count", -1)):
-            raise InputError("previous feed membership roster population_count does not match its members")
+            if not isinstance(member, dict):
+                raise InputError("previous feed membership roster member must bind cnpj14 to cnpj_root")
+            cnpj = normalize_cnpj14(str(member.get("cnpj14") or ""))
+            if not cnpj or str(member.get("cnpj_root") or "") != cnpj[:8]:
+                raise InputError("previous feed membership roster contains an invalid root binding")
+            cnpjs.append(cnpj)
+        previous = _members_by_root(cnpjs, source="previous feed membership roster")
+        expected = canonical_target_membership(list(previous.values()))
+        roster_contract = {
+            "scope": FEED_SCOPE,
+            "schema_version": expected["schema_version"],
+            "identity_key": expected["identity_key"],
+            "hash_algorithm": expected["hash_algorithm"],
+            "population_count": expected["population_count"],
+            "membership_hash": expected["membership_hash"],
+        }
+        for field, value in roster_contract.items():
+            if payload.get(field) != value:
+                raise InputError(f"previous feed membership roster {field} is not reproducible from its members")
         return previous, "MEMBERSHIP_ROSTER"
     manifest_path = directory / "manifest.json"
     if not manifest_path.is_file():
@@ -946,7 +1035,7 @@ def _load_previous_feed_membership(previous_feed_dir: Path | None) -> tuple[set[
         raise InputError(f"invalid previous feed manifest: {manifest_path}") from exc
     if not isinstance(manifest, dict) or not isinstance(manifest.get("chunks"), list):
         raise InputError(f"previous feed manifest has no chunks: {manifest_path}")
-    previous = set()
+    previous_cnpjs: list[str] = []
     for chunk in manifest["chunks"]:
         if not isinstance(chunk, dict):
             raise InputError("previous feed manifest chunk is not an object")
@@ -956,6 +1045,9 @@ def _load_previous_feed_membership(previous_feed_dir: Path | None) -> tuple[set[
         chunk_path = directory / name
         if not chunk_path.is_file():
             raise InputError(f"previous feed manifest references a missing chunk: {name}")
+        expected_hash = str(chunk.get("content_hash") or "")
+        if not expected_hash or hashlib.sha256(chunk_path.read_bytes()).hexdigest() != expected_hash:
+            raise InputError(f"previous feed manifest chunk hash mismatch: {name}")
         try:
             payload = json.loads(chunk_path.read_bytes())
         except (OSError, json.JSONDecodeError) as exc:
@@ -965,28 +1057,52 @@ def _load_previous_feed_membership(previous_feed_dir: Path | None) -> tuple[set[
                 continue
             cnpj = normalize_cnpj14(str((lead.get("company") or {}).get("cnpj14") or ""))
             if cnpj:
-                previous.add(cnpj)
+                previous_cnpjs.append(cnpj)
+    previous = _members_by_root(
+        previous_cnpjs,
+        source="previous feed chunks",
+        allow_legacy_branch_duplicates=True,
+    )
+    declared_membership = manifest.get("authoritative_target_membership")
+    declared_membership = declared_membership if isinstance(declared_membership, dict) else {}
+    expected = canonical_target_membership(list(previous.values()))
+    if str(declared_membership.get("membership_hash") or "") != expected["membership_hash"]:
+        raise InputError("previous feed manifest membership_hash is not reproducible from its chunks")
+    if int(declared_membership.get("population_count", -1)) != len(previous):
+        raise InputError("previous feed manifest population_count does not match its unique roots")
     return previous, "PRIOR_RELEASE_CHUNKS"
 
 
 def _membership_drop_deactivations(
-    previous_members: set[str],
+    previous_members: dict[str, str],
     feed_leads: list[dict[str, Any]],
     decision_leads: list[dict[str, Any]],
     *,
     observed_at: str,
 ) -> list[dict[str, Any]]:
     """Emit one deactivation per account that left the shipped population."""
-    shipped = {normalize_cnpj14(str((lead.get("company") or {}).get("cnpj14") or "")) for lead in feed_leads}
-    decision_class = {
-        cnpj: str(lead.get("target_fit_class") or "")
-        for lead in decision_leads
+    shipped_roots = {
+        cnpj[:8]
+        for lead in feed_leads
         for cnpj in (normalize_cnpj14(str((lead.get("company") or {}).get("cnpj14") or "")),)
         if cnpj
     }
+    decision_classes: dict[str, set[str]] = {}
+    for lead in decision_leads:
+        cnpj = normalize_cnpj14(str((lead.get("company") or {}).get("cnpj14") or ""))
+        if cnpj:
+            decision_classes.setdefault(cnpj[:8], set()).add(str(lead.get("target_fit_class") or ""))
     deactivations: list[dict[str, Any]] = []
-    for cnpj in sorted(previous_members - shipped):
-        target_fit_class = decision_class.get(cnpj) or "TARGET_FIT_ABSENT"
+    for root in sorted(set(previous_members) - shipped_roots):
+        cnpj = previous_members[root]
+        classes = decision_classes.get(root) or set()
+        target_fit_class = (
+            "TARGET_OUT_OF_SCOPE"
+            if "TARGET_OUT_OF_SCOPE" in classes
+            else "TARGET_INSUFFICIENT_EVIDENCE"
+            if "TARGET_INSUFFICIENT_EVIDENCE" in classes
+            else "TARGET_FIT_ABSENT"
+        )
         to_state = "SUPPRESSED" if target_fit_class == "TARGET_OUT_OF_SCOPE" else "RESEARCH_REQUIRED"
         deactivations.append(
             {
@@ -1015,9 +1131,14 @@ def _merge_deactivations(
     state already travels inside the lead payload, so the contradiction is
     dropped here and counted, never applied.
     """
-    shipped = {normalize_cnpj14(str((lead.get("company") or {}).get("cnpj14") or "")) for lead in feed_leads}
+    shipped_roots = {
+        cnpj[:8]
+        for lead in feed_leads
+        for cnpj in (normalize_cnpj14(str((lead.get("company") or {}).get("cnpj14") or "")),)
+        if cnpj
+    }
     merged: list[dict[str, Any]] = []
-    seen: set[str] = set()
+    seen_roots: set[str] = set()
     suppressed = 0
     for entry in declared:
         if not isinstance(entry, dict):
@@ -1025,18 +1146,20 @@ def _merge_deactivations(
         cnpj = normalize_cnpj14(str(entry.get("cnpj14") or ""))
         if not cnpj:
             raise InputError("declared deactivation has a non-canonical cnpj14")
-        if cnpj in shipped:
+        root = cnpj[:8]
+        if root in shipped_roots:
             suppressed += 1
             continue
-        if cnpj in seen:
+        if root in seen_roots:
             continue
-        seen.add(cnpj)
+        seen_roots.add(root)
         merged.append({**entry, "cnpj14": cnpj})
     for entry in membership_drops:
         cnpj = str(entry["cnpj14"])
-        if cnpj in seen:
+        root = cnpj[:8]
+        if root in seen_roots:
             continue
-        seen.add(cnpj)
+        seen_roots.add(root)
         merged.append(entry)
     for entry in merged:
         to_state = str(entry.get("to_state") or "").strip().upper()
@@ -1113,6 +1236,11 @@ def _chunk_leads(
         )
         over_count = trial_count > max_leads
         over_bytes = size > max_bytes and len(current) >= 1
+        if size > max_bytes and not current:
+            raise InputError(
+                "single TARGET_CONFIRMED lead exceeds the encoded chunk byte ceiling; "
+                f"bytes={size} max={max_bytes}"
+            )
         if (over_count or over_bytes) and current:
             chunks.append(current)
             current = [lead]
@@ -1315,6 +1443,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
     _assert_consumer_ceilings(lead_count=len(feed_leads), chunk_count=len(chunk_specs))
 
     chunk_meta: list[dict[str, Any]] = []
+    total_chunk_bytes = 0
     for slice_leads, pagination in chunk_specs:
         # First pass: compute content hash of leads+source (stable) for hashes block.
         leads_hash = content_hash_obj({"leads": slice_leads, "source": source})
@@ -1334,6 +1463,12 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
             "leads": slice_leads,
         }
         raw = _encode_chunk(feed)
+        if len(raw) > cfg.max_bytes_per_chunk:
+            raise InputError(
+                "encoded outreach chunk exceeds --max-bytes-per-chunk; "
+                f"chunk_index={pagination['chunk_index']} bytes={len(raw)} max={cfg.max_bytes_per_chunk}"
+            )
+        total_chunk_bytes += len(raw)
         file_hash = hashlib.sha256(raw).hexdigest()
         idx = int(pagination["chunk_index"])
         filename = f"chunk_{idx:04d}.json"
@@ -1349,6 +1484,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
                         "content_hash": file_hash,
                         "leads_hash": leads_hash,
                         "lead_count": len(slice_leads),
+                        "byte_count": len(raw),
                         "cursor": pagination.get("cursor"),
                         "next_cursor": pagination.get("next_cursor"),
                         "has_more": pagination.get("has_more"),
@@ -1364,12 +1500,19 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
                 "content_hash": file_hash,
                 "leads_hash": leads_hash,
                 "lead_count": len(slice_leads),
+                "byte_count": len(raw),
                 "cursor": pagination.get("cursor"),
                 "next_cursor": pagination.get("next_cursor"),
                 "has_more": pagination.get("has_more"),
                 "status": "written",
             }
         )
+
+    _assert_consumer_ceilings(
+        lead_count=len(feed_leads),
+        chunk_count=len(chunk_meta),
+        staged_bytes=total_chunk_bytes,
+    )
 
     # Remove stale chunks from previous larger runs with different snapshot (same out dir).
     # Only delete chunk_*.json not in this run when snapshot changes — safer: delete extras.
@@ -1418,6 +1561,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         "chunk_count": len(chunk_meta),
         "max_leads_per_chunk": cfg.max_leads_per_chunk,
         "max_bytes_per_chunk": cfg.max_bytes_per_chunk,
+        "total_chunk_bytes": total_chunk_bytes,
         "limit": cfg.limit,
         "authoritative_target_fit": {
             "source": "target_fit_snapshot" if cfg.target_fit_snapshot is not None else "universe_embedded_snapshot",
@@ -1488,6 +1632,7 @@ def export_outreach(cfg: ExportConfig) -> dict[str, Any]:
         "lead_count": len(feed_leads),
         "decision_count": decision_count,
         "chunk_count": len(chunk_meta),
+        "total_chunk_bytes": total_chunk_bytes,
         "deactivation_count": len(deacts),
         "authoritative_feed_scope": {**feed_scope, **membership_proof},
         "authoritative_target_membership": target_membership,

--- a/tests/test_confenge_activation_planner.py
+++ b/tests/test_confenge_activation_planner.py
@@ -346,8 +346,11 @@ def test_atomic_publish(tmp_path: Path):
                 "content_hash": chash,
                 "chunk_index": 0,
                 "lead_count": 1,
+                "byte_count": len(raw),
             }
         ],
+        "max_bytes_per_chunk": 512_000,
+        "total_chunk_bytes": len(raw),
         "deactivations": [],
         "deactivation_count": 0,
         "authoritative_target_fit": {
@@ -391,6 +394,10 @@ def test_atomic_publish(tmp_path: Path):
             "generated_at": payload["generated_at"],
             "population_hash": "b" * 64,
             "population_as_of": payload["generated_at"],
+            "population_as_of_source": "target_fit_full_reconcile",
+            "population_verified_at": payload["generated_at"],
+            "population_coverage_ratio": 1.0,
+            "population_publication_ready": True,
             "projection_hash": "c" * 64,
             "controlled_email_policy_version": "controlled-email-policy.v3",
             "discovery_policy_version": "dui.policy.v1",

--- a/tests/test_confenge_feed_publication.py
+++ b/tests/test_confenge_feed_publication.py
@@ -87,10 +87,13 @@ def _build(
                 "file": "chunk_0000.json",
                 "chunk_index": 0,
                 "content_hash": hashlib.sha256(raw).hexdigest(),
+                "byte_count": len(raw),
                 "lead_count": 1,
                 "has_more": False,
             }
         ],
+        "max_bytes_per_chunk": 512_000,
+        "total_chunk_bytes": len(raw),
         "authoritative_target_fit": {
             "coverage_complete": True,
             "omission_preserves_authorization": False,
@@ -141,6 +144,10 @@ def _build(
             "generated_at": generated,
             "population_hash": "b" * 64,
             "population_as_of": generated,
+            "population_as_of_source": "target_fit_full_reconcile",
+            "population_verified_at": generated,
+            "population_coverage_ratio": 1.0,
+            "population_publication_ready": True,
             "projection_hash": "c" * 64,
             "controlled_email_policy_version": "controlled-email-policy.v3",
             "discovery_policy_version": "dui.policy.v1",
@@ -186,6 +193,82 @@ def _build(
 
 def _paths(tmp_path: Path) -> tuple[Path, Path, Path]:
     return tmp_path / "public", tmp_path / "state.json", tmp_path / "alerts.jsonl"
+
+
+def _zero_membership_build(root: Path, *, include_drop: bool = True) -> Path:
+    build = _build(root, snapshot="snapshot-zero")
+    chunk_path = build / "chunk_0000.json"
+    chunk = json.loads(chunk_path.read_text(encoding="utf-8"))
+    chunk["leads"] = []
+    raw = (json.dumps(chunk, ensure_ascii=False, sort_keys=True) + "\n").encode()
+    chunk_path.write_bytes(raw)
+
+    manifest_path = build / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    empty = canonical_target_membership([])
+    manifest.update({"lead_count": 0, "total_chunk_bytes": len(raw)})
+    manifest["chunks"][0].update(
+        {"content_hash": hashlib.sha256(raw).hexdigest(), "lead_count": 0, "byte_count": len(raw)}
+    )
+    manifest["authoritative_target_fit"].update(
+        {"shipped_lead_count": 0, "decision_class_distribution": {"TARGET_OUT_OF_SCOPE": 1}}
+    )
+    manifest["authoritative_feed_scope"].update(
+        {
+            "shipped_lead_count": 0,
+            "withheld_decision_count": 1,
+            "membership_hash_reproduced_from_feed": True,
+        }
+    )
+    manifest["authoritative_target_membership"] = {
+        **empty,
+        "target_fit_class": "TARGET_CONFIRMED",
+        "target_confirmed_count": 0,
+        "supplier_confirmed_count": 0,
+        "source_member_count": 0,
+        "membership_complete": True,
+        "target_fit_policy_versions": [],
+        "target_party_role_distribution": {},
+        "contractor_role_status_distribution": {},
+    }
+    manifest["authoritative_party_roles"].update(
+        {"target_party_role_distribution": {}, "status_distribution": {}, "supplier_confirmed_count": 0}
+    )
+    projection = manifest["authoritative_contact_projection"]
+    projection.update(
+        {
+            "population_count": 0,
+            "membership_count": 0,
+            "membership_hash": empty["membership_hash"],
+            "membership_schema_version": empty["schema_version"],
+            "membership_identity_key": empty["identity_key"],
+            "membership_hash_algorithm": empty["hash_algorithm"],
+            "enrichment_states": {},
+            "recipient_states": {
+                "RECIPIENT_ATTRIBUTED": 0,
+                "READY": 0,
+                "NO_PUBLIC_EMAIL_FOUND": 0,
+                "BLOCKED_WITH_REASON": 0,
+            },
+            "output_preferred_route_class_distribution": {},
+            "input_preferred_route_count": 0,
+            "output_preferred_route_count": 0,
+        }
+    )
+    manifest["deactivations"] = (
+        [
+            {
+                "cnpj14": "12345678000195",
+                "to_state": "SUPPRESSED",
+                "reason_codes": ["TARGET_CONFIRMED_MEMBERSHIP_DROPPED"],
+            }
+        ]
+        if include_drop
+        else []
+    )
+    manifest["deactivation_count"] = len(manifest["deactivations"])
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return build
 
 
 def test_publish_records_live_contact_metrics_and_immutable_release(tmp_path: Path) -> None:
@@ -271,6 +354,8 @@ def test_buyer_supplier_conflict_with_authorized_route_is_refused(tmp_path: Path
     chunk_path.write_bytes(raw)
     manifest = json.loads((bad / "manifest.json").read_text())
     manifest["chunks"][0]["content_hash"] = hashlib.sha256(raw).hexdigest()
+    manifest["chunks"][0]["byte_count"] = len(raw)
+    manifest["total_chunk_bytes"] = len(raw)
     manifest["authoritative_target_membership"]["target_party_role_distribution"] = {"BUYER_CONFLICT": 1}
     manifest["authoritative_target_membership"]["contractor_role_status_distribution"] = {"PARTY_ROLE_CONFLICT": 1}
     manifest["authoritative_party_roles"]["target_party_role_distribution"] = {"BUYER_CONFLICT": 1}
@@ -326,6 +411,8 @@ def test_policy_excluded_preferred_routes_can_reconcile_at_zero(tmp_path: Path) 
     raw = json.dumps(chunk, separators=(",", ":"), sort_keys=True).encode()
     chunk_path.write_bytes(raw)
     manifest["chunks"][0]["content_hash"] = hashlib.sha256(raw).hexdigest()
+    manifest["chunks"][0]["byte_count"] = len(raw)
+    manifest["total_chunk_bytes"] = len(raw)
     (build / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
     result = atomic_publish_directory(
@@ -508,16 +595,40 @@ def test_feed_above_consumer_chunk_ceiling_is_refused_without_replacing_current(
     assert (public / "current").resolve() == prior
 
 
-def test_empty_feed_is_refused_without_replacing_current(tmp_path: Path) -> None:
+def test_complete_zero_membership_deactivates_all_and_promotes(tmp_path: Path) -> None:
     public, state, alerts = _paths(tmp_path)
     first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
     prior = Path(first["current"]).resolve()
-    empty = _build(tmp_path / "empty", snapshot="snapshot-b", declared_lead_count=0)
+    result = atomic_publish_directory(
+        _zero_membership_build(tmp_path / "empty"),
+        public,
+        state_path=state,
+        alert_ledger=alerts,
+        now=NOW,
+    )
 
-    with pytest.raises(ValueError, match="at least one TARGET_CONFIRMED lead"):
-        atomic_publish_directory(empty, public, state_path=state, alert_ledger=alerts, now=NOW)
+    assert result["ok"] is True
+    assert result["lead_count"] == 0
+    assert result["deactivation_count"] == 1
+    assert (public / "current").resolve() != prior
+
+
+def test_zero_membership_missing_a_drop_preserves_current(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    prior = Path(first["current"]).resolve()
+
+    with pytest.raises(ValueError, match="do not close"):
+        atomic_publish_directory(
+            _zero_membership_build(tmp_path / "empty", include_drop=False),
+            public,
+            state_path=state,
+            alert_ledger=alerts,
+            now=NOW,
+        )
 
     assert (public / "current").resolve() == prior
+    assert "PUBLICATION_REFUSED" in alerts.read_text(encoding="utf-8")
 
 
 def test_decision_universe_may_not_be_redefined_to_the_feed_size(tmp_path: Path) -> None:
@@ -525,17 +636,26 @@ def test_decision_universe_may_not_be_redefined_to_the_feed_size(tmp_path: Path)
     public, state, alerts = _paths(tmp_path)
     build = _build(tmp_path / "wide")
     manifest = json.loads((build / "manifest.json").read_text())
+    decision_count = 10_000
     authority = manifest["authoritative_target_fit"]
-    authority.update({"full_decision_count": 406_076, "universe_count": 406_076, "declared_universe_count": 406_076})
-    manifest["authoritative_feed_scope"].update({"decision_universe_count": 406_076, "withheld_decision_count": 406_075})
+    authority.update(
+        {
+            "full_decision_count": decision_count,
+            "universe_count": decision_count,
+            "declared_universe_count": decision_count,
+        }
+    )
+    manifest["authoritative_feed_scope"].update(
+        {"decision_universe_count": decision_count, "withheld_decision_count": decision_count - 1}
+    )
     (build / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
     result = atomic_publish_directory(build, public, state_path=state, alert_ledger=alerts, now=NOW)
 
     assert result["ok"] is True
     assert result["lead_count"] == 1
-    assert result["decision_universe_count"] == 406_076
-    assert result["withheld_decision_count"] == 406_075
+    assert result["decision_universe_count"] == decision_count
+    assert result["withheld_decision_count"] == decision_count - 1
     assert result["feed_scope"] == "TARGET_CONFIRMED_MEMBERSHIP"
 
 
@@ -548,6 +668,20 @@ def test_manifest_cannot_publish_and_deactivate_the_same_account(tmp_path: Path)
     (build / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
     with pytest.raises(ValueError, match="both publishes and deactivates"):
+        atomic_publish_directory(build, public, state_path=state, alert_ledger=alerts, now=NOW)
+
+    assert not (public / "current").exists()
+
+
+def test_manifest_cannot_publish_and_deactivate_another_branch_of_the_same_root(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    build = _build(tmp_path / "root-contradiction")
+    manifest = json.loads((build / "manifest.json").read_text())
+    manifest["deactivations"] = [{"cnpj14": "12345678000276", "to_state": "WATCH"}]
+    manifest["deactivation_count"] = 1
+    (build / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="both publishes and deactivates cnpj_root8"):
         atomic_publish_directory(build, public, state_path=state, alert_ledger=alerts, now=NOW)
 
     assert not (public / "current").exists()
@@ -591,6 +725,50 @@ def test_new_producer_semantics_defeat_the_same_snapshot_skip(tmp_path: Path) ->
     assert second["snapshot_hash"] == first["snapshot_hash"]
     assert second["producer_identity"] != first["producer_identity"]
     assert (public / "current").resolve() != Path(first["current"]).resolve()
+
+
+def test_same_snapshot_with_new_deactivation_delta_promotes(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(
+        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    changed = _build(tmp_path / "changed")
+    manifest_path = changed / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["deactivations"] = [{"cnpj14": "11222333000181", "to_state": "WATCH"}]
+    manifest["deactivation_count"] = 1
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    second = atomic_publish_directory(changed, public, state_path=state, alert_ledger=alerts, now=NOW)
+    assert second["ok"] is True
+    assert second["snapshot_hash"] == first["snapshot_hash"]
+    assert second["producer_identity"] == first["producer_identity"]
+    assert second["publication_semantic_hash"] != first["publication_semantic_hash"]
+    assert (public / "current").resolve() != Path(first["current"]).resolve()
+
+
+def test_failed_current_swap_preserves_last_known_good(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(
+        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
+    )
+    prior = Path(first["current"]).resolve()
+    changed = _build(tmp_path / "changed", snapshot="snapshot-b")
+    real_replace = os.replace
+
+    def fail_current_swap(source: str, destination: str) -> None:
+        if Path(destination) == public / "current":
+            raise OSError("injected current swap failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", fail_current_swap)
+    with pytest.raises(OSError, match="injected current swap failure"):
+        atomic_publish_directory(changed, public, state_path=state, alert_ledger=alerts, now=NOW)
+
+    assert (public / "current").resolve() == prior
+    assert json.loads(state.read_text(encoding="utf-8"))["last_success_at"] == first["generated_at"]
+    assert not list(public.glob(".current.tmp-*"))
+    assert len(list((public / "releases").iterdir())) == 1
 
 
 def test_identical_inputs_and_semantics_still_replay(tmp_path: Path) -> None:

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -13,6 +13,7 @@ import pytest
 
 from deploy.confenge.pin_release import (
     CANONICAL_PREFIX,
+    CHAIN_DISABLED_TIMERS,
     CHAIN_ENABLED_SERVICES,
     CHAIN_TIMERS,
     CHAIN_UNITS,
@@ -20,6 +21,7 @@ from deploy.confenge.pin_release import (
     PinError,
     plan,
     render_dropin,
+    verify,
 )
 
 SHA = "a" * 40
@@ -31,7 +33,7 @@ def test_every_chain_unit_has_a_versioned_source_file():
 
 
 def test_every_chain_timer_has_a_versioned_source_file():
-    for timer in CHAIN_TIMERS:
+    for timer in (*CHAIN_TIMERS, *CHAIN_DISABLED_TIMERS):
         assert (UNIT_SOURCE / timer).is_file(), f"{timer} must be versioned in deploy/systemd"
 
 
@@ -51,6 +53,7 @@ def test_rendered_dropin_repoints_code_at_the_release():
     body = render_dropin(unit, SHA)
     assert f"/opt/extra-consultoria-releases/{SHA}/.venv/bin/python" in body
     assert f"Environment=EXTRA_DEPLOYED_SHA={SHA}" in body
+    assert "Environment=PYTHONDONTWRITEBYTECODE=1" in body
     assert "ExecStart=\n" in body, "inherited ExecStart must be cleared before appending"
     for line in body.splitlines():
         if line.startswith(("Environment=PYTHONPATH=", "ExecStart=/")):
@@ -79,6 +82,29 @@ def test_pinned_interpreter_is_isolated_from_the_working_directory():
     body = render_dropin(unit, SHA)
     exec_line = next(line for line in body.splitlines() if line.startswith("ExecStart=/"))
     assert f"/opt/extra-consultoria-releases/{SHA}/.venv/bin/python -P " in exec_line
+
+
+def test_release_cut_uses_the_exact_git_tree_and_an_isolated_import_guard():
+    source = (Path(__file__).resolve().parents[1] / "deploy" / "confenge" / "cut_release.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'git -C "$APP" archive "$SHA"' in source
+    assert 'PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$STAGING" "$STAGING/.venv/bin/python" -P -c' in source
+    assert "git checkout" not in source
+    assert "git reset" not in source
+
+
+def test_existing_release_is_reverified_before_pin():
+    source = (Path(__file__).resolve().parents[1] / "deploy" / "confenge" / "cut_release.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'find "$TARGET" -xdev \\( -type f -o -type d \\) -perm /222' in source
+    assert 'find "$TARGET" -xdev \\( ! -user root -o ! -group root \\)' in source
+    assert 'git -C "$APP" show "$SHA:$CRITICAL_PATH" | cmp -s - "$TARGET/$CRITICAL_PATH"' in source
+    assert source.index('echo "CUT_RELEASE_SKIP:') < source.index('if find "$TARGET"')
+    pin = 'PYTHONDONTWRITEBYTECODE=1 python3 -P "$TARGET/deploy/confenge/pin_release.py"'
+    assert pin in source
+    assert source.index('if find "$TARGET"') < source.index(pin)
 
 
 def test_isolation_flag_is_not_duplicated():
@@ -123,17 +149,20 @@ def test_long_running_worker_is_marked_for_reboot_persistence():
     assert "extra-confenge-target-fit-worker.service" in CHAIN_ENABLED_SERVICES
 
 
-def test_timers_are_started_not_only_enabled():
-    """`systemctl enable` alone leaves a timer unloaded until the next boot.
-
-    That is exactly how the contact-cycle and feed-cycle safety nets came to
-    report `enabled` while `systemctl list-timers` showed neither of them.
-    """
+def test_only_source_and_monitor_timers_are_scheduled():
     source = (Path(__file__).resolve().parents[1] / "deploy" / "confenge" / "pin_release.py").read_text(
         encoding="utf-8"
     )
     assert '"enable", "--now", *CHAIN_TIMERS' in source
+    assert '"disable", "--now", *CHAIN_DISABLED_TIMERS' in source
     assert '"timers_not_active"' in source, "verification must read back whether the timer is loaded"
+    assert set(CHAIN_TIMERS) == {"pncp-contracts.timer", "extra-confenge-feed-monitor.timer"}
+    assert set(CHAIN_DISABLED_TIMERS) == {
+        "extra-confenge-target-fit-reconcile.timer",
+        "extra-confenge-target-fit-refresh.timer",
+        "extra-confenge-contact-cycle.timer",
+        "extra-confenge-feed-cycle.timer",
+    }
 
 
 def test_pncp_checkpoint_dir_is_versioned_and_outside_the_release():
@@ -176,3 +205,112 @@ def test_our_own_dropin_is_not_reported_as_foreign(tmp_path, monkeypatch):
     monkeypatch.setattr(pin, "SYSTEMD_ROOT", root)
 
     assert pin.foreign_execstart_dropins() == {}
+
+
+def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_path, monkeypatch):
+    import subprocess
+
+    import deploy.confenge.pin_release as pin
+
+    release_root = tmp_path / "releases"
+    release = release_root / SHA
+    workdir = tmp_path / "writable"
+    workdir.mkdir()
+    monkeypatch.setattr(pin, "RELEASE_ROOT", release_root)
+
+    def fake_run(argv: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+        del check
+        if argv[:2] == ["systemctl", "show"]:
+            prop = argv[argv.index("-p") + 1]
+            values = {
+                "ExecStart": f"{release}/.venv/bin/python -P -m scripts.example",
+                "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1",
+                "WorkingDirectory": str(workdir),
+                "User": "extra-consultoria",
+            }
+            return subprocess.CompletedProcess(argv, 0, stdout=values[prop], stderr="")
+        if argv[:2] == ["systemctl", "is-enabled"] or argv[:2] == ["systemctl", "is-active"]:
+            is_downstream = argv[2] in CHAIN_DISABLED_TIMERS
+            if argv[1] == "is-enabled":
+                value = "disabled" if is_downstream else "enabled"
+            else:
+                value = "inactive" if is_downstream else "active"
+            return subprocess.CompletedProcess(argv, 0, stdout=value)
+        if argv[:4] == ["runuser", "-u", "extra-consultoria", "--"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(pin, "_run", fake_run)
+
+    report = verify(SHA)
+    assert report["ok"] is True
+    assert report["release_drift"] == []
+    assert report["unsafe_python_path"] == []
+    assert report["bytecode_writes_enabled"] == []
+    assert report["working_directory_drift"] == []
+    assert report["working_directory_not_writable"] == []
+    assert report["downstream_timers_scheduled"] == []
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["unsafe-python", "bytecode-enabled", "readonly-workdir", "release-workdir", "downstream-timer"],
+)
+def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, failure):
+    import subprocess
+
+    import deploy.confenge.pin_release as pin
+
+    release_root = tmp_path / "releases"
+    release = release_root / SHA
+    workdir = release if failure == "release-workdir" else tmp_path / "work"
+    monkeypatch.setattr(pin, "RELEASE_ROOT", release_root)
+
+    def fake_run(argv: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+        del check
+        if argv[:2] == ["systemctl", "show"]:
+            prop = argv[argv.index("-p") + 1]
+            values = {
+                "ExecStart": (
+                    f"{release}/.venv/bin/python -m scripts.example"
+                    if failure == "unsafe-python"
+                    else f"{release}/.venv/bin/python -P -m scripts.example"
+                ),
+                "Environment": (
+                    f"PYTHONPATH={release}"
+                    if failure == "bytecode-enabled"
+                    else f"PYTHONPATH={release} PYTHONDONTWRITEBYTECODE=1"
+                ),
+                "WorkingDirectory": str(workdir),
+                "User": "extra-consultoria",
+            }
+            return subprocess.CompletedProcess(argv, 0, stdout=values[prop], stderr="")
+        if argv[:2] == ["systemctl", "is-enabled"] or argv[:2] == ["systemctl", "is-active"]:
+            is_downstream = argv[2] in CHAIN_DISABLED_TIMERS
+            if failure == "downstream-timer" and is_downstream:
+                value = "enabled" if argv[1] == "is-enabled" else "active"
+                return subprocess.CompletedProcess(argv, 0, stdout=value)
+            if argv[1] == "is-enabled":
+                value = "disabled" if is_downstream else "enabled"
+            else:
+                value = "inactive" if is_downstream else "active"
+            return subprocess.CompletedProcess(argv, 0, stdout=value)
+        if argv[:4] == ["runuser", "-u", "extra-consultoria", "--"]:
+            code = 1 if failure == "readonly-workdir" else 0
+            return subprocess.CompletedProcess(argv, code, stdout="", stderr="")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(pin, "_run", fake_run)
+
+    report = verify(SHA)
+    assert report["ok"] is False
+    if failure == "unsafe-python":
+        assert len(report["unsafe_python_path"]) == len(CHAIN_UNITS)
+    elif failure == "bytecode-enabled":
+        assert len(report["bytecode_writes_enabled"]) == len(CHAIN_UNITS)
+    elif failure == "readonly-workdir":
+        assert len(report["working_directory_not_writable"]) == len(CHAIN_UNITS)
+    elif failure == "release-workdir":
+        assert len(report["working_directory_drift"]) == len(CHAIN_UNITS)
+    else:
+        assert len(report["downstream_timers_scheduled"]) == len(CHAIN_DISABLED_TIMERS)

--- a/tests/test_publication_readiness_and_freshness.py
+++ b/tests/test_publication_readiness_and_freshness.py
@@ -111,6 +111,27 @@ def test_publisher_accepts_complete_population():
     )
 
 
+def test_publisher_refuses_a_legacy_projection_without_publication_attestation():
+    with pytest.raises(ValueError, match="missing or invalid"):
+        _assert_publication_ready_population({})
+
+
+@pytest.mark.parametrize("ratio", [True, "1.0"])
+def test_publisher_refuses_non_numeric_coverage_attestations(ratio: object):
+    with pytest.raises(ValueError, match="missing or invalid"):
+        _assert_publication_ready_population(
+            {"population_coverage_ratio": ratio, "population_publication_ready": True}
+        )
+
+
+@pytest.mark.parametrize("ratio", [float("nan"), float("inf"), 1.001])
+def test_publisher_refuses_non_finite_or_overcomplete_coverage(ratio: float):
+    with pytest.raises(ValueError, match="not publication ready"):
+        _assert_publication_ready_population(
+            {"population_coverage_ratio": ratio, "population_publication_ready": True}
+        )
+
+
 # --- 2. freshness follows the verified reconcile, not row churn ------------
 
 
@@ -139,11 +160,17 @@ def test_missing_attestation_preserves_the_previous_fail_closed_behaviour():
     assert out["population_as_of_source"] == "target_fit_computed_at_max"
 
 
-def test_freshness_never_moves_backwards_past_observed_evidence():
+def test_fresh_row_does_not_refresh_an_older_full_population_attestation():
     newer_rows = ["2026-08-27T20:00:00+00:00"]
     out = _population_freshness(newer_rows, _snapshot(canonical=1000, materialized=1000))
-    assert out["population_as_of"] == newer_rows[-1]
-    assert out["population_as_of_source"] == "target_fit_computed_at_max"
+    assert out["population_as_of"] == VERIFIED_AT
+    assert out["population_as_of_source"] == "target_fit_full_reconcile"
+
+
+def test_timestamp_comparison_uses_instants_not_rfc3339_string_order():
+    rows = ["2026-08-27T09:30:00-03:00", "2026-08-27T12:00:00+00:00"]
+    out = _population_freshness(rows, None)
+    assert out["population_as_of"] == rows[0], "12:30Z is newer than 12:00Z"
 
 
 # --- 3. the operator always gets the factual cause -------------------------

--- a/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
+++ b/tests/warmbly_bridge/test_authoritative_target_fit_feed.py
@@ -247,6 +247,10 @@ def _export(
                     "population_count": membership["population_count"],
                     "population_hash": "f" * 64,
                     "population_as_of": NOW,
+                    "population_as_of_source": "target_fit_full_reconcile",
+                    "population_verified_at": NOW,
+                    "population_coverage_ratio": 1.0,
+                    "population_publication_ready": True,
                     "membership_schema_version": membership["schema_version"],
                     "membership_identity_key": membership["identity_key"],
                     "membership_count": membership["population_count"],
@@ -298,6 +302,42 @@ def _export(
     # The decision universe stays complete; only the TARGET_CONFIRMED membership ships.
     assert result["decision_count"] == len(universe)
     return out, _read_leads(out)
+
+
+def test_authoritative_export_rejects_partial_publication_attestation(tmp_path: Path) -> None:
+    universe = [{"cnpj14": "11222333000181", "razao_social": "ALFA ENGENHARIA", "commercial_state": "NEW"}]
+    source = tmp_path / "partial-attestation"
+    # Build the otherwise-valid fixture once, then alter only the explicit
+    # publication attestation consumed by the exporter.
+    out, _ = _export(
+        tmp_path,
+        universe=universe,
+        target_fit=[_decision("11222333000181", "TARGET_CONFIRMED", evidence_ids=["e1"])],
+        suffix="partial-attestation-seed",
+        authoritative_contact_report=True,
+    )
+    report = out.parent / "contact-projection-report.json"
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    payload.update({"population_coverage_ratio": 0.997, "population_publication_ready": False})
+    report.write_text(json.dumps(payload), encoding="utf-8")
+    source.mkdir()
+
+    with pytest.raises(InputError, match="not PUBLICATION_READY"):
+        export_outreach(
+            ExportConfig(
+                universe=out.parent / "universe.jsonl",
+                account_intelligence=out.parent / "intelligence.jsonl",
+                contacts=out.parent / "contacts.jsonl",
+                contact_projection_report=report,
+                target_fit_snapshot=out.parent / "target-fit.jsonl",
+                expected_universe_count=1,
+                out_dir=source / "feed",
+                generated_at=NOW,
+                datalake_watermark=NOW,
+                repo_sha="authoritative-test",
+                require_authoritative_contact_projection_metadata=True,
+            )
+        )
 
 
 def test_full_snapshot_decides_all_and_ships_only_confirmed_membership(tmp_path: Path) -> None:

--- a/tests/warmbly_bridge/test_target_confirmed_feed_scope.py
+++ b/tests/warmbly_bridge/test_target_confirmed_feed_scope.py
@@ -85,6 +85,7 @@ def _export(
     previous_feed_dir: Path | None = None,
     deactivations: list[dict[str, Any]] | None = None,
     max_leads_per_chunk: int = 50,
+    max_bytes_per_chunk: int = 512_000,
     watermarks: dict[str, str] | None = None,
 ) -> tuple[Path, dict[str, Any]]:
     """Export one feed from an explicit (cnpj, target_fit_class) decision list."""
@@ -120,6 +121,7 @@ def _export(
             datalake_watermark=NOW,
             repo_sha="feed-scope-test",
             max_leads_per_chunk=max_leads_per_chunk,
+            max_bytes_per_chunk=max_bytes_per_chunk,
             previous_feed_dir=previous_feed_dir,
             deactivations=deactivations,
         )
@@ -366,6 +368,23 @@ def test_member_leaving_target_confirmed_becomes_a_deactivation(tmp_path: Path) 
     assert manifest["authoritative_feed_scope"]["previous_membership_count"] == 3
 
 
+def test_representative_flip_within_the_same_root_is_not_a_deactivation(tmp_path: Path) -> None:
+    matrix = "11222333000181"
+    branch = "11222333000262"
+    first_out, _ = _export(tmp_path, [(matrix, "TARGET_CONFIRMED")], suffix="representative-before")
+    second_out, _ = _export(
+        tmp_path,
+        [(branch, "TARGET_CONFIRMED")],
+        suffix="representative-after",
+        previous_feed_dir=first_out,
+    )
+
+    manifest = _manifest(second_out)
+    assert _shipped(second_out) == [branch]
+    assert manifest["deactivations"] == []
+    assert manifest["authoritative_feed_scope"]["previous_membership_count"] == 1
+
+
 def test_still_published_account_is_never_also_deactivated(tmp_path: Path) -> None:
     cnpj = "11222333000181"
     out, _result = _export(
@@ -403,6 +422,66 @@ def test_previous_release_without_a_roster_is_recovered_from_its_chunks(tmp_path
     assert [row["cnpj14"] for row in manifest["deactivations"]] == [leaves]
 
 
+def test_legacy_chunks_collapse_branch_duplicates_deterministically(tmp_path: Path) -> None:
+    matrix = "11222333000181"
+    branch = "11222333000262"
+    first_out, _first = _export(
+        tmp_path,
+        [(matrix, "TARGET_CONFIRMED")],
+        suffix="legacy-branches-before",
+    )
+    (first_out / "membership.json").unlink()
+    chunk_path = first_out / "chunk_0000.json"
+    chunk = json.loads(chunk_path.read_text(encoding="utf-8"))
+    duplicate = json.loads(json.dumps(chunk["leads"][0]))
+    duplicate["company"]["cnpj14"] = branch
+    duplicate["company"]["cnpj_root"] = branch[:8]
+    chunk["leads"].append(duplicate)
+    raw = (json.dumps(chunk, ensure_ascii=False, indent=2, sort_keys=True, default=str) + "\n").encode("utf-8")
+    chunk_path.write_bytes(raw)
+    manifest_path = first_out / "manifest.json"
+    legacy_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    legacy_manifest["chunks"][0]["content_hash"] = hashlib.sha256(raw).hexdigest()
+    manifest_path.write_text(json.dumps(legacy_manifest), encoding="utf-8")
+
+    next_out, _next = _export(
+        tmp_path,
+        [("22333444000172", "TARGET_CONFIRMED")],
+        suffix="legacy-branches-after",
+        previous_feed_dir=first_out,
+    )
+
+    manifest = _manifest(next_out)
+    assert manifest["authoritative_feed_scope"]["previous_membership_count"] == 1
+    drop = next(row for row in manifest["deactivations"] if "TARGET_CONFIRMED_MEMBERSHIP_DROPPED" in row["reason_codes"])
+    assert drop["cnpj14"] == min(matrix, branch)
+
+
+@pytest.mark.parametrize("tamper", ["hash", "duplicate-root"])
+def test_previous_roster_must_reproduce_hash_and_unique_roots(tmp_path: Path, tamper: str) -> None:
+    first_out, _ = _export(
+        tmp_path,
+        [("11222333000181", "TARGET_CONFIRMED")],
+        suffix=f"roster-{tamper}-before",
+    )
+    roster_path = first_out / "membership.json"
+    roster = json.loads(roster_path.read_text(encoding="utf-8"))
+    if tamper == "hash":
+        roster["membership_hash"] = "0" * 64
+    else:
+        roster["members"].append({"cnpj14": "11222333000262", "cnpj_root": "11222333"})
+        roster["population_count"] = 2
+    roster_path.write_text(json.dumps(roster), encoding="utf-8")
+
+    with pytest.raises(InputError, match="reproducible|repeats cnpj_root8"):
+        _export(
+            tmp_path,
+            [("11222333000181", "TARGET_CONFIRMED")],
+            suffix=f"roster-{tamper}-after",
+            previous_feed_dir=first_out,
+        )
+
+
 def test_declared_previous_feed_without_a_feed_fails_closed(tmp_path: Path) -> None:
     empty = tmp_path / "empty-release"
     empty.mkdir()
@@ -428,6 +507,30 @@ def test_consumer_ceilings_never_truncate() -> None:
         _assert_consumer_ceilings(lead_count=CONSUMER_MAX_LEADS + 1, chunk_count=1)
     with pytest.raises(InputError, match="exceeds the consumer chunk ceiling"):
         _assert_consumer_ceilings(lead_count=1, chunk_count=CONSUMER_MAX_CHUNKS + 1)
+
+
+def test_single_oversized_lead_is_refused_instead_of_exceeding_chunk_bytes(tmp_path: Path) -> None:
+    with pytest.raises(InputError, match="single TARGET_CONFIRMED lead exceeds|encoded outreach chunk exceeds"):
+        _export(
+            tmp_path,
+            [("11222333000181", "TARGET_CONFIRMED")],
+            suffix="oversized-single",
+            max_bytes_per_chunk=1024,
+        )
+
+
+def test_reported_chunk_bytes_equal_the_files(tmp_path: Path) -> None:
+    out, result = _export(
+        tmp_path,
+        [("11222333000181", "TARGET_CONFIRMED"), ("22333444000172", "TARGET_CONFIRMED")],
+        suffix="derived-bytes",
+        max_leads_per_chunk=1,
+    )
+    manifest = _manifest(out)
+    actual = {path.name: path.stat().st_size for path in sorted(out.glob("chunk_*.json"))}
+    assert manifest["total_chunk_bytes"] == result["total_chunk_bytes"] == sum(actual.values())
+    assert {chunk["file"]: chunk["byte_count"] for chunk in manifest["chunks"]} == actual
+    assert all(size <= manifest["max_bytes_per_chunk"] for size in actual.values())
 
 
 def test_membership_hash_must_be_reproducible_from_the_shipped_leads(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

Closes the producer/release gaps audited under #468 while preserving fail-closed source freshness.

- requires exact PUBLICATION_READY coverage and binds population_as_of to a valid full reconcile
- publishes exactly TARGET_CONFIRMED root membership while retaining full decision-universe accounting
- proves membership hash, root uniqueness, deactivation closure, replay semantics, byte ceilings, and atomic last-known-good preservation
- hardens exact-SHA release cut/pin with clean git archive, read-only/root-owned verification, Python safe path, bytecode suppression, writable external WorkingDirectory, and no independent downstream timers
- adds sanitized contemporary live evidence without raw feed, secrets, or PII

## Verification

- impacted regression: 179 passed
- release/pin tests: 25 passed
- ruff: pass
- shellcheck: pass
- systemd validation: pass
- generated-artifacts policy: pass
- PR reviewability policy: pass

## Live status

Producer candidate: GO:PRODUCER_FEED

Live: DEGRADED:SOURCE_STALE

Blocker: PNCP_CONTRACT_FRESHNESS/1.0:STALE:UNCLOSED_CURRENT_WINDOW,WINDOW_INCOMPLETE,LAG_ABOVE_HARD_GUARDRAIL

The live gate exited 2 and did not start downstream stages. The prior current feed and Warmbly authority were preserved. No SMTP/provider mutation was performed.

Refs #468.