### PR TITLE
fix(confenge): keep contact-cycle DUI children on the pinned release

### DIFF
--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -154,6 +154,10 @@ def render_dropin(unit_text: str, sha: str) -> str:
         # otherwise immutable release. Suppress bytecode for every pinned
         # process; the venv remains the only mutable interpreter input.
         "Environment=PYTHONDONTWRITEBYTECODE=1",
+        # Parent ExecStart uses -P, but children (contact-cycle DUI export)
+        # inherit Environment only. PYTHONSAFEPATH stops cwd from shadowing
+        # the release scripts package the same way -P does for the parent.
+        "Environment=PYTHONSAFEPATH=1",
         # Clear the inherited ExecStart before appending the pinned one.
         "ExecStart=",
         exec_start,
@@ -270,6 +274,8 @@ def verify(sha: str) -> dict[str, object]:
             drift.append({"unit": unit, "resolved": environment[:400]})
         if "PYTHONDONTWRITEBYTECODE=1" not in environment:
             bytecode_writes_enabled.append({"unit": unit, "resolved": environment[:400]})
+        if "PYTHONSAFEPATH=1" not in environment:
+            unsafe_python_path.append({"unit": unit, "resolved": environment[:400]})
 
         working_directory = (
             _run(["systemctl", "show", unit, "-p", "WorkingDirectory", "--value"], check=False).stdout or ""

--- a/scripts/ops/confenge_contact_cycle.py
+++ b/scripts/ops/confenge_contact_cycle.py
@@ -93,8 +93,30 @@ def _fsync_dir(path: Path) -> None:
         os.close(fd)
 
 
+def _runtime_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _child_env() -> dict[str, str]:
+    """Bind DUI children to this release even when cwd is the live checkout.
+
+    systemd pin_release keeps WorkingDirectory=/opt/extra-consultoria (writable)
+    and isolates only the parent interpreter with python -P. A child spawned as
+    ``python -m scripts.decision_unit_intelligence`` without -P prepends cwd to
+    sys.path, so an older checkout shadows export-contacts and the OnSuccess
+    chain dies after a FRESH source close.
+    """
+    env = os.environ.copy()
+    env["PYTHONSAFEPATH"] = "1"
+    inherited = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (str(_runtime_root()), inherited) if part)
+    return env
+
+
 def _run_json(command: list[str]) -> dict[str, Any]:
-    completed = subprocess.run(command, check=False, capture_output=True, text=True)  # noqa: S603
+    completed = subprocess.run(  # noqa: S603
+        command, check=False, capture_output=True, text=True, env=_child_env()
+    )
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout)[-4_000:].strip()
         raise CommandError(f"command exited {completed.returncode}: {detail}")
@@ -108,7 +130,7 @@ def _run_json(command: list[str]) -> dict[str, Any]:
 
 
 def _batch_command(*args: str) -> list[str]:
-    return [sys.executable, "-m", "scripts.decision_unit_intelligence", "batch", *args]
+    return [sys.executable, "-P", "-m", "scripts.decision_unit_intelligence", "batch", *args]
 
 
 def _counts(progress: dict[str, Any]) -> dict[str, int]:

--- a/tests/test_confenge_contact_cycle.py
+++ b/tests/test_confenge_contact_cycle.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ops.confenge_contact_cycle import run_cycle
+from scripts.ops.confenge_contact_cycle import _batch_command, _child_env, run_cycle
 
 NOW = datetime(2026, 8, 24, 20, 0, tzinfo=UTC)
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,7 +20,7 @@ class FakeRunner:
 
     def __call__(self, command: list[str]) -> dict:
         self.commands.append(command)
