### PR TITLE
fix(confenge): split commercial authority from PNCP crawler liveness (#468)

### DIFF
--- a/deploy/systemd/extra-confenge-feed-monitor.service
+++ b/deploy/systemd/extra-confenge-feed-monitor.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Extra Consultoria — fail-closed CONFENGE public feed freshness monitor
+Description=Extra Consultoria — fail-closed CONFENGE public feed integrity and commercial-authority monitor
 After=network-online.target
 OnFailure=extra-onfailure@%n.service
 
@@ -9,6 +9,8 @@ User=extra-consultoria
 Group=extra-consultoria
 WorkingDirectory=/opt/extra-consultoria
 Environment=PYTHONPATH=/opt/extra-consultoria
+# 24h remains the new-promotion / PNCP source-health budget, not a commercial
+# hard-stop on last-good. Live crawler SLO is PNCP_CONTRACT_FRESHNESS/1.0.
 Environment=CONFENGE_FEED_MAX_AGE_HOURS=24
 EnvironmentFile=-/opt/extra-consultoria/.env
 EnvironmentFile=-/etc/extra-consultoria/confenge-feed.env

--- a/docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.md
+++ b/docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.md
@@ -1,0 +1,72 @@
+# COMMERCIAL_AUTHORITY/1.0
+
+Additive, machine-readable contract over the last fully proven
+`confenge.outreach.v1` publication. It does **not** replace
+`PNCP_CONTRACT_FRESHNESS/1.0`.
+
+## Two planes
+
+| Plane | Contract | Question |
+|---|---|---|
+| Source operational health | `PNCP_CONTRACT_FRESHNESS/1.0` | Is the crawler/maintenance plane healthy? Default SLO: 6 h target / 24 h hard. Statuses `FRESH\|DEGRADED\|STALE\|UNKNOWN`. Never fabricated to permit outbound. |
+| Commercial authority | `COMMERCIAL_AUTHORITY/1.0` | May the last publication-ready population still sustain new admissions and/or already-bound transport? |
+
+A failed next crawl, lock-busy, incomplete window, same-snapshot replay or
+process restart **degrades source health**. It does **not** promote a new feed,
+does **not** mutate `current`, and does **not** rewrite a previously proven
+population into "never valid".
+
+## Policy `COMMERCIAL_AUTHORITY_POLICY/1.0`
+
+Inclusive upper bounds on the age of `validated_at` (last-good `generated_at`):
+
+| Age | State | New admission | Already-bound first-touch transport |
+|---|---|---|---|
+| `0 ≤ age ≤ 24 h` | `CURRENT` | allowed | allowed |
+| `24 h < age ≤ 72 h` | `DEGRADED` | allowed only when that lead's evidence bundle is still valid and there is no drift | allowed |
+| `72 h < age ≤ 7 d` | `FROZEN_FOR_NEW_ADMISSION` | forbidden | allowed if every other gate still passes |
+| `age > 7 d` | `EXPIRED` | forbidden | forbidden |
+| missing/mismatched binding | `UNKNOWN` | forbidden | forbidden |
+
+Suppression, opt-out, DNC, hard bounce, party-role conflict, deactivation,
+recipient/evidence expiry and explicit revocation **always win** over grace.
+Email/recipient TTLs are not lengthened by this policy.
+
+## Binding
+
+Authority is bound to all of:
+
+- `basis_source_run_id`
+- `basis_snapshot_hash`
+- `basis_membership_hash`
+- `basis_publication_semantic_hash`
+- `producer_identity` (when present)
+
+A membership, source-run, snapshot or semantic-hash mismatch yields `UNKNOWN`
+and both flags false. Never reuse authorization across a divergent basis.
+
+## Warmbly compatibility
+
+Existing field meanings stay fail-closed:
+
+- `authoritative_source_freshness.status` remains PNCP source health.
+- `FRESH` is **not** redefined as commercial `CURRENT`.
+- Unknown new fields must be ignored by an older consumer; they must not
+  silently authorize transport.
+
+New consumers should read `commercial_authority` for admission/transport
+eligibility of the last-good snapshot, and `source_operational_health` for
+incident/SLO.
+
+## New promotion vs last-good
+
+| Event | New promotion | Last-good `current` | Commercial authority |
+|---|---|---|---|
+| Candidate not publication-ready | refuse | unchanged | recomputed from last-good |
+| Live PNCP not `FRESH` | refuse new facts | unchanged | last-good policy |
+| Same snapshot + same semantics | skip (`SAME_SNAPSHOT_NOT_FRESHNESS`) | unchanged | last-good policy |
+| Integrity of last-good holds, source stale | n/a | unchanged | policy on last-good age |
+| Root deactivated | explicit revocation in feed | promoted only with the delta | that root cannot ride grace |
+
+Terminal extra-cli state for this contract is `READY_FOR_FINAL_CONVERGENCE`.
+It does **not** emit `GO_FOR_CONTROLLED_EMAIL_PILOT`.

--- a/docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.schema.json
+++ b/docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.schema.json
@@ -17,7 +17,8 @@
     "basis_source_run_id",
     "basis_snapshot_hash",
     "basis_membership_hash",
-    "basis_publication_semantic_hash"
+    "basis_publication_semantic_hash",
+    "producer_identity"
   ],
   "properties": {
     "schema": { "type": "string", "const": "COMMERCIAL_AUTHORITY/1.0" },

--- a/docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.schema.json
+++ b/docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://extra.consultoria/contracts/confenge-commercial-authority/v1",
+  "title": "COMMERCIAL_AUTHORITY/1.0",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "contract_version",
+    "policy_version",
+    "state",
+    "new_admission_allowed",
+    "existing_bound_touch_transport_allowed",
+    "reason_codes",
+    "validated_at",
+    "valid_until",
+    "age_hours",
+    "basis_source_run_id",
+    "basis_snapshot_hash",
+    "basis_membership_hash",
+    "basis_publication_semantic_hash"
+  ],
+  "properties": {
+    "schema": { "type": "string", "const": "COMMERCIAL_AUTHORITY/1.0" },
+    "contract_version": { "type": "string", "const": "COMMERCIAL_AUTHORITY/1.0" },
+    "policy_version": { "type": "string", "const": "COMMERCIAL_AUTHORITY_POLICY/1.0" },
+    "state": {
+      "type": "string",
+      "enum": ["CURRENT", "DEGRADED", "FROZEN_FOR_NEW_ADMISSION", "EXPIRED", "UNKNOWN"]
+    },
+    "new_admission_allowed": { "type": "boolean" },
+    "existing_bound_touch_transport_allowed": { "type": "boolean" },
+    "reason_codes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "validated_at": { "type": ["string", "null"], "format": "date-time" },
+    "valid_until": { "type": ["string", "null"], "format": "date-time" },
+    "age_hours": { "type": ["number", "null"], "minimum": 0 },
+    "classified_at": { "type": "string", "format": "date-time" },
+    "basis_source_run_id": { "type": "string" },
+    "basis_snapshot_hash": { "type": "string" },
+    "basis_membership_hash": { "type": "string" },
+    "basis_publication_semantic_hash": { "type": "string" },
+    "producer_identity": { "type": "string" },
+    "source_operational_health_hash": { "type": ["string", "null"] },
+    "windows_hours": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "current_max_hours": { "type": "number" },
+        "degraded_max_hours": { "type": "number" },
+        "frozen_max_hours": { "type": "number" }
+      }
+    }
+  }
+}

--- a/docs/contracts/confenge-commercial-authority/v1/examples/warmbly-manifest-authority.json
+++ b/docs/contracts/confenge-commercial-authority/v1/examples/warmbly-manifest-authority.json
@@ -1,0 +1,46 @@
+{
+  "comment": "Warmbly-consumable example. Old fields keep their PNCP meaning. commercial_authority is additive. An older consumer that only understands authoritative_source_freshness stays fail-closed on FRESH.",
+  "schema_version": "confenge.outreach.manifest.v1",
+  "generated_at": "2026-01-15T06:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "run-snapshot-a",
+    "snapshot_hash": "snapshot-a"
+  },
+  "feed_scope": "TARGET_CONFIRMED_MEMBERSHIP",
+  "lead_count": 2,
+  "authoritative_source_freshness": {
+    "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+    "status": "FRESH",
+    "expires_at": "2026-01-16T06:00:00Z"
+  },
+  "authoritative_target_membership": {
+    "target_fit_class": "TARGET_CONFIRMED",
+    "membership_hash": "membership-a",
+    "population_count": 2
+  },
+  "source_operational_health": {
+    "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+    "status": "STALE",
+    "reason_codes": ["UNCLOSED_CURRENT_WINDOW"],
+    "comment": "Live crawler health. Independent of last-good commercial authority. Never fabricate FRESH."
+  },
+  "commercial_authority": {
+    "schema": "COMMERCIAL_AUTHORITY/1.0",
+    "contract_version": "COMMERCIAL_AUTHORITY/1.0",
+    "policy_version": "COMMERCIAL_AUTHORITY_POLICY/1.0",
+    "state": "CURRENT",
+    "new_admission_allowed": true,
+    "existing_bound_touch_transport_allowed": true,
+    "reason_codes": ["COMMERCIAL_AUTHORITY_CURRENT"],
+    "validated_at": "2026-01-15T06:00:00Z",
+    "valid_until": "2026-01-16T06:00:00Z",
+    "age_hours": 6.0,
+    "classified_at": "2026-01-15T12:00:00Z",
+    "basis_source_run_id": "run-snapshot-a",
+    "basis_snapshot_hash": "snapshot-a",
+    "basis_membership_hash": "membership-a",
+    "basis_publication_semantic_hash": "semantic-a",
+    "producer_identity": "producer-a"
+  }
+}

--- a/docs/contracts/confenge-commercial-authority/v1/fixtures/current.json
+++ b/docs/contracts/confenge-commercial-authority/v1/fixtures/current.json
@@ -1,0 +1,19 @@
+{
+  "fixture_id": "commercial-authority-current",
+  "now": "2026-01-15T12:00:00Z",
+  "validated_at": "2026-01-14T12:00:00Z",
+  "binding": {
+    "basis_source_run_id": "run-snapshot-a",
+    "basis_snapshot_hash": "snapshot-a",
+    "basis_membership_hash": "membership-a",
+    "basis_publication_semantic_hash": "semantic-a",
+    "producer_identity": "producer-a"
+  },
+  "expected": {
+    "state": "CURRENT",
+    "new_admission_allowed": true,
+    "existing_bound_touch_transport_allowed": true,
+    "valid_until": "2026-01-15T12:00:00Z",
+    "reason_codes": ["COMMERCIAL_AUTHORITY_CURRENT"]
+  }
+}

--- a/docs/contracts/confenge-commercial-authority/v1/fixtures/degraded.json
+++ b/docs/contracts/confenge-commercial-authority/v1/fixtures/degraded.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "commercial-authority-degraded",
+  "now": "2026-01-15T12:00:00Z",
+  "validated_at": "2026-01-14T11:59:00Z",
+  "binding": {
+    "basis_source_run_id": "run-snapshot-a",
+    "basis_snapshot_hash": "snapshot-a",
+    "basis_membership_hash": "membership-a",
+    "basis_publication_semantic_hash": "semantic-a",
+    "producer_identity": "producer-a"
+  },
+  "expected": {
+    "state": "DEGRADED",
+    "new_admission_allowed": true,
+    "existing_bound_touch_transport_allowed": true,
+    "valid_until": "2026-01-17T11:59:00Z",
+    "reason_codes": [
+      "COMMERCIAL_AUTHORITY_DEGRADED",
+      "NEW_ADMISSION_REQUIRES_VALID_EVIDENCE_AND_NO_DRIFT"
+    ]
+  }
+}

--- a/docs/contracts/confenge-commercial-authority/v1/fixtures/expired.json
+++ b/docs/contracts/confenge-commercial-authority/v1/fixtures/expired.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "commercial-authority-expired",
+  "now": "2026-01-15T12:00:00Z",
+  "validated_at": "2026-01-08T11:59:00Z",
+  "binding": {
+    "basis_source_run_id": "run-snapshot-a",
+    "basis_snapshot_hash": "snapshot-a",
+    "basis_membership_hash": "membership-a",
+    "basis_publication_semantic_hash": "semantic-a",
+    "producer_identity": "producer-a"
+  },
+  "expected": {
+    "state": "EXPIRED",
+    "new_admission_allowed": false,
+    "existing_bound_touch_transport_allowed": false,
+    "valid_until": "2026-01-15T11:59:00Z",
+    "reason_codes": [
+      "COMMERCIAL_AUTHORITY_EXPIRED",
+      "ALL_NEW_TRANSPORT_EXPIRED"
+    ]
+  }
+}

--- a/docs/contracts/confenge-commercial-authority/v1/fixtures/failed-next-run-preserves-last-good.json
+++ b/docs/contracts/confenge-commercial-authority/v1/fixtures/failed-next-run-preserves-last-good.json
@@ -1,0 +1,35 @@
+{
+  "fixture_id": "failed-next-run-preserves-last-good",
+  "description": "A failed next crawl degrades source health and refuses a new promotion. Last-good current stays byte-identical. Commercial authority is recomputed from last-good validated_at, not from the failed attempt.",
+  "now": "2026-01-15T12:00:00Z",
+  "last_good": {
+    "validated_at": "2026-01-15T06:00:00Z",
+    "binding": {
+      "basis_source_run_id": "run-snapshot-a",
+      "basis_snapshot_hash": "snapshot-a",
+      "basis_membership_hash": "membership-a",
+      "basis_publication_semantic_hash": "semantic-a",
+      "producer_identity": "producer-a"
+    }
+  },
+  "failed_attempt": {
+    "reason": "WINDOW_INCOMPLETE",
+    "promoted": false,
+    "source_operational_health": {
+      "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+      "status": "STALE",
+      "reason_codes": ["WINDOW_INCOMPLETE", "UNCLOSED_CURRENT_WINDOW"]
+    }
+  },
+  "expected": {
+    "current_byte_identical": true,
+    "new_feed_promoted": false,
+    "source_operational_health_status": "STALE",
+    "commercial_authority": {
+      "state": "CURRENT",
+      "new_admission_allowed": true,
+      "existing_bound_touch_transport_allowed": true,
+      "basis_snapshot_hash": "snapshot-a"
+    }
+  }
+}

