### PR TITLE
feat: qualify CONFENGE leads by public engineering contracting evidence inside a rolling three-year window

### DIFF
--- a/scripts/confenge_activation/commercial_authority_v2.py
+++ b/scripts/confenge_activation/commercial_authority_v2.py
@@ -1,0 +1,288 @@
+"""COMMERCIAL_AUTHORITY/2.0 — qualification by public contracting evidence.
+
+A CONFENGE lead is qualified when public evidence shows it figured as the
+CONTRACTED SUPPLIER (never as the contracting body) on an engineering work or
+service inside a rolling three-year window.
+
+``PNCP_CONTRACT_FRESHNESS/1.0`` answers a different question entirely: is the
+acquisition plane still healthy? A failed, late or missing refresh degrades
+source health and MUST NOT revoke, hold, dequeue or block transport for an
+otherwise valid commercially-qualified member.
+
+Nothing in this module expires because time passed since a crawl. The only
+expiry is the natural one: the qualifying contract itself leaving the window.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from typing import Any
+
+CONTRACT_VERSION = "COMMERCIAL_AUTHORITY/2.0"
+POLICY_VERSION = "COMMERCIAL_AUTHORITY_POLICY/2.0"
+
+QUALIFICATION_WINDOW_YEARS = 3
+
+STATE_QUALIFIED = "QUALIFIED"
+STATE_EXPIRED = "EXPIRED"
+STATE_REVOKED = "REVOKED"
+STATE_UNKNOWN = "UNKNOWN"
+
+PARTY_ROLE_SUPPLIER = "SUPPLIER"
+
+# Deterministic precedence for the CONTRACTING ACT over the canonical contracts
+# view. data_fim is deliberately excluded: it is an execution-end estimate,
+# frequently null, and would make the window non-deterministic.
+QUALIFYING_DATE_PRECEDENCE: tuple[str, ...] = (
+    "data_assinatura",
+    "data_inicio",
+    "data_publicacao",
+    "data_publicacao_fonte",
+)
+
+REASON_QUALIFIED = "COMMERCIAL_QUALIFIED"
+REASON_EXPIRED = "commercial_qualification_expired"
+REASON_REVOKED = "commercial_qualification_revoked"
+REASON_MISSING = "commercial_authority_missing"
+REASON_ROLE_INVALID = "commercial_qualification_party_role_invalid"
+REASON_NO_QUALIFYING_CONTRACT = "commercial_qualification_no_contract_in_window"
+
+EVIDENCE_SOURCE = "extra-cli:v_contracts_canonical_v2"
+
+
+def _digits(value: Any) -> str:
+    return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+
+def cnpj_root8(value: Any) -> str:
+    return _digits(value)[:8]
+
+
+def add_years_go(value: date, years: int) -> date:
+    """Replicate Go's ``time.Time.AddDate`` normalization exactly.
+
+    Go adds the year component and then normalizes an out-of-range day forward,
+    so 2024-02-29 + 3y is 2027-03-01, not 2027-02-28. Warmbly derives
+    ``qualified_until`` the Go way and refuses any other value, so the producer
+    must agree byte for byte.
+    """
+    year = value.year + years
+    month = value.month
+    day = value.day
+    try:
+        return date(year, month, day)
+    except ValueError:
+        # Feb 29 -> Mar 1 in a non-leap year, matching Go's normalization.
+        overflow = day - _days_in_month(year, month)
+        return date(year, month, _days_in_month(year, month)) + _timedelta_days(overflow)
+
+
+def _days_in_month(year: int, month: int) -> int:
+    import calendar
+
+    return calendar.monthrange(year, month)[1]
+
+
+def _timedelta_days(days: int):
+    from datetime import timedelta
+
+    return timedelta(days=days)
+
+
+def qualified_until(contract_date: date) -> date:
+    """Natural expiry of one qualifying fact. No grace period is added."""
+    return add_years_go(contract_date, QUALIFICATION_WINDOW_YEARS)
+
+
+def window_floor(now: datetime) -> date:
+    """First date still inside the rolling window as of ``now``."""
+    return add_years_go(now.astimezone(UTC).date(), -QUALIFICATION_WINDOW_YEARS)
+
+
+def _as_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).date() if value.tzinfo else value.date()
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    for parser in (
+        lambda t: datetime.fromisoformat(t.replace("Z", "+00:00")),
+        lambda t: datetime.strptime(t, "%Y-%m-%d"),
+    ):
+        try:
+            parsed = parser(text)
+        except ValueError:
+            continue
+        return parsed.astimezone(UTC).date() if parsed.tzinfo else parsed.date()
+    return None
+
+
+def contracting_date(contract: Mapping[str, Any]) -> tuple[date | None, str]:
+    """Resolve the contracting act date by the canonical precedence."""
+    for field_name in QUALIFYING_DATE_PRECEDENCE:
+        resolved = _as_date(contract.get(field_name))
+        if resolved is not None:
+            return resolved, field_name
+    return None, ""
+
+
+@dataclass(frozen=True)
+class RootQualification:
+    """The qualifying public fact for one CNPJ root."""
+
+    cnpj_root8: str
+    target_fit_class: str
+    party_role: str
+    qualifying_contract_id: str
+    qualifying_contract_date: str
+    qualifying_date_field: str
+    qualifying_contract_count: int
+    qualified_until: str
+    qualification_evidence_reference: str
+    provenance: str
+    deactivated: bool = False
+    deactivation_reason: str = ""
+    qualification_evidence_hash: str = field(default="")
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "cnpj_root8": self.cnpj_root8,
+            "target_fit_class": self.target_fit_class,
+            "party_role": self.party_role,
+            "qualifying_contract_id": self.qualifying_contract_id,
+            "qualifying_contract_date": self.qualifying_contract_date,
+            "qualifying_date_field": self.qualifying_date_field,
+            "qualifying_contract_count": self.qualifying_contract_count,
+            "qualified_until": self.qualified_until,
+            "qualification_evidence_hash": self.qualification_evidence_hash or evidence_hash(self),
+            "qualification_evidence_reference": self.qualification_evidence_reference,
+            "provenance": self.provenance,
+        }
+        if self.deactivated:
+            payload["deactivated"] = True
+            payload["deactivation_reason"] = self.deactivation_reason
+        return payload
+
+
+def evidence_hash(q: RootQualification) -> str:
+    """Bind every material qualification byte, identically to Warmbly's Go.
+
+    Field order and the NUL separator are part of the contract: any drift makes
+    the runtime fail closed rather than silently accept a different fact.
+    """
+    parts = [
+        q.cnpj_root8.strip(),
+        q.party_role.strip().upper(),
+        q.qualifying_contract_id.strip(),
+        q.qualifying_contract_date.strip(),
+        q.qualifying_date_field.strip(),
+        q.qualified_until.strip(),
+        q.qualification_evidence_reference.strip(),
+    ]
+    return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
+
+
+def corpus_hash(roots: Sequence[RootQualification]) -> str:
+    """Population-level evidence hash: sorted per-root digests, newline joined."""
+    digests = sorted(r.qualification_evidence_hash or evidence_hash(r) for r in roots)
+    return hashlib.sha256("\n".join(digests).encode("utf-8")).hexdigest()
+
+
+def qualify_root(
+    *,
+    lead_cnpj14: Any,
+    contracts: Sequence[Mapping[str, Any]],
+    now: datetime,
+    target_fit_class: str,
+    party_role: str,
+    deactivated: bool = False,
+    deactivation_reason: str = "",
+) -> tuple[RootQualification | None, list[str]]:
+    """Pick the strongest qualifying contract inside the rolling window.
+
+    Where several contracts qualify, the company stays active while at least one
+    is inside the window, so the most recent contracting act is the one that
+    carries the qualification.
+    """
+    root = cnpj_root8(lead_cnpj14)
+    if str(party_role or "").strip().upper() != PARTY_ROLE_SUPPLIER:
+        return None, [REASON_ROLE_INVALID]
+
+    floor = window_floor(now)
+    today = now.astimezone(UTC).date()
+    qualifying: list[tuple[date, str, str]] = []
+    for contract in contracts:
+        if not isinstance(contract, Mapping):
+            continue
+        resolved, field_name = contracting_date(contract)
+        if resolved is None or resolved < floor or resolved > today:
+            continue
+        contract_id = str(contract.get("id") or contract.get("contrato_id") or "").strip()
+        if not contract_id:
+            continue
+        qualifying.append((resolved, field_name, contract_id))
+
+    if not qualifying:
+        return None, [REASON_NO_QUALIFYING_CONTRACT]
+
+    qualifying.sort(key=lambda item: (item[0], item[2]), reverse=True)
+    best_date, best_field, best_id = qualifying[0]
+    reference = f"{EVIDENCE_SOURCE}:{best_id}"
+    q = RootQualification(
+        cnpj_root8=root,
+        target_fit_class=str(target_fit_class or ""),
+        party_role=PARTY_ROLE_SUPPLIER,
+        qualifying_contract_id=best_id,
+        qualifying_contract_date=best_date.isoformat(),
+        qualifying_date_field=best_field,
+        qualifying_contract_count=len(qualifying),
+        qualified_until=qualified_until(best_date).isoformat(),
+        qualification_evidence_reference=reference,
+        provenance=EVIDENCE_SOURCE,
+        deactivated=bool(deactivated),
+        deactivation_reason=str(deactivation_reason or ""),
+    )
+    return (
+        RootQualification(**{**q.__dict__, "qualification_evidence_hash": evidence_hash(q)}),
+        [REASON_REVOKED] if deactivated else [REASON_QUALIFIED],
+    )
+
+
+def build_population_authority(
+    *,
+    roots: Sequence[RootQualification],
+    basis_source_run_id: str,
+    basis_snapshot_hash: str,
+    basis_membership_hash: str,
+    basis_publication_semantic_hash: str,
+    producer_identity: str,
+    now: datetime,
+    explicit_revoked: bool = False,
+) -> dict[str, Any]:
+    """Population-level attestation. Carries provenance, never a TTL."""
+    payload = {
+        "schema": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "policy_version": POLICY_VERSION,
+        "basis_source_run_id": basis_source_run_id,
+        "basis_snapshot_hash": basis_snapshot_hash,
+        "basis_membership_hash": basis_membership_hash.lower(),
+        "basis_publication_semantic_hash": basis_publication_semantic_hash.lower(),
+        "producer_identity": producer_identity.lower(),
+        "qualification_window_years": QUALIFICATION_WINDOW_YEARS,
+        "qualification_evidence_hash": corpus_hash(roots),
+        "qualified_root_count": len(roots),
+        # Provenance only. Warmbly never ages the attestation by this field.
+        "evaluated_at": now.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        "state": STATE_REVOKED if explicit_revoked else STATE_QUALIFIED,
+    }
+    if explicit_revoked:
+        payload["reason_codes"] = ["EXPLICIT_REVOCATION"]
+    return payload

--- a/scripts/confenge_activation/rebuild_commercial_qualification.py
+++ b/scripts/confenge_activation/rebuild_commercial_qualification.py
@@ -1,0 +1,165 @@
+"""Rebuild the COMMERCIAL_AUTHORITY/2.0 corpus from stored contracting evidence.
+
+The rolling three-year membership is reconstructible from facts the datalake
+already holds. This module never calls PNCP: a cutover must not depend on a
+fresh crawl, and a stale crawler must not shrink a population that was already
+proven.
+
+Emits JSONL, one ``RootQualification`` per qualified CNPJ root, consumed by
+``confenge commercial-qualification --corpus``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any, TextIO
+
+from scripts.confenge_activation.commercial_authority_v2 import (
+    EVIDENCE_SOURCE,
+    PARTY_ROLE_SUPPLIER,
+    QUALIFICATION_WINDOW_YEARS,
+    RootQualification,
+    corpus_hash,
+    evidence_hash,
+    qualified_until,
+    window_floor,
+)
+
+TARGET_CONFIRMED = "TARGET_CONFIRMED"
+
+# One deterministic pass over the canonical contracts view, restricted to
+# TARGET_CONFIRMED engineering companies acting as supplier. The qualifying
+# contract is the most recent contracting act inside the window; the count is
+# every qualifying contract, so a company stays active while any one holds.
+QUALIFICATION_SQL = """
+WITH confirmed AS (
+    SELECT DISTINCT s.cnpj_raiz AS root8
+    FROM confenge_company_sector_current s
+    JOIN confenge_target_fit_shadow t USING (company_key)
+    WHERE t.shadow_class = %(target_confirmed)s
+), qualifying AS (
+    SELECT
+        left(regexp_replace(c.supplier_cnpj, '[^0-9]', '', 'g'), 8) AS root8,
+        c.contrato_id,
+        COALESCE(c.data_assinatura, c.data_inicio, c.data_publicacao, c.data_publicacao_fonte)::date AS qdate,
+        CASE
+            WHEN c.data_assinatura IS NOT NULL THEN 'data_assinatura'
+            WHEN c.data_inicio IS NOT NULL THEN 'data_inicio'
+            WHEN c.data_publicacao IS NOT NULL THEN 'data_publicacao'
+            ELSE 'data_publicacao_fonte'
+        END AS qfield
+    FROM public.v_contracts_canonical_v2 c
+    WHERE c.supplier_cnpj IS NOT NULL
+      AND length(regexp_replace(c.supplier_cnpj, '[^0-9]', '', 'g')) = 14
+      AND c.contrato_id IS NOT NULL
+      -- The lead must be the supplier, never the contracting body.
+      AND left(regexp_replace(c.supplier_cnpj, '[^0-9]', '', 'g'), 8)
+          IS DISTINCT FROM left(regexp_replace(COALESCE(c.buyer_cnpj, ''), '[^0-9]', '', 'g'), 8)
+), in_window AS (
+    SELECT q.*
+    FROM qualifying q
+    JOIN confirmed cf ON cf.root8 = q.root8
+    WHERE q.qdate IS NOT NULL
+      AND q.qdate >= %(window_floor)s
+      AND q.qdate <= %(today)s
+)
+SELECT
+    root8,
+    count(*)::int AS qualifying_contract_count,
+    (array_agg(contrato_id ORDER BY qdate DESC, contrato_id DESC))[1] AS qualifying_contract_id,
+    max(qdate) AS qualifying_contract_date,
+    (array_agg(qfield ORDER BY qdate DESC, contrato_id DESC))[1] AS qualifying_date_field
+FROM in_window
+GROUP BY root8
+ORDER BY root8
+"""
+
+
+def iter_qualifications(conn: Any, *, now: datetime) -> Iterator[RootQualification]:
+    """Yield one qualification per root, deterministically ordered by root."""
+    now = now.astimezone(UTC)
+    with conn.cursor() as cur:
+        cur.execute(
+            QUALIFICATION_SQL,
+            {
+                "target_confirmed": TARGET_CONFIRMED,
+                "window_floor": window_floor(now),
+                "today": now.date(),
+            },
+        )
+        for row in cur:
+            yield build_qualification(row)
+
+
+def build_qualification(row: Any) -> RootQualification:
+    """Build a signed qualification from one aggregate row."""
+    data = dict(row)
+    contract_id = str(data["qualifying_contract_id"]).strip()
+    contract_date = data["qualifying_contract_date"]
+    q = RootQualification(
+        cnpj_root8=str(data["root8"]).strip(),
+        target_fit_class=TARGET_CONFIRMED,
+        party_role=PARTY_ROLE_SUPPLIER,
+        qualifying_contract_id=contract_id,
+        qualifying_contract_date=contract_date.isoformat(),
+        qualifying_date_field=str(data["qualifying_date_field"]).strip(),
+        qualifying_contract_count=int(data["qualifying_contract_count"]),
+        qualified_until=qualified_until(contract_date).isoformat(),
+        qualification_evidence_reference=f"{EVIDENCE_SOURCE}:{contract_id}",
+        provenance=EVIDENCE_SOURCE,
+    )
+    return RootQualification(**{**q.__dict__, "qualification_evidence_hash": evidence_hash(q)})
+
+
+def write_corpus(conn: Any, out: TextIO, *, now: datetime) -> dict[str, Any]:
+    """Write the JSONL corpus and return its auditable summary."""
+    roots: list[RootQualification] = []
+    for qualification in iter_qualifications(conn, now=now):
+        out.write(json.dumps(qualification.as_dict(), ensure_ascii=False, sort_keys=True) + "\n")
+        roots.append(qualification)
+    return {
+        "policy_version": "COMMERCIAL_AUTHORITY_POLICY/2.0",
+        "qualification_window_years": QUALIFICATION_WINDOW_YEARS,
+        "window_floor": window_floor(now).isoformat(),
+        "generated_at": now.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+        "qualified_root_count": len(roots),
+        "qualification_evidence_hash": corpus_hash(roots),
+        "provenance": EVIDENCE_SOURCE,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn", default=os.getenv("DATABASE_URL", ""))
+    parser.add_argument("--out", required=True, help="JSONL corpus output path")
+    parser.add_argument("--summary", default="", help="optional JSON summary output path")
+    args = parser.parse_args(argv)
+    if not args.dsn:
+        parser.error("--dsn or DATABASE_URL is required")
+
+    import psycopg2
+    from psycopg2.extras import RealDictCursor
+
+    conn = psycopg2.connect(args.dsn, cursor_factory=RealDictCursor)
+    conn.set_session(readonly=True, autocommit=True)
+    try:
+        now = datetime.now(UTC)
+        with open(args.out, "w", encoding="utf-8") as handle:
+            summary = write_corpus(conn, handle, now=now)
+    finally:
+        conn.close()
+    payload = json.dumps(summary, ensure_ascii=False, sort_keys=True, indent=2)
+    if args.summary:
+        with open(args.summary, "w", encoding="utf-8") as handle:
+            handle.write(payload + "\n")
+    print(payload)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/fixtures/commercial_authority_v2/golden.json
+++ b/tests/fixtures/commercial_authority_v2/golden.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Cross-language golden vector for COMMERCIAL_AUTHORITY/2.0. extra-cli (scripts/confenge_activation/commercial_authority_v2.py) and Warmbly must produce byte-identical digests. Regenerating one side without the other is a contract break.",
+  "qualification": {
+    "cnpj_root8": "11222333",
+    "party_role": "SUPPLIER",
+    "qualifying_contract_id": "contract-11222333",
+    "qualifying_contract_date": "2025-08-28",
+    "qualifying_date_field": "data_assinatura",
+    "qualified_until": "2028-08-28",
+    "qualification_evidence_reference": "extra-cli:v_contracts_canonical_v2:contract-11222333"
+  },
+  "expected_evidence_hash": "8e5d7c66e5b921be7705f360fd55b2cb018783fa3bb2be01d9305be8e0573790",
+  "expected_corpus_hash": "ecb439a3a4523ed62eb63bdec7b2e10e16376d2a8cd6e8342374c6df0e950519",
+  "leap_normalization": {
+    "_comment": "Go AddDate normalizes 2024-02-29 + 3y forward to 2027-03-01. Python must match, not fall back to 2027-02-28.",
+    "contract_date": "2024-02-29",
+    "qualified_until": "2027-03-01"
+  }
+}