-        action = command[4]
+        action = command[command.index("batch") + 1]
         if action == "enqueue":
             return {
                 "progress": {
@@ -95,14 +95,14 @@ def test_full_cycle_promotes_only_after_terminal_projection(tmp_path: Path) -> N
     state = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
     assert state["last_status"] == "COMPLETED"
     assert state["active_cohort"] is None
-    enqueue = next(command for command in runner.commands if command[4] == "enqueue")
+    enqueue = next(command for command in runner.commands if command[command.index("batch") + 1] == "enqueue")
     assert "target-confirmed" in enqueue
     assert str((previous / "contacts.jsonl").resolve()) in enqueue
     assert "--verify-email-dns" in enqueue
     assert str(output / "search-cache") in enqueue
-    assert sum(command[4] == "publish" for command in runner.commands) == 1
-    assert sum(command[4] == "export-contacts" for command in runner.commands) == 1
-    export = next(command for command in runner.commands if command[4] == "export-contacts")
+    assert sum(command[command.index("batch") + 1] == "publish" for command in runner.commands) == 1
+    assert sum(command[command.index("batch") + 1] == "export-contacts" for command in runner.commands) == 1
+    export = next(command for command in runner.commands if command[command.index("batch") + 1] == "export-contacts")
     assert export[export.index("--prior-contacts") + 1] == str((previous / "contacts.jsonl").resolve())
 
 
@@ -137,7 +137,7 @@ def test_failed_partial_cycle_keeps_previous_projection_and_is_resumable(tmp_pat
     assert state["last_status"] == "FAILED"
     assert state["active_cohort"].startswith("target-confirmed-auto-")
     assert "CONTACT_CYCLE_FAILED" in (tmp_path / "alerts.jsonl").read_text(encoding="utf-8")
-    assert all(command[4] not in {"publish", "export-contacts"} for command in runner.commands)
+    assert all(command[command.index("batch") + 1] not in {"publish", "export-contacts"} for command in runner.commands)
 
 
 def test_resume_terminal_cohort_does_not_enqueue_again(tmp_path: Path) -> None:
@@ -171,7 +171,7 @@ def test_resume_terminal_cohort_does_not_enqueue_again(tmp_path: Path) -> None:
     )
 
     assert result["resumed"] is True
-    assert all(command[4] != "enqueue" for command in runner.commands)
+    assert all(command[command.index("batch") + 1] != "enqueue" for command in runner.commands)
 
 
 def test_public_backend_and_positive_concurrency_are_required(tmp_path: Path) -> None:
@@ -203,3 +203,19 @@ def test_systemd_cycle_and_workers_share_private_search_endpoint_contract() -> N
     for unit in (cycle, worker):
         assert "EnvironmentFile=-/etc/extra-consultoria/contact-discovery.env" in unit
     assert "--out /var/lib/extra-consultoria/output/contact-discovery" in worker
+
+
+def test_batch_children_use_isolated_interpreter() -> None:
+    command = _batch_command("export-contacts", "--cohort", "c1")
+    assert command[1] == "-P"
+    assert command[2:5] == ["-m", "scripts.decision_unit_intelligence", "batch"]
+    assert command[5] == "export-contacts"
+
+
+def test_child_env_keeps_release_ahead_of_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PYTHONPATH", "/opt/extra-consultoria")
+    env = _child_env()
+    assert env["PYTHONSAFEPATH"] == "1"
+    pythonpath = env["PYTHONPATH"].split(":")
+    assert pythonpath[0] == str(ROOT)
+    assert "/opt/extra-consultoria" in pythonpath

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -54,6 +54,7 @@ def test_rendered_dropin_repoints_code_at_the_release():
     assert f"/opt/extra-consultoria-releases/{SHA}/.venv/bin/python" in body
     assert f"Environment=EXTRA_DEPLOYED_SHA={SHA}" in body
     assert "Environment=PYTHONDONTWRITEBYTECODE=1" in body
+    assert "Environment=PYTHONSAFEPATH=1" in body
     assert "ExecStart=\n" in body, "inherited ExecStart must be cleared before appending"
     for line in body.splitlines():
         if line.startswith(("Environment=PYTHONPATH=", "ExecStart=/")):
@@ -224,7 +225,7 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
             prop = argv[argv.index("-p") + 1]
             values = {
                 "ExecStart": f"{release}/.venv/bin/python -P -m scripts.example",
-                "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1",
+                "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1 PYTHONSAFEPATH=1",
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
             }
@@ -279,7 +280,7 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
                 "Environment": (
                     f"PYTHONPATH={release}"
                     if failure == "bytecode-enabled"
-                    else f"PYTHONPATH={release} PYTHONDONTWRITEBYTECODE=1"
+                    else f"PYTHONPATH={release} PYTHONDONTWRITEBYTECODE=1 PYTHONSAFEPATH=1"
                 ),
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",


### PR DESCRIPTION
## Summary

The immutable pin already isolates the **parent** interpreter with `python -P`. `confenge_contact_cycle` then spawned `decision-unit-intelligence batch export-contacts` **without** `-P`. systemd keeps `WorkingDirectory=/opt/extra-consultoria` (the live checkout), so cwd was prepended to `sys.path` and an older DUI CLI (no `export-contacts`) shadowed the pinned release.

Live symptom after PNCP `FRESH` + target-fit reconcile OnSuccess:

```
invalid choice: 'export-contacts' (choose from enqueue, inspect, progress, failures, retry, cancel, resume, publish, worker, kill-switch)
```

That broke the canonical OnSuccess chain. Operator workaround: run the cycle with cwd = the release so cwd *is* the pinned tree. This PR makes the chain survive the next source close without that workaround.

## What landed

1. `_batch_command` passes `-P`.
2. `_run_json` sets `PYTHONSAFEPATH=1` and puts the runtime root first on `PYTHONPATH`.
3. `pin_release.py` drop-ins now also set `Environment=PYTHONSAFEPATH=1` so *any* child of a pinned unit inherits the same isolation.
4. Tests for interpreter isolation, child env, and drop-in/verify contracts.

Does not send mail. Does not change recipient/evidence/CNPJ/suppression/window/caps.

## Test plan

- [x] `pytest tests/test_confenge_contact_cycle.py tests/test_confenge_release_pin.py` (32 passed)
- [ ] required CI green
- [ ] after merge: cut/pin immutable release so AUTO_REFILL OnSuccess uses the fix