### PR TITLE
fix: retry transient PNCP source drift before CONFENGE freshness expires

### DIFF
--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -324,7 +324,7 @@ def verify(sha: str) -> dict[str, object]:
             or ""
         ).strip()
         if prop == "SuccessExitStatus":
-            if "75" in observed.split():
+            if observed:
                 pncp_service_semantic_drift.append({"property": prop, "observed": observed})
         elif observed != "no":
             pncp_service_semantic_drift.append({"property": prop, "observed": observed})

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -72,6 +72,11 @@ CHAIN_DISABLED_TIMERS = (
     "extra-confenge-feed-cycle.timer",
 )
 
+# These are the only base units managed by the immutable CONFENGE release pin.
+# Their drop-ins select the release interpreter, but directives such as retry,
+# OnSuccess and StartLimit live in the base unit and must be installed too.
+CHAIN_BASE_UNITS = tuple(dict.fromkeys((*CHAIN_UNITS, *CHAIN_TIMERS, *CHAIN_DISABLED_TIMERS)))
+
 # Long-running workers that must come back after a reboot.
 CHAIN_ENABLED_SERVICES = ("extra-confenge-target-fit-worker.service",)
 
@@ -190,6 +195,30 @@ def plan(sha: str) -> dict[str, str]:
     return rendered
 
 
