### PR TITLE
fix(source): enforce PNCP maintenance liveness

### DIFF
--- a/deploy/systemd/extra-confenge-target-fit-reconcile.service
+++ b/deploy/systemd/extra-confenge-target-fit-reconcile.service
@@ -16,7 +16,7 @@ Environment=TARGET_FIT_ASYNC_MODE=SHADOW
 Environment=TARGET_FIT_EXPORT_DB=1
 EnvironmentFile=-/opt/extra-consultoria/.env
 EnvironmentFile=-/etc/extra-cli/extra-collector.env
-ExecStart=/usr/bin/flock --nonblock /run/lock/extra-confenge-target-fit-reconcile.lock \
+ExecStart=/usr/bin/flock --verbose --nonblock /run/lock/extra-confenge-target-fit-reconcile.lock \
   /opt/extra-consultoria/.venv/bin/python -m scripts.confenge_target_fit reconcile
 Nice=15
 TimeoutStartSec=6h

--- a/deploy/systemd/extra-confenge-target-fit-reconcile.timer
+++ b/deploy/systemd/extra-confenge-target-fit-reconcile.timer
@@ -1,6 +1,9 @@
 [Unit]
 Description=Timer — CONFENGE target-fit daily reconciliation
-Documentation=file:/opt/extra-cli/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
+Documentation=file:/opt/extra-consultoria/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
+# extra-cli source/target maintenance timer.
+# Never couple this timer lifecycle to its oneshot. A failed reconcile must
+# leave the next daily safety-net trigger scheduled.
 
 [Timer]
 OnCalendar=*-*-* 05:15:00

--- a/deploy/systemd/extra-confenge-target-fit-refresh.service
+++ b/deploy/systemd/extra-confenge-target-fit-refresh.service
@@ -3,6 +3,7 @@ Description=Extra Consultoria — CONFENGE target-fit CDC refresh (fast path)
 Documentation=file:/opt/extra-consultoria/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
 After=network-online.target postgresql.service
 Wants=network-online.target
+OnFailure=extra-onfailure@%n.service
 # Async consumer of datalake: never hard-fail ETL on target-fit.
 
 [Service]
@@ -17,7 +18,7 @@ Environment=TARGET_FIT_BATCH_SIZE=50
 Environment=TARGET_FIT_WORKERS=1
 EnvironmentFile=-/opt/extra-consultoria/.env
 EnvironmentFile=-/etc/extra-cli/extra-collector.env
-ExecStart=/usr/bin/flock --nonblock /run/lock/extra-confenge-target-fit-refresh.lock \
+ExecStart=/usr/bin/flock --verbose --nonblock /run/lock/extra-confenge-target-fit-refresh.lock \
   /opt/extra-consultoria/.venv/bin/python -m scripts.confenge_target_fit refresh --max-batches 5
 Nice=15
 IOSchedulingClass=best-effort

--- a/deploy/systemd/extra-confenge-target-fit-refresh.timer
+++ b/deploy/systemd/extra-confenge-target-fit-refresh.timer
@@ -1,6 +1,9 @@
 [Unit]
 Description=Timer — CONFENGE target-fit CDC refresh (safety net)
-Documentation=file:/opt/extra-cli/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
+Documentation=file:/opt/extra-consultoria/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
+# extra-cli source/target maintenance timer.
+# Never couple this timer lifecycle to its oneshot. A failed refresh must leave
+# the next safety-net trigger scheduled.
 
 [Timer]
 # Safety net every 30 minutes; prefer datalake completion trigger when wired.

--- a/deploy/systemd/extra-confenge-target-fit-worker.service
+++ b/deploy/systemd/extra-confenge-target-fit-worker.service
@@ -3,6 +3,7 @@ Description=Extra Consultoria — CONFENGE target-fit worker (long-running)
 Documentation=file:/opt/extra-consultoria/docs/confenge/TARGET-FIT-CONTINUOUS-REFRESH.md
 After=network-online.target postgresql.service
 Wants=network-online.target
+OnFailure=extra-onfailure@%n.service
 # Stop restarting a worker that cannot start cleanly. Without a start limit a
 # crash-looping worker retries every RestartSec forever and keeps re-poisoning
 # the shared DataLake cluster. 4 failures inside 15 min -> unit enters `failed`

--- a/deploy/systemd/extra-health-check.service
+++ b/deploy/systemd/extra-health-check.service
@@ -17,7 +17,9 @@ Environment=PYTHONPATH=/opt/extra-consultoria
 EnvironmentFile=/opt/extra-consultoria/.env
 # One wrapper always runs both independent checks. Never chain ExecStart lines:
 # a failed infrastructure check must not suppress the freshness artifact.
-ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.ops.health_bundle --freshness-output /var/lib/extra-consultoria/output/pncp-contract-freshness.json
+ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.ops.health_bundle \
+  --freshness-output /var/lib/extra-consultoria/output/pncp-contract-freshness.json \
+  --maintenance-output /var/lib/extra-consultoria/output/source-maintenance-health.json
 User=extra-consultoria
 Group=extra-consultoria
 TimeoutStartSec=5min

--- a/deploy/systemd/extra-health-check.timer
+++ b/deploy/systemd/extra-health-check.timer
@@ -8,7 +8,7 @@ Description=Extra Consultoria — Health Check Timer
 [Timer]
 OnCalendar=*:0/30:00
 RandomizedDelaySec=60
-Persistent=false
+Persistent=true
 
 [Install]
 WantedBy=timers.target

--- a/scripts/confenge_target_fit/status.py
+++ b/scripts/confenge_target_fit/status.py
@@ -37,6 +37,23 @@ from scripts.confenge_target_fit.store import (
 )
 
 
