### PR TITLE
fix: preserve versioned service timeout in release pins

### DIFF
--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -29,6 +29,7 @@ import json
 import re
 import subprocess
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -94,17 +95,25 @@ PRESERVED_DIRECTIVES = ("WorkingDirectory=", "TimeoutStartSec=")
 # bind the code it claims to bind.
 ISOLATED_INTERPRETER_FLAG = "-P"
 
-_DURATION_PART = re.compile(r"(?P<value>\d+(?:\.\d+)?)(?P<unit>us|µs|ms|s|min|m|h|d|w)")
+_DURATION_PART = re.compile(
+    r"(?P<value>\d+(?:\.\d+)?)(?P<unit>"
+    r"useconds?|usecs?|us|µs|milliseconds?|msecs?|ms|seconds?|secs?|s|"
+    r"minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d|weeks?|w|months?|years?)"
+)
 _DURATION_SECONDS = {
-    "us": 0.000001,
-    "µs": 0.000001,
-    "ms": 0.001,
-    "s": 1,
-    "min": 60,
-    "m": 60,
-    "h": 60 * 60,
-    "d": 24 * 60 * 60,
-    "w": 7 * 24 * 60 * 60,
+    "usecond": Decimal("0.000001"), "useconds": Decimal("0.000001"),
+    "usec": Decimal("0.000001"), "usecs": Decimal("0.000001"), "us": Decimal("0.000001"),
+    "µs": Decimal("0.000001"), "millisecond": Decimal("0.001"),
+    "milliseconds": Decimal("0.001"), "msec": Decimal("0.001"), "msecs": Decimal("0.001"),
+    "ms": Decimal("0.001"), "second": Decimal(1), "seconds": Decimal(1), "sec": Decimal(1),
+    "secs": Decimal(1), "s": Decimal(1), "minute": Decimal(60), "minutes": Decimal(60),
+    "min": Decimal(60), "mins": Decimal(60), "m": Decimal(60), "hour": Decimal(60 * 60),
+    "hours": Decimal(60 * 60), "hr": Decimal(60 * 60), "hrs": Decimal(60 * 60), "h": Decimal(60 * 60),
+    "day": Decimal(24 * 60 * 60), "days": Decimal(24 * 60 * 60), "d": Decimal(24 * 60 * 60),
+    "week": Decimal(7 * 24 * 60 * 60), "weeks": Decimal(7 * 24 * 60 * 60), "w": Decimal(7 * 24 * 60 * 60),
+    # systemd defines these calendar-independent units as fixed 30.44/365.25-day spans.
+    "month": Decimal("2629800"), "months": Decimal("2629800"),
+    "year": Decimal("31557600"), "years": Decimal("31557600"),
 }
 
 
@@ -112,25 +121,30 @@ class PinError(RuntimeError):
     """A pin was refused before anything on the host changed."""
 
 
-def _duration_seconds(value: str) -> float:
-    """Parse the compact systemd duration formats used by unit/show output."""
-    normalized = value.strip().replace(" ", "")
-    if normalized.isdecimal():
-        return float(normalized)
+def _duration_seconds(value: str) -> Decimal | None:
+    """Parse systemd time spans, returning ``None`` for an infinite timeout."""
+    normalized = value.strip().replace(" ", "").lower()
+    if normalized == "infinity":
+        return None
+    if re.fullmatch(r"\d+(?:\.\d+)?", normalized):
+        return Decimal(normalized)
     parts = list(_DURATION_PART.finditer(normalized))
     if not parts or "".join(part.group(0) for part in parts) != normalized:
         raise PinError(f"unsupported systemd duration: {value!r}")
-    return sum(float(part["value"]) * _DURATION_SECONDS[part["unit"]] for part in parts)
+    return sum(
+        (Decimal(part["value"]) * _DURATION_SECONDS[part["unit"]] for part in parts),
+        Decimal(0),
+    )
 
 
-def _source_timeout_start_seconds(unit: str) -> float | None:
-    """Return the effective timeout intent from the versioned source unit."""
+def _source_timeout_start_seconds(unit: str) -> tuple[bool, Decimal | None]:
+    """Return whether a unit sets the timeout plus its versioned intent."""
     source = UNIT_SOURCE / unit
     timeout: str | None = None
     for line in _logical_lines(source.read_text(encoding="utf-8")):
         if line.startswith("TimeoutStartSec="):
             timeout = line.removeprefix("TimeoutStartSec=")