--- a/docs/contracts/confenge-commercial-authority/v1/fixtures/frozen.json
+++ b/docs/contracts/confenge-commercial-authority/v1/fixtures/frozen.json
@@ -1,0 +1,23 @@
+{
+  "fixture_id": "commercial-authority-frozen",
+  "now": "2026-01-15T12:00:00Z",
+  "validated_at": "2026-01-12T11:59:00Z",
+  "binding": {
+    "basis_source_run_id": "run-snapshot-a",
+    "basis_snapshot_hash": "snapshot-a",
+    "basis_membership_hash": "membership-a",
+    "basis_publication_semantic_hash": "semantic-a",
+    "producer_identity": "producer-a"
+  },
+  "expected": {
+    "state": "FROZEN_FOR_NEW_ADMISSION",
+    "new_admission_allowed": false,
+    "existing_bound_touch_transport_allowed": true,
+    "valid_until": "2026-01-19T11:59:00Z",
+    "reason_codes": [
+      "COMMERCIAL_AUTHORITY_FROZEN_FOR_NEW_ADMISSION",
+      "NEW_ADMISSION_FROZEN",
+      "EXISTING_BOUND_TOUCH_MAY_CONTINUE"
+    ]
+  }
+}

--- a/scripts/confenge_activation/commercial_authority.py
+++ b/scripts/confenge_activation/commercial_authority.py
@@ -54,6 +54,7 @@ REASON_MEMBERSHIP_HASH_MISMATCH = "MEMBERSHIP_HASH_MISMATCH"
 REASON_SOURCE_RUN_MISMATCH = "SOURCE_RUN_MISMATCH"
 REASON_SNAPSHOT_HASH_MISMATCH = "SNAPSHOT_HASH_MISMATCH"
 REASON_SEMANTIC_HASH_MISMATCH = "PUBLICATION_SEMANTIC_HASH_MISMATCH"
+REASON_PRODUCER_IDENTITY_MISMATCH = "PRODUCER_IDENTITY_MISMATCH"
 REASON_MISSING_VALIDATED_AT = "MISSING_VALIDATED_AT"
 REASON_ROOT_DEACTIVATED = "ROOT_EXPLICITLY_DEACTIVATED"
 
@@ -288,6 +289,7 @@ def _binding_is_complete(binding: CommercialAuthorityBinding) -> bool:
         and binding.basis_snapshot_hash.strip()
         and binding.basis_membership_hash.strip()
         and binding.basis_publication_semantic_hash.strip()
+        and binding.producer_identity.strip()
     )
 
 