+def canonical_base_units() -> dict[str, str]:
+    """Load the small, versioned systemd base-unit set before touching the host."""
+    base: dict[str, str] = {}
+    for unit in CHAIN_BASE_UNITS:
+        source = UNIT_SOURCE / unit
+        if not source.is_file():
+            raise PinError(f"versioned base unit file is missing: {source}")
+        base[unit] = source.read_text(encoding="utf-8")
+    return base
+
+
+def install_base_units(units: dict[str, str]) -> list[str]:
+    """Atomically replace only the managed base units, with safe permissions."""
+    written: list[str] = []
+    for unit, body in units.items():
+        target = SYSTEMD_ROOT / unit
+        tmp = target.with_name(f".{unit}.tmp")
+        tmp.write_text(body, encoding="utf-8")
+        tmp.chmod(0o644)
+        tmp.replace(target)
+        written.append(str(target))
+    return written
+
+
 def foreign_execstart_dropins() -> dict[str, list[str]]:
     """Find drop-ins other than ours that also override ExecStart.
 
@@ -217,13 +246,18 @@ def foreign_execstart_dropins() -> dict[str, list[str]]:
 
 def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
     rendered = plan(sha)
+    base_units = canonical_base_units()
     if foreign := foreign_execstart_dropins():
         raise PinError(
             "drop-ins outside this tool also set ExecStart and would be discarded by the pin; "
             f"move their configuration into deploy/systemd and remove them: {foreign}"
         )
     written: list[str] = []
+    base_written: list[str] = []
     if not dry_run:
+        # Install base units before drop-ins and daemon-reload. This deliberately
+        # does not provision unrelated systemd configuration or EnvironmentFiles.
+        base_written = install_base_units(base_units)
         for unit, body in rendered.items():
             target_dir = SYSTEMD_ROOT / f"{unit}.d"
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -242,6 +276,7 @@ def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
         "schema": "confenge.release_pin.v1",
         "release_sha": sha,
         "units_pinned": list(rendered),
+        "base_units_installed": base_written,
         "timers_enabled": list(CHAIN_TIMERS),
         "timers_disabled": list(CHAIN_DISABLED_TIMERS),
         "services_enabled": list(CHAIN_ENABLED_SERVICES),

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -72,11 +72,6 @@ CHAIN_DISABLED_TIMERS = (
     "extra-confenge-feed-cycle.timer",
 )
 
-# These are the only base units managed by the immutable CONFENGE release pin.
-# Their drop-ins select the release interpreter, but directives such as retry,
-# OnSuccess and StartLimit live in the base unit and must be installed too.
-CHAIN_BASE_UNITS = tuple(dict.fromkeys((*CHAIN_UNITS, *CHAIN_TIMERS, *CHAIN_DISABLED_TIMERS)))
-
 # Long-running workers that must come back after a reboot.
 CHAIN_ENABLED_SERVICES = ("extra-confenge-target-fit-worker.service",)
 
@@ -167,6 +162,11 @@ def render_dropin(unit_text: str, sha: str) -> str:
         "ExecStart=",
         exec_start,
     ]
+    # A legacy base unit on the VPS may still consider lock-busy exit 75 a
+    # success. The immutable PNCP drop-in must override that semantic even
+    # before a fresh-install base unit is deployed.
+    if "scripts.crawl.run_contracts_incremental" in unit_text:
+        body.extend(["SuccessExitStatus=", "Restart=no"])
     return "\n".join(body) + "\n"
 
 
@@ -193,30 +193,6 @@ def plan(sha: str) -> dict[str, str]:
         except PinError as exc:
             raise PinError(f"{unit}: {exc}") from exc
     return rendered
-
-
-def canonical_base_units() -> dict[str, str]:
-    """Load the small, versioned systemd base-unit set before touching the host."""
-    base: dict[str, str] = {}
-    for unit in CHAIN_BASE_UNITS:
-        source = UNIT_SOURCE / unit
-        if not source.is_file():
-            raise PinError(f"versioned base unit file is missing: {source}")
-        base[unit] = source.read_text(encoding="utf-8")
-    return base
-
-
-def install_base_units(units: dict[str, str]) -> list[str]:
-    """Atomically replace only the managed base units, with safe permissions."""
-    written: list[str] = []
-    for unit, body in units.items():
-        target = SYSTEMD_ROOT / unit
-        tmp = target.with_name(f".{unit}.tmp")
-        tmp.write_text(body, encoding="utf-8")
-        tmp.chmod(0o644)
-        tmp.replace(target)
-        written.append(str(target))
-    return written
 
 
 def foreign_execstart_dropins() -> dict[str, list[str]]:
@@ -246,18 +222,13 @@ def foreign_execstart_dropins() -> dict[str, list[str]]:
 
 def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
     rendered = plan(sha)
-    base_units = canonical_base_units()
     if foreign := foreign_execstart_dropins():
         raise PinError(
             "drop-ins outside this tool also set ExecStart and would be discarded by the pin; "
             f"move their configuration into deploy/systemd and remove them: {foreign}"
         )
     written: list[str] = []
-    base_written: list[str] = []
     if not dry_run:
-        # Install base units before drop-ins and daemon-reload. This deliberately
-        # does not provision unrelated systemd configuration or EnvironmentFiles.
-        base_written = install_base_units(base_units)
         for unit, body in rendered.items():
             target_dir = SYSTEMD_ROOT / f"{unit}.d"
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -276,7 +247,6 @@ def apply(sha: str, *, dry_run: bool = False) -> dict[str, object]:
         "schema": "confenge.release_pin.v1",
         "release_sha": sha,
         "units_pinned": list(rendered),
-        "base_units_installed": base_written,
         "timers_enabled": list(CHAIN_TIMERS),
         "timers_disabled": list(CHAIN_DISABLED_TIMERS),
         "services_enabled": list(CHAIN_ENABLED_SERVICES),
@@ -347,6 +317,17 @@ def verify(sha: str) -> dict[str, object]:
             independently_scheduled.append(
                 f"{unit}=enabled:{enabled or 'unknown'},active:{active or 'unknown'}"
             )
+    pncp_service_semantic_drift: list[dict[str, str]] = []
+    for prop in ("SuccessExitStatus", "Restart"):
+        observed = (
+            _run(["systemctl", "show", "pncp-contracts.service", "-p", prop, "--value"], check=False).stdout
+            or ""
+        ).strip()
+        if prop == "SuccessExitStatus":
+            if "75" in observed.split():
+                pncp_service_semantic_drift.append({"property": prop, "observed": observed})
+        elif observed != "no":
+            pncp_service_semantic_drift.append({"property": prop, "observed": observed})
     return {
         "schema": "confenge.release_pin_verification.v1",
         "release_sha": sha,
@@ -360,6 +341,7 @@ def verify(sha: str) -> dict[str, object]:
                 disabled,
                 inactive_timers,
                 independently_scheduled,
+                pncp_service_semantic_drift,
             )
         ),
         "release_drift": drift,
@@ -370,6 +352,7 @@ def verify(sha: str) -> dict[str, object]:
         "not_enabled": disabled,
         "timers_not_active": inactive_timers,
         "downstream_timers_scheduled": independently_scheduled,
+        "pncp_service_semantic_drift": pncp_service_semantic_drift,
     }
 
 

--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -27,7 +27,9 @@ Environment=CONTRACTS_PAGE_RETRY_BASE_SECONDS=5
 Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30
 # The update-date population is legitimately mutable while PNCP retifications
 # move contracts between days. Replay from page 1; only a later stable full
-# pass may close the window. The whole oneshot remains bounded to 150 minutes.
+# pass may close the window. The Python runner may perform one complete second
+# attempt after a five-minute delay, so the whole oneshot is bounded to 320
+# minutes while the single writer fence remains held.
 Environment=CONTRACTS_WINDOW_RETRY_MAX=2
 Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60
 # ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental.
@@ -43,7 +45,7 @@ ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.crawl.run_contracts
     --checkpoint-dir /var/lib/extra-consultoria/checkpoints/contracts
 User=extra-consultoria
 Group=extra-consultoria
-TimeoutStartSec=150min
+TimeoutStartSec=320min
 Restart=no
 StandardOutput=journal
 StandardError=journal

--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -6,10 +6,12 @@ Description=PNCP Contracts Crawler — Extra Consultoria
 After=network-online.target
 Wants=network-online.target
 OnFailure=extra-onfailure@%n.service
-# SuccessExitStatus=75 below is intentionally considered successful by
-# systemd. Never point this unit directly at target-fit: the dedicated gate
-# re-evaluates the semantic source contract and blocks 75/partial/stale/error.
+# Never point this unit directly at target-fit: the dedicated gate re-evaluates
+# the semantic source contract before any downstream stage may advance.
 OnSuccess=extra-confenge-source-freshness-gate.service
+# One initial start plus one forced retry inside this source timer interval.
+StartLimitIntervalSec=4h
+StartLimitBurst=2
 
 [Service]
 Type=oneshot
@@ -31,16 +33,15 @@ Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30
 # pass may close the window. The whole oneshot remains bounded to 150 minutes.
 Environment=CONTRACTS_WINDOW_RETRY_MAX=2
 Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60
-# ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental
-# (/run/lock/extra-contracts-writer.lock). Do NOT wrap with outer flock on the
-# same path (would always exit 75). Exit 75 = lock busy (not a source failure).
-# SuccessExitStatus=75 keeps systemd from treating expected writer contention as
-# a unit failure (avoids OnFailure storms). It is NOT a closed window and NOT
-# freshness success: PNCP_CONTRACT_FRESHNESS classifies LOCK_BUSY_NO_CLOSE and
-# the next 4h OnCalendar is the catch-up/retry. --days 7 remains the overlap for
-# late arrivals/retificações, split by the runner into seven daily completion
-# units so mutable upstream pagination cannot invalidate the whole lookback.
-SuccessExitStatus=75
+# ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental.
+# Exit 75 means another writer owns the fence: it is neither a source success
+# nor retryable, so it must not trigger OnSuccess. Exit 77 is emitted only for
+# a fully classified transient PNCP failure/source-population drift. The runner
+# only emits 0, 1, 2, 75 or 77: prevent the structural/lock codes and restart
+# 77 once after a delay. (RestartForceExitStatus is invalid for Type=oneshot.)
+Restart=on-failure
+RestartPreventExitStatus=1 2 75
+RestartSec=5min
 # The checkpoint has to live outside the release tree: releases are immutable and
 # read-only, and a crawl that cannot write its checkpoint restarts from zero and
 # fails closed. This was a hand-written drop-in on the host, which is how a

--- a/deploy/systemd/pncp-contracts.service
+++ b/deploy/systemd/pncp-contracts.service
@@ -9,9 +9,6 @@ OnFailure=extra-onfailure@%n.service
 # Never point this unit directly at target-fit: the dedicated gate re-evaluates
 # the semantic source contract before any downstream stage may advance.
 OnSuccess=extra-confenge-source-freshness-gate.service
-# One initial start plus one forced retry inside this source timer interval.
-StartLimitIntervalSec=4h
-StartLimitBurst=2
 
 [Service]
 Type=oneshot
@@ -35,13 +32,8 @@ Environment=CONTRACTS_WINDOW_RETRY_MAX=2
 Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60
 # ONE_PRODUCTION_LOCK_DOMAIN — lock acquired inside run_contracts_incremental.
 # Exit 75 means another writer owns the fence: it is neither a source success
-# nor retryable, so it must not trigger OnSuccess. Exit 77 is emitted only for
-# a fully classified transient PNCP failure/source-population drift. The runner
-# only emits 0, 1, 2, 75 or 77: prevent the structural/lock codes and restart
-# 77 once after a delay. (RestartForceExitStatus is invalid for Type=oneshot.)
-Restart=on-failure
-RestartPreventExitStatus=1 2 75
-RestartSec=5min
+# nor retryable, so it must not trigger OnSuccess. The Python runner owns its
+# single bounded replay for typed upstream failures; systemd never restarts it.
 # The checkpoint has to live outside the release tree: releases are immutable and
 # read-only, and a crawl that cannot write its checkpoint restarts from zero and
 # fails closed. This was a hand-written drop-in on the host, which is how a

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Índice da documentação — Extra Consultoria
 
-**Atualizado:** 2026-08-29
+**Atualizado:** 2026-08-31
 **Regra:** docs **vivas** descrevem o estado atual; sessões e audits datados são **evidência/snapshot**, não onboarding.
 
 Precedência: `DOD.md` → ADR vigente → código testado → evidência reproduzível.
@@ -35,6 +35,7 @@ Precedência: `DOD.md` → ADR vigente → código testado → evidência reprod
 | [`docs/ops/searxng-private-backend.md`](ops/searxng-private-backend.md) | SearXNG privado CONFENGE (HTTP boundary, runbook) |
 | [`docs/ops/confenge-activation-planner.md`](ops/confenge-activation-planner.md) | Ciclo canônico, publicação atômica e freshness do feed Warmbly |
 | [`docs/ops/national-census-operation.md`](ops/national-census-operation.md) | Census nacional retomável e gate factual #302 |
+| [`docs/ops/handoff-2026-08-31-confenge-source-retry.md`](ops/handoff-2026-08-31-confenge-source-retry.md) | Retry limitado da fonte e pin das unidades-base CONFENGE |
 | `artifacts/campaigns/HISTORICAL-CONTRACTS-OPERATIONAL-CLOSURE-01/` | Campanha HC (STATUS/HANDOFF) |
 | `specs/001-*`, `specs/002-*` | Spec Kit dual / historical contracts |
 | `deploy/systemd/` | Units de produção |

--- a/docs/ops/handoff-2026-08-31-confenge-source-retry.md
+++ b/docs/ops/handoff-2026-08-31-confenge-source-retry.md
@@ -21,9 +21,9 @@ curta de recuperação.
   janela de quatro horas. Códigos estruturais `1` e `2` não reiniciam.
 - A cadeia permanece serial e só avança para o freshness gate depois de um
   resultado `0`.
-- O pin imutável instala apenas as unidades-base versionadas da cadeia
-  CONFENGE, preserva drop-ins e EnvironmentFiles, e só então aplica os
-  drop-ins do release e faz `daemon-reload`.
+- O drop-in do release imutável limpa o legado `SuccessExitStatus=75` e fixa
+  `Restart=no`, de modo que a correção alcance hosts já provisionados sem
+  substituir unidades-base, EnvironmentFiles ou drop-ins externos.
 
 O retry não transforma freshness vencida em aprovada e não altera a
 `COMMERCIAL_AUTHORITY/2.0`. Integridade do last-good, saúde da fonte e
@@ -32,7 +32,7 @@ autoridade comercial continuam sinais separados.
 ## Verificação do branch
 
 ```text
-pytest focado: 133 passed
+pytest focado: 136 passed
 ruff check: PASS
 git diff --check: PASS
 ```
@@ -45,5 +45,5 @@ Depois do merge, cortar e pinar o release imutável. Em seguida comprovar:
 2. uma única tentativa ocorre após cinco minutos;
 3. exit `0` aciona freshness gate, target-fit, contact cycle e feed cycle;
 4. exit `1`, `2` ou `75` não reinicia nem aciona downstream;
-5. `pin_release.py verify <sha>` não encontra drift de unidade ou release.
-
+5. `pin_release.py --verify-only <sha>` confirma `Restart=no`, ausência de
+   success exit `75` e identidade de release sem drift.

--- a/docs/ops/handoff-2026-08-31-confenge-source-retry.md
+++ b/docs/ops/handoff-2026-08-31-confenge-source-retry.md
@@ -1,6 +1,6 @@
 # Handoff: retry limitado da fonte CONFENGE
 
-**Data:** 2026-08-31  
+**Data:** 2026-08-31
 **Estado:** `VERIFIED` no branch; requer CI, merge e validação live para `ACCEPTED`
 
 ## Incidente
@@ -17,8 +17,8 @@ curta de recuperação.
 - `75` significa writer lock ocupado e não é sucesso nem condição de retry.
 - `77` é emitido somente quando todos os erros observados são transitórios:
   source-population drift, timeout, conexão, rate limit ou HTTP 5xx.
-- O systemd executa no máximo uma nova tentativa após cinco minutos dentro da
-  janela de quatro horas. Códigos estruturais `1` e `2` não reiniciam.
+- O runner Python executa no máximo uma nova tentativa após cinco minutos,
+  ainda sob a mesma trava de writer. Códigos estruturais `1` e `2` não repetem.
 - A cadeia permanece serial e só avança para o freshness gate depois de um
   resultado `0`.
 - O drop-in do release imutável limpa o legado `SuccessExitStatus=75` e fixa
@@ -32,7 +32,7 @@ autoridade comercial continuam sinais separados.
 ## Verificação do branch
 
 ```text
-pytest focado: 136 passed
+pytest focado: 137 passed
 ruff check: PASS
 git diff --check: PASS
 ```

--- a/docs/ops/handoff-2026-08-31-confenge-source-retry.md
+++ b/docs/ops/handoff-2026-08-31-confenge-source-retry.md
@@ -1,0 +1,49 @@
+# Handoff: retry limitado da fonte CONFENGE
+
+**Data:** 2026-08-31  
+**Estado:** `VERIFIED` no branch; requer CI, merge e validação live para `ACCEPTED`
+
+## Incidente
+
+O ciclo PNCP das 08:00 BRT terminou `partial` depois de detectar mudança de
+população durante a paginação. O serviço aguardaria o próximo slot de quatro
+horas, enquanto a autoridade de freshness usada para nova publicação expirava.
+O pipeline downstream permaneceu corretamente fechado, mas sem uma tentativa
+curta de recuperação.
+
+## Contrato implementado
+
+- `0` continua sendo o único sucesso que aciona `OnSuccess`.
+- `75` significa writer lock ocupado e não é sucesso nem condição de retry.
+- `77` é emitido somente quando todos os erros observados são transitórios:
+  source-population drift, timeout, conexão, rate limit ou HTTP 5xx.
+- O systemd executa no máximo uma nova tentativa após cinco minutos dentro da
+  janela de quatro horas. Códigos estruturais `1` e `2` não reiniciam.
+- A cadeia permanece serial e só avança para o freshness gate depois de um
+  resultado `0`.
+- O pin imutável instala apenas as unidades-base versionadas da cadeia
+  CONFENGE, preserva drop-ins e EnvironmentFiles, e só então aplica os
+  drop-ins do release e faz `daemon-reload`.
+
+O retry não transforma freshness vencida em aprovada e não altera a
+`COMMERCIAL_AUTHORITY/2.0`. Integridade do last-good, saúde da fonte e
+autoridade comercial continuam sinais separados.
+
+## Verificação do branch
+
+```text
+pytest focado: 133 passed
+ruff check: PASS
+git diff --check: PASS
+```
+
+## Aceite live
+
+Depois do merge, cortar e pinar o release imutável. Em seguida comprovar:
+
+1. exit `77` mantém downstream parado;
+2. uma única tentativa ocorre após cinco minutos;
+3. exit `0` aciona freshness gate, target-fit, contact cycle e feed cycle;
+4. exit `1`, `2` ou `75` não reinicia nem aciona downstream;
+5. `pin_release.py verify <sha>` não encontra drift de unidade ou release.
+

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -28,7 +28,9 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
+import time
 from datetime import UTC, date, datetime
 from pathlib import Path
 
@@ -60,6 +62,7 @@ DEFAULT_CAMPAIGN = "historical_contracts_incremental"
 INCREMENTAL_QUERY_KIND = "update"
 INCREMENTAL_WINDOW_DAYS = 1
 EXIT_RETRYABLE_SOURCE = 77
+RETRY_DELAY_SECONDS = 300
 
 
 def current_incremental_window_keys(
@@ -127,15 +130,17 @@ def _is_retryable_source_error(error: str) -> bool:
     error even when optional database modules are unavailable after a failed
     attempt.  Everything not named here is structural and therefore terminal.
     """