-    return _duration_seconds(timeout) if timeout is not None else None
+    return timeout is not None, _duration_seconds(timeout) if timeout is not None else None
 
 
 def _logical_lines(text: str) -> list[str]:
@@ -227,6 +241,9 @@ def plan(sha: str) -> dict[str, str]:
         if not source.is_file():
             raise PinError(f"versioned unit file is missing: {source}")
         try:
+            # Validate every preserved timeout before the first host write, so
+            # an unsupported source directive cannot leave a half-pinned chain.
+            _source_timeout_start_seconds(unit)
             rendered[unit] = render_dropin(source.read_text(encoding="utf-8"), sha)
         except PinError as exc:
             raise PinError(f"{unit}: {exc}") from exc
@@ -337,8 +354,8 @@ def verify(sha: str) -> dict[str, object]:
                 working_directory_not_writable.append(
                     {"unit": unit, "user": user or "root", "working_directory": working_directory}
                 )
-        expected_timeout = _source_timeout_start_seconds(unit)
-        if expected_timeout is not None:
+        has_timeout, expected_timeout = _source_timeout_start_seconds(unit)
+        if has_timeout:
             observed_timeout = (
                 _run(["systemctl", "show", unit, "-p", "TimeoutStartUSec", "--value"], check=False).stdout
                 or ""
@@ -347,11 +364,14 @@ def verify(sha: str) -> dict[str, object]:
                 actual_timeout = _duration_seconds(observed_timeout)
             except PinError:
                 actual_timeout = None
-            if actual_timeout != expected_timeout:
+                timeout_was_parsed = False
+            else:
+                timeout_was_parsed = True
+            if not timeout_was_parsed or actual_timeout != expected_timeout:
                 timeout_start_drift.append(
                     {
                         "unit": unit,
-                        "expected": f"{expected_timeout:g}s",
+                        "expected": "infinity" if expected_timeout is None else f"{expected_timeout:f}s",
                         "observed": observed_timeout or "MISSING",
                     }
                 )

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -96,7 +96,9 @@ PRESERVED_DIRECTIVES = ("WorkingDirectory=", "TimeoutStartSec=")
 ISOLATED_INTERPRETER_FLAG = "-P"
 
 _DURATION_PART = re.compile(
-    r"(?P<value>[+]?(?:\d+(?:\.\d+)?|\.\d+))(?P<unit>"
+    # systemd accepts a leading `+` only before an integral component; `.5h`
+    # is valid, while `+.5h` is not.
+    r"(?P<value>(?:\+\d+(?:\.\d+)?|\d+(?:\.\d+)?|\.\d+))(?P<unit>"
     # Long aliases must precede their short prefixes: `month` would otherwise
     # be consumed as `m` plus an invalid `onth` suffix.
     r"seconds?|minutes?|hours?|months?|years?|days?|weeks?|usec|µs|msec|min|sec|hr|"
@@ -122,10 +124,10 @@ class PinError(RuntimeError):
 
 def _duration_seconds(value: str) -> Decimal | None:
     """Parse systemd time spans, returning ``None`` for an infinite timeout."""
-    normalized = value.strip().replace(" ", "")
+    normalized = re.sub(r"\s+", "", value.strip())
     if normalized == "infinity":
         return None
-    if re.fullmatch(r"[+]?(?:\d+(?:\.\d+)?|\.\d+)", normalized):
+    if re.fullmatch(r"(?:\+\d+(?:\.\d+)?|\d+(?:\.\d+)?|\.\d+)", normalized):
         return Decimal(normalized)
     parts = list(_DURATION_PART.finditer(normalized))
     if not parts or "".join(part.group(0) for part in parts) != normalized:
@@ -143,7 +145,11 @@ def _source_timeout_start_seconds(unit: str) -> tuple[bool, Decimal | None]:
     for line in _logical_lines(source.read_text(encoding="utf-8")):
         if line.startswith("TimeoutStartSec="):
             timeout = line.removeprefix("TimeoutStartSec=")
-    return timeout is not None, _duration_seconds(timeout) if timeout is not None else None
+    parsed = _duration_seconds(timeout) if timeout is not None else None
+    # systemd treats TimeoutStartSec=0 as no start timeout and resolves it as
+    # `infinity` in TimeoutStartUSec. Compare that semantic intent, not the
+    # spelling in the source unit.
+    return timeout is not None, None if parsed == Decimal(0) else parsed
 
 
 def _logical_lines(text: str) -> list[str]:

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -97,23 +97,22 @@ ISOLATED_INTERPRETER_FLAG = "-P"
 
 _DURATION_PART = re.compile(
     r"(?P<value>\d+(?:\.\d+)?)(?P<unit>"
-    r"useconds?|usecs?|us|µs|milliseconds?|msecs?|ms|seconds?|secs?|s|"
-    r"minutes?|mins?|min|m|hours?|hrs?|hr|h|days?|d|weeks?|w|months?|years?)"
+    # Long aliases must precede their short prefixes: `month` would otherwise
+    # be consumed as `m` plus an invalid `onth` suffix.
+    r"seconds?|minutes?|hours?|months?|years?|days?|weeks?|usec|µs|msec|min|sec|hr|"
+    r"ms|us|s|m|h|d|w|y)"
 )
 _DURATION_SECONDS = {
-    "usecond": Decimal("0.000001"), "useconds": Decimal("0.000001"),
-    "usec": Decimal("0.000001"), "usecs": Decimal("0.000001"), "us": Decimal("0.000001"),
-    "µs": Decimal("0.000001"), "millisecond": Decimal("0.001"),
-    "milliseconds": Decimal("0.001"), "msec": Decimal("0.001"), "msecs": Decimal("0.001"),
-    "ms": Decimal("0.001"), "second": Decimal(1), "seconds": Decimal(1), "sec": Decimal(1),
-    "secs": Decimal(1), "s": Decimal(1), "minute": Decimal(60), "minutes": Decimal(60),
-    "min": Decimal(60), "mins": Decimal(60), "m": Decimal(60), "hour": Decimal(60 * 60),
-    "hours": Decimal(60 * 60), "hr": Decimal(60 * 60), "hrs": Decimal(60 * 60), "h": Decimal(60 * 60),
+    "usec": Decimal("0.000001"), "µs": Decimal("0.000001"), "us": Decimal("0.000001"),
+    "msec": Decimal("0.001"), "ms": Decimal("0.001"), "second": Decimal(1),
+    "seconds": Decimal(1), "sec": Decimal(1), "s": Decimal(1), "minute": Decimal(60),
+    "minutes": Decimal(60), "min": Decimal(60), "m": Decimal(60), "hour": Decimal(60 * 60),
+    "hours": Decimal(60 * 60), "hr": Decimal(60 * 60), "h": Decimal(60 * 60),
     "day": Decimal(24 * 60 * 60), "days": Decimal(24 * 60 * 60), "d": Decimal(24 * 60 * 60),
     "week": Decimal(7 * 24 * 60 * 60), "weeks": Decimal(7 * 24 * 60 * 60), "w": Decimal(7 * 24 * 60 * 60),
     # systemd defines these calendar-independent units as fixed 30.44/365.25-day spans.
     "month": Decimal("2629800"), "months": Decimal("2629800"),
-    "year": Decimal("31557600"), "years": Decimal("31557600"),
+    "year": Decimal("31557600"), "years": Decimal("31557600"), "y": Decimal("31557600"),
 }
 
 

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -96,11 +96,11 @@ PRESERVED_DIRECTIVES = ("WorkingDirectory=", "TimeoutStartSec=")
 ISOLATED_INTERPRETER_FLAG = "-P"
 
 _DURATION_PART = re.compile(
-    r"(?P<value>\d+(?:\.\d+)?)(?P<unit>"
+    r"(?P<value>[+]?(?:\d+(?:\.\d+)?|\.\d+))(?P<unit>"
     # Long aliases must precede their short prefixes: `month` would otherwise
     # be consumed as `m` plus an invalid `onth` suffix.
     r"seconds?|minutes?|hours?|months?|years?|days?|weeks?|usec|µs|msec|min|sec|hr|"
-    r"ms|us|s|m|h|d|w|y)"
+    r"ms|us|s|M|m|h|d|w|y)"
 )
 _DURATION_SECONDS = {
     "usec": Decimal("0.000001"), "µs": Decimal("0.000001"), "us": Decimal("0.000001"),
@@ -111,7 +111,7 @@ _DURATION_SECONDS = {
     "day": Decimal(24 * 60 * 60), "days": Decimal(24 * 60 * 60), "d": Decimal(24 * 60 * 60),
     "week": Decimal(7 * 24 * 60 * 60), "weeks": Decimal(7 * 24 * 60 * 60), "w": Decimal(7 * 24 * 60 * 60),
     # systemd defines these calendar-independent units as fixed 30.44/365.25-day spans.
-    "month": Decimal("2629800"), "months": Decimal("2629800"),
+    "month": Decimal("2629800"), "months": Decimal("2629800"), "M": Decimal("2629800"),
     "year": Decimal("31557600"), "years": Decimal("31557600"), "y": Decimal("31557600"),
 }
 
@@ -122,10 +122,10 @@ class PinError(RuntimeError):
 
 def _duration_seconds(value: str) -> Decimal | None:
     """Parse systemd time spans, returning ``None`` for an infinite timeout."""
-    normalized = value.strip().replace(" ", "").lower()
+    normalized = value.strip().replace(" ", "")
     if normalized == "infinity":
         return None
-    if re.fullmatch(r"\d+(?:\.\d+)?", normalized):
+    if re.fullmatch(r"[+]?(?:\d+(?:\.\d+)?|\.\d+)", normalized):
         return Decimal(normalized)
     parts = list(_DURATION_PART.finditer(normalized))
     if not parts or "".join(part.group(0) for part in parts) != normalized:

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -82,7 +82,11 @@ CHAIN_ENABLED_SERVICES = ("extra-confenge-target-fit-worker.service",)
 # PermissionError: 'output/contracts/incremental-latest.json' after a window it
 # had already crawled successfully.
 PINNED_DIRECTIVES = ("Environment=PYTHONPATH=", "ExecStart=")
-PRESERVED_DIRECTIVES = ("WorkingDirectory=",)
+# Keep operational limits authored with the versioned unit. In particular, a
+# host-local base unit may still have the old 150-minute PNCP limit; omitting
+# this from the immutable pin would silently discard the 320-minute bounded
+# two-pass recovery budget in the release being pinned.
+PRESERVED_DIRECTIVES = ("WorkingDirectory=", "TimeoutStartSec=")
 
 # With the working directory outside the release, Python would otherwise prepend
 # that directory to sys.path and let the checkout at /opt/extra-consultoria
@@ -90,9 +94,43 @@ PRESERVED_DIRECTIVES = ("WorkingDirectory=",)
 # bind the code it claims to bind.
 ISOLATED_INTERPRETER_FLAG = "-P"
 
+_DURATION_PART = re.compile(r"(?P<value>\d+(?:\.\d+)?)(?P<unit>us|µs|ms|s|min|m|h|d|w)")
+_DURATION_SECONDS = {
+    "us": 0.000001,
+    "µs": 0.000001,
+    "ms": 0.001,
+    "s": 1,
+    "min": 60,
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+    "w": 7 * 24 * 60 * 60,
+}
+
 
 class PinError(RuntimeError):
     """A pin was refused before anything on the host changed."""
+
+
+def _duration_seconds(value: str) -> float:
+    """Parse the compact systemd duration formats used by unit/show output."""
+    normalized = value.strip().replace(" ", "")
+    if normalized.isdecimal():
+        return float(normalized)
+    parts = list(_DURATION_PART.finditer(normalized))
+    if not parts or "".join(part.group(0) for part in parts) != normalized:
+        raise PinError(f"unsupported systemd duration: {value!r}")
+    return sum(float(part["value"]) * _DURATION_SECONDS[part["unit"]] for part in parts)
+
+
+def _source_timeout_start_seconds(unit: str) -> float | None:
+    """Return the effective timeout intent from the versioned source unit."""
+    source = UNIT_SOURCE / unit
+    timeout: str | None = None
+    for line in _logical_lines(source.read_text(encoding="utf-8")):
+        if line.startswith("TimeoutStartSec="):
+            timeout = line.removeprefix("TimeoutStartSec=")
+    return _duration_seconds(timeout) if timeout is not None else None
 
 
 def _logical_lines(text: str) -> list[str]:
@@ -262,6 +300,7 @@ def verify(sha: str) -> dict[str, object]:
     bytecode_writes_enabled: list[dict[str, str]] = []
     working_directory_drift: list[dict[str, str]] = []
     working_directory_not_writable: list[dict[str, str]] = []
+    timeout_start_drift: list[dict[str, str]] = []
     release = f"{RELEASE_ROOT}/{sha}"
     for unit in CHAIN_UNITS:
         result = _run(["systemctl", "show", unit, "-p", "ExecStart", "--value"], check=False)
@@ -297,6 +336,24 @@ def verify(sha: str) -> dict[str, object]:
             if _run(writable_probe, check=False).returncode != 0:
                 working_directory_not_writable.append(
                     {"unit": unit, "user": user or "root", "working_directory": working_directory}
+                )
+        expected_timeout = _source_timeout_start_seconds(unit)
+        if expected_timeout is not None:
+            observed_timeout = (
+                _run(["systemctl", "show", unit, "-p", "TimeoutStartUSec", "--value"], check=False).stdout
+                or ""
+            ).strip()
+            try:
+                actual_timeout = _duration_seconds(observed_timeout)
+            except PinError:
+                actual_timeout = None
+            if actual_timeout != expected_timeout:
+                timeout_start_drift.append(
+                    {
+                        "unit": unit,
+                        "expected": f"{expected_timeout:g}s",
+                        "observed": observed_timeout or "MISSING",
+                    }
                 )
     disabled: list[str] = []
     for unit in (*CHAIN_TIMERS, *CHAIN_ENABLED_SERVICES):
@@ -338,6 +395,7 @@ def verify(sha: str) -> dict[str, object]:
                 bytecode_writes_enabled,
                 working_directory_drift,
                 working_directory_not_writable,
+                timeout_start_drift,
                 disabled,
                 inactive_timers,
                 independently_scheduled,
@@ -349,6 +407,7 @@ def verify(sha: str) -> dict[str, object]:
         "bytecode_writes_enabled": bytecode_writes_enabled,
         "working_directory_drift": working_directory_drift,
         "working_directory_not_writable": working_directory_not_writable,
+        "timeout_start_drift": timeout_start_drift,
         "not_enabled": disabled,
         "timers_not_active": inactive_timers,
         "downstream_timers_scheduled": independently_scheduled,

--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -116,6 +116,7 @@ _DURATION_SECONDS = {
     "month": Decimal("2629800"), "months": Decimal("2629800"), "M": Decimal("2629800"),
     "year": Decimal("31557600"), "years": Decimal("31557600"), "y": Decimal("31557600"),
 }
+_MICROSECOND = Decimal("0.000001")
 
 
 class PinError(RuntimeError):
@@ -138,6 +139,14 @@ def _duration_seconds(value: str) -> Decimal | None:
     )
 
 
+def _systemd_timeout_seconds(value: str) -> Decimal | None:
+    """Mirror systemd's integer-microsecond timeout resolution."""
+    parsed = _duration_seconds(value)
+    if parsed is None:
+        return None
+    return Decimal(int(parsed / _MICROSECOND)) * _MICROSECOND
+
+
 def _source_timeout_start_seconds(unit: str) -> tuple[bool, Decimal | None]:
     """Return whether a unit sets the timeout plus its versioned intent."""
     source = UNIT_SOURCE / unit
@@ -145,7 +154,7 @@ def _source_timeout_start_seconds(unit: str) -> tuple[bool, Decimal | None]:
     for line in _logical_lines(source.read_text(encoding="utf-8")):
         if line.startswith("TimeoutStartSec="):
             timeout = line.removeprefix("TimeoutStartSec=")
-    parsed = _duration_seconds(timeout) if timeout is not None else None
+    parsed = _systemd_timeout_seconds(timeout) if timeout is not None else None
     # systemd treats TimeoutStartSec=0 as no start timeout and resolves it as
     # `infinity` in TimeoutStartUSec. Compare that semantic intent, not the
     # spelling in the source unit.
@@ -366,7 +375,7 @@ def verify(sha: str) -> dict[str, object]:
                 or ""
             ).strip()
             try:
-                actual_timeout = _duration_seconds(observed_timeout)
+                actual_timeout = _systemd_timeout_seconds(observed_timeout)
             except PinError:
                 actual_timeout = None
                 timeout_was_parsed = False
@@ -376,7 +385,9 @@ def verify(sha: str) -> dict[str, object]:
                 timeout_start_drift.append(
                     {
                         "unit": unit,
-                        "expected": "infinity" if expected_timeout is None else f"{expected_timeout:f}s",
+                        "expected": (
+                            "infinity" if expected_timeout is None else f"{expected_timeout.normalize():f}s"
+                        ),
                         "observed": observed_timeout or "MISSING",
                     }
                 )

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -19,6 +19,7 @@ from deploy.confenge.pin_release import (
     CHAIN_UNITS,
     UNIT_SOURCE,
     PinError,
+    _duration_seconds,
     plan,
     render_dropin,
     verify,
@@ -76,6 +77,45 @@ def test_dropins_preserve_versioned_timeout_intent_for_every_bounded_unit():
         body = render_dropin(unit, SHA)
         rendered_timeout = next((line for line in body.splitlines() if line.startswith("TimeoutStartSec=")), None)
         assert rendered_timeout == source_timeout, unit_name
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1hour", "3600"),
+        ("1msec", "0.001"),
+        ("1h 20min", "4800"),
+        ("infinity", None),
+    ],
+)
+def test_duration_parser_accepts_systemd_timeout_spellings(raw, expected):
+    parsed = _duration_seconds(raw)
+    assert (None if parsed is None else f"{parsed:f}") == expected
+
+
+def test_plan_rejects_an_unsupported_timeout_before_any_host_write(tmp_path, monkeypatch):
+    import deploy.confenge.pin_release as pin
+
+    source_root = tmp_path / "units"
+    source_root.mkdir()
+    release_root = tmp_path / "releases"
+    (release_root / SHA / ".venv" / "bin").mkdir(parents=True)
+    (release_root / SHA / ".venv" / "bin" / "python").touch()
+    for unit_name in CHAIN_UNITS:
+        timeout = "TimeoutStartSec=1fortnight\n" if unit_name == CHAIN_UNITS[-1] else ""
+        (source_root / unit_name).write_text(
+            "[Service]\n"
+            "ExecStart=/opt/extra-consultoria/.venv/bin/python -m scripts.example\n"
+            f"{timeout}",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(pin, "UNIT_SOURCE", source_root)
+    monkeypatch.setattr(pin, "RELEASE_ROOT", release_root)
+    monkeypatch.setattr(pin, "SYSTEMD_ROOT", tmp_path / "systemd")
+
+    with pytest.raises(PinError, match="extra-confenge-feed-monitor.service: unsupported systemd duration"):
+        pin.apply(SHA)
+    assert not pin.SYSTEMD_ROOT.exists()
 
 
 def test_working_directory_stays_outside_the_read_only_release():
@@ -240,13 +280,13 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
         del check
         if argv[:2] == ["systemctl", "show"]:
             prop = argv[argv.index("-p") + 1]
-            timeout = pin._source_timeout_start_seconds(argv[2])
+            has_timeout, timeout = pin._source_timeout_start_seconds(argv[2])
             values = {
                 "ExecStart": f"{release}/.venv/bin/python -P -m scripts.example",
                 "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1 PYTHONSAFEPATH=1",
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
-                "TimeoutStartUSec": f"{timeout:g}s" if timeout is not None else "infinity",
+                "TimeoutStartUSec": f"{timeout:f}s" if has_timeout and timeout is not None else "infinity",
                 "SuccessExitStatus": "",
                 "Restart": "no",
             }
@@ -304,7 +344,7 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
         del check
         if argv[:2] == ["systemctl", "show"]:
             prop = argv[argv.index("-p") + 1]
-            timeout = pin._source_timeout_start_seconds(argv[2])
+            has_timeout, timeout = pin._source_timeout_start_seconds(argv[2])
             values = {
                 "ExecStart": (
                     f"{release}/.venv/bin/python -m scripts.example"
@@ -321,7 +361,7 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
                 "TimeoutStartUSec": (
                     "150min"
                     if failure == "pncp-timeout" and argv[2] == "pncp-contracts.service"
-                    else f"{timeout:g}s" if timeout is not None else "infinity"
+                    else f"{timeout:f}s" if has_timeout and timeout is not None else "infinity"
                 ),
                 "SuccessExitStatus": (
                     "75" if failure == "pncp-success75" else "77" if failure == "pncp-success77" else ""

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -105,15 +105,23 @@ def test_calendar_timeout_aliases_match_systemd_timespan_semantics():
     assert _duration_seconds("1y") == _duration_seconds("31557600s")
 
 
-def test_source_zero_timeout_has_systemd_infinity_semantics(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("source_timeout", "expected"),
+    [("0", None), ("0.1us", None), ("1.1us", "0.000001")],
+)
+def test_source_timeout_is_quantized_to_systemd_microseconds(tmp_path, monkeypatch, source_timeout, expected):
     import deploy.confenge.pin_release as pin
 
     source_root = tmp_path / "units"
     source_root.mkdir()
-    (source_root / "pncp-contracts.service").write_text("[Service]\nTimeoutStartSec=0\n", encoding="utf-8")
+    (source_root / "pncp-contracts.service").write_text(
+        f"[Service]\nTimeoutStartSec={source_timeout}\n", encoding="utf-8"
+    )
     monkeypatch.setattr(pin, "UNIT_SOURCE", source_root)
 
-    assert pin._source_timeout_start_seconds("pncp-contracts.service") == (True, None)
+    has_timeout, parsed = pin._source_timeout_start_seconds("pncp-contracts.service")
+    assert has_timeout is True
+    assert (None if parsed is None else f"{parsed:f}") == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -86,7 +86,7 @@ def test_dropins_preserve_versioned_timeout_intent_for_every_bounded_unit():
         ("1msec", "0.001"),
         ("+1h", "3600"),
         (".5h", "1800"),
-        ("1h 20min", "4800"),
+        ("1h\t20min", "4800"),
         ("1month", "2629800"),
         ("1M", "2629800"),
         ("1y", "31557600"),
@@ -105,11 +105,22 @@ def test_calendar_timeout_aliases_match_systemd_timespan_semantics():
     assert _duration_seconds("1y") == _duration_seconds("31557600s")
 
 
+def test_source_zero_timeout_has_systemd_infinity_semantics(tmp_path, monkeypatch):
+    import deploy.confenge.pin_release as pin
+
+    source_root = tmp_path / "units"
+    source_root.mkdir()
+    (source_root / "pncp-contracts.service").write_text("[Service]\nTimeoutStartSec=0\n", encoding="utf-8")
+    monkeypatch.setattr(pin, "UNIT_SOURCE", source_root)
+
+    assert pin._source_timeout_start_seconds("pncp-contracts.service") == (True, None)
+
+
 @pytest.mark.parametrize(
     "raw",
     [
         "1usecs", "1msecx", "1secs", "1mins", "1hrs", "1millisecond",
-        "1H", "1MS", "1SEC", "1Hour", "INFINITY",
+        "1H", "1MS", "1SEC", "1Hour", "INFINITY", "+.5h", "1h+.5min",
     ],
 )
 def test_duration_parser_rejects_non_systemd_timeout_aliases(raw):

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -85,12 +85,26 @@ def test_dropins_preserve_versioned_timeout_intent_for_every_bounded_unit():
         ("1hour", "3600"),
         ("1msec", "0.001"),
         ("1h 20min", "4800"),
+        ("1month", "2629800"),
+        ("1y", "31557600"),
         ("infinity", None),
     ],
 )
 def test_duration_parser_accepts_systemd_timeout_spellings(raw, expected):
     parsed = _duration_seconds(raw)
     assert (None if parsed is None else f"{parsed:f}") == expected
+
+
+def test_calendar_timeout_aliases_match_systemd_timespan_semantics():
+    assert _duration_seconds("1month") == _duration_seconds("1months") == _duration_seconds("2629800s")
+    assert _duration_seconds("1y") == _duration_seconds("1year") == _duration_seconds("1years")
+    assert _duration_seconds("1y") == _duration_seconds("31557600s")
+
+
+@pytest.mark.parametrize("raw", ["1usecs", "1msecx", "1secs", "1mins", "1hrs", "1millisecond"])
+def test_duration_parser_rejects_non_systemd_timeout_aliases(raw):
+    with pytest.raises(PinError, match="unsupported systemd duration"):
+        _duration_seconds(raw)
 
 
 def test_plan_rejects_an_unsupported_timeout_before_any_host_write(tmp_path, monkeypatch):

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -66,6 +66,16 @@ def test_pncp_dropin_clears_legacy_lock_success_and_disables_systemd_restart():
     body = render_dropin(unit, SHA)
     assert "SuccessExitStatus=\n" in body
     assert "Restart=no\n" in body
+    assert "TimeoutStartSec=320min\n" in body
+
+
+def test_dropins_preserve_versioned_timeout_intent_for_every_bounded_unit():
+    for unit_name in CHAIN_UNITS:
+        unit = (UNIT_SOURCE / unit_name).read_text(encoding="utf-8")
+        source_timeout = next((line for line in unit.splitlines() if line.startswith("TimeoutStartSec=")), None)
+        body = render_dropin(unit, SHA)
+        rendered_timeout = next((line for line in body.splitlines() if line.startswith("TimeoutStartSec=")), None)
+        assert rendered_timeout == source_timeout, unit_name
 
 
 def test_working_directory_stays_outside_the_read_only_release():
@@ -230,11 +240,13 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
         del check
         if argv[:2] == ["systemctl", "show"]:
             prop = argv[argv.index("-p") + 1]
+            timeout = pin._source_timeout_start_seconds(argv[2])
             values = {
                 "ExecStart": f"{release}/.venv/bin/python -P -m scripts.example",
                 "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1 PYTHONSAFEPATH=1",
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
+                "TimeoutStartUSec": f"{timeout:g}s" if timeout is not None else "infinity",
                 "SuccessExitStatus": "",
                 "Restart": "no",
             }
@@ -259,6 +271,7 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
     assert report["bytecode_writes_enabled"] == []
     assert report["working_directory_drift"] == []
     assert report["working_directory_not_writable"] == []
+    assert report["timeout_start_drift"] == []
     assert report["downstream_timers_scheduled"] == []
     assert report["pncp_service_semantic_drift"] == []
 
@@ -274,6 +287,7 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
         "pncp-restart",
         "pncp-success75",
         "pncp-success77",
+        "pncp-timeout",
     ],
 )
 def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, failure):