@@ -304,6 +306,8 @@ def _binding_mismatch_reasons(
         reasons.append(REASON_MEMBERSHIP_HASH_MISMATCH)
     if observed.basis_publication_semantic_hash != expected.basis_publication_semantic_hash:
         reasons.append(REASON_SEMANTIC_HASH_MISMATCH)
+    if observed.producer_identity != expected.producer_identity:
+        reasons.append(REASON_PRODUCER_IDENTITY_MISMATCH)
     if reasons:
         reasons.insert(0, REASON_BINDING_MISMATCH)
     return reasons
@@ -350,6 +354,7 @@ def authority_from_manifest(
             binding.basis_snapshot_hash,
             binding.basis_membership_hash,
             binding.basis_publication_semantic_hash,
+            binding.producer_identity,
         )
     ):
         return classify_commercial_authority(

--- a/scripts/confenge_activation/commercial_authority.py
+++ b/scripts/confenge_activation/commercial_authority.py
@@ -212,10 +212,10 @@ def classify_commercial_authority(
     clock = _as_utc(now, field="now")
     health_hash = source_operational_health_hash(source_operational_health)
 
-    if binding is None:
+    if binding is None or not _binding_is_complete(binding):
         return _unknown(
             policy=resolved_policy,
-            binding=None,
+            binding=binding,
             now=clock,
             reasons=[REASON_UNKNOWN, REASON_BINDING_MISMATCH],
             source_health_hash=health_hash,
@@ -252,11 +252,13 @@ def classify_commercial_authority(
     age_hours = _age_hours(proven_at, clock)
     state = _state_for_age(age_hours, resolved_policy)
     new_admission, existing_bound, reasons = _flags_and_reasons(state)
+    valid_until = _valid_until(proven_at, state, resolved_policy)
     if explicit_revoked:
         new_admission = False
         existing_bound = False
         reasons = [REASON_EXPLICIT_REVOCATION, *reasons]
         state = "EXPIRED"
+        valid_until = clock
 
     return {
         "schema": CONTRACT_VERSION,
@@ -267,7 +269,7 @@ def classify_commercial_authority(
         "existing_bound_touch_transport_allowed": existing_bound,
         "reason_codes": reasons,
         "validated_at": _rfc3339(proven_at),
-        "valid_until": _rfc3339(_valid_until(proven_at, state if state != "EXPIRED" else "EXPIRED", resolved_policy)),
+        "valid_until": _rfc3339(valid_until),
         "age_hours": round(age_hours, 6),
         "classified_at": _rfc3339(clock),
         "source_operational_health_hash": health_hash,
@@ -278,6 +280,15 @@ def classify_commercial_authority(
             "frozen_max_hours": resolved_policy.frozen_max_hours,
         },
     }
+
+
+def _binding_is_complete(binding: CommercialAuthorityBinding) -> bool:
+    return bool(
+        binding.basis_source_run_id.strip()
+        and binding.basis_snapshot_hash.strip()
+        and binding.basis_membership_hash.strip()
+        and binding.basis_publication_semantic_hash.strip()
+    )
 
 
 def _binding_mismatch_reasons(

--- a/scripts/confenge_activation/commercial_authority.py
+++ b/scripts/confenge_activation/commercial_authority.py
@@ -1,0 +1,400 @@
+"""Versioned commercial authority over the last fully proven outreach population.
+
+``PNCP_CONTRACT_FRESHNESS/1.0`` answers whether the crawler/maintenance plane
+is healthy. This contract answers a different question: may the last
+publication-ready feed still sustain new admissions and/or already-bound
+transport?
+
+A failed refresh degrades source health. It does not rewrite a previously
+proven population into "never valid". Authority expires only by this policy
+or an explicit factual revoke. New facts still require a publication-ready
+candidate with live PNCP ``FRESH``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+CONTRACT_VERSION = "COMMERCIAL_AUTHORITY/1.0"
+POLICY_VERSION = "COMMERCIAL_AUTHORITY_POLICY/1.0"
+
+CommercialState = Literal[
+    "CURRENT",
+    "DEGRADED",
+    "FROZEN_FOR_NEW_ADMISSION",
+    "EXPIRED",
+    "UNKNOWN",
+]
+
+STATES: tuple[CommercialState, ...] = (
+    "CURRENT",
+    "DEGRADED",
+    "FROZEN_FOR_NEW_ADMISSION",
+    "EXPIRED",
+    "UNKNOWN",
+)
+
+REASON_CURRENT = "COMMERCIAL_AUTHORITY_CURRENT"
+REASON_DEGRADED = "COMMERCIAL_AUTHORITY_DEGRADED"
+REASON_FROZEN = "COMMERCIAL_AUTHORITY_FROZEN_FOR_NEW_ADMISSION"
+REASON_EXPIRED = "COMMERCIAL_AUTHORITY_EXPIRED"
+REASON_UNKNOWN = "COMMERCIAL_AUTHORITY_UNKNOWN"
+REASON_NEW_ADMISSION_REQUIRES_EVIDENCE = "NEW_ADMISSION_REQUIRES_VALID_EVIDENCE_AND_NO_DRIFT"
+REASON_NEW_ADMISSION_FROZEN = "NEW_ADMISSION_FROZEN"
+REASON_EXISTING_BOUND_MAY_CONTINUE = "EXISTING_BOUND_TOUCH_MAY_CONTINUE"
+REASON_ALL_NEW_TRANSPORT_EXPIRED = "ALL_NEW_TRANSPORT_EXPIRED"
+REASON_EXPLICIT_REVOCATION = "EXPLICIT_REVOCATION"
+REASON_BINDING_MISMATCH = "BINDING_MISMATCH"
+REASON_MEMBERSHIP_HASH_MISMATCH = "MEMBERSHIP_HASH_MISMATCH"
+REASON_SOURCE_RUN_MISMATCH = "SOURCE_RUN_MISMATCH"
+REASON_SNAPSHOT_HASH_MISMATCH = "SNAPSHOT_HASH_MISMATCH"
+REASON_SEMANTIC_HASH_MISMATCH = "PUBLICATION_SEMANTIC_HASH_MISMATCH"
+REASON_MISSING_VALIDATED_AT = "MISSING_VALIDATED_AT"
+REASON_ROOT_DEACTIVATED = "ROOT_EXPLICITLY_DEACTIVATED"
+
+
+@dataclass(frozen=True)
+class CommercialAuthorityPolicy:
+    """Inclusive upper bounds: age <= N hours remains in that band."""
+
+    version: str = POLICY_VERSION
+    current_max_hours: float = 24.0
+    degraded_max_hours: float = 72.0
+    frozen_max_hours: float = 24.0 * 7
+
+    def __post_init__(self) -> None:
+        if not (0 < self.current_max_hours <= self.degraded_max_hours <= self.frozen_max_hours):
+            raise ValueError("commercial authority policy windows must be strictly ordered and positive")
+
+
+DEFAULT_POLICY = CommercialAuthorityPolicy()
+
+
+@dataclass(frozen=True)
+class CommercialAuthorityBinding:
+    basis_source_run_id: str
+    basis_snapshot_hash: str
+    basis_membership_hash: str
+    basis_publication_semantic_hash: str
+    producer_identity: str = ""
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "basis_source_run_id": self.basis_source_run_id,
+            "basis_snapshot_hash": self.basis_snapshot_hash,
+            "basis_membership_hash": self.basis_membership_hash,
+            "basis_publication_semantic_hash": self.basis_publication_semantic_hash,
+            "producer_identity": self.producer_identity,
+        }
+
+
+def _as_utc(value: datetime, *, field: str) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError(f"{field} must include a timezone")
+    return value.astimezone(UTC)
+
+
+def parse_timestamp(value: Any, *, field: str) -> datetime:
+    text = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field} is missing or invalid: {text!r}") from exc
+    return _as_utc(parsed, field=field)
+
+
+def source_operational_health_hash(snapshot: Mapping[str, Any] | None) -> str | None:
+    if not snapshot:
+        return None
+    encoded = json.dumps(dict(snapshot), ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _rfc3339(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _age_hours(validated_at: datetime, now: datetime) -> float:
+    return max(0.0, (now - validated_at).total_seconds() / 3600.0)
+
+
+def _state_for_age(age_hours: float, policy: CommercialAuthorityPolicy) -> CommercialState:
+    if age_hours <= policy.current_max_hours:
+        return "CURRENT"
+    if age_hours <= policy.degraded_max_hours:
+        return "DEGRADED"
+    if age_hours <= policy.frozen_max_hours:
+        return "FROZEN_FOR_NEW_ADMISSION"
+    return "EXPIRED"
+
+
+def _valid_until(validated_at: datetime, state: CommercialState, policy: CommercialAuthorityPolicy) -> datetime:
+    if state == "CURRENT":
+        return validated_at + timedelta(hours=policy.current_max_hours)
+    if state == "DEGRADED":
+        return validated_at + timedelta(hours=policy.degraded_max_hours)
+    return validated_at + timedelta(hours=policy.frozen_max_hours)
+
+
+def _flags_and_reasons(state: CommercialState) -> tuple[bool, bool, list[str]]:
+    if state == "CURRENT":
+        return True, True, [REASON_CURRENT]
+    if state == "DEGRADED":
+        return (
+            True,
+            True,
+            [
+                REASON_DEGRADED,
+                REASON_NEW_ADMISSION_REQUIRES_EVIDENCE,
+            ],
+        )
+    if state == "FROZEN_FOR_NEW_ADMISSION":
+        return (
+            False,
+            True,
+            [
+                REASON_FROZEN,
+                REASON_NEW_ADMISSION_FROZEN,
+                REASON_EXISTING_BOUND_MAY_CONTINUE,
+            ],
+        )
+    if state == "EXPIRED":
+        return False, False, [REASON_EXPIRED, REASON_ALL_NEW_TRANSPORT_EXPIRED]
+    return False, False, [REASON_UNKNOWN]
+
+
+def _unknown(
+    *,
+    policy: CommercialAuthorityPolicy,
+    binding: CommercialAuthorityBinding | None,
+    now: datetime,
+    reasons: Sequence[str],
+    source_health_hash: str | None,
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "policy_version": policy.version,
+        "state": "UNKNOWN",
+        "new_admission_allowed": False,
+        "existing_bound_touch_transport_allowed": False,
+        "reason_codes": list(dict.fromkeys(reasons)),
+        "validated_at": None,
+        "valid_until": None,
+        "age_hours": None,
+        "classified_at": _rfc3339(now),
+        "source_operational_health_hash": source_health_hash,
+        **(binding.as_dict() if binding is not None else {}),
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def classify_commercial_authority(
+    *,
+    validated_at: datetime | None,
+    now: datetime,
+    binding: CommercialAuthorityBinding | None = None,
+    expected_binding: CommercialAuthorityBinding | None = None,
+    explicit_revoked: bool = False,
+    source_operational_health: Mapping[str, Any] | None = None,
+    policy: CommercialAuthorityPolicy | None = None,
+) -> dict[str, Any]:
+    """Pure classifier. ``now`` must be injected; never reads wall clock."""
+    resolved_policy = policy or DEFAULT_POLICY
+    clock = _as_utc(now, field="now")
+    health_hash = source_operational_health_hash(source_operational_health)
+
+    if binding is None:
+        return _unknown(
+            policy=resolved_policy,
+            binding=None,
+            now=clock,
+            reasons=[REASON_UNKNOWN, REASON_BINDING_MISMATCH],
+            source_health_hash=health_hash,
+        )
+    if expected_binding is not None:
+        mismatch_reasons = _binding_mismatch_reasons(binding, expected_binding)
+        if mismatch_reasons:
+            return _unknown(
+                policy=resolved_policy,
+                binding=binding,
+                now=clock,
+                reasons=mismatch_reasons,
+                source_health_hash=health_hash,
+            )
+    if validated_at is None:
+        return _unknown(
+            policy=resolved_policy,
+            binding=binding,
+            now=clock,
+            reasons=[REASON_UNKNOWN, REASON_MISSING_VALIDATED_AT],
+            source_health_hash=health_hash,
+        )
+
+    proven_at = _as_utc(validated_at, field="validated_at")
+    if proven_at > clock + timedelta(minutes=5):
+        return _unknown(
+            policy=resolved_policy,
+            binding=binding,
+            now=clock,
+            reasons=[REASON_UNKNOWN, "VALIDATED_AT_IN_THE_FUTURE"],
+            source_health_hash=health_hash,
+        )
+
+    age_hours = _age_hours(proven_at, clock)
+    state = _state_for_age(age_hours, resolved_policy)
+    new_admission, existing_bound, reasons = _flags_and_reasons(state)
+    if explicit_revoked:
+        new_admission = False
+        existing_bound = False
+        reasons = [REASON_EXPLICIT_REVOCATION, *reasons]
+        state = "EXPIRED"
+
+    return {
+        "schema": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "policy_version": resolved_policy.version,
+        "state": state,
+        "new_admission_allowed": new_admission,
+        "existing_bound_touch_transport_allowed": existing_bound,
+        "reason_codes": reasons,
+        "validated_at": _rfc3339(proven_at),
+        "valid_until": _rfc3339(_valid_until(proven_at, state if state != "EXPIRED" else "EXPIRED", resolved_policy)),
+        "age_hours": round(age_hours, 6),
+        "classified_at": _rfc3339(clock),
+        "source_operational_health_hash": health_hash,
+        **binding.as_dict(),
+        "windows_hours": {
+            "current_max_hours": resolved_policy.current_max_hours,
+            "degraded_max_hours": resolved_policy.degraded_max_hours,
+            "frozen_max_hours": resolved_policy.frozen_max_hours,
+        },
+    }
+
+
+def _binding_mismatch_reasons(
+    observed: CommercialAuthorityBinding,
+    expected: CommercialAuthorityBinding,
+) -> list[str]:
+    reasons: list[str] = []
+    if observed.basis_source_run_id != expected.basis_source_run_id:
+        reasons.append(REASON_SOURCE_RUN_MISMATCH)
+    if observed.basis_snapshot_hash != expected.basis_snapshot_hash:
+        reasons.append(REASON_SNAPSHOT_HASH_MISMATCH)
+    if observed.basis_membership_hash != expected.basis_membership_hash:
+        reasons.append(REASON_MEMBERSHIP_HASH_MISMATCH)
+    if observed.basis_publication_semantic_hash != expected.basis_publication_semantic_hash:
+        reasons.append(REASON_SEMANTIC_HASH_MISMATCH)
+    if reasons:
+        reasons.insert(0, REASON_BINDING_MISMATCH)
+    return reasons
+
+
+def binding_from_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    producer_identity: str = "",
+    publication_semantic_hash: str = "",
+) -> CommercialAuthorityBinding:
+    source_raw = manifest.get("source")
+    source = source_raw if isinstance(source_raw, dict) else {}
+    membership_raw = manifest.get("authoritative_target_membership")
+    membership = membership_raw if isinstance(membership_raw, dict) else {}
+    return CommercialAuthorityBinding(
+        basis_source_run_id=str(source.get("run_id") or "").strip(),
+        basis_snapshot_hash=str(source.get("snapshot_hash") or "").strip(),
+        basis_membership_hash=str(membership.get("membership_hash") or "").strip(),
+        basis_publication_semantic_hash=publication_semantic_hash,
+        producer_identity=producer_identity,
+    )
+
+
+def authority_from_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    now: datetime,
+    producer_identity: str = "",
+    publication_semantic_hash: str = "",
+    expected_binding: CommercialAuthorityBinding | None = None,
+    explicit_revoked: bool = False,
+    source_operational_health: Mapping[str, Any] | None = None,
+    policy: CommercialAuthorityPolicy | None = None,
+) -> dict[str, Any]:
+    binding = binding_from_manifest(
+        manifest,
+        producer_identity=producer_identity,
+        publication_semantic_hash=publication_semantic_hash,
+    )
+    if not all(
+        (
+            binding.basis_source_run_id,
+            binding.basis_snapshot_hash,
+            binding.basis_membership_hash,
+            binding.basis_publication_semantic_hash,
+        )
+    ):
+        return classify_commercial_authority(
+            validated_at=None,
+            now=now,
+            binding=None,
+            source_operational_health=source_operational_health,
+            policy=policy,
+        )
+    try:
+        validated_at = parse_timestamp(manifest.get("generated_at"), field="manifest.generated_at")
+    except ValueError:
+        validated_at = None
+    return classify_commercial_authority(
+        validated_at=validated_at,
+        now=now,
+        binding=binding,
+        expected_binding=expected_binding,
+        explicit_revoked=explicit_revoked,
+        source_operational_health=source_operational_health,
+        policy=policy,
+    )
+
+
+def root_transport_allowed(
+    authority: Mapping[str, Any],
+    *,
+    cnpj_root8: str,
+    deactivated_roots: Sequence[str] = (),
+    new_admission: bool,
+) -> tuple[bool, list[str]]:
+    """Per-root gate. Explicit deactivation always beats commercial grace."""
+    root = "".join(char for char in cnpj_root8 if char.isdigit())[:8]
+    deactivated = {"".join(char for char in item if char.isdigit())[:8] for item in deactivated_roots}
+    if root and root in deactivated:
+        return False, [REASON_ROOT_DEACTIVATED, REASON_EXPLICIT_REVOCATION]
+    if new_admission:
+        allowed = bool(authority.get("new_admission_allowed"))
+        reasons = list(authority.get("reason_codes") or [])
+        if not allowed:
+            reasons = list(dict.fromkeys([*reasons, REASON_NEW_ADMISSION_FROZEN]))
+        return allowed, reasons
+    allowed = bool(authority.get("existing_bound_touch_transport_allowed"))
+    reasons = list(authority.get("reason_codes") or [])
+    if not allowed:
+        reasons = list(dict.fromkeys([*reasons, REASON_ALL_NEW_TRANSPORT_EXPIRED]))
+    return allowed, reasons
+
+
+def historical_source_was_proven_fresh(freshness: Mapping[str, Any] | None) -> None:
+    """Last-good must have been FRESH at publication. Do not re-test expires_at against now."""
+    if not isinstance(freshness, dict):
+        raise ValueError("last-good feed is missing historical PNCP freshness attestation")
+    if freshness.get("contract_version") != "PNCP_CONTRACT_FRESHNESS/1.0":
+        raise ValueError("last-good feed has an unsupported PNCP freshness contract")
+    if freshness.get("status") != "FRESH":
+        raise ValueError(
+            f"last-good feed was never proven FRESH at publication; observed={freshness.get('status') or 'MISSING'}"
+        )

--- a/scripts/confenge_activation/publish.py
+++ b/scripts/confenge_activation/publish.py
@@ -1121,16 +1121,18 @@ def check_current_publication(
             },
             at=clock,
         )
-    _atomic_json(
-        state_path,
-        {
-            **state,
-            "schema_id": "confenge.feed_publication_state.v1",
-            "last_monitor_at": clock.isoformat().replace("+00:00", "Z"),
-            "last_monitor_status": "HEALTHY",
-            **result,
-            "error": None,
-            "monitor": result,
-        },
-    )
+    persisted = {
+        **state,
+        "schema_id": "confenge.feed_publication_state.v1",
+        "last_monitor_at": clock.isoformat().replace("+00:00", "Z"),
+        "last_monitor_status": "HEALTHY",
+        "monitor": result,
+        "commercial_authority": authority,
+        "last_good_publication": last_good,
+    }
+    if "error" in state:
+        persisted["error"] = state.get("error")
+    if "last_status" in state:
+        persisted["last_status"] = state.get("last_status")
+    _atomic_json(state_path, persisted)
     return result

--- a/scripts/confenge_activation/publish.py
+++ b/scripts/confenge_activation/publish.py
@@ -17,6 +17,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from scripts.confenge_activation.commercial_authority import (
+    CONTRACT_VERSION as COMMERCIAL_AUTHORITY_CONTRACT,
+)
+from scripts.confenge_activation.commercial_authority import (
+    authority_from_manifest,
+    classify_commercial_authority,
+)
 from scripts.confenge_outreach_pipeline.party_role import PARTY_ROLE_POLICY_V1
 from scripts.confenge_target_fit.company_key import canonical_target_membership
 
@@ -200,10 +207,11 @@ def _assert_membership_deactivation_delta(
         )
 
 
-def _append_alert(path: Path, *, reason: str, detail: dict[str, Any]) -> None:
+def _append_alert(path: Path, *, reason: str, detail: dict[str, Any], at: datetime | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    clock = (at or datetime.now(UTC)).astimezone(UTC)
     event = {
-        "at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "at": clock.isoformat().replace("+00:00", "Z"),
         "event": "confenge_feed_publication_alert",
         "reason": reason,
         "project": "extra-cli",
@@ -323,9 +331,7 @@ def publication_semantic_hash(manifest: dict[str, Any]) -> str:
     for entry in manifest.get("deactivations") or []:
         if not isinstance(entry, dict):
             continue
-        normalized_deactivations.append(
-            {key: value for key, value in entry.items() if key not in {"evaluated_at"}}
-        )
+        normalized_deactivations.append({key: value for key, value in entry.items() if key not in {"evaluated_at"}})
     normalized_deactivations.sort(
         key=lambda row: (str(row.get("cnpj14") or "")[:8], json.dumps(row, sort_keys=True, default=str))
     )
@@ -343,12 +349,43 @@ def publication_semantic_hash(manifest: dict[str, Any]) -> str:
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
+def _source_operational_health_plane(snapshot: dict[str, Any] | None) -> dict[str, Any]:
+    """Live crawler health. Absence is UNKNOWN — never a fabricated FRESH."""
+    if isinstance(snapshot, dict) and snapshot.get("contract_version") == "PNCP_CONTRACT_FRESHNESS/1.0":
+        status = str(snapshot.get("status") or "UNKNOWN")
+        if status not in {"FRESH", "DEGRADED", "STALE", "UNKNOWN"}:
+            status = "UNKNOWN"
+        return {
+            "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+            "status": status,
+            "reason_codes": list(snapshot.get("reason_codes") or []),
+            "as_of": snapshot.get("as_of") or snapshot.get("classified_at"),
+        }
+    return {
+        "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+        "status": "UNKNOWN",
+        "reason_codes": ["SOURCE_OPERATIONAL_HEALTH_NOT_PROVIDED"],
+    }
+
+
+def _publication_candidate_health(state: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "last_status": state.get("last_status"),
+        "last_attempt_at": state.get("last_attempt_at"),
+        "last_cycle_status": state.get("last_cycle_status"),
+        "last_cycle_at": state.get("last_cycle_at"),
+        "skipped_same": bool(state.get("skipped_same")),
+        "error": state.get("error") or (state.get("cycle") or {}).get("error"),
+    }
+
+
 def _validate_authoritative_manifest(
     build_dir: Path,
     manifest: dict[str, Any],
     *,
     max_age_hours: float,
     now: datetime,
+    require_live_source_freshness: bool = True,
 ) -> dict[str, Any]:
     if manifest.get("schema_version") != MANIFEST_SCHEMA:
         raise ValueError("unsupported or missing manifest schema_version")
@@ -386,19 +423,19 @@ def _validate_authoritative_manifest(
         raise ValueError("manifest.generated_at is in the future")
     generated_age = max(0.0, (now - generated_at).total_seconds() / 3600)
     watermark_age = max(0.0, (now - watermark).total_seconds() / 3600)
-    if generated_age > max_age_hours:
-        raise ValueError(f"manifest stale: generated_at age {generated_age:.3f}h > {max_age_hours:.3f}h")
-    if watermark_age > max_age_hours:
-        raise ValueError(f"datalake watermark stale: age {watermark_age:.3f}h > {max_age_hours:.3f}h")
-
     freshness = manifest.get("authoritative_source_freshness")
     freshness = freshness if isinstance(freshness, dict) else {}
     if freshness.get("contract_version") != "PNCP_CONTRACT_FRESHNESS/1.0":
         raise ValueError("authoritative PNCP freshness contract is required")
     if freshness.get("status") != "FRESH":
         raise ValueError(f"authoritative PNCP freshness is not FRESH: {freshness.get('status') or 'MISSING'}")
-    if _parse_timestamp(freshness.get("expires_at"), field="authoritative_source_freshness.expires_at") <= now:
-        raise ValueError("authoritative PNCP freshness expired before publication")
+    if require_live_source_freshness:
+        if generated_age > max_age_hours:
+            raise ValueError(f"manifest stale: generated_at age {generated_age:.3f}h > {max_age_hours:.3f}h")
+        if watermark_age > max_age_hours:
+            raise ValueError(f"datalake watermark stale: age {watermark_age:.3f}h > {max_age_hours:.3f}h")
+        if _parse_timestamp(freshness.get("expires_at"), field="authoritative_source_freshness.expires_at") <= now:
+            raise ValueError("authoritative PNCP freshness expired before publication")
 
     chunks = manifest.get("chunks")
     if not isinstance(chunks, list) or not chunks:
@@ -639,10 +676,11 @@ def _validate_authoritative_manifest(
         raise ValueError("authoritative contact population_as_of must equal its full reconcile attestation")
     if contact_generated > now + timedelta(minutes=5) or contact_population_as_of > now + timedelta(minutes=5):
         raise ValueError("authoritative contact projection timestamp is in the future")
-    if max(0.0, (now - contact_generated).total_seconds() / 3600) > max_age_hours:
-        raise ValueError("authoritative contact projection is stale")
-    if max(0.0, (now - contact_population_as_of).total_seconds() / 3600) > max_age_hours:
-        raise ValueError("authoritative contact population is stale")
+    if require_live_source_freshness:
+        if max(0.0, (now - contact_generated).total_seconds() / 3600) > max_age_hours:
+            raise ValueError("authoritative contact projection is stale")
+        if max(0.0, (now - contact_population_as_of).total_seconds() / 3600) > max_age_hours:
+            raise ValueError("authoritative contact population is stale")
     if contact_projection.get("coverage_complete") is not True:
         raise ValueError("authoritative contact projection coverage_complete=true is required")
     _assert_publication_ready_population(contact_projection)
@@ -799,8 +837,21 @@ def atomic_publish_directory(
         )
     except Exception as exc:
         detail = {"build_dir": str(build_dir), "error": str(exc)}
-        _append_alert(alert_ledger, reason="PUBLICATION_REFUSED", detail=detail)
+        _append_alert(alert_ledger, reason="PUBLICATION_REFUSED", detail=detail, at=clock)
         state = _read_state(state_path)
+        last_good_authority = None
+        current_dir = publish_dir / current_name
+        if current_dir.is_dir():
+            try:
+                prior_manifest = _read_json(current_dir / "manifest.json")
+                last_good_authority = authority_from_manifest(
+                    prior_manifest,
+                    now=clock,
+                    producer_identity=producer_identity(prior_manifest),
+                    publication_semantic_hash=publication_semantic_hash(prior_manifest),
+                )
+            except (OSError, ValueError, json.JSONDecodeError):
+                last_good_authority = classify_commercial_authority(validated_at=None, now=clock)
         _atomic_json(
             state_path,
             {
@@ -808,6 +859,7 @@ def atomic_publish_directory(
                 "schema_id": "confenge.feed_publication_state.v1",
                 "last_attempt_at": clock.isoformat().replace("+00:00", "Z"),
                 "last_status": "REFUSED",
+                "commercial_authority": last_good_authority,
                 **detail,
             },
         )
@@ -824,8 +876,16 @@ def atomic_publish_directory(
             _assert_membership_deactivation_delta(current, prior, build_dir, manifest)
         except Exception as exc:
             detail = {"build_dir": str(build_dir), "error": str(exc)}
-            _append_alert(alert_ledger, reason="PUBLICATION_REFUSED", detail=detail)
+            _append_alert(alert_ledger, reason="PUBLICATION_REFUSED", detail=detail, at=clock)
             state = _read_state(state_path)
+            last_good_authority = None
+            if prior:
+                last_good_authority = authority_from_manifest(
+                    prior,
+                    now=clock,
+                    producer_identity=producer_identity(prior),
+                    publication_semantic_hash=publication_semantic_hash(prior),
+                )
             _atomic_json(
                 state_path,
                 {
@@ -833,6 +893,7 @@ def atomic_publish_directory(
                     "schema_id": "confenge.feed_publication_state.v1",
                     "last_attempt_at": clock.isoformat().replace("+00:00", "Z"),
                     "last_status": "REFUSED",
+                    "commercial_authority": last_good_authority,
                     **detail,
                 },
             )
@@ -850,9 +911,15 @@ def atomic_publish_directory(
                 "publish_dir": str(publish_dir.resolve()),
                 "current": str(current.resolve()),
                 **metrics,
+                "commercial_authority": authority_from_manifest(
+                    prior,
+                    now=clock,
+                    producer_identity=producer_identity(prior),
+                    publication_semantic_hash=publication_semantic_hash(prior),
+                ),
                 "duration_seconds": round(time.monotonic() - started, 6),
             }
-            _append_alert(alert_ledger, reason="SAME_SNAPSHOT_NOT_FRESHNESS", detail=result)
+            _append_alert(alert_ledger, reason="SAME_SNAPSHOT_NOT_FRESHNESS", detail=result, at=clock)
             state = _read_state(state_path)
             _atomic_json(
                 state_path,
@@ -920,6 +987,12 @@ def atomic_publish_directory(
         "current": str(current.resolve()),
         "release_dir": str(release_dir.resolve()),
         **metrics,
+        "commercial_authority": authority_from_manifest(
+            manifest,
+            now=clock,
+            producer_identity=str(metrics["producer_identity"]),
+            publication_semantic_hash=str(metrics["publication_semantic_hash"]),
+        ),
         "snapshot_changed": str(state.get("snapshot_hash") or "") != str(metrics["snapshot_hash"]),
         "contact_count_delta": (
             int(metrics["contacts_total"]) - int(previous_contacts) if previous_contacts is not None else None
@@ -953,22 +1026,43 @@ def check_current_publication(
     state_path: Path = DEFAULT_STATE_PATH,
     alert_ledger: Path = DEFAULT_ALERT_LEDGER,
     now: datetime | None = None,
+    source_operational_health: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Fail closed when the publicly served current release is stale or corrupt."""
+    """Read back last-good integrity, live source health, and commercial authority.
+
+    ``max_age_hours`` remains the new-promotion source-health budget. Last-good
+    commercial expiry is ``COMMERCIAL_AUTHORITY/1.0``, not this parameter.
+    ``ok`` is last-good artifact integrity, never a fabricated PNCP FRESH.
+    """
+    del max_age_hours  # new-promotion budget; last-good uses commercial policy
     clock = (now or datetime.now(UTC)).astimezone(UTC)
     current = Path(publish_dir) / current_name
+    source_plane = _source_operational_health_plane(source_operational_health)
+    state = _read_state(state_path)
+    candidate = _publication_candidate_health(state)
     try:
         manifest = _read_json(current / "manifest.json")
         metrics = _validate_authoritative_manifest(
             current,
             manifest,
-            max_age_hours=max_age_hours,
+            max_age_hours=DEFAULT_MAX_AGE_HOURS,
             now=clock,
+            require_live_source_freshness=False,
         )
     except Exception as exc:
-        result = {"ok": False, "status": "UNHEALTHY", "current": str(current), "error": str(exc)}
-        _append_alert(alert_ledger, reason="PUBLIC_FEED_UNHEALTHY", detail=result)
-        state = _read_state(state_path)
+        result = {
+            "ok": False,
+            "status": "UNHEALTHY",
+            "integrity_status": "UNHEALTHY",
+            "current": str(current),
+            "error": str(exc),
+            "source_operational_health": source_plane,
+            "publication_candidate_health": candidate,
+            "last_good_publication": None,
+            "commercial_authority": classify_commercial_authority(validated_at=None, now=clock),
+            "commercial_authority_contract": COMMERCIAL_AUTHORITY_CONTRACT,
+        }
+        _append_alert(alert_ledger, reason="PUBLIC_FEED_UNHEALTHY", detail=result, at=clock)
         _atomic_json(
             state_path,
             {
@@ -981,8 +1075,52 @@ def check_current_publication(
             },
         )
         return result
-    result = {"ok": True, "status": "HEALTHY", "current": str(current.resolve()), **metrics}
-    state = _read_state(state_path)
+    authority = authority_from_manifest(
+        manifest,
+        now=clock,
+        producer_identity=str(metrics["producer_identity"]),
+        publication_semantic_hash=str(metrics["publication_semantic_hash"]),
+        source_operational_health=source_plane,
+    )
+    last_good = {
+        "run_id": metrics["run_id"],
+        "snapshot_hash": metrics["snapshot_hash"],
+        "membership_hash": metrics["membership_hash"],
+        "publication_semantic_hash": metrics["publication_semantic_hash"],
+        "lead_count": metrics["lead_count"],
+        "generated_at": metrics["generated_at"],
+        "release_dir": str(current.resolve()),
+    }
+    last_good_attestation = manifest.get("authoritative_source_freshness")
+    last_good_attestation = last_good_attestation if isinstance(last_good_attestation, dict) else {}
+    result = {
+        "ok": True,
+        "status": "HEALTHY",
+        "integrity_status": "HEALTHY",
+        "current": str(current.resolve()),
+        "source_operational_health": source_plane,
+        "last_good_source_attestation": last_good_attestation,
+        "publication_candidate_health": candidate,
+        "last_good_publication": last_good,
+        "commercial_authority": authority,
+        "commercial_authority_contract": COMMERCIAL_AUTHORITY_CONTRACT,
+        **metrics,
+    }
+    commercial_state = str(authority.get("state") or "UNKNOWN")
+    if commercial_state in {"DEGRADED", "FROZEN_FOR_NEW_ADMISSION", "EXPIRED"}:
+        _append_alert(
+            alert_ledger,
+            reason=f"COMMERCIAL_AUTHORITY_{commercial_state}",
+            detail={
+                "state": commercial_state,
+                "new_admission_allowed": authority.get("new_admission_allowed"),
+                "existing_bound_touch_transport_allowed": authority.get("existing_bound_touch_transport_allowed"),
+                "reason_codes": authority.get("reason_codes"),
+                "age_hours": authority.get("age_hours"),
+                "valid_until": authority.get("valid_until"),
+            },
+            at=clock,
+        )
     _atomic_json(
         state_path,
         {

--- a/scripts/confenge_activation/publish.py
+++ b/scripts/confenge_activation/publish.py
@@ -128,6 +128,58 @@ def _parse_timestamp(value: Any, *, field: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
+SERVED_COMMERCIAL_BINDING_FIELDS = (
+    "basis_source_run_id",
+    "basis_snapshot_hash",
+    "basis_membership_hash",
+    "basis_publication_semantic_hash",
+    "producer_identity",
+)
+
+
+def _embed_commercial_authority_into_served_manifest(
+    served_dir: Path,
+    *,
+    now: datetime,
+    producer_identity_value: str,
+    publication_semantic_hash_value: str,
+    source_operational_health: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Write the full producer binding into the bytes Warmbly actually imports.
+
+    ``publication_semantic_hash`` / ``producer_identity`` are clock-free identity
+    of the build. ``commercial_authority`` is additive envelope: its live
+    ``state``/``age_hours``/``classified_at`` are a snapshot at promote time and
+    do not participate in those hashes. Consumers recompute state from
+    ``validated_at`` + injected now. Incomplete binding refuses the serve.
+    """
+    manifest_path = Path(served_dir) / "manifest.json"
+    manifest = _read_json(manifest_path)
+    identity = str(producer_identity_value or "").strip()
+    semantic = str(publication_semantic_hash_value or "").strip()
+    if not identity or not semantic:
+        raise ValueError("producer identity and publication semantic hash are required on the served manifest")
+    authority = authority_from_manifest(
+        manifest,
+        now=now,
+        producer_identity=identity,
+        publication_semantic_hash=semantic,
+        source_operational_health=source_operational_health,
+    )
+    missing = [field for field in SERVED_COMMERCIAL_BINDING_FIELDS if not str(authority.get(field) or "").strip()]
+    if missing:
+        raise ValueError(
+            "commercial authority binding incomplete; refusing to serve an unbound manifest: "
+            + ",".join(missing)
+        )
+    served = dict(manifest)
+    served["producer_identity"] = identity
+    served["publication_semantic_hash"] = semantic
+    served["commercial_authority"] = authority
+    _atomic_json(manifest_path, served)
+    return authority
+
+
 def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, raw_tmp = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
@@ -952,6 +1004,12 @@ def atomic_publish_directory(
                 # fsync file
                 with dest.open("rb") as f:
                     os.fsync(f.fileno())
+        _embed_commercial_authority_into_served_manifest(
+            tmp,
+            now=clock,
+            producer_identity_value=str(metrics["producer_identity"]),
+            publication_semantic_hash_value=str(metrics["publication_semantic_hash"]),
+        )
         _make_public_feed_tree_readable(tmp)
         _fsync_dir(tmp)
         os.replace(str(tmp), str(release_dir))

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -35,17 +35,16 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
-from scripts.confenge_activation.commercial_authority import (
-    CommercialAuthorityBinding,
-    classify_commercial_authority,
-    historical_source_was_proven_fresh,
-    parse_timestamp,
-)
-
 _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
+from scripts.confenge_activation.commercial_authority import (  # noqa: E402
+    authority_from_manifest,
+    historical_source_was_proven_fresh,
+    parse_timestamp,
+)
+from scripts.confenge_activation.publish import producer_identity, publication_semantic_hash  # noqa: E402
 from scripts.confenge_contact_resolution.discovery.official_domain import (  # noqa: E402
     is_credible_company_domain,
 )
@@ -395,24 +394,21 @@ def assert_authoritative_source_freshness(
     clock = (now or datetime.now(UTC)).astimezone(UTC)
     generated_raw = source_manifest.get("generated_at") or (freshness or {}).get("as_of")
     try:
-        validated_at = parse_timestamp(generated_raw, field="last-good generated_at")
+        parse_timestamp(generated_raw, field="last-good generated_at")
     except ValueError as exc:
         raise ValueError("source feed is missing generated_at for commercial authority") from exc
+    source = source_manifest.get("source") if isinstance(source_manifest.get("source"), dict) else {}
     membership = source_manifest.get("authoritative_target_membership")
     membership = membership if isinstance(membership, dict) else {}
-    source = source_manifest.get("source") if isinstance(source_manifest.get("source"), dict) else {}
-    snapshot_hash = str(source.get("snapshot_hash") or "").strip() or "unknown"
-    membership_hash = str(membership.get("membership_hash") or "").strip() or "unknown"
-    authority = classify_commercial_authority(
-        validated_at=validated_at,
+    run_id = str(source.get("run_id") or "").strip()
+    snapshot_hash = str(source.get("snapshot_hash") or "").strip()
+    membership_hash = str(membership.get("membership_hash") or "").strip()
+    semantic_hash = publication_semantic_hash(source_manifest) if run_id and snapshot_hash and membership_hash else ""
+    authority = authority_from_manifest(
+        source_manifest,
         now=clock,
-        binding=CommercialAuthorityBinding(
-            basis_source_run_id=str(source.get("run_id") or "").strip() or "unknown",
-            basis_snapshot_hash=snapshot_hash,
-            basis_membership_hash=membership_hash,
-            basis_publication_semantic_hash=snapshot_hash,
-            producer_identity=str(source.get("repo_sha") or ""),
-        ),
+        producer_identity=producer_identity(source_manifest),
+        publication_semantic_hash=semantic_hash,
     )
     if not authority.get("new_admission_allowed"):
         raise ValueError(

--- a/scripts/ops/build_controlled_email_cohort.py
+++ b/scripts/ops/build_controlled_email_cohort.py
@@ -35,6 +35,13 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
+from scripts.confenge_activation.commercial_authority import (
+    CommercialAuthorityBinding,
+    classify_commercial_authority,
+    historical_source_was_proven_fresh,
+    parse_timestamp,
+)
+
 _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
@@ -380,27 +387,39 @@ def write_private_feed(
 def assert_authoritative_source_freshness(
     source_manifest: dict[str, Any], *, now: datetime | None = None
 ) -> dict[str, Any]:
-    """Reject an unproven or expired authoritative source attestation."""
+    """Reject a feed that was never proven FRESH. Clock expiry is commercial authority."""
     freshness = source_manifest.get("authoritative_source_freshness")
     if not isinstance(freshness, dict):
         freshness = (source_manifest.get("source") or {}).get("authoritative_freshness")
-    if not isinstance(freshness, dict):
-        raise ValueError("source feed is missing authoritative PNCP freshness")
-    if freshness.get("contract_version") != "PNCP_CONTRACT_FRESHNESS/1.0":
-        raise ValueError("source feed has an unsupported PNCP freshness contract")
-    if freshness.get("status") != "FRESH":
-        raise ValueError(f"source feed freshness is {freshness.get('status') or 'UNKNOWN'}, not FRESH")
-    expires_raw = str(freshness.get("expires_at") or "")
+    historical_source_was_proven_fresh(freshness if isinstance(freshness, dict) else None)
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
+    generated_raw = source_manifest.get("generated_at") or (freshness or {}).get("as_of")
     try:
-        expires_at = datetime.fromisoformat(expires_raw.replace("Z", "+00:00"))
+        validated_at = parse_timestamp(generated_raw, field="last-good generated_at")
     except ValueError as exc:
-        raise ValueError("source feed freshness has no valid expires_at") from exc
-    observed_now = now or datetime.now(UTC)
-    if expires_at <= observed_now:
+        raise ValueError("source feed is missing generated_at for commercial authority") from exc
+    membership = source_manifest.get("authoritative_target_membership")
+    membership = membership if isinstance(membership, dict) else {}
+    source = source_manifest.get("source") if isinstance(source_manifest.get("source"), dict) else {}
+    snapshot_hash = str(source.get("snapshot_hash") or "").strip() or "unknown"
+    membership_hash = str(membership.get("membership_hash") or "").strip() or "unknown"
+    authority = classify_commercial_authority(
+        validated_at=validated_at,
+        now=clock,
+        binding=CommercialAuthorityBinding(
+            basis_source_run_id=str(source.get("run_id") or "").strip() or "unknown",
+            basis_snapshot_hash=snapshot_hash,
+            basis_membership_hash=membership_hash,
+            basis_publication_semantic_hash=snapshot_hash,
+            producer_identity=str(source.get("repo_sha") or ""),
+        ),
+    )
+    if not authority.get("new_admission_allowed"):
         raise ValueError(
-            f"source feed freshness attestation expired at {expires_at.isoformat().replace('+00:00', 'Z')}"
+            "commercial authority does not allow new admissions: "
+            f"state={authority.get('state')} reasons={authority.get('reason_codes')}"
         )
-    return freshness
+    return {**freshness, "commercial_authority": authority}
 
 
 def build(
@@ -410,9 +429,11 @@ def build(
     limit: int,
     as_of: str,
     run_stamp: str,
+    now: datetime | None = None,
 ) -> dict[str, Any]:
+    clock = (now or datetime.now(UTC)).astimezone(UTC)
     source_manifest = read_feed_manifest(feed_dir)
-    source_freshness = assert_authoritative_source_freshness(source_manifest)
+    source_freshness = assert_authoritative_source_freshness(source_manifest, now=clock)
     # Two streaming passes: one to decide who keeps each shared mailbox across
     # the whole feed, one to select. Never the whole feed in memory at once.
     owner = shared_preferred_mailbox_owner(iter_feed_leads(feed_dir))
@@ -436,7 +457,7 @@ def build(
     funnel["as_of"] = as_of
     manifest = {
         "schema": MANIFEST_SCHEMA,
-        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "generated_at": clock.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         "fresh_run_id": run_id,
         "as_of": as_of,
         "auto_send": False,

--- a/tests/test_commercial_authority.py
+++ b/tests/test_commercial_authority.py
@@ -99,6 +99,8 @@ def test_explicit_revocation_beats_grace() -> None:
     assert payload["new_admission_allowed"] is False
     assert payload["existing_bound_touch_transport_allowed"] is False
     assert payload["reason_codes"][0] == "EXPLICIT_REVOCATION"
+    assert payload["valid_until"] == "2026-01-15T12:00:00Z"
+    assert payload["valid_until"] == payload["classified_at"]
 
 
 def test_deactivated_root_cannot_ride_grace() -> None:
@@ -131,6 +133,23 @@ def test_binding_mismatch_is_unknown_and_closed(field: str) -> None:
         now=NOW,
         binding=BINDING,
         expected_binding=expected,
+    )
+    assert payload["state"] == "UNKNOWN"
+    assert payload["new_admission_allowed"] is False
+    assert payload["existing_bound_touch_transport_allowed"] is False
+    assert "BINDING_MISMATCH" in payload["reason_codes"]
+
+
+def test_empty_binding_hashes_are_unknown_and_closed() -> None:
+    payload = classify_commercial_authority(
+        validated_at=NOW,
+        now=NOW,
+        binding=CommercialAuthorityBinding(
+            basis_source_run_id="",
+            basis_snapshot_hash="",
+            basis_membership_hash="",
+            basis_publication_semantic_hash="",
+        ),
     )
     assert payload["state"] == "UNKNOWN"
     assert payload["new_admission_allowed"] is False

--- a/tests/test_commercial_authority.py
+++ b/tests/test_commercial_authority.py
@@ -1,0 +1,212 @@
+"""Drive COMMERCIAL_AUTHORITY/1.0 on the shipped classifier. Clock is injected."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts.confenge_activation.commercial_authority import (
+    CONTRACT_VERSION,
+    DEFAULT_POLICY,
+    POLICY_VERSION,
+    CommercialAuthorityBinding,
+    authority_from_manifest,
+    classify_commercial_authority,
+    historical_source_was_proven_fresh,
+    root_transport_allowed,
+)
+
+NOW = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+BINDING = CommercialAuthorityBinding(
+    basis_source_run_id="run-snapshot-a",
+    basis_snapshot_hash="snapshot-a",
+    basis_membership_hash="membership-a",
+    basis_publication_semantic_hash="semantic-a",
+    producer_identity="producer-a",
+)
+FIXTURE_DIR = Path("docs/contracts/confenge-commercial-authority/v1/fixtures")
+SCHEMA_PATH = Path("docs/contracts/confenge-commercial-authority/v1/commercial-authority-v1.schema.json")
+
+CLOCK_CASES = (
+    (timedelta(hours=23, minutes=59), "CURRENT", True, True),
+    (timedelta(hours=24), "CURRENT", True, True),
+    (timedelta(hours=24, minutes=1), "DEGRADED", True, True),
+    (timedelta(hours=71, minutes=59), "DEGRADED", True, True),
+    (timedelta(hours=72), "DEGRADED", True, True),
+    (timedelta(hours=72, minutes=1), "FROZEN_FOR_NEW_ADMISSION", False, True),
+    (timedelta(days=6, hours=23, minutes=59), "FROZEN_FOR_NEW_ADMISSION", False, True),
+    (timedelta(days=7), "FROZEN_FOR_NEW_ADMISSION", False, True),
+    (timedelta(days=7, minutes=1), "EXPIRED", False, False),
+)
+
+
+def test_contract_and_policy_are_versioned() -> None:
+    assert CONTRACT_VERSION == "COMMERCIAL_AUTHORITY/1.0"
+    assert POLICY_VERSION == "COMMERCIAL_AUTHORITY_POLICY/1.0"
+    assert DEFAULT_POLICY.current_max_hours == 24.0
+    assert DEFAULT_POLICY.degraded_max_hours == 72.0
+    assert DEFAULT_POLICY.frozen_max_hours == 168.0
+
+
+@pytest.mark.parametrize("age, state, new_admission, bound", CLOCK_CASES)
+def test_injected_clock_boundaries(age: timedelta, state: str, new_admission: bool, bound: bool) -> None:
+    payload = classify_commercial_authority(
+        validated_at=NOW - age,
+        now=NOW,
+        binding=BINDING,
+    )
+    assert payload["state"] == state
+    assert payload["new_admission_allowed"] is new_admission
+    assert payload["existing_bound_touch_transport_allowed"] is bound
+    assert payload["basis_snapshot_hash"] == "snapshot-a"
+    assert payload["basis_membership_hash"] == "membership-a"
+    assert payload["basis_source_run_id"] == "run-snapshot-a"
+    assert payload["basis_publication_semantic_hash"] == "semantic-a"
+    assert payload["valid_until"]
+    assert payload["age_hours"] == pytest.approx(age.total_seconds() / 3600, abs=1e-6)
+
+
+def test_state_matrix_reason_codes_and_valid_until() -> None:
+    current = classify_commercial_authority(validated_at=NOW, now=NOW, binding=BINDING)
+    assert current["reason_codes"] == ["COMMERCIAL_AUTHORITY_CURRENT"]
+    assert current["valid_until"] == "2026-01-16T12:00:00Z"
+
+    degraded = classify_commercial_authority(
+        validated_at=NOW - timedelta(hours=24, minutes=1), now=NOW, binding=BINDING
+    )
+    assert "NEW_ADMISSION_REQUIRES_VALID_EVIDENCE_AND_NO_DRIFT" in degraded["reason_codes"]
+    assert degraded["valid_until"] == "2026-01-17T11:59:00Z"
+
+    frozen = classify_commercial_authority(validated_at=NOW - timedelta(hours=72, minutes=1), now=NOW, binding=BINDING)
+    assert "NEW_ADMISSION_FROZEN" in frozen["reason_codes"]
+    assert "EXISTING_BOUND_TOUCH_MAY_CONTINUE" in frozen["reason_codes"]
+
+    expired = classify_commercial_authority(validated_at=NOW - timedelta(days=7, minutes=1), now=NOW, binding=BINDING)
+    assert "ALL_NEW_TRANSPORT_EXPIRED" in expired["reason_codes"]
+
+
+def test_explicit_revocation_beats_grace() -> None:
+    payload = classify_commercial_authority(
+        validated_at=NOW - timedelta(hours=1),
+        now=NOW,
+        binding=BINDING,
+        explicit_revoked=True,
+    )
+    assert payload["state"] == "EXPIRED"
+    assert payload["new_admission_allowed"] is False
+    assert payload["existing_bound_touch_transport_allowed"] is False
+    assert payload["reason_codes"][0] == "EXPLICIT_REVOCATION"
+
+
+def test_deactivated_root_cannot_ride_grace() -> None:
+    payload = classify_commercial_authority(validated_at=NOW, now=NOW, binding=BINDING)
+    allowed, reasons = root_transport_allowed(
+        payload,
+        cnpj_root8="12345678",
+        deactivated_roots=["12345678000195"],
+        new_admission=False,
+    )
+    assert allowed is False
+    assert "ROOT_EXPLICITLY_DEACTIVATED" in reasons
+    sibling, _ = root_transport_allowed(
+        payload,
+        cnpj_root8="87654321",
+        deactivated_roots=["12345678000195"],
+        new_admission=False,
+    )
+    assert sibling is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("basis_source_run_id", "basis_snapshot_hash", "basis_membership_hash", "basis_publication_semantic_hash"),
+)
+def test_binding_mismatch_is_unknown_and_closed(field: str) -> None:
+    expected = CommercialAuthorityBinding(**{**BINDING.as_dict(), field: "other"})
+    payload = classify_commercial_authority(
+        validated_at=NOW,
+        now=NOW,
+        binding=BINDING,
+        expected_binding=expected,
+    )
+    assert payload["state"] == "UNKNOWN"
+    assert payload["new_admission_allowed"] is False
+    assert payload["existing_bound_touch_transport_allowed"] is False
+    assert "BINDING_MISMATCH" in payload["reason_codes"]
+
+
+def test_historical_fresh_attestation_does_not_mean_live_fresh() -> None:
+    historical_source_was_proven_fresh(
+        {
+            "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+            "status": "FRESH",
+            "expires_at": "2026-01-01T00:00:00Z",
+        }
+    )
+    with pytest.raises(ValueError, match="never proven FRESH"):
+        historical_source_was_proven_fresh({"contract_version": "PNCP_CONTRACT_FRESHNESS/1.0", "status": "STALE"})
+
+
+def test_golden_fixtures_match_shipped_classifier() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    required = schema["required"]
+    for name in ("current", "degraded", "frozen", "expired"):
+        fixture = json.loads((FIXTURE_DIR / f"{name}.json").read_text(encoding="utf-8"))
+        binding = CommercialAuthorityBinding(**fixture["binding"])
+        payload = classify_commercial_authority(
+            validated_at=datetime.fromisoformat(fixture["validated_at"].replace("Z", "+00:00")),
+            now=datetime.fromisoformat(fixture["now"].replace("Z", "+00:00")),
+            binding=binding,
+        )
+        expected = fixture["expected"]
+        assert payload["state"] == expected["state"]
+        assert payload["new_admission_allowed"] is expected["new_admission_allowed"]
+        assert payload["existing_bound_touch_transport_allowed"] is expected["existing_bound_touch_transport_allowed"]
+        assert payload["valid_until"] == expected["valid_until"]
+        assert payload["reason_codes"] == expected["reason_codes"]
+        for key in required:
+            assert key in payload
+
+
+def test_failed_next_run_fixture_preserves_last_good_authority() -> None:
+    fixture = json.loads((FIXTURE_DIR / "failed-next-run-preserves-last-good.json").read_text(encoding="utf-8"))
+    last_good = fixture["last_good"]
+    payload = classify_commercial_authority(
+        validated_at=datetime.fromisoformat(last_good["validated_at"].replace("Z", "+00:00")),
+        now=datetime.fromisoformat(fixture["now"].replace("Z", "+00:00")),
+        binding=CommercialAuthorityBinding(**last_good["binding"]),
+        source_operational_health=fixture["failed_attempt"]["source_operational_health"],
+    )
+    expected = fixture["expected"]["commercial_authority"]
+    assert fixture["expected"]["new_feed_promoted"] is False
+    assert fixture["failed_attempt"]["promoted"] is False
+    assert payload["state"] == expected["state"]
+    assert payload["new_admission_allowed"] is expected["new_admission_allowed"]
+    assert payload["basis_snapshot_hash"] == expected["basis_snapshot_hash"]
+    assert fixture["failed_attempt"]["source_operational_health"]["status"] == "STALE"
+    assert payload["source_operational_health_hash"]
+
+
+def test_warmbly_example_keeps_pncp_field_meaning() -> None:
+    example = json.loads(
+        Path("docs/contracts/confenge-commercial-authority/v1/examples/warmbly-manifest-authority.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    freshness = example["authoritative_source_freshness"]
+    assert freshness["contract_version"] == "PNCP_CONTRACT_FRESHNESS/1.0"
+    assert freshness["status"] == "FRESH"
+    assert example["source_operational_health"]["status"] == "STALE"
+    authority = example["commercial_authority"]
+    replay = authority_from_manifest(
+        example,
+        now=datetime.fromisoformat(authority["classified_at"].replace("Z", "+00:00")),
+        producer_identity=authority["producer_identity"],
+        publication_semantic_hash=authority["basis_publication_semantic_hash"],
+        source_operational_health=example["source_operational_health"],
+    )
+    assert replay["state"] == "CURRENT"
+    assert replay["new_admission_allowed"] is True

--- a/tests/test_commercial_authority.py
+++ b/tests/test_commercial_authority.py
@@ -124,7 +124,13 @@ def test_deactivated_root_cannot_ride_grace() -> None:
 
 @pytest.mark.parametrize(
     "field",
-    ("basis_source_run_id", "basis_snapshot_hash", "basis_membership_hash", "basis_publication_semantic_hash"),
+    (
+        "basis_source_run_id",
+        "basis_snapshot_hash",
+        "basis_membership_hash",
+        "basis_publication_semantic_hash",
+        "producer_identity",
+    ),
 )
 def test_binding_mismatch_is_unknown_and_closed(field: str) -> None:
     expected = CommercialAuthorityBinding(**{**BINDING.as_dict(), field: "other"})
@@ -149,6 +155,7 @@ def test_empty_binding_hashes_are_unknown_and_closed() -> None:
             basis_snapshot_hash="",
             basis_membership_hash="",
             basis_publication_semantic_hash="",
+            producer_identity="",
         ),
     )
     assert payload["state"] == "UNKNOWN"
@@ -229,3 +236,21 @@ def test_warmbly_example_keeps_pncp_field_meaning() -> None:
     )
     assert replay["state"] == "CURRENT"
     assert replay["new_admission_allowed"] is True
+    assert authority["producer_identity"] == "producer-a"
+    assert authority["basis_publication_semantic_hash"] == "semantic-a"
+
+
+def test_one_byte_producer_or_semantic_drift_fails_closed() -> None:
+    payload = classify_commercial_authority(validated_at=NOW, now=NOW, binding=BINDING)
+    for field in ("basis_publication_semantic_hash", "producer_identity", "basis_membership_hash"):
+        drifted = CommercialAuthorityBinding(**{**BINDING.as_dict(), field: payload[field][:-1] + "b"})
+        closed = classify_commercial_authority(
+            validated_at=NOW,
+            now=NOW,
+            binding=BINDING,
+            expected_binding=drifted,
+        )
+        assert closed["state"] == "UNKNOWN"
+        assert closed["new_admission_allowed"] is False
+        assert closed["existing_bound_touch_transport_allowed"] is False
+        assert "BINDING_MISMATCH" in closed["reason_codes"]

--- a/tests/test_confenge_feed_publication.py
+++ b/tests/test_confenge_feed_publication.py
@@ -5,11 +5,13 @@ import json
 import os
 import stat
 import subprocess
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from scripts.confenge_activation.commercial_authority import root_transport_allowed
 from scripts.confenge_activation.publish import (
     atomic_publish_directory,
     check_current_publication,
@@ -184,9 +186,7 @@ def _build(
         manifest["lead_count"] = declared_lead_count
     if declared_chunk_count is not None:
         manifest["chunk_count"] = declared_chunk_count
-        manifest["chunks"] = [
-            {**manifest["chunks"][0], "chunk_index": index} for index in range(declared_chunk_count)
-        ]
+        manifest["chunks"] = [{**manifest["chunks"][0], "chunk_index": index} for index in range(declared_chunk_count)]
     (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     return root
 
@@ -445,23 +445,38 @@ def test_same_snapshot_is_not_freshness_and_alerts(tmp_path: Path) -> None:
     assert "SAME_SNAPSHOT_NOT_FRESHNESS" in alerts.read_text()
 
 
-def test_monitor_fails_after_24_hours_without_touching_publication(tmp_path: Path) -> None:
+def test_monitor_keeps_last_good_after_24_hours_and_splits_commercial_authority(
+    tmp_path: Path,
+) -> None:
     public, state, alerts = _paths(tmp_path)
-    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    current_bytes = (public / "current" / "manifest.json").read_bytes()
     result = check_current_publication(
         public,
         state_path=state,
         alert_ledger=alerts,
         now=NOW + timedelta(hours=25),
+        source_operational_health={
+            "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+            "status": "STALE",
+            "reason_codes": ["LAG_ABOVE_HARD_GUARDRAIL"],
+        },
     )
-    assert result["ok"] is False
-    assert result["status"] == "UNHEALTHY"
-    assert "stale" in result["error"]
-    assert (public / "current" / "manifest.json").is_file()
-    assert "PUBLIC_FEED_UNHEALTHY" in alerts.read_text()
+    assert result["ok"] is True
+    assert result["status"] == "HEALTHY"
+    assert result["integrity_status"] == "HEALTHY"
+    assert result["source_operational_health"]["status"] == "STALE"
+    assert result["source_operational_health"]["status"] != "FRESH"
+    assert result["commercial_authority"]["state"] == "DEGRADED"
+    assert result["commercial_authority"]["new_admission_allowed"] is True
+    assert result["commercial_authority"]["existing_bound_touch_transport_allowed"] is True
+    assert (public / "current" / "manifest.json").read_bytes() == current_bytes
+    assert Path(first["current"]).resolve() == (public / "current").resolve()
+    assert "PUBLIC_FEED_UNHEALTHY" not in alerts.read_text()
+    assert "COMMERCIAL_AUTHORITY_DEGRADED" in alerts.read_text()
     saved = json.loads(state.read_text())
     assert saved["last_success_at"] == NOW.isoformat().replace("+00:00", "Z")
-    assert saved["last_monitor_status"] == "UNHEALTHY"
+    assert saved["last_monitor_status"] == "HEALTHY"
 
 
 def test_cycle_failure_preserves_last_publication_and_records_alert(tmp_path: Path) -> None:
@@ -707,9 +722,7 @@ def test_new_producer_semantics_defeat_the_same_snapshot_skip(tmp_path: Path) ->
     SAME_SNAPSHOT_NOT_FRESHNESS and never reached the feed.
     """
     public, state, alerts = _paths(tmp_path)
-    first = atomic_publish_directory(
-        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
-    )
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
     assert first["ok"] is True
 
     changed = _build(tmp_path / "changed")
@@ -729,9 +742,7 @@ def test_new_producer_semantics_defeat_the_same_snapshot_skip(tmp_path: Path) ->
 
 def test_same_snapshot_with_new_deactivation_delta_promotes(tmp_path: Path) -> None:
     public, state, alerts = _paths(tmp_path)
-    first = atomic_publish_directory(
-        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
-    )
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
     changed = _build(tmp_path / "changed")
     manifest_path = changed / "manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -749,9 +760,7 @@ def test_same_snapshot_with_new_deactivation_delta_promotes(tmp_path: Path) -> N
 
 def test_failed_current_swap_preserves_last_known_good(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     public, state, alerts = _paths(tmp_path)
-    first = atomic_publish_directory(
-        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
-    )
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
     prior = Path(first["current"]).resolve()
     changed = _build(tmp_path / "changed", snapshot="snapshot-b")
     real_replace = os.replace
@@ -773,15 +782,313 @@ def test_failed_current_swap_preserves_last_known_good(monkeypatch: pytest.Monke
 
 def test_identical_inputs_and_semantics_still_replay(tmp_path: Path) -> None:
     public, state, alerts = _paths(tmp_path)
-    first = atomic_publish_directory(
-        _build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW
-    )
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
     second = atomic_publish_directory(
         _build(tmp_path / "second"), public, state_path=state, alert_ledger=alerts, now=NOW
     )
     assert second["reason"] == "SAME_SNAPSHOT_NOT_FRESHNESS"
     assert second["producer_identity"] == first["producer_identity"]
     assert second["prior_producer_identity"] == first["producer_identity"]
+
+
+def _rewrite_manifest(build: Path, mutator) -> Path:
+    path = build / "manifest.json"
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    mutator(manifest)
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return build
+
+
+def _stale_source_health() -> dict:
+    return {
+        "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+        "status": "STALE",
+        "reason_codes": ["WINDOW_INCOMPLETE", "UNCLOSED_CURRENT_WINDOW"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("age", "state", "new_admission", "bound"),
+    (
+        (timedelta(hours=23, minutes=59), "CURRENT", True, True),
+        (timedelta(hours=24), "CURRENT", True, True),
+        (timedelta(hours=24, minutes=1), "DEGRADED", True, True),
+        (timedelta(hours=71, minutes=59), "DEGRADED", True, True),
+        (timedelta(hours=72), "DEGRADED", True, True),
+        (timedelta(hours=72, minutes=1), "FROZEN_FOR_NEW_ADMISSION", False, True),
+        (timedelta(days=6, hours=23, minutes=59), "FROZEN_FOR_NEW_ADMISSION", False, True),
+        (timedelta(days=7), "FROZEN_FOR_NEW_ADMISSION", False, True),
+        (timedelta(days=7, minutes=1), "EXPIRED", False, False),
+    ),
+)
+def test_readback_classifies_last_good_commercial_authority(
+    tmp_path: Path, age: timedelta, state: str, new_admission: bool, bound: bool
+) -> None:
+    public, state_path, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state_path, alert_ledger=alerts, now=NOW)
+    before = (public / "current" / "manifest.json").read_bytes()
+    result = check_current_publication(
+        public,
+        state_path=state_path,
+        alert_ledger=alerts,
+        now=NOW + age,
+        source_operational_health=_stale_source_health(),
+    )
+    assert result["ok"] is True
+    assert result["integrity_status"] == "HEALTHY"
+    assert result["source_operational_health"]["status"] == "STALE"
+    assert result["commercial_authority"]["state"] == state
+    assert result["commercial_authority"]["new_admission_allowed"] is new_admission
+    assert result["commercial_authority"]["existing_bound_touch_transport_allowed"] is bound
+    assert result["last_good_publication"]["membership_hash"]
+    assert (public / "current" / "manifest.json").read_bytes() == before
+
+
+def test_new_promotion_still_requires_live_pncp_fresh(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    before = (public / "current" / "manifest.json").read_bytes()
+    later = NOW + timedelta(hours=1)
+    candidate = _rewrite_manifest(
+        _build(tmp_path / "next", snapshot="snapshot-b", generated_at=later),
+        lambda manifest: manifest["authoritative_source_freshness"].__setitem__("status", "STALE"),
+    )
+    with pytest.raises(ValueError, match="not FRESH"):
+        atomic_publish_directory(candidate, public, state_path=state, alert_ledger=alerts, now=later)
+    assert (public / "current" / "manifest.json").read_bytes() == before
+    readback = check_current_publication(
+        public,
+        state_path=state,
+        alert_ledger=alerts,
+        now=later,
+        source_operational_health=_stale_source_health(),
+    )
+    assert readback["commercial_authority"]["state"] == "CURRENT"
+    assert readback["commercial_authority"]["basis_snapshot_hash"] == first["snapshot_hash"]
+    assert Path(first["current"]).resolve() == (public / "current").resolve()
+
+
+def test_failed_next_run_preserves_authority_across_current_degraded_frozen(
+    tmp_path: Path,
+) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    before = (public / "current" / "manifest.json").read_bytes()
+    for age, expected in (
+        (timedelta(hours=1), "CURRENT"),
+        (timedelta(hours=25), "DEGRADED"),
+        (timedelta(hours=73), "FROZEN_FOR_NEW_ADMISSION"),
+    ):
+        clock = NOW + age
+        candidate = _rewrite_manifest(
+            _build(tmp_path / f"next-{expected}", snapshot=f"snap-{expected}", generated_at=clock),
+            lambda manifest: manifest["authoritative_source_freshness"].__setitem__("status", "UNKNOWN"),
+        )
+        with pytest.raises(ValueError, match="not FRESH"):
+            atomic_publish_directory(candidate, public, state_path=state, alert_ledger=alerts, now=clock)
+        assert (public / "current" / "manifest.json").read_bytes() == before
+        readback = check_current_publication(
+            public,
+            state_path=state,
+            alert_ledger=alerts,
+            now=clock,
+            source_operational_health={
+                "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+                "status": "UNKNOWN",
+                "reason_codes": ["LOCK_BUSY_NO_CLOSE"],
+            },
+        )
+        assert readback["commercial_authority"]["state"] == expected
+        assert readback["source_operational_health"]["status"] == "UNKNOWN"
+
+
+def test_expired_prior_authority_does_not_revive_on_failed_refresh(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    clock = NOW + timedelta(days=7, minutes=1)
+    candidate = _rewrite_manifest(
+        _build(tmp_path / "next", snapshot="snapshot-b", generated_at=clock),
+        lambda manifest: manifest["authoritative_source_freshness"].__setitem__("status", "DEGRADED"),
+    )
+    with pytest.raises(ValueError, match="not FRESH"):
+        atomic_publish_directory(candidate, public, state_path=state, alert_ledger=alerts, now=clock)
+    readback = check_current_publication(
+        public,
+        state_path=state,
+        alert_ledger=alerts,
+        now=clock,
+        source_operational_health={
+            "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+            "status": "DEGRADED",
+            "reason_codes": ["LAG_ABOVE_OPERATIONAL_TARGET"],
+        },
+    )
+    assert readback["commercial_authority"]["state"] == "EXPIRED"
+    assert readback["commercial_authority"]["new_admission_allowed"] is False
+    assert readback["commercial_authority"]["existing_bound_touch_transport_allowed"] is False
+    assert "ALL_NEW_TRANSPORT_EXPIRED" in readback["commercial_authority"]["reason_codes"]
+
+
+def test_membership_mismatch_on_candidate_preserves_last_good(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    before = (public / "current" / "manifest.json").read_bytes()
+    later = NOW + timedelta(hours=2)
+    candidate = _rewrite_manifest(
+        _build(tmp_path / "next", snapshot="snapshot-b", generated_at=later),
+        lambda manifest: manifest["authoritative_target_membership"].__setitem__("membership_hash", "deadbeef"),
+    )
+    with pytest.raises(ValueError, match="membership_hash"):
+        atomic_publish_directory(candidate, public, state_path=state, alert_ledger=alerts, now=later)
+    assert (public / "current" / "manifest.json").read_bytes() == before
+    readback = check_current_publication(public, state_path=state, alert_ledger=alerts, now=later)
+    assert readback["commercial_authority"]["basis_membership_hash"] == first["membership_hash"]
+
+
+def test_source_run_mismatch_on_binding_is_unknown() -> None:
+    from scripts.confenge_activation.commercial_authority import (
+        CommercialAuthorityBinding,
+        classify_commercial_authority,
+    )
+
+    observed = CommercialAuthorityBinding(
+        basis_source_run_id="run-a",
+        basis_snapshot_hash="snap-a",
+        basis_membership_hash="mem-a",
+        basis_publication_semantic_hash="sem-a",
+    )
+    expected = CommercialAuthorityBinding(
+        basis_source_run_id="run-b",
+        basis_snapshot_hash="snap-a",
+        basis_membership_hash="mem-a",
+        basis_publication_semantic_hash="sem-a",
+    )
+    payload = classify_commercial_authority(validated_at=NOW, now=NOW, binding=observed, expected_binding=expected)
+    assert payload["state"] == "UNKNOWN"
+    assert "SOURCE_RUN_MISMATCH" in payload["reason_codes"]
+    assert payload["new_admission_allowed"] is False
+
+
+def test_partial_reconcile_candidate_does_not_replace_current(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    before = (public / "current" / "manifest.json").read_bytes()
+    later = NOW + timedelta(hours=3)
+    candidate = _rewrite_manifest(
+        _build(tmp_path / "next", snapshot="snapshot-b", generated_at=later),
+        lambda manifest: (
+            manifest["authoritative_contact_projection"].__setitem__("population_publication_ready", False),
+            manifest["authoritative_contact_projection"].__setitem__("population_coverage_ratio", 0.996),
+        ),
+    )
+    with pytest.raises(ValueError, match="not publication ready"):
+        atomic_publish_directory(candidate, public, state_path=state, alert_ledger=alerts, now=later)
+    assert (public / "current" / "manifest.json").read_bytes() == before
+
+
+def test_same_snapshot_replay_preserves_last_good_authority(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    first = atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    later = NOW + timedelta(hours=2)
+    second = atomic_publish_directory(
+        _build(tmp_path / "second", generated_at=later), public, state_path=state, alert_ledger=alerts, now=later
+    )
+    assert second["skipped_same"] is True
+    assert second["reason"] == "SAME_SNAPSHOT_NOT_FRESHNESS"
+    assert Path(first["current"]).resolve() == (public / "current").resolve()
+    assert second["commercial_authority"]["state"] == "CURRENT"
+    assert second["commercial_authority"]["basis_snapshot_hash"] == first["snapshot_hash"]
+
+
+def test_cli_check_publication_emits_both_planes_twice(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    command = [
+        sys.executable,
+        "-m",
+        "scripts.confenge_activation",
+        "check-publication",
+        "--publish-dir",
+        str(public),
+        "--state",
+        str(state),
+        "--alert-ledger",
+        str(alerts),
+        "--max-age-hours",
+        "24",
+    ]
+    payloads = []
+    for _ in range(2):
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+        assert completed.returncode == 0, completed.stderr
+        payload = json.loads(completed.stdout)
+        payloads.append(payload)
+        assert payload["ok"] is True
+        assert "commercial_authority" in payload
+        assert "source_operational_health" in payload
+        assert payload["commercial_authority"]["state"] in {
+            "CURRENT",
+            "DEGRADED",
+            "FROZEN_FOR_NEW_ADMISSION",
+            "EXPIRED",
+        }
+        assert payload["last_good_publication"]["membership_hash"]
+        assert "new_admission_allowed" in payload["commercial_authority"]
+        assert "existing_bound_touch_transport_allowed" in payload["commercial_authority"]
+    assert (
+        payloads[0]["last_good_publication"]["membership_hash"]
+        == payloads[1]["last_good_publication"]["membership_hash"]
+    )
+    assert (
+        payloads[0]["commercial_authority"]["basis_snapshot_hash"]
+        == payloads[1]["commercial_authority"]["basis_snapshot_hash"]
+    )
+
+
+def test_process_restart_readback_is_stable(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    clock = NOW + timedelta(hours=5)
+    first = check_current_publication(public, state_path=state, alert_ledger=alerts, now=clock)
+    second = check_current_publication(public, state_path=state, alert_ledger=alerts, now=clock)
+    assert first["commercial_authority"] == second["commercial_authority"]
+    assert first["last_good_publication"]["membership_hash"] == second["last_good_publication"]["membership_hash"]
+    assert first["ok"] is True and second["ok"] is True
+
+
+def test_published_deactivation_beats_commercial_grace(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    later = NOW + timedelta(hours=2)
+    second = atomic_publish_directory(
+        _zero_membership_build(tmp_path / "zero"), public, state_path=state, alert_ledger=alerts, now=later
+    )
+    assert second["ok"] is True
+    readback = check_current_publication(public, state_path=state, alert_ledger=alerts, now=later)
+    allowed, reasons = root_transport_allowed(
+        readback["commercial_authority"],
+        cnpj_root8="12345678",
+        deactivated_roots=["12345678000195"],
+        new_admission=False,
+    )
+    assert allowed is False
+    assert "ROOT_EXPLICITLY_DEACTIVATED" in reasons
+
+
+def test_new_promotion_refuses_25h_old_candidate_without_touching_current(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    before = (public / "current" / "manifest.json").read_bytes()
+    clock = NOW + timedelta(hours=25)
+    with pytest.raises(ValueError, match="stale"):
+        atomic_publish_directory(
+            _build(tmp_path / "next", snapshot="snapshot-b", generated_at=NOW),
+            public,
+            state_path=state,
+            alert_ledger=alerts,
+            now=clock,
+        )
+    assert (public / "current" / "manifest.json").read_bytes() == before
 
 
 def test_producer_identity_is_deterministic_and_clock_free() -> None:

--- a/tests/test_confenge_feed_publication.py
+++ b/tests/test_confenge_feed_publication.py
@@ -13,9 +13,11 @@ import pytest
 
 from scripts.confenge_activation.commercial_authority import root_transport_allowed
 from scripts.confenge_activation.publish import (
+    SERVED_COMMERCIAL_BINDING_FIELDS,
     atomic_publish_directory,
     check_current_publication,
     producer_identity,
+    publication_semantic_hash,
     record_feed_cycle_state,
 )
 from scripts.confenge_outreach_pipeline.party_role import PARTY_ROLE_POLICY_V1
@@ -981,12 +983,14 @@ def test_source_run_mismatch_on_binding_is_unknown() -> None:
         basis_snapshot_hash="snap-a",
         basis_membership_hash="mem-a",
         basis_publication_semantic_hash="sem-a",
+        producer_identity="producer-a",
     )
     expected = CommercialAuthorityBinding(
         basis_source_run_id="run-b",
         basis_snapshot_hash="snap-a",
         basis_membership_hash="mem-a",
         basis_publication_semantic_hash="sem-a",
+        producer_identity="producer-a",
     )
     payload = classify_commercial_authority(validated_at=NOW, now=NOW, binding=observed, expected_binding=expected)
     assert payload["state"] == "UNKNOWN"
@@ -1114,6 +1118,35 @@ def test_new_promotion_refuses_25h_old_candidate_without_touching_current(tmp_pa
             now=clock,
         )
     assert (public / "current" / "manifest.json").read_bytes() == before
+
+
+def test_served_manifest_bytes_carry_full_commercial_binding(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    build = _build(tmp_path / "first")
+    result = atomic_publish_directory(build, public, state_path=state, alert_ledger=alerts, now=NOW)
+    served_bytes = (public / "current" / "manifest.json").read_bytes()
+    served = json.loads(served_bytes)
+    authority = served["commercial_authority"]
+    build_manifest = json.loads((build / "manifest.json").read_text(encoding="utf-8"))
+    assert served["producer_identity"] == producer_identity(build_manifest)
+    assert served["publication_semantic_hash"] == publication_semantic_hash(build_manifest)
+    for field in SERVED_COMMERCIAL_BINDING_FIELDS:
+        assert str(authority[field]).strip(), field
+    assert authority["basis_source_run_id"] == served["source"]["run_id"]
+    assert authority["basis_snapshot_hash"] == served["source"]["snapshot_hash"]
+    assert authority["basis_membership_hash"] == served["authoritative_target_membership"]["membership_hash"]
+    assert authority["basis_publication_semantic_hash"] == served["publication_semantic_hash"]
+    assert authority["producer_identity"] == served["producer_identity"]
+    assert authority["schema"] == "COMMERCIAL_AUTHORITY/1.0"
+    assert result["commercial_authority"]["basis_publication_semantic_hash"] == authority["basis_publication_semantic_hash"]
+    replay = json.loads((public / "current" / "manifest.json").read_bytes())
+    assert replay["commercial_authority"] == authority
+    drifted = json.loads(served_bytes)
+    original_semantic = drifted["commercial_authority"]["basis_publication_semantic_hash"]
+    drifted["commercial_authority"]["basis_publication_semantic_hash"] = original_semantic[:-1] + (
+        "0" if original_semantic[-1] != "0" else "1"
+    )
+    assert drifted["commercial_authority"]["basis_publication_semantic_hash"] != served["publication_semantic_hash"]
 
 
 def test_producer_identity_is_deterministic_and_clock_free() -> None:

--- a/tests/test_confenge_feed_publication.py
+++ b/tests/test_confenge_feed_publication.py
@@ -578,8 +578,8 @@ def test_fresh_publication_and_monitor_clear_prior_unhealthy_state(tmp_path: Pat
     )
     assert result["status"] == "HEALTHY"
     healthy = json.loads(state.read_text())
-    assert healthy["status"] == "HEALTHY"
     assert healthy["last_monitor_status"] == "HEALTHY"
+    assert healthy["last_status"] == "PUBLISHED"
     assert healthy["error"] is None
 
 
@@ -842,6 +842,31 @@ def test_readback_classifies_last_good_commercial_authority(
     assert result["commercial_authority"]["existing_bound_touch_transport_allowed"] is bound
     assert result["last_good_publication"]["membership_hash"]
     assert (public / "current" / "manifest.json").read_bytes() == before
+
+
+def test_failed_next_run_readback_preserves_candidate_error_twice(tmp_path: Path) -> None:
+    public, state, alerts = _paths(tmp_path)
+    atomic_publish_directory(_build(tmp_path / "first"), public, state_path=state, alert_ledger=alerts, now=NOW)
+    later = NOW + timedelta(hours=1)
+    candidate = _rewrite_manifest(
+        _build(tmp_path / "next", snapshot="snapshot-b", generated_at=later),
+        lambda manifest: manifest["authoritative_source_freshness"].__setitem__("status", "STALE"),
+    )
+    with pytest.raises(ValueError, match="not FRESH"):
+        atomic_publish_directory(candidate, public, state_path=state, alert_ledger=alerts, now=later)
+    first = check_current_publication(public, state_path=state, alert_ledger=alerts, now=later)
+    second = check_current_publication(public, state_path=state, alert_ledger=alerts, now=later)
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["publication_candidate_health"]["last_status"] == "REFUSED"
+    assert second["publication_candidate_health"]["last_status"] == "REFUSED"
+    assert first["publication_candidate_health"]["error"]
+    assert first["publication_candidate_health"] == second["publication_candidate_health"]
+    saved = json.loads(state.read_text(encoding="utf-8"))
+    assert saved["last_status"] == "REFUSED"
+    assert saved["error"]
+    assert saved["last_monitor_status"] == "HEALTHY"
+    assert first["commercial_authority"]["state"] == "CURRENT"
 
 
 def test_new_promotion_still_requires_live_pncp_fresh(tmp_path: Path) -> None:

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -12,7 +12,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from scripts.ops.build_controlled_email_cohort import build, select_cohort
+from scripts.confenge_target_fit.company_key import canonical_target_membership
+from scripts.ops.build_controlled_email_cohort import assert_authoritative_source_freshness, build, select_cohort
 from scripts.warmbly_bridge import SCHEMA_OUTREACH
 
 COHORT_NOW = datetime(2026, 8, 22, tzinfo=UTC)
@@ -68,6 +69,8 @@ def _lead(cnpj14: str, contacts: list[dict[str, Any]], *, website: str | None = 
 def _write_export(tmp_path: Path, leads: list[dict[str, Any]]) -> Path:
     feed_dir = tmp_path / "06_warmbly_feed"
     feed_dir.mkdir(parents=True)
+    cnpjs = [str((lead.get("company") or {}).get("cnpj14") or "") for lead in leads]
+    membership = canonical_target_membership(cnpjs)
     (feed_dir / "chunk_0000.json").write_text(
         json.dumps(
             {
@@ -86,6 +89,10 @@ def _write_export(tmp_path: Path, leads: list[dict[str, Any]]) -> Path:
                 "lead_count": len(leads),
                 "generated_at": "2026-08-22T00:00:00Z",
                 "source": {"repo_sha": "0" * 40, "run_id": "run-test", "snapshot_hash": "snapshot-test"},
+                "authoritative_target_membership": {
+                    "membership_hash": membership["membership_hash"],
+                    "population_count": membership["population_count"],
+                },
                 "authoritative_source_freshness": {
                     "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
                     "status": "FRESH",
@@ -166,6 +173,31 @@ def test_expired_pncp_attestation_does_not_kill_current_last_good_cohort(tmp_pat
     )
     assert result["member_count"] == 1
     assert result["source_feed"]["authoritative_freshness"]["commercial_authority"]["state"] == "CURRENT"
+
+
+def test_incomplete_binding_hashes_refuse_new_admission(tmp_path: Path) -> None:
+    feed_dir = _write_export(
+        tmp_path,
+        [_lead("11111111000191", [_contact("contato@alphaengenharia.com.br")])],
+    )
+    manifest_path = feed_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["authoritative_target_membership"] = {}
+    manifest["source"]["snapshot_hash"] = ""
+    manifest["source"]["run_id"] = ""
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    with __import__("pytest").raises(ValueError, match="does not allow new admissions"):
+        assert_authoritative_source_freshness(manifest, now=COHORT_NOW)
+    with __import__("pytest").raises(ValueError, match="does not allow new admissions"):
+        build(
+            feed_dir=feed_dir,
+            private_root=tmp_path / "private",
+            limit=10,
+            as_of="2026-08-22",
+            run_stamp="unbound",
+            now=COHORT_NOW,
+        )
+    assert not (tmp_path / "private" / "unbound").exists()
 
 
 def test_risky_and_suppressed_never_enter_the_cohort():
@@ -441,6 +473,8 @@ def test_the_producer_never_holds_the_whole_feed(tmp_path):
             {
                 "lead_count": 12,
                 "generated_at": "2026-08-22T00:00:00Z",
+                "source": {"run_id": "run-stream", "snapshot_hash": "snapshot-stream"},
+                "authoritative_target_membership": {"membership_hash": "a" * 64, "population_count": 12},
                 "authoritative_source_freshness": {
                     "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
                     "status": "FRESH",

--- a/tests/test_controlled_email_cohort_builder.py
+++ b/tests/test_controlled_email_cohort_builder.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 import json
 import os
 import stat
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from scripts.ops.build_controlled_email_cohort import build, select_cohort
 from scripts.warmbly_bridge import SCHEMA_OUTREACH
+
+COHORT_NOW = datetime(2026, 8, 22, tzinfo=UTC)
 
 
 def _contact(
@@ -81,7 +84,8 @@ def _write_export(tmp_path: Path, leads: list[dict[str, Any]]) -> Path:
         json.dumps(
             {
                 "lead_count": len(leads),
-                "source": {"repo_sha": "0" * 40, "run_id": "run-test"},
+                "generated_at": "2026-08-22T00:00:00Z",
+                "source": {"repo_sha": "0" * 40, "run_id": "run-test", "snapshot_hash": "snapshot-test"},
                 "authoritative_source_freshness": {
                     "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
                     "status": "FRESH",
@@ -107,13 +111,14 @@ def test_stale_source_feed_is_refused_before_private_cohort_write(tmp_path: Path
     manifest["authoritative_source_freshness"]["status"] = "STALE"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    with __import__("pytest").raises(ValueError, match="STALE, not FRESH"):
+    with __import__("pytest").raises(ValueError, match="never proven FRESH"):
         build(
             feed_dir=feed_dir,
             private_root=tmp_path / "private",
             limit=10,
             as_of="2026-08-22",
             run_stamp="stale",
+            now=COHORT_NOW,
         )
     assert not (tmp_path / "private" / "stale").exists()
 
@@ -125,18 +130,42 @@ def test_expired_freshness_attestation_is_refused(tmp_path: Path):
     )
     manifest_path = feed_dir / "manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest["authoritative_source_freshness"]["expires_at"] = "2000-01-01T00:00:00Z"
+    manifest["generated_at"] = "2026-08-14T23:59:00Z"
+    manifest["authoritative_source_freshness"]["as_of"] = "2026-08-14T23:59:00Z"
+    manifest["authoritative_source_freshness"]["expires_at"] = "2026-08-15T23:59:00Z"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-    with __import__("pytest").raises(ValueError, match="expired"):
+    with __import__("pytest").raises(ValueError, match="does not allow new admissions"):
         build(
             feed_dir=feed_dir,
             private_root=tmp_path / "private",
             limit=10,
             as_of="2026-08-22",
             run_stamp="expired",
+            now=COHORT_NOW,
         )
     assert not (tmp_path / "private" / "expired").exists()
+
+
+def test_expired_pncp_attestation_does_not_kill_current_last_good_cohort(tmp_path: Path):
+    feed_dir = _write_export(
+        tmp_path,
+        [_lead("11111111000191", [_contact("contato@alphaengenharia.com.br")])],
+    )
+    manifest_path = feed_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["authoritative_source_freshness"]["expires_at"] = "2026-08-22T01:00:00Z"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    result = build(
+        feed_dir=feed_dir,
+        private_root=tmp_path / "private",
+        limit=10,
+        as_of="2026-08-22",
+        run_stamp="pncp-expired-commercial-current",
+        now=COHORT_NOW + timedelta(hours=2),
+    )
+    assert result["member_count"] == 1
+    assert result["source_feed"]["authoritative_freshness"]["commercial_authority"]["state"] == "CURRENT"
 
 
 def test_risky_and_suppressed_never_enter_the_cohort():
@@ -211,6 +240,7 @@ def test_private_feed_is_0600_and_the_manifest_carries_no_pii(tmp_path):
         limit=50,
         as_of="2026-08-22",
         run_stamp="20260822T000000Z",
+        now=COHORT_NOW,
     )
 
     assert manifest["member_count"] == 2
@@ -251,6 +281,7 @@ def test_feed_hash_matches_the_bytes_on_disk(tmp_path):
         limit=50,
         as_of="2026-08-22",
         run_stamp="20260822T000000Z",
+        now=COHORT_NOW,
     )
     body = Path(manifest["private_feed_path"]).read_bytes()
     assert hashlib.sha256(body).hexdigest() == manifest["feed_sha256"]
@@ -352,6 +383,7 @@ def test_the_sample_publishes_the_name_credibility_verdict(tmp_path):
         limit=50,
         as_of="2026-08-22",
         run_stamp="20260822T000000Z",
+        now=COHORT_NOW,
     )
     sample = manifest["sample_qa"][0]
     assert sample["mailbox_domain_matches_official"] is True
@@ -374,6 +406,7 @@ def test_the_sample_never_carries_the_company_name(tmp_path):
         limit=50,
         as_of="2026-08-22",
         run_stamp="20260822T000000Z",
+        now=COHORT_NOW,
     )
     assert manifest["member_count"] == 1
     redacted = Path(manifest["manifest_path"]).read_text(encoding="utf-8")
@@ -407,9 +440,11 @@ def test_the_producer_never_holds_the_whole_feed(tmp_path):
         json.dumps(
             {
                 "lead_count": 12,
+                "generated_at": "2026-08-22T00:00:00Z",
                 "authoritative_source_freshness": {
                     "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
                     "status": "FRESH",
+                    "as_of": "2026-08-22T00:00:00Z",
                     "expires_at": "2999-01-01T00:00:00Z",
                 },
             }
@@ -427,6 +462,7 @@ def test_the_producer_never_holds_the_whole_feed(tmp_path):
         limit=50,
         as_of="2026-08-22",
         run_stamp="20260822T000000Z",
+        now=COHORT_NOW,
     )
     assert manifest["member_count"] == 12
     assert manifest["funnel"]["accounts_considered"] == 12


### PR DESCRIPTION
## Summary

Desacopla a liveness do crawler PNCP da autoridade comercial do último feed comprovado. `PNCP_CONTRACT_FRESHNESS/1.0` continua o contrato de saúde da fonte (6 h target / 24 h hard). `COMMERCIAL_AUTHORITY/1.0` responde se a última população `TARGET_CONFIRMED` integralmente provada ainda pode sustentar admissões novas e/ou transporte já bound.

Uma tentativa de refresh que falha **não** promove feed novo, **não** muta `current` e **não** transforma uma população anterior comprovada em “nunca foi válida”. Promoção nova continua fail-closed em `FRESH` + publication-ready.

Estado terminal extra-cli: **`READY_FOR_FINAL_CONVERGENCE`**. Este PR **não** emite `GO_FOR_CONTROLLED_EMAIL_PILOT`. Zero SMTP, dispatch, resume, import Warmbly ou publicação live.

## Policy `COMMERCIAL_AUTHORITY_POLICY/1.0`

Inclusive upper bounds no `validated_at` do last-good (relógio injetado):

| Age | State | New admission | Bound transport |
|---|---|---|---|
| ≤ 24 h | CURRENT | yes | yes |
| 24 h < age ≤ 72 h | DEGRADED | yes, se evidence bundle ainda válido e sem drift | yes |
| 72 h < age ≤ 7 d | FROZEN_FOR_NEW_ADMISSION | no | yes se os demais gates passam |
| > 7 d | EXPIRED | no | no |

Suppression, opt-out, DNC, hard bounce, party-role conflict, deactivation, evidence expiry e revogação explícita sempre vencem o grace. TTL de email/recipient não foi alongado.

## What changed

- Classifier puro `scripts/confenge_activation/commercial_authority.py` (clock injetado).
- `check_current_publication` emite os dois planos: source health, candidate health, last-good identity, commercial authority.
- Nova promoção ainda exige PNCP `FRESH` + 24 h; last-good não é mais `UNHEALTHY` só porque a attestation de fonte envelheceu.
- Cohort builder recusa feed que nunca foi FRESH na publicação, mas usa autoridade comercial para admissão nova (não re-testa `expires_at` contra o relógio).
- Contrato, schema e fixtures Warmbly-consumable em `docs/contracts/confenge-commercial-authority/v1/`.
- Monitor systemd documenta que 24 h é budget de promoção nova / saúde da fonte, não hard-stop comercial universal.

## Invariants preserved

- `PNCP_CONTRACT_FRESHNESS/1.0` statuses `FRESH|DEGRADED|STALE|UNKNOWN`; UNKNOWN/HTTP-200/timer-enabled/single-row nunca viram FRESH.
- Timer PNCP a cada 4 h (`00,04,08,12,16,20` America/Sao_Paulo).
- Feed scope `TARGET_CONFIRMED_MEMBERSHIP` (não o universo bruto).
- Immutable release `run_id-snapshot[:12]-semantic[:12]` (#519).
- `SOURCE_MAINTENANCE_HEALTH/1.0` (#520) não tocado.
- Significado de campos Warmbly existentes não muda: `authoritative_source_freshness.status` continua saúde PNCP.

## Tests

- 9 frontiers de relógio no classifier e no readback publicado.
- Matriz de estados (flags, reason codes, valid_until, binding).
- Matriz de falha: crawl falho em CURRENT/DEGRADED/FROZEN, prior EXPIRED, deactivation, membership/source-run mismatch, reconcile parcial, same-snapshot replay, process restart.
- CLI `check-publication` duas vezes no last-good.
- Fixtures golden CURRENT/DEGRADED/FROZEN/EXPIRED + failed-next-run + exemplo Warmbly.

Local: ruff nos arquivos tocados; mypy subset CI; generated-artifacts PASS; pytest-skip PASS; pr-reviewability PASS; bandit nos módulos tocados; pip-audit (venv) sem CVEs conhecidas; readiness/operational subsets verdes. Full suite com Postgres de CI não rodou neste host (sem PG local). CI do PR é a prova fail-closed completa.

## Issue #468

Comentário aditivo: 24 h permanece hard guardrail de ingestão; deixa de ser hard-stop comercial universal. Não fechar a issue. Closeout live de dois ciclos continua onda posterior.

## Terminal state

`READY_FOR_FINAL_CONVERGENCE`

Não emitir `GO_FOR_CONTROLLED_EMAIL_PILOT`.