-    text = error.lower()
-    retry_markers = (
-        "timeout",
-        "timed out",
-        "connection_failed",
-        "rate_limit",
-        "http_server_error",
+    text = str(error or "").strip().lower()
+    return bool(
+        re.match(
+            r"^(source_population_drift|connection_failed|rate_limit|http_server_error)(:|\b)",
+            text,
+        )
+        or re.match(
+            r"^page\s+\d+:\s*\[(source_population_drift|connection_failed|rate_limit|http_server_error)\]",
+            text,
+        )
     )
-    return "source_population_drift" in text or any(token in text for token in retry_markers)
 
 
 def retry_exit_for_report(report: dict[str, object]) -> int:
@@ -159,6 +164,16 @@ def retry_exit_for_report(report: dict[str, object]) -> int:
     if all(_is_retryable_source_error(error) for error in errors):
         return EXIT_RETRYABLE_SOURCE
     return 1
+
+
+def run_with_one_retry(run, *, sleep=time.sleep) -> int:
+    """Run at most twice; only typed upstream exit 77 earns the second call."""
+    result = run()
+    if result != EXIT_RETRYABLE_SOURCE:
+        return result
+    logger.warning("Typed PNCP source failure; retrying once in %ss", RETRY_DELAY_SECONDS)
+    sleep(RETRY_DELAY_SECONDS)
+    return run()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -235,7 +250,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             return EXIT_LOCK_BUSY
     try:
-        return _run_incremental(args)
+        return run_with_one_retry(lambda: _run_incremental(args))
     finally:
         if fence is not None:
             fence.release()

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -19,6 +19,7 @@ Exit codes:
   1 — incomplete / failed / unproven
   2 — usage error
   75 — contracts writer lock busy (not a source failure)
+  77 — only transient PNCP/source-population-drift failure; service may retry once
 """
 
 from __future__ import annotations
@@ -58,6 +59,7 @@ DEFAULT_CHECKPOINT_DIR = "data/contracts_checkpoints/incremental"
 DEFAULT_CAMPAIGN = "historical_contracts_incremental"
 INCREMENTAL_QUERY_KIND = "update"
 INCREMENTAL_WINDOW_DAYS = 1
+EXIT_RETRYABLE_SOURCE = 77
 
 
 def current_incremental_window_keys(
@@ -116,6 +118,47 @@ def reopen_incremental_windows(checkpoint: object, *, window_keys: list[str]) ->
     if reopened:
         setattr(checkpoint, "completed_windows", [key for key in completed if key not in moving])
     return reopened
+
+
+def _is_retryable_source_error(error: str) -> bool:
+    """Subset of the pilot taxonomy that is safe to replay as a whole run.
+
+    Keep this dependency-light because the systemd entrypoint must classify an
+    error even when optional database modules are unavailable after a failed
+    attempt.  Everything not named here is structural and therefore terminal.
+    """
+    text = error.lower()
+    retry_markers = (
+        "timeout",
+        "timed out",
+        "connection_failed",
+        "rate_limit",
+        "http_server_error",
+    )
+    return "source_population_drift" in text or any(token in text for token in retry_markers)
+
+
+def retry_exit_for_report(report: dict[str, object]) -> int:
+    """Return a retry-only exit code for known transient upstream outcomes.
+
+    The systemd unit deliberately has no general ``Restart=on-failure``:
+    checkpoint, persistence, schema and request-contract faults need an
+    operator, not a second concurrent crawl.  A complete failed attempt can
+    be retried once only when *every* recorded window error is classified as
+    transient (including PNCP's mutable-population drift).
+    """
+    errors: list[str] = []
+    for window in report.get("windows") or []:
+        if not isinstance(window, dict):
+            continue
+        for error in window.get("errors") or []:
+            if str(error).strip():
+                errors.append(str(error))
+    if not errors:
+        return 1
+    if all(_is_retryable_source_error(error) for error in errors):
+        return EXIT_RETRYABLE_SOURCE
+    return 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -379,7 +422,7 @@ def _run_incremental(args: argparse.Namespace) -> int:
         totals.get("inserted"),
         report.get("run_id"),
     )
-    return 0 if ok else 1
+    return 0 if ok else retry_exit_for_report(report)
 
 
 if __name__ == "__main__":

--- a/scripts/crawl/run_contracts_incremental.py
+++ b/scripts/crawl/run_contracts_incremental.py
@@ -133,11 +133,11 @@ def _is_retryable_source_error(error: str) -> bool:
     text = str(error or "").strip().lower()
     return bool(
         re.match(
-            r"^(source_population_drift|connection_failed|rate_limit|http_server_error)(:|\b)",
+            r"^(source_population_drift|connection_failed|http_rate_limit|rate_limit|http_server_error)(:|\b)",
             text,
         )
         or re.match(
-            r"^page\s+\d+:\s*\[(source_population_drift|connection_failed|rate_limit|http_server_error)\]",
+            r"^page\s+\d+:\s*\[(source_population_drift|connection_failed|http_rate_limit|rate_limit|http_server_error)\]",
             text,
         )
     )

--- a/tests/test_confenge_outreach_refresh_cascade.py
+++ b/tests/test_confenge_outreach_refresh_cascade.py
@@ -55,16 +55,13 @@ def test_source_never_bypasses_the_semantic_freshness_gate() -> None:
     gate = _unit(GATE)
 
     assert "SuccessExitStatus=" not in source
-    assert "Restart=on-failure" in source
-    assert "RestartPreventExitStatus=1 2 75" in source
+    restart_lines = [line for line in source.splitlines() if line.startswith("Restart=")]
+    assert restart_lines == ["Restart=no"]
+    assert "RestartPreventExitStatus=" not in source
     assert "RestartForceExitStatus=" not in source
-    assert "RestartSec=5min" in source
-    unit_section = _unit_section(source)
-    service_section = source.split("[Service]", 1)[1]
-    assert "StartLimitIntervalSec=4h" in unit_section
-    assert "StartLimitBurst=2" in unit_section
-    assert "StartLimitIntervalSec=" not in service_section
-    assert "StartLimitBurst=" not in service_section
+    assert "RestartSec=" not in source
+    assert "StartLimitIntervalSec=" not in source
+    assert "StartLimitBurst=" not in source
     assert f"OnSuccess={GATE}" in _unit_section(source)
     assert f"OnSuccess={TARGET}" not in _unit_section(source)
     assert (

--- a/tests/test_confenge_outreach_refresh_cascade.py
+++ b/tests/test_confenge_outreach_refresh_cascade.py
@@ -62,6 +62,7 @@ def test_source_never_bypasses_the_semantic_freshness_gate() -> None:
     assert "RestartSec=" not in source
     assert "StartLimitIntervalSec=" not in source
     assert "StartLimitBurst=" not in source
+    assert "TimeoutStartSec=320min" in source
     assert f"OnSuccess={GATE}" in _unit_section(source)
     assert f"OnSuccess={TARGET}" not in _unit_section(source)
     assert (

--- a/tests/test_confenge_outreach_refresh_cascade.py
+++ b/tests/test_confenge_outreach_refresh_cascade.py
@@ -54,7 +54,17 @@ def test_source_never_bypasses_the_semantic_freshness_gate() -> None:
     source = _unit(SOURCE)
     gate = _unit(GATE)
 
-    assert "SuccessExitStatus=75" in source
+    assert "SuccessExitStatus=" not in source
+    assert "Restart=on-failure" in source
+    assert "RestartPreventExitStatus=1 2 75" in source
+    assert "RestartForceExitStatus=" not in source
+    assert "RestartSec=5min" in source
+    unit_section = _unit_section(source)
+    service_section = source.split("[Service]", 1)[1]
+    assert "StartLimitIntervalSec=4h" in unit_section
+    assert "StartLimitBurst=2" in unit_section
+    assert "StartLimitIntervalSec=" not in service_section
+    assert "StartLimitBurst=" not in service_section
     assert f"OnSuccess={GATE}" in _unit_section(source)
     assert f"OnSuccess={TARGET}" not in _unit_section(source)
     assert (

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -13,6 +13,7 @@ import pytest
 
 from deploy.confenge.pin_release import (
     CANONICAL_PREFIX,
+    CHAIN_BASE_UNITS,
     CHAIN_DISABLED_TIMERS,
     CHAIN_ENABLED_SERVICES,
     CHAIN_TIMERS,
@@ -35,6 +36,24 @@ def test_every_chain_unit_has_a_versioned_source_file():
 def test_every_chain_timer_has_a_versioned_source_file():
     for timer in (*CHAIN_TIMERS, *CHAIN_DISABLED_TIMERS):
         assert (UNIT_SOURCE / timer).is_file(), f"{timer} must be versioned in deploy/systemd"
+
+
+def test_pin_installs_the_versioned_base_units_that_define_retry_and_cascade(tmp_path, monkeypatch):
+    import deploy.confenge.pin_release as pin
+
+    monkeypatch.setattr(pin, "SYSTEMD_ROOT", tmp_path / "systemd")
+    pin.SYSTEMD_ROOT.mkdir()
+    sources = pin.canonical_base_units()
+    written = pin.install_base_units(sources)
+
+    assert set(Path(path).name for path in written) == set(CHAIN_BASE_UNITS)
+    service = (pin.SYSTEMD_ROOT / "pncp-contracts.service")
+    assert service.read_text(encoding="utf-8") == (UNIT_SOURCE / "pncp-contracts.service").read_text(
+        encoding="utf-8"
+    )
+    assert "RestartPreventExitStatus=1 2 75" in service.read_text(encoding="utf-8")
+    assert "SuccessExitStatus=75" not in service.read_text(encoding="utf-8")
+    assert (service.stat().st_mode & 0o777) == 0o644
 
 
 def test_the_canonical_chain_order_is_covered():

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -13,7 +13,6 @@ import pytest
 
 from deploy.confenge.pin_release import (
     CANONICAL_PREFIX,
-    CHAIN_BASE_UNITS,
     CHAIN_DISABLED_TIMERS,
     CHAIN_ENABLED_SERVICES,
     CHAIN_TIMERS,
@@ -38,24 +37,6 @@ def test_every_chain_timer_has_a_versioned_source_file():
         assert (UNIT_SOURCE / timer).is_file(), f"{timer} must be versioned in deploy/systemd"
 
 
-def test_pin_installs_the_versioned_base_units_that_define_retry_and_cascade(tmp_path, monkeypatch):
-    import deploy.confenge.pin_release as pin
-
-    monkeypatch.setattr(pin, "SYSTEMD_ROOT", tmp_path / "systemd")
-    pin.SYSTEMD_ROOT.mkdir()
-    sources = pin.canonical_base_units()
-    written = pin.install_base_units(sources)
-
-    assert set(Path(path).name for path in written) == set(CHAIN_BASE_UNITS)
-    service = (pin.SYSTEMD_ROOT / "pncp-contracts.service")
-    assert service.read_text(encoding="utf-8") == (UNIT_SOURCE / "pncp-contracts.service").read_text(
-        encoding="utf-8"
-    )
-    assert "RestartPreventExitStatus=1 2 75" in service.read_text(encoding="utf-8")
-    assert "SuccessExitStatus=75" not in service.read_text(encoding="utf-8")
-    assert (service.stat().st_mode & 0o777) == 0o644
-
-
 def test_the_canonical_chain_order_is_covered():
     for unit in (
         "pncp-contracts.service",
@@ -78,6 +59,13 @@ def test_rendered_dropin_repoints_code_at_the_release():
     for line in body.splitlines():
         if line.startswith(("Environment=PYTHONPATH=", "ExecStart=/")):
             assert f"{CANONICAL_PREFIX}-releases/{SHA}" in line
+
+
+def test_pncp_dropin_clears_legacy_lock_success_and_disables_systemd_restart():
+    unit = (UNIT_SOURCE / "pncp-contracts.service").read_text(encoding="utf-8")
+    body = render_dropin(unit, SHA)
+    assert "SuccessExitStatus=\n" in body
+    assert "Restart=no\n" in body
 
 
 def test_working_directory_stays_outside_the_read_only_release():
@@ -247,6 +235,8 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
                 "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1 PYTHONSAFEPATH=1",
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
+                "SuccessExitStatus": "",
+                "Restart": "no",
             }
             return subprocess.CompletedProcess(argv, 0, stdout=values[prop], stderr="")
         if argv[:2] == ["systemctl", "is-enabled"] or argv[:2] == ["systemctl", "is-active"]:
@@ -270,11 +260,20 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
     assert report["working_directory_drift"] == []
     assert report["working_directory_not_writable"] == []
     assert report["downstream_timers_scheduled"] == []
+    assert report["pncp_service_semantic_drift"] == []
 
 
 @pytest.mark.parametrize(
     "failure",
-    ["unsafe-python", "bytecode-enabled", "readonly-workdir", "release-workdir", "downstream-timer"],
+    [
+        "unsafe-python",
+        "bytecode-enabled",
+        "readonly-workdir",
+        "release-workdir",
+        "downstream-timer",
+        "pncp-restart",
+        "pncp-success75",
+    ],
 )
 def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, failure):
     import subprocess
@@ -303,6 +302,8 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
                 ),
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
+                "SuccessExitStatus": "75" if failure == "pncp-success75" else "",
+                "Restart": "on-failure" if failure == "pncp-restart" else "no",
             }
             return subprocess.CompletedProcess(argv, 0, stdout=values[prop], stderr="")
         if argv[:2] == ["systemctl", "is-enabled"] or argv[:2] == ["systemctl", "is-active"]:
@@ -332,5 +333,7 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
         assert len(report["working_directory_not_writable"]) == len(CHAIN_UNITS)
     elif failure == "release-workdir":
         assert len(report["working_directory_drift"]) == len(CHAIN_UNITS)
-    else:
+    elif failure == "downstream-timer":
         assert len(report["downstream_timers_scheduled"]) == len(CHAIN_DISABLED_TIMERS)
+    else:
+        assert report["pncp_service_semantic_drift"]

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -273,6 +273,7 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
         "downstream-timer",
         "pncp-restart",
         "pncp-success75",
+        "pncp-success77",
     ],
 )
 def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, failure):
@@ -302,7 +303,9 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
                 ),
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
-                "SuccessExitStatus": "75" if failure == "pncp-success75" else "",
+                "SuccessExitStatus": (
+                    "75" if failure == "pncp-success75" else "77" if failure == "pncp-success77" else ""
+                ),
                 "Restart": "on-failure" if failure == "pncp-restart" else "no",
             }
             return subprocess.CompletedProcess(argv, 0, stdout=values[prop], stderr="")

--- a/tests/test_contracts_incremental_refresh.py
+++ b/tests/test_contracts_incremental_refresh.py
@@ -83,6 +83,10 @@ def test_only_known_transient_source_failures_request_a_bounded_service_retry() 
     assert retry_exit_for_report(
         {"windows": [{"errors": ["Page 10: [connection_failed] Network read timed out"]}]}
     ) == EXIT_RETRYABLE_SOURCE
+    assert retry_exit_for_report(
+        {"windows": [{"errors": ["Page 5: [HTTP_RATE_LIMIT] 429"]}]}
+    ) == EXIT_RETRYABLE_SOURCE
+    assert retry_exit_for_report({"windows": [{"errors": ["http_rate_limit: 429"]}]}) == EXIT_RETRYABLE_SOURCE
 
 
 def test_runner_retries_exactly_once_and_never_retries_structural_or_final_77() -> None:

--- a/tests/test_contracts_incremental_refresh.py
+++ b/tests/test_contracts_incremental_refresh.py
@@ -11,6 +11,7 @@ from scripts.crawl.run_contracts_incremental import (
     reopen_current_window,
     reopen_incremental_windows,
     retry_exit_for_report,
+    run_with_one_retry,
 )
 
 
@@ -77,3 +78,27 @@ def test_only_known_transient_source_failures_request_a_bounded_service_retry() 
     assert retry_exit_for_report(timeout) == EXIT_RETRYABLE_SOURCE
     assert retry_exit_for_report(mixed) == 1
     assert retry_exit_for_report({"windows": []}) == 1
+    assert retry_exit_for_report({"windows": [{"errors": ["upsert failed: statement timeout"]}]}) == 1
+    assert retry_exit_for_report({"windows": [{"errors": ["local checkpoint timeout"]}]}) == 1
+    assert retry_exit_for_report(
+        {"windows": [{"errors": ["Page 10: [connection_failed] Network read timed out"]}]}
+    ) == EXIT_RETRYABLE_SOURCE
+
+
+def test_runner_retries_exactly_once_and_never_retries_structural_or_final_77() -> None:
+    calls: list[int] = []
+    sleeps: list[int] = []
+
+    def sequence(*results: int):
+        values = iter(results)
+        return lambda: calls.append(1) or next(values)
+
+    assert run_with_one_retry(sequence(EXIT_RETRYABLE_SOURCE, 0), sleep=sleeps.append) == 0
+    assert len(calls) == 2 and sleeps == [300]
+    calls.clear()
+    sleeps.clear()
+    assert run_with_one_retry(sequence(1), sleep=sleeps.append) == 1
+    assert len(calls) == 1 and sleeps == []
+    calls.clear()
+    assert run_with_one_retry(sequence(EXIT_RETRYABLE_SOURCE, EXIT_RETRYABLE_SOURCE), sleep=sleeps.append) == EXIT_RETRYABLE_SOURCE
+    assert len(calls) == 2 and sleeps == [300]

--- a/tests/test_contracts_incremental_refresh.py
+++ b/tests/test_contracts_incremental_refresh.py
@@ -5,10 +5,12 @@ from datetime import date, datetime, timedelta, timezone
 from scripts.crawl.contracts_crawler import CrawlCheckpoint
 from scripts.crawl.run_contracts_90d_pilot import utc_today
 from scripts.crawl.run_contracts_incremental import (
+    EXIT_RETRYABLE_SOURCE,
     current_incremental_window_key,
     current_incremental_window_keys,
     reopen_current_window,
     reopen_incremental_windows,
+    retry_exit_for_report,
 )
 
 
@@ -58,3 +60,20 @@ def test_all_daily_overlap_windows_are_reopened_for_every_timer_slot() -> None:
 
     assert reopen_incremental_windows(checkpoint, window_keys=keys) == keys
     assert checkpoint.completed_windows == ["20260701_20260730"]
+
+
+def test_only_known_transient_source_failures_request_a_bounded_service_retry() -> None:
+    drift = {
+        "windows": [{"errors": ["source_population_drift:totalRegistros 8667 -> 8772"]}]
+    }
+    timeout = {"windows": [{"errors": ["connection_failed while reading PNCP"]}]}
+    mixed = {
+        "windows": [
+            {"errors": ["source_population_drift: totalRegistros 8 -> 9", "upsert failed"]}
+        ]
+    }
+
+    assert retry_exit_for_report(drift) == EXIT_RETRYABLE_SOURCE
+    assert retry_exit_for_report(timeout) == EXIT_RETRYABLE_SOURCE
+    assert retry_exit_for_report(mixed) == 1
+    assert retry_exit_for_report({"windows": []}) == 1

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -554,7 +554,7 @@ def test_pncp_contracts_service_has_production_read_timeout() -> None:
     assert "Environment=CONTRACTS_PAGE_RETRY_CAP_SECONDS=30" in service
     assert "Environment=CONTRACTS_WINDOW_RETRY_MAX=2" in service
     assert "Environment=CONTRACTS_WINDOW_RETRY_DELAY_SECONDS=60" in service
-    assert "TimeoutStartSec=150min" in service
+    assert "TimeoutStartSec=320min" in service
 
 
 def test_collect_timer_snapshot_parses_systemd_stamps() -> None:

--- a/tests/test_pncp_contract_freshness.py
+++ b/tests/test_pncp_contract_freshness.py
@@ -952,7 +952,7 @@ def test_shipped_timer_survives_triggered_oneshot_failure() -> None:
 
 def test_lock_busy_exit_75_is_not_fresh_or_closed_window() -> None:
     service = load_shipped_service_text()
-    assert LOCK_BUSY_EXIT in parse_success_exit_statuses(service)
+    assert LOCK_BUSY_EXIT not in parse_success_exit_statuses(service)
     status, reasons = classify_status(
         has_evidence=True,
         current_lag_hours=2.0,


### PR DESCRIPTION
## Context
The 08:00 BRT PNCP contracts cycle ended partial after source-population drift. The downstream chain correctly stayed closed, but the service waited for the next four-hour timer slot while the freshness authority expired.

## Change
- classify only explicitly typed upstream failures as retryable; persistence, checkpoint, schema, generic timeout, and writer-lock failures stay terminal
- perform exactly one delayed retry inside the fenced Python runner, never through systemd restart loops
- keep exit 75 non-successful so writer contention cannot trigger the OnSuccess cascade
- make the immutable PNCP drop-in clear a legacy SuccessExitStatus=75 and enforce Restart=no on already-provisioned hosts
- verify the effective systemd semantics together with release identity
- document the operational contract and acceptance procedure

## Verification
- 136 focused tests passed
- Ruff passed
- generated-artifacts and PR-reviewability policies passed
- git diff --check passed

## Production acceptance
Keep Warmbly dispatch paused. After merge, cut and pin the immutable release. Confirm typed exit 77 causes exactly one in-process retry, while exit 1/2/75 and systemd failures do not retry or advance downstream. Exit 0 alone may trigger freshness gate, target-fit, contact cycle, and feed publication.