@@ -290,6 +304,7 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
         del check
         if argv[:2] == ["systemctl", "show"]:
             prop = argv[argv.index("-p") + 1]
+            timeout = pin._source_timeout_start_seconds(argv[2])
             values = {
                 "ExecStart": (
                     f"{release}/.venv/bin/python -m scripts.example"
@@ -303,6 +318,11 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
                 ),
                 "WorkingDirectory": str(workdir),
                 "User": "extra-consultoria",
+                "TimeoutStartUSec": (
+                    "150min"
+                    if failure == "pncp-timeout" and argv[2] == "pncp-contracts.service"
+                    else f"{timeout:g}s" if timeout is not None else "infinity"
+                ),
                 "SuccessExitStatus": (
                     "75" if failure == "pncp-success75" else "77" if failure == "pncp-success77" else ""
                 ),
@@ -338,5 +358,9 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
         assert len(report["working_directory_drift"]) == len(CHAIN_UNITS)
     elif failure == "downstream-timer":
         assert len(report["downstream_timers_scheduled"]) == len(CHAIN_DISABLED_TIMERS)
+    elif failure == "pncp-timeout":
+        assert report["timeout_start_drift"] == [
+            {"unit": "pncp-contracts.service", "expected": "19200s", "observed": "150min"}
+        ]
     else:
         assert report["pncp_service_semantic_drift"]

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -84,24 +84,34 @@ def test_dropins_preserve_versioned_timeout_intent_for_every_bounded_unit():
     [
         ("1hour", "3600"),
         ("1msec", "0.001"),
+        ("+1h", "3600"),
+        (".5h", "1800"),
         ("1h 20min", "4800"),
         ("1month", "2629800"),
+        ("1M", "2629800"),
         ("1y", "31557600"),
         ("infinity", None),
     ],
 )
 def test_duration_parser_accepts_systemd_timeout_spellings(raw, expected):
     parsed = _duration_seconds(raw)