+def dirty_progress_stale(oldest_age_seconds: float | None, *, slo_minutes: int) -> bool:
+    """A dirty queue crossing its configured SLO is already degraded."""
+    return bool(
+        oldest_age_seconds is not None
+        and oldest_age_seconds > max(0, int(slo_minutes)) * 60
+    )
+
+
+def target_fit_progress_watermark(
+    *,
+    control_watermark: object,
+    materialized_watermark: object,
+) -> str:
+    """Resolve only watermarks proven by target-fit, never the CDC cursor."""
+    return str(control_watermark or materialized_watermark or "")
+
+
 def build_health(
     dsn: str,
     *,
@@ -57,10 +74,9 @@ def build_health(
         dl_ts = datalake_max_ingested_at(conn)
         dl_wm = watermark_str(dl_ts) or str(cdc.get("watermark") or "")
         tf_ctrl = get_control(conn, "target_fit_watermark")
-        tf_wm = (
-            str(tf_ctrl.get("watermark") or "")
-            or max_current_watermark(conn)
-            or str(cdc.get("watermark") or "")
+        tf_wm = target_fit_progress_watermark(
+            control_watermark=tf_ctrl.get("watermark"),
+            materialized_watermark=max_current_watermark(conn),
         )
 
         lag: float | None = None
@@ -103,7 +119,7 @@ def build_health(
             status = HEALTH_FAILED
         elif lag is not None and lag > cfg.max_watermark_lag_seconds:
             status = HEALTH_STALE
-        elif oldest is not None and oldest > cfg.reclass_slo_minutes * 60 * 2:
+        elif dirty_progress_stale(oldest, slo_minutes=cfg.reclass_slo_minutes):
             status = HEALTH_DEGRADED
         elif dirty > cfg.cdc_max_companies_per_cycle:
             status = HEALTH_DEGRADED

--- a/scripts/confenge_target_fit/store.py
+++ b/scripts/confenge_target_fit/store.py
@@ -858,9 +858,11 @@ def _is_iso_watermark(value: str) -> bool:
 
 
 def max_current_watermark(conn: Any) -> str:
-    """Best parseable watermark from materialization tables + control plane.
+    """Best parseable watermark proven by target-fit materialization/progress.
 
-    Ignores synthetic test watermarks (e.g. ``wm-b``) so status lag stays meaningful.
+    The CDC watermark is intentionally excluded. CDC proves refresh/enqueue
+    progress, not worker/materialization progress; treating it as target-fit's
+    watermark can report zero lag while the worker is stopped.
     """
     candidates: list[tuple[datetime, str]] = []
     with conn.cursor() as cur:
@@ -889,27 +891,6 @@ def max_current_watermark(conn: Any) -> str:
                     candidates.append((ts, wm))
             except Exception:  # noqa: BLE001, S110 — table may not exist mid-migration
                 pass
-        # Control plane CDC watermark
-        cur.execute(
-            "SELECT value FROM confenge_target_fit_control WHERE key = 'cdc_watermark'"
-        )
-        row = cur.fetchone()
-        if row:
-            val = row["value"]
-            if isinstance(val, str):
-                import json as _json
-
-                try:
-                    val = _json.loads(val)
-                except Exception:  # noqa: BLE001
-                    val = {}
-            wm = str((val or {}).get("watermark") or "")
-            if _is_iso_watermark(wm):
-                try:
-                    ts = datetime.fromisoformat(wm.replace("Z", "+00:00"))
-                    candidates.append((ts, wm))
-                except ValueError:
-                    pass
         # Explicit target-fit progress watermark (written by worker)
         cur.execute(
             "SELECT value FROM confenge_target_fit_control WHERE key = 'target_fit_watermark'"

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -140,7 +140,7 @@ def classify_incident_error_text(message: str) -> dict[str, Any]:
             "transience": "transient",
             "owner": "pncp",
         }
-    if "timeout" in text or "rate_limit" in text or "http_server_error" in text:
+    if error_indicates_timeout(text) or "rate_limit" in text or "http_server_error" in text:
         return {"class": "transient", "transience": "transient", "owner": "transport_or_pncp"}
     if (
         "upsert failed" in text
@@ -152,6 +152,12 @@ def classify_incident_error_text(message: str) -> dict[str, Any]:
     if "http_client_error" in text:
         return {"class": "permanent", "transience": "permanent", "owner": "request_contract"}
     return {"class": "permanent", "transience": "unknown", "owner": "unknown"}
+
+
+def error_indicates_timeout(message: str) -> bool:
+    """Recognize the typed status and real urllib timeout spellings."""
+    text = str(message or "").lower()
+    return any(token in text for token in ("timeout", "timed out", "connection_failed"))
 
 
 def should_replay_mutable_window(
@@ -1267,7 +1273,7 @@ def run_pilot(
 
             pagination.mark_first_pass_complete()
             persist_failed = any("upsert failed" in err for err in window_errors)
-            timed_out = any("timeout" in err.lower() or "CONNECTION_FAILED" in err for err in window_errors)
+            timed_out = any(error_indicates_timeout(err) for err in window_errors)
             first_pass = pagination.finish(
                 pass_count=1,
                 timeout=timed_out,

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -135,10 +135,16 @@ def check_system() -> tuple[bool, str]:
 
 CRITICAL_TIMERS = (
     "pncp-contracts.timer",
+    "extra-confenge-target-fit-refresh.timer",
+    "extra-confenge-target-fit-reconcile.timer",
     "extra-crawl-pncp.timer",
     "extra-crawl-ciga-ckan.timer",
     "extra-health-check.timer",
     "extra-contracts-soak.timer",
+)
+
+CRITICAL_SERVICES = (
+    "extra-confenge-target-fit-worker.service",
 )
 
 CRITICAL_UNIT_TOKENS = (
@@ -195,6 +201,34 @@ def check_critical_timers() -> tuple[bool, str]:
     if bad:
         return False, "; ".join(bad[:5])
     return True, f"critical timers OK ({len(CRITICAL_TIMERS)})"
+
+
+def check_critical_services() -> tuple[bool, str]:
+    """Require long-running maintenance workers enabled + active."""
+    bad: list[str] = []
+    for unit in CRITICAL_SERVICES:
+        try:
+            en = subprocess.run(  # noqa: S603
+                ["systemctl", "is-enabled", unit],  # noqa: S607
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            ac = subprocess.run(  # noqa: S603
+                ["systemctl", "is-active", unit],  # noqa: S607
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            en_s = (en.stdout or "").strip()
+            ac_s = (ac.stdout or "").strip()
+            if en_s != "enabled" or ac_s != "active":
+                bad.append(f"{unit}:enabled={en_s}:active={ac_s}")
+        except Exception as exc:  # noqa: BLE001 - health reports every unit
+            bad.append(f"{unit}:err={type(exc).__name__}:{exc}")
+    if bad:
+        return False, "; ".join(bad)
+    return True, f"critical services OK ({len(CRITICAL_SERVICES)})"
 
 
 def validate_dual_coverage_summary(data: dict) -> tuple[bool, str]:
@@ -307,6 +341,14 @@ def main() -> int:
     tm_ok, tm_msg = check_critical_timers()
     results["critical_timers"] = {"status": "pass" if tm_ok else "fail", "message": tm_msg}
     if not tm_ok:
+        exit_code = 2
+
+    svc_ok, svc_msg = check_critical_services()
+    results["critical_services"] = {
+        "status": "pass" if svc_ok else "fail",
+        "message": svc_msg,
+    }
+    if not svc_ok:
         exit_code = 2
 
     dual_ok, dual_msg = check_dual_coverage_artifact()

--- a/scripts/ops/health_bundle.py
+++ b/scripts/ops/health_bundle.py
@@ -22,9 +22,9 @@ def _run_check(name: str, fn: Callable[[], int]) -> dict[str, object]:
         return {"name": name, "exit_code": 2, "status": "error", "error": f"{type(exc).__name__}: {exc}"}
 
 
-def run_bundle(*, freshness_output: Path) -> dict[str, object]:
+def run_bundle(*, freshness_output: Path, maintenance_output: Path) -> dict[str, object]:
     from scripts import health_check
-    from scripts.ops import pncp_contract_freshness
+    from scripts.ops import pncp_contract_freshness, source_maintenance_health
 
     checks = [
         _run_check("infrastructure", health_check.main),
@@ -32,6 +32,12 @@ def run_bundle(*, freshness_output: Path) -> dict[str, object]:
             "pncp_contract_freshness",
             lambda: pncp_contract_freshness.main(
                 ["--live", "--health", "--output", str(freshness_output)]
+            ),
+        ),
+        _run_check(
+            "source_maintenance",
+            lambda: source_maintenance_health.main(
+                ["--health", "--output", str(maintenance_output)]
             ),
         ),
     ]
@@ -52,8 +58,16 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=Path("output/ops/pncp-contract-freshness.json"),
     )
+    parser.add_argument(
+        "--maintenance-output",
+        type=Path,
+        default=Path("output/ops/source-maintenance-health.json"),
+    )
     args = parser.parse_args(argv)
-    report = run_bundle(freshness_output=args.freshness_output)
+    report = run_bundle(
+        freshness_output=args.freshness_output,
+        maintenance_output=args.maintenance_output,
+    )
     print(json.dumps(report, ensure_ascii=False, default=str))
     return int(report["exit_code"])
 

--- a/scripts/ops/source_maintenance_health.py
+++ b/scripts/ops/source_maintenance_health.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Fail-closed readback for PNCP and target-fit maintenance.
+
+The source freshness contract proves whether PNCP produced a newly closed
+window.  This module proves the independent maintenance plane is still alive:
+timers remain loaded/enabled/active, the long-running worker remains enabled
+and active, and worker/refresh/reconcile cycles keep recording successful
+progress inside their operational windows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+CONTRACT_VERSION = "SOURCE_MAINTENANCE_HEALTH/1.0"
+
+PNCP_TIMER = "pncp-contracts.timer"
+PNCP_SERVICE = "pncp-contracts.service"
+SOURCE_FRESHNESS_SERVICE = "extra-confenge-source-freshness-gate.service"
+TARGET_FIT_WORKER = "extra-confenge-target-fit-worker.service"
+TARGET_FIT_REFRESH_TIMER = "extra-confenge-target-fit-refresh.timer"
+TARGET_FIT_REFRESH_SERVICE = "extra-confenge-target-fit-refresh.service"
+TARGET_FIT_RECONCILE_TIMER = "extra-confenge-target-fit-reconcile.timer"
+TARGET_FIT_RECONCILE_SERVICE = "extra-confenge-target-fit-reconcile.service"
+HEALTH_TIMER = "extra-health-check.timer"
+
+TIMER_TO_SERVICE = {
+    PNCP_TIMER: PNCP_SERVICE,
+    TARGET_FIT_REFRESH_TIMER: TARGET_FIT_REFRESH_SERVICE,
+    TARGET_FIT_RECONCILE_TIMER: TARGET_FIT_RECONCILE_SERVICE,
+    HEALTH_TIMER: "extra-health-check.service",
+}
+READBACK_UNITS = tuple(
+    dict.fromkeys(
+        [
+            *TIMER_TO_SERVICE,
+            *TIMER_TO_SERVICE.values(),
+            SOURCE_FRESHNESS_SERVICE,
+            TARGET_FIT_WORKER,
+        ]
+    )
+)
+
+# The limits include each timer's RandomizedDelaySec and the service runtime
+# budget.  They are liveness contracts, not business/freshness thresholds.
+def progress_max_age_seconds() -> dict[str, int]:
+    """Resolve liveness windows from the shipped operational contracts."""
+    from scripts.confenge_target_fit.config import TargetFitRefreshConfig
+
+    cfg = TargetFitRefreshConfig.from_env()
+    return {
+        "worker": int(cfg.reclass_slo_minutes) * 60,
+        "refresh": 90 * 60,
+        "reconcile": 31 * 60 * 60,
+    }
+
+EXPECTED_ON_SUCCESS = {
+    PNCP_SERVICE: SOURCE_FRESHNESS_SERVICE,
+    SOURCE_FRESHNESS_SERVICE: TARGET_FIT_RECONCILE_SERVICE,
+}
+
+SYSTEMD_PROPERTIES = (
+    "LoadState",
+    "UnitFileState",
+    "ActiveState",
+    "SubState",
+    "Result",
+    "ExecMainStatus",
+    "ExecMainStartTimestamp",
+    "ExecMainExitTimestamp",
+    "LastTriggerUSec",
+    "NextElapseUSecRealtime",
+    "Persistent",
+    "OnSuccess",
+    "Requires",
+    "Requisite",
+    "BindsTo",
+    "PartOf",
+    "Conflicts",
+    "PropagatesStopTo",
+    "StopWhenUnneeded",
+    "FragmentPath",
+)
+
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?i)\b(password|passwd|token|secret|api[_-]?key)\s*[:=]\s*[^\s,;]+"
+)
+_DSN_USERINFO = re.compile(r"(?i)\b(postgres(?:ql)?://)[^@\s]+@")
+
+
+def sanitize_error(value: object, *, limit: int = 500) -> str:
+    """Keep the factual cause while removing common secret-bearing forms."""
+    text = " ".join(str(value or "").split())
+    text = _DSN_USERINFO.sub(r"\1[REDACTED]@", text)
+    text = _SECRET_ASSIGNMENT.sub(lambda m: f"{m.group(1)}=[REDACTED]", text)
+    return text[:limit]
+
+
+def parse_timestamp(value: object) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw or raw.lower() in {"n/a", "never", "0"}:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            parsed = datetime.strptime(raw, "%a %Y-%m-%d %H:%M:%S %z")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _systemctl_show(
+    unit: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> dict[str, str]:
+    command = [
+        "systemctl",
+        "show",
+        unit,
+        "--no-pager",
+        f"--property={','.join(SYSTEMD_PROPERTIES)}",
+    ]
+    try:
+        completed = runner(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - readback must preserve sibling checks
+        return {"LoadState": "error", "Error": sanitize_error(f"{type(exc).__name__}: {exc}")}
+    payload: dict[str, str] = {}
+    for line in (completed.stdout or "").splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            payload[key] = value
+    if completed.returncode != 0:
+        payload.setdefault("LoadState", "error")
+        payload["Error"] = sanitize_error(completed.stderr or f"systemctl exit {completed.returncode}")
+    return payload
+
+
+def collect_unit_readback(
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> dict[str, dict[str, str]]:
+    return {unit: _systemctl_show(unit, runner=runner) for unit in READBACK_UNITS}
+
+
+def _connect(dsn: str) -> Any:
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    return psycopg2.connect(dsn, cursor_factory=RealDictCursor)
+
+
+def collect_progress(
+    *,
+    dsn: str | None = None,
+    connect: Callable[[str], Any] | None = None,
+) -> dict[str, dict[str, Any]]:
+    effective = (dsn or os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL") or "").strip()
+    if not effective:
+        return {"_error": {"code": "NO_DSN", "message": "state DSN is not configured"}}
+    conn = None
+    try:
+        conn = (connect or _connect)(effective)
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT kinds.cycle_kind,
+                       latest.started_at AS latest_started_at,
+                       latest.finished_at AS latest_finished_at,
+                       latest.status AS latest_status,
+                       latest.error_message AS latest_error_message,
+                       latest.cycle_id AS latest_cycle_id,
+                       successful.last_success_at
+                FROM (VALUES ('worker'), ('refresh'), ('reconcile')) AS kinds(cycle_kind)
+                LEFT JOIN LATERAL (
+                    SELECT started_at, finished_at, status, error_message, cycle_id
+                    FROM confenge_target_fit_cycle_meta
+                    WHERE cycle_kind = kinds.cycle_kind
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                ) AS latest ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT finished_at AS last_success_at
+                    FROM confenge_target_fit_cycle_meta
+                    WHERE cycle_kind = kinds.cycle_kind
+                      AND status = 'success'
+                      AND finished_at IS NOT NULL
+                    ORDER BY started_at DESC
+                    LIMIT 1
+                ) AS successful ON TRUE
+                """
+            )
+            rows = list(cur.fetchall() or [])
+        return {
+            str(row["cycle_kind"]): {
+                "last_success_at": (
+                    row["last_success_at"].isoformat()
+                    if hasattr(row.get("last_success_at"), "isoformat")
+                    else row.get("last_success_at")
+                ),
+                "latest_attempt": {
+                    "started_at": (
+                        row["latest_started_at"].isoformat()
+                        if hasattr(row.get("latest_started_at"), "isoformat")
+                        else row.get("latest_started_at")
+                    ),
+                    "finished_at": (
+                        row["latest_finished_at"].isoformat()
+                        if hasattr(row.get("latest_finished_at"), "isoformat")
+                        else row.get("latest_finished_at")
+                    ),
+                    "status": row.get("latest_status"),
+                    "cycle_id": row.get("latest_cycle_id"),
+                    "error": sanitize_error(row.get("latest_error_message")),
+                },
+            }
+            for row in rows
+        }
+    except Exception as exc:  # noqa: BLE001 - structured diagnostic, never blank exit
+        return {
+            "_error": {
+                "code": type(exc).__name__.upper(),
+                "message": sanitize_error(f"{type(exc).__name__}: {exc}"),
+            }
+        }
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def _git_sha(repo_root: Path) -> str | None:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    try:
+        completed = subprocess.run(  # noqa: S603 - shell is not used
+            ["git", "rev-parse", "HEAD"],  # noqa: S607 - canonical local executable
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    return completed.stdout.strip() if completed.returncode == 0 else None
+
+
+def collect_release_identity(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    env_sha = (os.getenv("EXTRA_DEPLOYED_SHA") or os.getenv("GIT_SHA") or "").strip()
+    marker = root / ".deployed_sha"
+    marker_sha = marker.read_text(encoding="utf-8").strip() if marker.is_file() else ""
+    checkout_sha = _git_sha(root) or ""
+    effective = env_sha or marker_sha or checkout_sha
+    observed = {value for value in (env_sha, marker_sha, checkout_sha) if value}
+    return {
+        "effective_sha": effective or None,
+        "env_sha": env_sha or None,
+        "marker_sha": marker_sha or None,
+        "checkout_sha": checkout_sha or None,
+        "consistent": len(observed) <= 1,
+    }
+
+
+def deployed_sha(repo_root: Path | None = None) -> str | None:
+    """Compatibility helper for callers that only need the effective SHA."""
+    return collect_release_identity(repo_root).get("effective_sha")
+
+
+def collect_snapshot(
+    *,
+    now: datetime | None = None,
+    dsn: str | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    connect: Callable[[str], Any] | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    observed_at = (now or datetime.now(UTC)).astimezone(UTC)
+    release = collect_release_identity(repo_root)
+    return {
+        "as_of": observed_at.isoformat().replace("+00:00", "Z"),
+        "release_sha": release.get("effective_sha"),
+        "release_identity": release,
+        "units": collect_unit_readback(runner=runner),
+        "progress": collect_progress(dsn=dsn, connect=connect),
+        "progress_max_age_seconds": progress_max_age_seconds(),
+    }
+
+
+def _words(value: object) -> set[str]:
+    return {part for part in str(value or "").split() if part}
+
+
+def build_contract(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    as_of = parse_timestamp(snapshot.get("as_of")) or datetime.now(UTC)
+    units = {str(k): dict(v) for k, v in dict(snapshot.get("units") or {}).items()}
+    progress = {str(k): dict(v) for k, v in dict(snapshot.get("progress") or {}).items()}
+    reasons: list[str] = []
+
+    for service in set(TIMER_TO_SERVICE.values()) | {
+        SOURCE_FRESHNESS_SERVICE,
+        TARGET_FIT_WORKER,
+    }:
+        if units.get(service, {}).get("LoadState") != "loaded":
+            reasons.append(
+                f"{service.upper().replace('-', '_').replace('.', '_')}_NOT_LOADED"
+            )
+
+    for timer, triggered_service in TIMER_TO_SERVICE.items():
+        state = units.get(timer, {})
+        prefix = timer.upper().replace("-", "_").replace(".", "_")
+        if state.get("LoadState") != "loaded":
+            reasons.append(f"{prefix}_NOT_LOADED")
+        if state.get("UnitFileState") != "enabled":
+            reasons.append(f"{prefix}_NOT_ENABLED")
+        if state.get("ActiveState") != "active":
+            reasons.append(f"{prefix}_NOT_ACTIVE")
+        triggered = units.get(triggered_service, {})
+        timer_is_running_job = (
+            state.get("SubState") == "running"
+            and triggered.get("ActiveState") in {"active", "activating"}
+        )
+        if not state.get("NextElapseUSecRealtime") and not timer_is_running_job:
+            reasons.append(f"{prefix}_NO_NEXT_TRIGGER")
+        if str(state.get("Persistent") or "").lower() not in {"yes", "true", "1"}:
+            reasons.append(f"{prefix}_NOT_PERSISTENT")
+        for relationship in (
+            "Requires",
+            "Requisite",
+            "BindsTo",
+            "PartOf",
+            "Conflicts",
+            "PropagatesStopTo",
+        ):
+            if triggered_service in _words(state.get(relationship)):
+                reasons.append(f"{prefix}_LIFECYCLE_COUPLED_{relationship.upper()}")
+        if str(state.get("StopWhenUnneeded") or "").lower() in {"yes", "true", "1"}:
+            reasons.append(f"{prefix}_STOP_WHEN_UNNEEDED")
+
+    worker = units.get(TARGET_FIT_WORKER, {})
+    if worker.get("LoadState") != "loaded":
+        reasons.append("TARGET_FIT_WORKER_NOT_LOADED")
+    if worker.get("UnitFileState") != "enabled":
+        reasons.append("TARGET_FIT_WORKER_NOT_ENABLED")
+    if worker.get("ActiveState") != "active":
+        reasons.append("TARGET_FIT_WORKER_NOT_ACTIVE")
+
+    for source, expected in EXPECTED_ON_SUCCESS.items():
+        if _words(units.get(source, {}).get("OnSuccess")) != {expected}:
+            reasons.append(
+                f"{source.upper().replace('-', '_').replace('.', '_')}_ONSUCCESS_NOT_EXACT"
+            )
+
+    progress_error = progress.get("_error")
+    if progress_error:
+        reasons.append(f"PROGRESS_READ_FAILED_{progress_error.get('code') or 'UNKNOWN'}")
+    progress_readback: dict[str, Any] = {}
+    resolved_limits = {
+        str(key): int(value)
+        for key, value in dict(
+            snapshot.get("progress_max_age_seconds") or progress_max_age_seconds()
+        ).items()
+    }
+    for cycle_kind, max_age in resolved_limits.items():
+        item = progress.get(cycle_kind, {})
+        finished = parse_timestamp(item.get("last_success_at"))
+        age = (as_of - finished).total_seconds() if finished else None
+        latest_attempt = dict(item.get("latest_attempt") or {})
+        progress_readback[cycle_kind] = {
+            **item,
+            "age_seconds": age,
+            "max_age_seconds": max_age,
+        }
+        if finished is None:
+            reasons.append(f"TARGET_FIT_{cycle_kind.upper()}_NO_PROGRESS")
+        elif age is not None and (age < -300 or age > max_age):
+            reasons.append(f"TARGET_FIT_{cycle_kind.upper()}_PROGRESS_STALE")
+        latest_status = str(latest_attempt.get("status") or "").lower()
+        if latest_status and latest_status not in {"success", "running"}:
+            reasons.append(
+                f"TARGET_FIT_{cycle_kind.upper()}_LAST_CYCLE_{latest_status.upper()}"
+            )
+
+    release_identity = dict(snapshot.get("release_identity") or {})
+    release_sha = str(
+        release_identity.get("effective_sha") or snapshot.get("release_sha") or ""
+    ).strip()
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", release_sha):
+        reasons.append("RELEASE_SHA_UNPROVEN")
+    observed_shas = {
+        str(release_identity.get(field) or "").strip()
+        for field in ("env_sha", "marker_sha", "checkout_sha")
+        if release_identity.get(field)
+    }
+    if len(observed_shas) > 1 or release_identity.get("consistent") is False:
+        reasons.append("RELEASE_SHA_DRIFT")
+
+    deduped_reasons = list(dict.fromkeys(reasons))
+    status = "HEALTHY" if not deduped_reasons else "UNHEALTHY"
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "as_of": as_of.isoformat().replace("+00:00", "Z"),
+        "status": status,
+        "health_exit": 0 if status == "HEALTHY" else 2,
+        "reason_codes": deduped_reasons,
+        "release_sha": release_sha or None,
+        "release_identity": release_identity or {"effective_sha": release_sha or None},
+        "units": units,
+        "progress": progress_readback,
+        "progress_error": progress_error,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-snapshot", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--health", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.from_snapshot:
+        snapshot = json.loads(args.from_snapshot.read_text(encoding="utf-8"))
+    else:
+        snapshot = collect_snapshot()
+    contract = build_contract(snapshot)
+    rendered = json.dumps(contract, ensure_ascii=False, indent=2, default=str)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        print(rendered)
+    return int(contract["health_exit"]) if args.health else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_incident_458.py
+++ b/tests/test_incident_458.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import sys
@@ -19,6 +20,7 @@ from scripts.crawl.run_contracts_90d_pilot import (
     _fetch_page_with_retry,
     classify_incident_error_text,
     closed_crawl_range,
+    error_indicates_timeout,
     should_replay_mutable_window,
 )
 
@@ -121,6 +123,83 @@ def test_retry_is_bounded_with_backoff_jitter_and_telemetry(monkeypatch) -> None
     assert telemetry[0]["classification"]["class"] == "transient"
 
 
+def test_real_timeout_502_503_use_one_bounded_retry_budget(monkeypatch) -> None:
+    from scripts.crawl import contracts_crawler
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self) -> bytes:
+            return b'{"data": [{"numeroControlePNCP": "stable"}], "totalRegistros": 1, "totalPaginas": 1}'
+
+    outcomes = iter(
+        (
+            TimeoutError("timed out"),
+            urllib.error.HTTPError(
+                "https://example.invalid",
+                502,
+                "bad gateway",
+                None,
+                io.BytesIO(b"bad gateway"),
+            ),
+            urllib.error.HTTPError(
+                "https://example.invalid",
+                503,
+                "unavailable",
+                None,
+                io.BytesIO(b"unavailable"),
+            ),
+            Response(),
+        )
+    )
+
+    def fake_open(_request, **_kwargs):
+        outcome = next(outcomes)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_open)
+    monkeypatch.setattr(contracts_crawler, "CONTRACTS_READ_TIMEOUT", 60)
+    sleeps: list[float] = []
+    telemetry: list[dict] = []
+    result = _fetch_page_with_retry(
+        "20260815",
+        "20260821",
+        1,
+        max_retries=3,
+        telemetry=telemetry,
+        sleeper=sleeps.append,
+        jitter=lambda _a, _b: 0,
+    )
+
+    assert result.status == FetchStatus.SUCCESS_DATA
+    assert sleeps == [1.0, 2.0, 4.0]
+    assert [row["status"] for row in telemetry] == [
+        "connection_failed",
+        "http_server_error",
+        "http_server_error",
+        "success_data",
+    ]
+    assert all(
+        row["classification"]["class"] == "transient"
+        for row in telemetry[:3]
+    )
+    assert error_indicates_timeout("[connection_failed] Network error: timed out")
+    assert (
+        classify_incident_error_text(
+            "[connection_failed] Network error: timed out"
+        )["class"]
+        == "transient"
+    )
+
+
 def test_production_retry_window_is_finite_and_capped(monkeypatch) -> None:
     from scripts.crawl import run_contracts_90d_pilot as pilot
 
@@ -221,6 +300,42 @@ def test_mutable_window_replay_closes_only_after_stable_full_pass(monkeypatch, t
     assert calls == [1, 2, 1, 2]
     assert len(report["window_retry_events"]) == 1
     assert report["windows"][0]["status"] == "completed"
+
+
+def test_persistent_population_drift_exhausts_replay_without_close(monkeypatch, tmp_path) -> None:
+    from scripts.crawl import run_contracts_90d_pilot as pilot
+
+    monkeypatch.setattr(pilot, "CONTRACTS_REQUEST_DELAY", 0)
+    monkeypatch.setattr(pilot, "CONTRACTS_JANELA_DELAY", 0)
+    monkeypatch.setattr(pilot, "UPSERT_BATCH", 1)
+    monkeypatch.setattr(pilot, "_WINDOW_RETRY_MAX", 1)
+    monkeypatch.setattr(pilot, "_WINDOW_RETRY_DELAY_SECONDS", 0)
+    monkeypatch.setattr(pilot, "transform", lambda rows: rows)
+    totals = iter((2, 1, 2, 1))
+
+    def fetch(_start, _end, page, **_kwargs):
+        return FetchResult(
+            status=FetchStatus.SUCCESS_DATA,
+            items=[{"numeroControlePNCP": f"page-{page}"}],
+            total_records=next(totals),
+            total_pages=2,
+            current_page=page,
+        )
+
+    monkeypatch.setattr(pilot, "_fetch_page", fetch)
+    report = pilot.run_pilot(
+        "",
+        days=1,
+        dry_run=True,
+        checkpoint_dir=str(tmp_path),
+        run_id="incident-458-persistent-drift",
+    )
+
+    assert report["status"] != "success"
+    assert report["totals"]["window_retries"] == 1
+    assert report["totals"]["windows_ok"] == 0
+    assert report["windows"][0]["status"] == "partial"
+    assert report["checkpoint"]["completed_windows"] == []
 
 
 def test_permanent_page_failure_is_not_retried(monkeypatch) -> None:
@@ -541,7 +656,7 @@ def test_tail_reconciliation_failure_is_not_suppressed(monkeypatch, tmp_path) ->
 
 
 def test_health_bundle_runs_freshness_after_infrastructure_failure(monkeypatch, tmp_path) -> None:
-    from scripts.ops import health_bundle, pncp_contract_freshness
+    from scripts.ops import health_bundle, pncp_contract_freshness, source_maintenance_health
 
     calls: list[str] = []
     monkeypatch.setattr(
@@ -554,8 +669,16 @@ def test_health_bundle_runs_freshness_after_infrastructure_failure(monkeypatch, 
         "main",
         lambda _argv: calls.append("freshness") or 1,
     )
-    report = health_bundle.run_bundle(freshness_output=tmp_path / "freshness.json")
-    assert calls == ["infrastructure", "freshness"]
+    monkeypatch.setattr(
+        source_maintenance_health,
+        "main",
+        lambda _argv: calls.append("maintenance") or 2,
+    )
+    report = health_bundle.run_bundle(
+        freshness_output=tmp_path / "freshness.json",
+        maintenance_output=tmp_path / "maintenance.json",
+    )
+    assert calls == ["infrastructure", "freshness", "maintenance"]
     assert report["status"] == "UNHEALTHY"
     assert report["exit_code"] == 2
 

--- a/tests/test_source_maintenance_health.py
+++ b/tests/test_source_maintenance_health.py
@@ -1,0 +1,273 @@
+"""Source/target maintenance liveness and readback regressions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from scripts import health_check
+from scripts.confenge_target_fit.status import (
+    dirty_progress_stale,
+    target_fit_progress_watermark,
+)
+from scripts.confenge_target_fit.store import max_current_watermark
+from scripts.ops.source_maintenance_health import (
+    EXPECTED_ON_SUCCESS,
+    HEALTH_TIMER,
+    PNCP_SERVICE,
+    PNCP_TIMER,
+    READBACK_UNITS,
+    SOURCE_FRESHNESS_SERVICE,
+    TARGET_FIT_RECONCILE_SERVICE,
+    TARGET_FIT_RECONCILE_TIMER,
+    TARGET_FIT_REFRESH_TIMER,
+    TARGET_FIT_WORKER,
+    TIMER_TO_SERVICE,
+    build_contract,
+    sanitize_error,
+)
+
+NOW = datetime(2026, 8, 27, 15, 0, tzinfo=UTC)
+SHA = "c02aad71259f13d2f019939442a1bca469344760"
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _timer_state() -> dict[str, str]:
+    return {
+        "LoadState": "loaded",
+        "UnitFileState": "enabled",
+        "ActiveState": "active",
+        "SubState": "waiting",
+        "Persistent": "yes",
+        "NextElapseUSecRealtime": "Thu 2026-08-27 16:03:00 -03",
+        "StopWhenUnneeded": "no",
+        "Requires": "",
+        "Requisite": "",
+        "BindsTo": "",
+        "PartOf": "",
+        "Conflicts": "",
+        "PropagatesStopTo": "",
+    }
+
+
+def _snapshot() -> dict:
+    units = {unit: {"LoadState": "loaded"} for unit in READBACK_UNITS}
+    for timer in TIMER_TO_SERVICE:
+        units[timer] = _timer_state()
+    units[TARGET_FIT_WORKER].update(
+        {"UnitFileState": "enabled", "ActiveState": "active", "SubState": "running"}
+    )
+    for source, target in EXPECTED_ON_SUCCESS.items():
+        units[source]["OnSuccess"] = target
+    return {
+        "as_of": NOW.isoformat(),
+        "release_sha": SHA,
+        "units": units,
+        "progress_max_age_seconds": {
+            "worker": 1800,
+            "refresh": 5400,
+            "reconcile": 111600,
+        },
+        "progress": {
+            "worker": {
+                "last_success_at": "2026-08-27T14:59:40Z",
+                "latest_attempt": {"status": "success", "cycle_id": "worker-live"},
+            },
+            "refresh": {
+                "last_success_at": "2026-08-27T14:31:55Z",
+                "latest_attempt": {"status": "success", "cycle_id": "refresh-live"},
+            },
+            "reconcile": {
+                "last_success_at": "2026-08-27T11:10:28Z",
+                "latest_attempt": {"status": "success", "cycle_id": "reconcile-live"},
+            },
+        },
+    }
+
+
+def test_healthy_readback_has_exact_release_and_per_kind_progress() -> None:
+    contract = build_contract(_snapshot())
+
+    assert contract["status"] == "HEALTHY"
+    assert contract["health_exit"] == 0
+    assert contract["release_sha"] == SHA
+    assert set(contract["progress"]) == {"worker", "refresh", "reconcile"}
+    assert contract["progress"]["worker"]["age_seconds"] == 20
+
+
+def test_worker_refresh_reconcile_each_alarm_independently() -> None:
+    for kind in ("worker", "refresh", "reconcile"):
+        snapshot = _snapshot()
+        snapshot["progress"][kind]["last_success_at"] = "2026-08-25T00:00:00Z"
+        contract = build_contract(snapshot)
+        assert f"TARGET_FIT_{kind.upper()}_PROGRESS_STALE" in contract["reason_codes"]
+        assert contract["health_exit"] == 2
+
+
+def test_latest_failure_is_reported_without_erasing_last_good() -> None:
+    snapshot = _snapshot()
+    snapshot["progress"]["refresh"] = {
+        "last_success_at": "2026-08-27T14:31:55Z",
+        "latest_attempt": {
+            "status": "failed",
+            "cycle_id": "refresh-failed",
+            "error": "lock busy",
+        },
+    }
+    contract = build_contract(snapshot)
+
+    assert "TARGET_FIT_REFRESH_LAST_CYCLE_FAILED" in contract["reason_codes"]
+    assert contract["progress"]["refresh"]["last_success_at"] == "2026-08-27T14:31:55Z"
+    assert contract["progress"]["refresh"]["latest_attempt"]["error"] == "lock busy"
+
+
+def test_failed_oneshot_does_not_demote_a_live_timer() -> None:
+    snapshot = _snapshot()
+    snapshot["units"][PNCP_SERVICE].update({"Result": "exit-code", "ExecMainStatus": "1"})
+    contract = build_contract(snapshot)
+
+    assert not any(
+        reason.startswith("PNCP_CONTRACTS_TIMER_LIFECYCLE")
+        for reason in contract["reason_codes"]
+    )
+    assert contract["units"][PNCP_TIMER]["ActiveState"] == "active"
+    assert contract["units"][PNCP_TIMER]["NextElapseUSecRealtime"]
+
+
+def test_running_timer_has_no_next_elapse_until_oneshot_finishes() -> None:
+    snapshot = _snapshot()
+    snapshot["units"][PNCP_TIMER].update(
+        {"SubState": "running", "NextElapseUSecRealtime": ""}
+    )
+    snapshot["units"][PNCP_SERVICE]["ActiveState"] = "activating"
+    contract = build_contract(snapshot)
+
+    assert "PNCP_CONTRACTS_TIMER_NO_NEXT_TRIGGER" not in contract["reason_codes"]
+
+
+def test_release_sha_drift_is_visible_and_fail_closed() -> None:
+    snapshot = _snapshot()
+    snapshot["release_identity"] = {
+        "effective_sha": SHA,
+        "marker_sha": "623acdcd251a20fb4d2f185cd8fedcfea474bb4a",
+        "checkout_sha": SHA,
+        "consistent": False,
+    }
+    contract = build_contract(snapshot)
+
+    assert "RELEASE_SHA_DRIFT" in contract["reason_codes"]
+    assert contract["release_identity"]["marker_sha"].startswith("623acdcd")
+
+
+def test_timer_lifecycle_coupling_or_missing_persistence_fails_closed() -> None:
+    snapshot = _snapshot()
+    snapshot["units"][PNCP_TIMER]["Requires"] = PNCP_SERVICE
+    snapshot["units"][HEALTH_TIMER]["Persistent"] = "no"
+    contract = build_contract(snapshot)
+
+    assert "PNCP_CONTRACTS_TIMER_LIFECYCLE_COUPLED_REQUIRES" in contract["reason_codes"]
+    assert "EXTRA_HEALTH_CHECK_TIMER_NOT_PERSISTENT" in contract["reason_codes"]
+
+
+def test_shipped_timers_survive_oneshot_failure_and_catch_up_after_reboot() -> None:
+    for timer_name, service_name in TIMER_TO_SERVICE.items():
+        text = (ROOT / "deploy" / "systemd" / timer_name).read_text(encoding="utf-8")
+        active_lines = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        assert "Persistent=true" in active_lines
+        for relationship in (
+            "Requires",
+            "Requisite",
+            "BindsTo",
+            "PartOf",
+            "Conflicts",
+            "PropagatesStopTo",
+        ):
+            assert f"{relationship}={service_name}" not in active_lines
+
+
+def test_shipped_on_success_chain_is_exact_and_lock_errors_are_verbose() -> None:
+    pncp = (ROOT / "deploy/systemd/pncp-contracts.service").read_text(encoding="utf-8")
+    gate = (ROOT / "deploy/systemd/extra-confenge-source-freshness-gate.service").read_text(
+        encoding="utf-8"
+    )
+    refresh = (ROOT / "deploy/systemd/extra-confenge-target-fit-refresh.service").read_text(
+        encoding="utf-8"
+    )
+    reconcile = (ROOT / "deploy/systemd/extra-confenge-target-fit-reconcile.service").read_text(
+        encoding="utf-8"
+    )
+    assert f"OnSuccess={SOURCE_FRESHNESS_SERVICE}" in pncp
+    assert f"OnSuccess={TARGET_FIT_RECONCILE_SERVICE}" in gate
+    assert "/usr/bin/flock --verbose --nonblock" in refresh
+    assert "/usr/bin/flock --verbose --nonblock" in reconcile
+    assert "OnFailure=extra-onfailure@%n.service" in refresh
+    worker = (ROOT / "deploy/systemd/extra-confenge-target-fit-worker.service").read_text(
+        encoding="utf-8"
+    )
+    assert "OnFailure=extra-onfailure@%n.service" in worker
+
+
+def test_health_contract_includes_target_fit_timers_and_worker() -> None:
+    assert TARGET_FIT_REFRESH_TIMER in health_check.CRITICAL_TIMERS
+    assert TARGET_FIT_RECONCILE_TIMER in health_check.CRITICAL_TIMERS
+    assert TARGET_FIT_WORKER in health_check.CRITICAL_SERVICES
+
+
+def test_target_fit_dirty_queue_alarms_at_the_configured_slo() -> None:
+    assert dirty_progress_stale(1801, slo_minutes=30) is True
+    assert dirty_progress_stale(1800, slo_minutes=30) is False
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.query = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, query: str) -> None:
+        self.query = query
+        assert "key = 'cdc_watermark'" not in query
+
+    def fetchall(self):
+        return []
+
+    def fetchone(self):
+        return None
+
+
+class _Connection:
+    def cursor(self) -> _Cursor:
+        return _Cursor()
+
+
+def test_cdc_watermark_cannot_impersonate_worker_progress() -> None:
+    assert max_current_watermark(_Connection()) == ""
+    assert (
+        target_fit_progress_watermark(
+            control_watermark="",
+            materialized_watermark="",
+        )
+        == ""
+    )
+    assert target_fit_progress_watermark(
+        control_watermark="2026-08-27T12:00:00Z",
+        materialized_watermark="2026-08-27T11:00:00Z",
+    ) == "2026-08-27T12:00:00Z"
+
+
+def test_error_sanitization_keeps_cause_without_credentials() -> None:
+    message = sanitize_error(
+        "OperationalError: postgresql://alice:secret@db/internal password=hunter2 timeout"
+    )
+    assert "timeout" in message
+    assert "alice:secret" not in message
+    assert "hunter2" not in message
+    assert "[REDACTED]" in message


### PR DESCRIPTION
## Outcome

Adds fail-closed source/target maintenance observability for PNCP and CONFENGE without touching feed publication, contact policy, identity, release pin tooling, workflows, or top-level manifests.

- reports loaded/enabled/active/next trigger/last success/release SHA for source and target maintenance;
- requires Persistent timers and rejects timer-to-oneshot lifecycle coupling;
- alarms worker/refresh/reconcile when successful progress exceeds its contract window;
- preserves last-good success separately from the latest failed attempt;
- classifies real urllib timeout spellings as transient and proves bounded timeout/502/503 retry plus mutable-window replay;
- surfaces lock and service failure causes through verbose flock and OnFailure;
- makes the health timer persistent and runs infrastructure, freshness, and maintenance checks independently.

## Validation

- 101 relevant tests passed with REQUIRE_REAL_DB=1 against a migrated PostgreSQL test database.
- ruff: PASS.
- systemd repository validator: PASS.
- generated-artifacts policy: PASS.
- PR reviewability policy, ready mode: PASS.
- source contract offline suite: 17/17 PASS.
- canonical full-suite diagnostic: 6140 passed; 19 failed; 2 errors; 128 skipped; 11 deselected. Failures are pre-existing/environmental outside this campaign ownership, including stale commercial freeze evidence and unseeded/non-isolated database assumptions. One in-scope timer invariant caught by the run was fixed and re-proved.

## Live readback

The scheduled PNCP run exercised bounded retries/backoff for timeout and HTTP 500/502/503 and did not close or advance freshness on incomplete windows. PNCP remains externally degraded. Source freshness remains stale at the prior last-good. No manual source start was issued because the existing OnSuccess chain reaches prohibited publication paths, and no feed was published by this campaign.

Refs #468.