### PR TITLE
fix(confenge): pack outreach chunks against the encoded byte ceiling

### DIFF
--- a/scripts/warmbly_bridge/export.py
+++ b/scripts/warmbly_bridge/export.py
@@ -234,6 +234,9 @@ def _encoded_lead_item_size(lead: dict[str, Any]) -> int:
     return len(raw) + 4 * (raw.count(b"\n") + 1)
 
 
+_CHUNK_HASH_PLACEHOLDER = "0" * 64
+
+
 def _provisional_chunk_size(
     *,
     lead_item_bytes: int,
@@ -242,17 +245,31 @@ def _provisional_chunk_size(
     generated_at: str,
     cursor: str,
     chunk_index: int,
+    next_cursor: str | None = None,
+    snapshot_hash: str | None = None,
 ) -> int:
-    """Measure a provisional chunk in O(1) after each lead is encoded once."""
+    """Measure a provisional chunk in O(1) after each lead is encoded once.
+
+    The estimate must be at least as large as the bytes later written by
+    ``_encode_chunk``. Production pagination adds 64-char content hashes after
+    packing; omitting them under-counted a live chunk by 51 bytes (512051 >
+    512000) and aborted publication.
+    """
+    digest = (snapshot_hash or _CHUNK_HASH_PLACEHOLDER).ljust(64, "0")[:64]
     envelope = {
         "schema_version": SCHEMA_OUTREACH,
         "generated_at": generated_at,
         "source": source,
         "pagination": {
-            "cursor": cursor,
-            "next_cursor": None,
-            "has_more": False,
             "chunk_index": chunk_index,
+            "content_hash": _CHUNK_HASH_PLACEHOLDER,
+            "cursor": cursor,
+            "has_more": next_cursor is not None,
+            "hashes": {
+                "leads": _CHUNK_HASH_PLACEHOLDER,
+                "snapshot": digest,
+            },
+            "next_cursor": next_cursor,
         },
         "leads": [],
     }
@@ -1233,6 +1250,9 @@ def _chunk_leads(
             generated_at=generated_at,
             cursor=_decision_cursor(current[0] if current else lead),
             chunk_index=len(chunks),
+            # Assume a following chunk so the estimate covers next_cursor + hashes.
+            next_cursor=_decision_cursor(lead),
+            snapshot_hash=str(source.get("snapshot_hash") or ""),
         )
         over_count = trial_count > max_leads
         over_bytes = size > max_bytes and len(current) >= 1

--- a/tests/warmbly_bridge/test_chunk_determinism.py
+++ b/tests/warmbly_bridge/test_chunk_determinism.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from scripts.warmbly_bridge.export import (
     ExportConfig,
+    _chunk_leads,
     _decision_cursor,
     _encode_chunk,
     _encoded_lead_item_size,
@@ -36,10 +37,12 @@ def test_incremental_provisional_size_matches_canonical_encoding() -> None:
     source = {"system": "extra-cli", "run_id": "run-size"}
     generated_at = "2026-08-12T12:00:00Z"
     pagination = {
-        "cursor": _decision_cursor(leads[0]),
-        "next_cursor": None,
-        "has_more": False,
         "chunk_index": 7,
+        "content_hash": "0" * 64,
+        "cursor": _decision_cursor(leads[0]),
+        "has_more": True,
+        "hashes": {"leads": "0" * 64, "snapshot": "0" * 64},
+        "next_cursor": _decision_cursor(leads[1]),
     }
     feed = {
         "schema_version": "confenge.outreach.v1",
@@ -56,9 +59,62 @@ def test_incremental_provisional_size_matches_canonical_encoding() -> None:
         generated_at=generated_at,
         cursor=pagination["cursor"],
         chunk_index=pagination["chunk_index"],
+        next_cursor=pagination["next_cursor"],
+        snapshot_hash="0" * 64,
     )
 
     assert measured == len(_encode_chunk(feed))
+    packed_without_hashes = {
+        **feed,
+        "pagination": {
+            "cursor": pagination["cursor"],
+            "next_cursor": pagination["next_cursor"],
+            "has_more": True,
+            "chunk_index": 7,
+            "content_hash": "a" * 64,
+            "hashes": {"leads": "b" * 64, "snapshot": "c" * 64},
+        },
+    }
+    assert measured == len(_encode_chunk(packed_without_hashes))
+
+
+def test_packed_chunks_stay_under_byte_ceiling_after_hash_fields_are_added() -> None:
+    """Live publication failed when packing ignored post-pack content hashes."""
+    leads = [
+        {
+            "source_lead_id": f"lead-{idx}",
+            "company": {"cnpj14": f"{idx:014d}"},
+            "target_fit_source_watermark": "wm",
+            "target_fit_computed_at": "2026-08-28T00:00:00Z",
+            "note": "payload " * 40,
+        }
+        for idx in range(1, 40)
+    ]
+    source = {"system": "extra-cli", "run_id": "run-ceiling", "snapshot_hash": "s" * 64}
+    generated_at = "2026-08-28T04:00:00Z"
+    max_bytes = 12_000
+    packed = _chunk_leads(
+        leads,
+        max_leads=100,
+        max_bytes=max_bytes,
+        source=source,
+        generated_at=generated_at,
+    )
+    assert len(packed) > 1
+    for slice_leads, pagination in packed:
+        leads_hash = "a" * 64
+        feed = {
+            "schema_version": "confenge.outreach.v1",
+            "generated_at": generated_at,
+            "source": source,
+            "pagination": {
+                **pagination,
+                "content_hash": leads_hash,
+                "hashes": {"leads": leads_hash, "snapshot": source["snapshot_hash"]},
+            },
+            "leads": slice_leads,
+        }
+        assert len(_encode_chunk(feed)) <= max_bytes
 
 
 def test_reexport_same_inputs_same_hashes(


### PR DESCRIPTION
## Summary

Production `extra-confenge-feed-cycle` failed closed at:

```
encoded outreach chunk exceeds --max-bytes-per-chunk; chunk_index=17 bytes=512051 max=512000
```

`_chunk_leads` estimated size from an envelope without `pagination.content_hash` / `pagination.hashes`, which `export_outreach` adds immediately before `_encode_chunk`. The live miss was 51 bytes. The consumer ceiling is not raised.

## Test plan

- [x] `test_incremental_provisional_size_matches_canonical_encoding`
- [x] `test_packed_chunks_stay_under_byte_ceiling_after_hash_fields_are_added`
- [x] `test_reported_chunk_bytes_equal_the_files`
- [ ] required CI green