-    assert (None if parsed is None else f"{parsed:f}") == expected
+    assert (None if parsed is None else f"{parsed.normalize():f}") == expected
 
 
 def test_calendar_timeout_aliases_match_systemd_timespan_semantics():
-    assert _duration_seconds("1month") == _duration_seconds("1months") == _duration_seconds("2629800s")
+    assert _duration_seconds("1month") == _duration_seconds("1months") == _duration_seconds("1M")
+    assert _duration_seconds("1month") == _duration_seconds("2629800s")
     assert _duration_seconds("1y") == _duration_seconds("1year") == _duration_seconds("1years")
     assert _duration_seconds("1y") == _duration_seconds("31557600s")
 
 
-@pytest.mark.parametrize("raw", ["1usecs", "1msecx", "1secs", "1mins", "1hrs", "1millisecond"])
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "1usecs", "1msecx", "1secs", "1mins", "1hrs", "1millisecond",
+        "1H", "1MS", "1SEC", "1Hour", "INFINITY",
+    ],
+)
 def test_duration_parser_rejects_non_systemd_timeout_aliases(raw):
     with pytest.raises(PinError, match="unsupported systemd duration"):
         _duration_seconds(raw)


### PR DESCRIPTION
Preserva TimeoutStartSec da unit versionada em todos os drop-ins imutáveis e verifica o TimeoutStartUSec efetivo. Inclui regressão para o PNCP de 320 minutos; mantém Restart=no e SuccessExitStatus vazio. Validado com 31 testes focados, ruff e git diff --check.