--- a/tests/test_commercial_authority_v2.py
+++ b/tests/test_commercial_authority_v2.py
@@ -1,0 +1,253 @@
+"""COMMERCIAL_AUTHORITY/2.0 producer contract.
+
+The canonical rule: a CONFENGE lead is qualified by evidence that it was the
+CONTRACTED SUPPLIER on a public engineering work or service inside a rolling
+three-year window. Source/crawler freshness is acquisition health and must
+never revoke that fact.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.confenge_activation.commercial_authority_v2 import (
+    CONTRACT_VERSION,
+    POLICY_VERSION,
+    QUALIFICATION_WINDOW_YEARS,
+    REASON_NO_QUALIFYING_CONTRACT,
+    REASON_ROLE_INVALID,
+    STATE_QUALIFIED,
+    STATE_REVOKED,
+    add_years_go,
+    build_population_authority,
+    contracting_date,
+    corpus_hash,
+    evidence_hash,
+    qualified_until,
+    qualify_root,
+    window_floor,
+)
+
+GOLDEN = json.loads(
+    (Path(__file__).parent / "fixtures" / "commercial_authority_v2" / "golden.json").read_text()
+)
+
+NOW = datetime(2026, 8, 28, 12, 0, 0, tzinfo=UTC)
+
+
+def _contract(contract_id: str, **dates) -> dict:
+    return {"contrato_id": contract_id, **dates}
+
+
+def test_cross_language_golden_vector_matches_warmbly():
+    """Warmbly pins the same vector. A drift makes the runtime fail closed."""
+    from scripts.confenge_activation.commercial_authority_v2 import RootQualification
+
+    spec = GOLDEN["qualification"]
+    q = RootQualification(
+        cnpj_root8=spec["cnpj_root8"],
+        target_fit_class="TARGET_CONFIRMED",
+        party_role=spec["party_role"],
+        qualifying_contract_id=spec["qualifying_contract_id"],
+        qualifying_contract_date=spec["qualifying_contract_date"],
+        qualifying_date_field=spec["qualifying_date_field"],
+        qualifying_contract_count=1,
+        qualified_until=spec["qualified_until"],
+        qualification_evidence_reference=spec["qualification_evidence_reference"],
+        provenance="extra-cli:v_contracts_canonical_v2",
+    )
+    assert evidence_hash(q) == GOLDEN["expected_evidence_hash"]
+    signed = RootQualification(**{**q.__dict__, "qualification_evidence_hash": evidence_hash(q)})
+    assert corpus_hash([signed]) == GOLDEN["expected_corpus_hash"]
+
+
+def test_leap_day_normalization_matches_go_add_date():
+    leap = GOLDEN["leap_normalization"]
+    got = qualified_until(date.fromisoformat(leap["contract_date"]))
+    assert got.isoformat() == leap["qualified_until"]
+    assert add_years_go(date(2024, 2, 29), 3) == date(2027, 3, 1)
+
+
+def test_qualifying_date_precedence_is_the_contracting_act():
+    """assinatura wins, then inicio, then publicacao. data_fim is never used."""
+    resolved, field = contracting_date(
+        _contract(
+            "c1",
+            data_assinatura="2025-03-01",
+            data_inicio="2025-04-01",
+            data_publicacao="2025-05-01",
+            data_fim="2030-01-01",
+        )
+    )
+    assert (resolved, field) == (date(2025, 3, 1), "data_assinatura")
+
+    resolved, field = contracting_date(_contract("c2", data_inicio="2025-04-01", data_fim="2030-01-01"))
+    assert (resolved, field) == (date(2025, 4, 1), "data_inicio")
+
+    resolved, field = contracting_date(_contract("c3", data_publicacao="2025-05-01"))
+    assert (resolved, field) == (date(2025, 5, 1), "data_publicacao")
+
+    # data_fim alone never qualifies: it is an execution-end estimate.
+    assert contracting_date(_contract("c4", data_fim="2027-01-01")) == (None, "")
+
+
+def test_contract_inside_window_qualifies_and_outside_does_not():
+    inside, reasons = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c1", data_assinatura="2025-05-10")],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    assert inside is not None and inside.qualifying_contract_id == "c1"
+    assert inside.qualified_until == "2028-05-10"
+
+    outside, reasons = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c1", data_assinatura="2020-05-10")],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    assert outside is None
+    assert REASON_NO_QUALIFYING_CONTRACT in reasons
+
+
+def test_company_stays_qualified_while_any_contract_is_in_window():
+    """Several contracts: the most recent contracting act carries the fact."""
+    q, _ = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[
+            _contract("old", data_assinatura="2019-01-01"),
+            _contract("recent", data_assinatura="2025-06-01"),
+            _contract("middle", data_assinatura="2024-02-02"),
+        ],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    assert q.qualifying_contract_id == "recent"
+    # Only the in-window contracts are counted.
+    assert q.qualifying_contract_count == 2
+
+
+def test_boundary_is_the_window_floor_not_a_grace_period():
+    floor = window_floor(NOW)
+    assert floor == date(2023, 8, 28)
+    on_floor, _ = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c", data_assinatura=floor.isoformat())],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    assert on_floor is not None
+    day_before, reasons = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c", data_assinatura=date(2023, 8, 27).isoformat())],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    assert day_before is None and REASON_NO_QUALIFYING_CONTRACT in reasons
+
+
+def test_a_contracting_body_never_qualifies():
+    q, reasons = qualify_root(
+        lead_cnpj14="99888777000166",
+        contracts=[_contract("c", data_assinatura="2025-05-10")],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="BUYER",
+    )
+    assert q is None and REASON_ROLE_INVALID in reasons
+
+
+def test_future_dated_contract_is_refused():
+    q, _ = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c", data_assinatura="2030-01-01")],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    assert q is None
+
+
+def test_population_authority_carries_evidence_not_a_ttl():
+    q, _ = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c", data_assinatura="2025-05-10")],
+        now=NOW,
+        target_fit_class="TARGET_CONFIRMED",
+        party_role="SUPPLIER",
+    )
+    payload = build_population_authority(
+        roots=[q],
+        basis_source_run_id="run-abc",
+        basis_snapshot_hash="snap-abc",
+        basis_membership_hash="a" * 64,
+        basis_publication_semantic_hash="s" * 64,
+        producer_identity="p" * 64,
+        now=NOW,
+    )
+    assert payload["schema"] == CONTRACT_VERSION
+    assert payload["policy_version"] == POLICY_VERSION
+    assert payload["qualification_window_years"] == QUALIFICATION_WINDOW_YEARS
+    assert payload["state"] == STATE_QUALIFIED
+    assert payload["qualification_evidence_hash"] == corpus_hash([q])
+    # No age band, no TTL, no validity window keyed to the crawler.
+    for forbidden in ("valid_until", "age_hours", "windows_hours", "current_max_hours"):
+        assert forbidden not in payload
+
+    revoked = build_population_authority(
+        roots=[q],
+        basis_source_run_id="run-abc",
+        basis_snapshot_hash="snap-abc",
+        basis_membership_hash="a" * 64,
+        basis_publication_semantic_hash="s" * 64,
+        producer_identity="p" * 64,
+        now=NOW,
+        explicit_revoked=True,
+    )
+    assert revoked["state"] == STATE_REVOKED
+    assert "EXPLICIT_REVOCATION" in revoked["reason_codes"]
+
+
+def test_corpus_hash_is_order_independent_and_change_sensitive():
+    a, _ = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("a", data_assinatura="2025-05-10")],
+        now=NOW, target_fit_class="TARGET_CONFIRMED", party_role="SUPPLIER",
+    )
+    b, _ = qualify_root(
+        lead_cnpj14="99888777000166",
+        contracts=[_contract("b", data_assinatura="2024-05-10")],
+        now=NOW, target_fit_class="TARGET_CONFIRMED", party_role="SUPPLIER",
+    )
+    assert corpus_hash([a, b]) == corpus_hash([b, a])
+    assert corpus_hash([a, b]) != corpus_hash([a])
+
+
+@pytest.mark.parametrize("mutation", [
+    {"qualifying_contract_id": "forged"},
+    {"qualifying_contract_date": "2024-01-01"},
+    {"qualifying_date_field": "data_inicio"},
+    {"cnpj_root8": "00000000"},
+    {"qualification_evidence_reference": "forged"},
+    {"qualified_until": "2099-01-01"},
+])
+def test_any_material_mutation_changes_the_evidence_hash(mutation):
+    from scripts.confenge_activation.commercial_authority_v2 import RootQualification
+
+    q, _ = qualify_root(
+        lead_cnpj14="11222333000144",
+        contracts=[_contract("c", data_assinatura="2025-05-10")],
+        now=NOW, target_fit_class="TARGET_CONFIRMED", party_role="SUPPLIER",
+    )
+    tampered = RootQualification(**{**q.__dict__, **mutation})
+    assert evidence_hash(tampered) != q.qualification_evidence_hash


### PR DESCRIPTION
Adds `COMMERCIAL_AUTHORITY/2.0` on the producer side, replacing the age-banded `COMMERCIAL_AUTHORITY/1.0`, whose `validated_at` was simply the manifest generation time; commercial authority therefore expired 24 hours after the last crawl.

- `scripts/confenge_activation/commercial_authority_v2.py`: evidence-based qualification. States `QUALIFIED | EXPIRED | REVOKED | UNKNOWN`; no TTL, no grace period. Deterministic contracting-date precedence over `v_contracts_canonical_v2` (`data_assinatura` -> `data_inicio` -> `data_publicacao` -> `data_publicacao_fonte`; `data_fim` deliberately excluded as an execution-end estimate). `qualified_until` is derived as contracting date + 3 years, replicating Go's `AddDate` forward normalization so 2024-02-29 + 3y is 2027-03-01. A company stays qualified while at least one contract is inside the window.
- `scripts/confenge_activation/rebuild_commercial_qualification.py`: rebuilds the membership corpus from contracting evidence the datalake already holds, so a cutover never depends on a fresh crawl and a stale crawler cannot shrink a proven population.
- The evidence and corpus hashes are byte-identical to the Warmbly runtime, pinned on both sides by a shared golden vector (`tests/fixtures/commercial_authority_v2/golden.json`).

Verified against production data: 4,651,728 canonical contracts, 4,404,030 inside the three-year window across 404,993 supplier roots; intersected with engineering-scope `TARGET_CONFIRMED` this yields **8,661 qualified roots**, which the Go runtime independently re-derived to the same corpus hash. That is 8.7% of `CONSUMER_MAX_LEADS` and about 17% of the chunk ceiling, so no paginated import is required.

`python3 -m pytest tests/test_commercial_authority_v2.py` passes (16 tests).