### PR TITLE
fix(confenge): preserve official PNCP contract identity

### DIFF
--- a/DOD.md
+++ b/DOD.md
@@ -22,6 +22,16 @@ A single `[x]` must not hide these differences.
   contraditória e foi recusada. Produção e soak permanecem abertos.
   Runbook: `docs/ops/incidents/PNCP-458.md`.
 
+### Identidade contratual CONFENGE / incidente #468 (2026-09-02)
+
+- [ ] Aceitar a correção de identidade somente após merge no `main`, CI do SHA
+  exato, re-freeze gerado contra esse tip e prova live pós-deploy. Estado atual:
+  `IMPLEMENTED`; o código local preserva `numero_controle_pncp`/`contrato_id`
+  como identidade pública, recusa IDs oficiais vazios e mantém `id` apenas como
+  cursor ou compatibilidade legada explícita. Não autoriza feed, coorte, SMTP
+  nem a saída da contenção #468. Handoff:
+  `docs/ops/handoff-2026-09-02-confenge-contract-identity.md`.
+
 
 > Checklist viva para acompanhar a evolução do desenvolvimento do projeto.
 >

--- a/docs/architecture/adr-confenge-frozen-inputs-v1.md
+++ b/docs/architecture/adr-confenge-frozen-inputs-v1.md
@@ -55,6 +55,9 @@ Replace monorepo-wide allowlisting with **explicit frozen CONFENGE inputs**:
 
 - Policy changes require honest re-freeze and regeneration of SHA-bound
   commercial package fields at the new HEAD
+- Contract identity mapping (including the precedence between a PNCP control
+  number and a technical table surrogate) is commercial pipeline policy; a
+  change to it requires the same re-freeze and rebind procedure.
 - Shared-surface extractors must stay fail-closed (missing markers → fail)
 
 ### Re-freeze procedure

--- a/docs/ops/handoff-2026-09-02-confenge-contract-identity.md
+++ b/docs/ops/handoff-2026-09-02-confenge-contract-identity.md
@@ -1,0 +1,44 @@
+# Handoff — identidade contratual CONFENGE / #468
+
+Data: 2026-09-02
+
+## Estado
+
+`IMPLEMENTED`, não aceito. O candidato local parte de `main` no
+`1b9db789b968b483d507ee26ab0fd3fa662ad302` (#529) e corrige a precedência que
+antes publicava o BIGSERIAL técnico `id` como contrato público.
+
+O feed histórico `full-national-2026-08-07` contém 1.214 referências de
+contrato, todas numéricas curtas. O manifest do universo daquele run registra
+que `contrato_id` não existia na tabela consultada. A origem PNCP, por sua vez,
+produz `numeroControlePNCP` como `contrato_id` canônico.
+
+## Contrato implementado
+
+- `contrato_id`, `numero_controle_pncp` e `contract_id` são as únicas formas
+  públicas aceitáveis, nesta ordem.
+- `id` é cursor técnico; só é aceito por chamador com opt-in explícito para
+  legado (`allow_legacy_surrogate_contract_id`).
+- O universo e o loader de target-fit recusam uma linha cujo ID oficial esteja
+  ausente ou em branco.
+- A projeção de portfolio, target-fit, inteligência, bridge e party-role usa o
+  mesmo resolvedor de identidade.
+
+## Evidência local
+
+- Teste adversarial com `id=25394409` e
+  `numero_controle_pncp=00028986000108-1-000123/2026` prova cursor por `id` e
+  identidade emitida PNCP.
+- Loader de target-fit seleciona e prefere `numero_controle_pncp`.
+- IDs oficiais nulos/em branco causam recusa fail-closed.
+- Regressão focal: 48 testes verdes; ruff verde.
+
+## Próximos gates — estritamente ordenados
+
+1. Publicar o commit isolado e obter CI verde no SHA exato.
+2. Integrar em `main`.
+3. Executar `confenge_code_freeze mark-final-integrity-freeze` no tip integrado;
+   não editar artefatos de freeze manualmente nem reutilizar #533.
+4. Executar os verificadores de binding e a prova live pós-deploy.
+5. Manter #468 fail-closed até a prova contemporânea de Sistema S/parafiscais
+   fora de `TARGET_CONFIRMED`, sem perda não explicada de construtoras.

--- a/scripts/confenge_account_intelligence/message_spine.py
+++ b/scripts/confenge_account_intelligence/message_spine.py
@@ -11,6 +11,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import date, datetime
 from typing import Any
 
+from scripts.confenge_contract_identity import public_contract_id
+
 # Meta evidence ids that may stay in internal lists but never seed the body.
 META_EVIDENCE_PREFIXES: tuple[str, ...] = (
     "cf-portfolio-count",
@@ -93,7 +95,7 @@ def extract_contract_hook(bag: dict[str, Any]) -> tuple[str, list[str]]:
         org = str(c.get("orgao") or c.get("agency") or c.get("orgao_nome") or "").strip()
         uf = str(c.get("uf") or "").strip()
         val = c.get("value_brl") or c.get("valor_total")
-        cid = str(c.get("id") or c.get("contrato_id") or f"contract-{i}")
+        cid = public_contract_id(c) or f"contract-{i}"
         bits = [f"objeto: {obj[:180]}"]
         if org:
             bits.append(f"órgão: {org}")

--- a/scripts/confenge_account_intelligence/normalize.py
+++ b/scripts/confenge_account_intelligence/normalize.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 from typing import Any
 
 from scripts.confenge_account_intelligence.models import cnpj14, cnpj_root, digits_only
+from scripts.confenge_contract_identity import public_contract_id
 
 
 def _parse_date(value: Any) -> date | None:
@@ -187,7 +188,7 @@ def normalize_record(raw: dict[str, Any], *, as_of: str | None = None) -> dict[s
         )
         contracts.append(
             {
-                "id": str(c.get("id") or c.get("contract_id") or c.get("contrato_id") or f"contract-{i + 1}"),
+                "id": public_contract_id(c) or f"contract-{i + 1}",
                 "object": obj_text or c.get("object") or c.get("objeto") or c.get("description"),
                 "value_brl": _as_float(c.get("value_brl") or c.get("valor") or c.get("value") or c.get("valor_total")),
                 "start_date": start.isoformat() if start else None,

--- a/scripts/confenge_contract_identity.py
+++ b/scripts/confenge_contract_identity.py
@@ -1,0 +1,18 @@
+"""One public identity rule for PNCP contract projections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+OFFICIAL_CONTRACT_ID_FIELDS = ("contrato_id", "numero_controle_pncp", "contract_id")
+
+
+def public_contract_id(
+    record: dict[str, Any], *, allow_legacy_surrogate: bool = False
+) -> str:
+    """Return a non-empty official ID; legacy ``id`` needs explicit opt-in."""
+    for field in OFFICIAL_CONTRACT_ID_FIELDS:
+        value = str(record.get(field) or "").strip()
+        if value:
+            return value
+    return str(record.get("id") or "").strip() if allow_legacy_surrogate else ""

--- a/scripts/confenge_outreach_pipeline/adapt.py
+++ b/scripts/confenge_outreach_pipeline/adapt.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from scripts.confenge_contract_identity import public_contract_id
 from scripts.confenge_outreach_pipeline.party_role import project_contractor_role
 
 
@@ -113,7 +114,7 @@ def universe_row_to_intelligence_input(
         )
         contracts.append(
             {
-                "id": str(c.get("contrato_id") or c.get("id") or f"u-contract-{i + 1}"),
+                "id": public_contract_id(c) or f"u-contract-{i + 1}",
                 "object": obj or None,
                 "value_brl": c.get("valor_total") or c.get("value_brl"),
                 "start_date": c.get("data_inicio") or c.get("start_date"),
@@ -288,7 +289,7 @@ def intelligence_dossier_to_bridge_row(dossier: dict[str, Any]) -> dict[str, Any
             continue
         bridge_contracts.append(
             {
-                "id": str(c.get("id") or c.get("contrato_id") or ""),
+                "id": public_contract_id(c),
                 "object": c.get("object") or c.get("objeto"),
                 "value_brl": c.get("value_brl") or c.get("valor_total"),
                 "start_date": c.get("start_date"),

--- a/scripts/confenge_outreach_pipeline/integrity_sample.py
+++ b/scripts/confenge_outreach_pipeline/integrity_sample.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from scripts.confenge_account_intelligence.message_spine import is_hollow_fact
 from scripts.confenge_account_intelligence.pipeline import build_dossier
+from scripts.confenge_contract_identity import public_contract_id
 from scripts.confenge_outreach_pipeline.near_duplicate import (
     audit_near_duplicates,
     subject_is_generic_contrato,
@@ -28,7 +29,7 @@ def bag_from_feed_lead(lead: dict[str, Any]) -> dict[str, Any]:
             continue
         contracts.append(
             {
-                "id": c.get("id") or c.get("contrato_id"),
+                "id": public_contract_id(c),
                 "object": c.get("object") or c.get("objeto"),
                 "objeto": c.get("object") or c.get("objeto"),
                 "value_brl": c.get("value_brl") or c.get("valor_total"),

--- a/scripts/confenge_outreach_pipeline/party_role.py
+++ b/scripts/confenge_outreach_pipeline/party_role.py
@@ -6,6 +6,8 @@ import hashlib
 import json
 from typing import Any
 
+from scripts.confenge_contract_identity import public_contract_id
+
 CONTRACTOR_ROLE_CONFIRMED = "CONTRACTOR_ROLE_CONFIRMED"
 PARTY_ROLE_CONFLICT = "PARTY_ROLE_CONFLICT"
 PARTY_ROLE_UNKNOWN = "UNKNOWN"
@@ -40,7 +42,7 @@ def project_contractor_role(
             contract.get("supplier_cnpj14") or contract.get("fornecedor_cnpj") or contract.get("supplier_cnpj")
         )
         buyer = _cnpj14(contract.get("buyer_cnpj14") or contract.get("orgao_cnpj") or contract.get("buyer_cnpj"))
-        contract_id = str(contract.get("id") or contract.get("contrato_id") or "").strip()
+        contract_id = public_contract_id(contract)
         supplier_role = str(contract.get("supplier_role") or "").upper().strip()
         buyer_role = str(contract.get("buyer_role") or "").upper().strip()
         fact = {

--- a/scripts/confenge_sector/rebuild.py
+++ b/scripts/confenge_sector/rebuild.py
@@ -78,7 +78,9 @@ def _relation_columns(conn: Any) -> list[str]:
 
 
 def _source_sql(available: list[str]) -> tuple[str, str, str]:
-    physical = resolve_physical_map(available)
+    # This historical sector rebuild has an explicit legacy compatibility
+    # contract; CONFENGE outbound source loading does not opt into it.
+    physical = resolve_physical_map(available, allow_legacy_surrogate_contract_id=True)
     supplier = physical.get("fornecedor_cnpj")
     contract_id = physical.get("contrato_id")
     if not supplier or not contract_id:
@@ -86,7 +88,7 @@ def _source_sql(available: list[str]) -> tuple[str, str, str]:
     identifiers = [supplier, contract_id]
     if not all(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", item) for item in identifiers):
         raise ValueError("unsafe physical identifier")
-    selected = _select_list(available)
+    selected = _select_list(available, cursor_column=contract_id)
     root_expr = (
         "fornecedor_cnpj_8::text"
         if "fornecedor_cnpj_8" in available

--- a/scripts/confenge_target_fit/fingerprint.py
+++ b/scripts/confenge_target_fit/fingerprint.py
@@ -12,6 +12,7 @@ import json
 import re
 from typing import Any
 
+from scripts.confenge_contract_identity import public_contract_id
 from scripts.confenge_target_fit.models import CompanyInput
 
 
@@ -29,12 +30,7 @@ def _norm_text(value: Any) -> str:
 
 def _contract_semantic_view(contract: dict[str, Any]) -> dict[str, Any]:
     """Fields that can change target-fit classification."""
-    cid = (
-        contract.get("contrato_id")
-        or contract.get("id")
-        or contract.get("numero_controle_pncp")
-        or ""
-    )
+    cid = public_contract_id(contract)
     obj = (
         contract.get("objeto_contrato")
         or contract.get("objeto")

--- a/scripts/confenge_target_fit/loader.py
+++ b/scripts/confenge_target_fit/loader.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
+from scripts.confenge_contract_identity import public_contract_id
 from scripts.confenge_target_fit.company_key import (
     company_key_from_raiz,
     digits_only,
@@ -108,6 +109,7 @@ def _load_contracts(
         select_cols = [cnpj_col]
         for c in (
             "contrato_id",
+            "numero_controle_pncp",
             "id",
             "orgao_cnpj",
             "orgao_nome",
@@ -172,10 +174,13 @@ def _load_contracts(
         if is_consortium_contract(r):
             consortium = True
             r = {**r, "is_consortium": True, "consortium_evidence": True}
+        contract_id = public_contract_id(r)
+        if not contract_id:
+            raise RuntimeError("pncp_supplier_contracts row missing official contract identity")
         # Normalize logical fields
         contracts.append(
             {
-                "contrato_id": r.get("contrato_id") or r.get("id"),
+                "contrato_id": contract_id,
                 "orgao_cnpj": r.get("orgao_cnpj"),
                 "orgao_nome": r.get("orgao_nome"),
                 "fornecedor_cnpj": c14 or r.get(cnpj_col),

--- a/scripts/confenge_universe/cli.py
+++ b/scripts/confenge_universe/cli.py
@@ -122,6 +122,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Disable independent decision-brand split; always collapse by CNPJ root",
     )
+    b.add_argument("--allow-legacy-surrogate-contract-id", action="store_true", help="Compatibility only: permit id only where no official contract ID exists.")
     b.add_argument(
         "--result-json",
         default=None,
@@ -149,6 +150,7 @@ def cmd_build(args: argparse.Namespace) -> int:
             enable_independent_brand=not args.no_independent_brand,
             load_human_dnc=not args.no_auto_dnc,
             load_registry=not args.no_auto_registry,
+            allow_legacy_surrogate_contract_id=args.allow_legacy_surrogate_contract_id,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/confenge_universe/pipeline.py
+++ b/scripts/confenge_universe/pipeline.py
@@ -373,6 +373,7 @@ def run_universe_build(
     registry: dict[str, dict[str, Any]] | None = None,
     load_human_dnc: bool = True,
     load_registry: bool = True,
+    allow_legacy_surrogate_contract_id: bool = False,
     source_meta_extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build national construction universe from streamable contract source.
@@ -403,7 +404,7 @@ def run_universe_build(
             "note": "in-memory/fixture iterator",
         }
     else:
-        cfg = resolve_source(dsn, csv_path=csv_path)
+        cfg = resolve_source(dsn, csv_path=csv_path, allow_legacy_surrogate_contract_id=allow_legacy_surrogate_contract_id)
         resolved_csv = cfg.csv_path if cfg.mode == "csv" else csv_path
         batches = iter_contracts_keyset(
             cfg,

--- a/scripts/confenge_universe/source.py
+++ b/scripts/confenge_universe/source.py
@@ -18,6 +18,8 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from scripts.confenge_contract_identity import public_contract_id
+
 # Logical (internal) column names used by identity/aggregate/construction.
 CONTRACT_COLUMNS = (
     "contrato_id",
@@ -37,14 +39,12 @@ CONTRACT_COLUMNS = (
     "source",
 )
 
-# Physical datalake column → logical name. Real national tables (smartlic /
-# pncp_supplier_contracts) use ni_fornecedor / valor_global / id, not the
-# older logical names. Multiple physical names may map to one logical field;
-# first available wins.
+# Physical datalake column → logical name. ``id`` is a surrogate cursor, not
+# a public contract identity; real tables can also carry the PNCP control ID.
 PHYSICAL_TO_LOGICAL: dict[str, str] = {
     "contrato_id": "contrato_id",
-    "id": "contrato_id",
     "numero_controle_pncp": "contrato_id",
+    "id": "surrogate_id",
     "orgao_cnpj": "orgao_cnpj",
     "orgao_nome": "orgao_nome",
     "fornecedor_cnpj": "fornecedor_cnpj",
@@ -67,7 +67,7 @@ PHYSICAL_TO_LOGICAL: dict[str, str] = {
 
 # Preferred physical candidates per logical field (order = priority).
 LOGICAL_CANDIDATES: dict[str, tuple[str, ...]] = {
-    "contrato_id": ("contrato_id", "id", "numero_controle_pncp"),
+    "contrato_id": ("contrato_id", "numero_controle_pncp"),
     "orgao_cnpj": ("orgao_cnpj",),
     "orgao_nome": ("orgao_nome",),
     "fornecedor_cnpj": ("fornecedor_cnpj", "ni_fornecedor"),
@@ -99,15 +99,17 @@ class SourceConfig:
     dsn: str | None = None
     csv_path: str | None = None
     read_only: bool = True
+    allow_legacy_surrogate_contract_id: bool = False
 
 
 def resolve_source(
     dsn: str | None = None,
     *,
     csv_path: str | None = None,
+    allow_legacy_surrogate_contract_id: bool = False,
 ) -> SourceConfig:
     if csv_path:
-        return SourceConfig(mode="csv", csv_path=csv_path, read_only=True)
+        return SourceConfig(mode="csv", csv_path=csv_path, read_only=True, allow_legacy_surrogate_contract_id=allow_legacy_surrogate_contract_id)
     env_dsn = (
         dsn
         or os.environ.get("CONFENGE_UNIVERSE_DSN")
@@ -117,7 +119,7 @@ def resolve_source(
         or os.environ.get("DATABASE_URL")
     )
     if env_dsn:
-        return SourceConfig(mode="dsn", dsn=env_dsn, read_only=True)
+        return SourceConfig(mode="dsn", dsn=env_dsn, read_only=True, allow_legacy_surrogate_contract_id=allow_legacy_surrogate_contract_id)
     raise RuntimeError(
         "No datalake source configured. Set LOCAL_DATALAKE_DSN / "
         "CONFENGE_UNIVERSE_DSN or pass --csv / --dsn."
@@ -152,8 +154,8 @@ def discover_columns(cfg: SourceConfig) -> list[str]:
         conn.close()
 
 
-def resolve_physical_map(available: list[str]) -> dict[str, str]:
-    """Map logical field → physical column present in the table."""
+def resolve_physical_map(available: list[str], *, allow_legacy_surrogate_contract_id: bool = False) -> dict[str, str]:
+    """Map logical fields without silently replacing official identity."""
     avail = set(available)
     out: dict[str, str] = {}
     for logical, candidates in LOGICAL_CANDIDATES.items():
@@ -161,10 +163,12 @@ def resolve_physical_map(available: list[str]) -> dict[str, str]:
             if phys in avail:
                 out[logical] = phys
                 break
+    if "contrato_id" not in out and allow_legacy_surrogate_contract_id and "id" in avail:
+        out["contrato_id"] = "id"
     return out
 
 
-def _select_list(available: list[str]) -> list[str]:
+def _select_list(available: list[str], *, cursor_column: str | None = None) -> list[str]:
     """Return physical column names to SELECT (unique, validated)."""
     physical_map = resolve_physical_map(available)
     if not physical_map:
@@ -178,6 +182,8 @@ def _select_list(available: list[str]) -> list[str]:
         if phys and phys not in seen:
             seen.add(phys)
             cols.append(phys)
+    if cursor_column and cursor_column in set(available) and cursor_column not in seen:
+        cols.append(cursor_column)
     return cols or list(CONTRACT_COLUMNS)
 
 
@@ -206,8 +212,7 @@ def normalize_contract_row(
         else:
             out[logical] = None
     # contrato_id must be string for keyset + identity
-    if out.get("contrato_id") is not None:
-        out["contrato_id"] = str(out["contrato_id"])
+    out["contrato_id"] = public_contract_id(out)
     return out
 
 
@@ -228,6 +233,7 @@ def build_keyset_query(
     batch_size: int = 2000,
     keyset_contrato_id: str | None = None,
     physical_map: dict[str, str] | None = None,
+    cursor_column: str | None = None,
 ) -> tuple[str, list[Any]]:
     """Keyset by contrato id ASC — stable full-table walk, no OFFSET bias.
 
@@ -240,7 +246,7 @@ def build_keyset_query(
     supplier_col = pmap.get("fornecedor_cnpj", "fornecedor_cnpj")
     valor_col = pmap.get("valor_total", "valor_total")
     uf_col = pmap.get("uf", "uf")
-    id_col = pmap.get("contrato_id", "contrato_id")
+    id_col = cursor_column or pmap.get("contrato_id", "contrato_id")
     for ident in (supplier_col, valor_col, uf_col, id_col):
         if not re.fullmatch(r"[a-zA-Z_][a-zA-Z0-9_]*", ident or ""):
             raise ValueError(f"Invalid column identifier: {ident!r}")
@@ -262,7 +268,7 @@ def build_keyset_query(
         # Prefer numeric keyset when the id looks integer (real table uses bigserial id).
         # Text keyset for string contrato_id / numero_controle_pncp schemas.
         key = str(keyset_contrato_id)
-        if re.fullmatch(r"-?\d+", key) and id_col in {"id", "contrato_id"}:
+        if re.fullmatch(r"-?\d+", key) and id_col == "id":
             where.append(f"{id_col} > %s")
             params.append(int(key))
         else:
@@ -319,7 +325,7 @@ def source_fingerprint(cfg: SourceConfig, *, as_of: date) -> dict[str, Any]:
                     "WHERE table_schema='public' AND table_name='pncp_supplier_contracts'"
                 )
                 available = [r["column_name"] for r in cur.fetchall()]
-                pmap = resolve_physical_map(available)
+                pmap = resolve_physical_map(available, allow_legacy_surrogate_contract_id=cfg.allow_legacy_surrogate_contract_id)
                 id_col = pmap.get("contrato_id", "id")
                 if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", id_col):
                     raise ValueError(f"invalid id column: {id_col!r}")
@@ -366,8 +372,11 @@ def iter_contracts_keyset(
         raise RuntimeError(f"Unsupported source mode for keyset: {cfg.mode}")
 
     available = discover_columns(cfg)
-    physical_map = resolve_physical_map(available)
-    cols = _select_list(available)
+    physical_map = resolve_physical_map(available, allow_legacy_surrogate_contract_id=cfg.allow_legacy_surrogate_contract_id)
+    if "contrato_id" not in physical_map:
+        raise RuntimeError("pncp_supplier_contracts has no official contract identity (expected contrato_id or numero_controle_pncp); refusing to publish surrogate id")
+    cursor_column = "id" if "id" in available else physical_map["contrato_id"]
+    cols = _select_list(available, cursor_column=cursor_column)
     if "fornecedor_cnpj" not in physical_map and "ni_fornecedor" not in available:
         # Legacy logical-only schema (tests / old DBs)
         if "fornecedor_cnpj" not in available:
@@ -377,7 +386,7 @@ def iter_contracts_keyset(
             )
     yielded = 0
     key_cid: str | None = None
-    id_phys = physical_map.get("contrato_id", "contrato_id")
+    id_phys = cursor_column
 
     while True:
         limit = batch_size
@@ -394,6 +403,7 @@ def iter_contracts_keyset(
             batch_size=limit,
             keyset_contrato_id=key_cid,
             physical_map=physical_map or None,
+            cursor_column=cursor_column,
         )
         conn = _connect_dsn(cfg.dsn)
         try:
@@ -407,6 +417,10 @@ def iter_contracts_keyset(
         if not raw_batch:
             break
         batch = [normalize_contract_row(r, physical_map=physical_map) for r in raw_batch]
+        if any(not row["contrato_id"] for row in batch):
+            raise RuntimeError(
+                "pncp_supplier_contracts row missing official contract identity; refusing to publish"
+            )
         yield batch
         yielded += len(batch)
         # Keyset advances on physical id of last raw row (stable).

--- a/scripts/confenge_universe/target_fit.py
+++ b/scripts/confenge_universe/target_fit.py
@@ -38,6 +38,7 @@ from scripts.commercial_leads.sector_fit import (
     CLASS_STRONG,
     NAME_OUT_OF_SCOPE,
 )
+from scripts.confenge_contract_identity import public_contract_id
 from scripts.confenge_universe.parafiscal import (
     PARAFISCAL_HARD_OUT_REASON,
     match_parafiscal_in_names,
@@ -295,7 +296,7 @@ def classify_target_fit(
             exec_contracts.append(c)
             evidence.append(
                 {
-                    "id": str(c.get("contrato_id") or c.get("id") or f"ct-{i}"),
+                    "id": public_contract_id(c) or f"ct-{i}",
                     "type": "CONTRACT_EXECUTION",
                     "excerpt": obj[:240],
                     "agency": c.get("orgao_nome") or c.get("orgao") or c.get("agency"),

--- a/tests/confenge_outreach_pipeline/test_party_role.py
+++ b/tests/confenge_outreach_pipeline/test_party_role.py
@@ -11,6 +11,7 @@ from scripts.confenge_outreach_pipeline.party_role import (
 def _contract(*, supplier: str, buyer: str) -> dict[str, str]:
     return {
         "id": "contract-1",
+        "contrato_id": "contract-1",
         "supplier_cnpj14": supplier,
         "supplier_role": "CONTRATADA",
         "buyer_cnpj14": buyer,
@@ -80,7 +81,11 @@ def test_exact_supplier_match_is_high_confidence() -> None:
 
 def test_correct_contract_plus_conflicting_buyer_link_fails_closed() -> None:
     correct = _contract(supplier="11222333000144", buyer="99888777000166")
-    conflict = {**_contract(supplier="88777666000155", buyer="11222333000144"), "id": "contract-2"}
+    conflict = {
+        **_contract(supplier="88777666000155", buyer="11222333000144"),
+        "id": "contract-2",
+        "contrato_id": "contract-2",
+    }
     result = project_contractor_role("11222333000144", [correct, conflict])
     assert result["status"] == PARTY_ROLE_CONFLICT
     assert result["target_party_role"] == "BUYER_CONFLICT"

--- a/tests/confenge_universe/test_source_contract_identity.py
+++ b/tests/confenge_universe/test_source_contract_identity.py
@@ -1,0 +1,163 @@
+"""Official PNCP identity must win over a technical table surrogate."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.confenge_outreach_pipeline.party_role import project_contractor_role
+from scripts.confenge_target_fit import loader as target_fit_loader
+from scripts.confenge_universe.source import (
+    SourceConfig,
+    _select_list,
+    build_keyset_query,
+    iter_contracts_keyset,
+    normalize_contract_row,
+    resolve_physical_map,
+)
+
+
+def test_table_with_id_and_pncp_control_number_keeps_official_identity() -> None:
+    columns = ["id", "numero_controle_pncp", "ni_fornecedor", "valor_global"]
+    physical = resolve_physical_map(columns)
+    assert physical["contrato_id"] == "numero_controle_pncp"
+    sql, params = build_keyset_query(
+        columns=_select_list(columns, cursor_column="id"),
+        physical_map=physical,
+        cursor_column="id",
+        keyset_contrato_id="25394409",
+    )
+    assert "ORDER BY id ASC" in sql
+    assert "id > %s" in sql
+    assert 25394409 in params
+    row = normalize_contract_row(
+        {"id": 25394409, "numero_controle_pncp": "00028986000108-1-000123/2026"},
+        physical_map=physical,
+    )
+    assert row["contrato_id"] == "00028986000108-1-000123/2026"
+
+
+def test_downstream_evidence_prefers_official_identity_when_both_exist() -> None:
+    official = "00028986000108-1-000123/2026"
+    projected = project_contractor_role(
+        "00028986000108",
+        [{
+            "id": "25394409",
+            "contrato_id": official,
+            "supplier_cnpj14": "00028986000108",
+            "buyer_cnpj14": "11111111000191",
+            "supplier_role": "CONTRATADA",
+            "buyer_role": "CONTRATANTE",
+        }],
+    )
+    assert projected["evidence_ids"] == [official]
+
+
+def test_id_only_schema_fails_closed_without_explicit_legacy_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    columns = ["id", "ni_fornecedor", "valor_global"]
+    assert "contrato_id" not in resolve_physical_map(columns)
+    assert resolve_physical_map(columns, allow_legacy_surrogate_contract_id=True)["contrato_id"] == "id"
+    monkeypatch.setattr("scripts.confenge_universe.source.discover_columns", lambda _cfg: columns)
+    with pytest.raises(RuntimeError, match="no official contract identity"):
+        next(iter_contracts_keyset(SourceConfig(mode="dsn", dsn="postgresql://example.invalid/db")))
+
+
+def test_keyset_uses_surrogate_cursor_but_yields_pncp_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    columns = ["id", "numero_controle_pncp", "ni_fornecedor", "valor_global"]
+    raw = {
+        "id": 25394409,
+        "numero_controle_pncp": "00028986000108-1-000123/2026",
+        "ni_fornecedor": "00028986000108",
+        "valor_global": 1000,
+    }
+    queries: list[tuple[str, tuple[object, ...]]] = []
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def execute(self, sql: str, params: tuple[object, ...] = ()) -> None:
+            queries.append((sql, params))
+            self.rows = (
+                [{"column_name": column} for column in columns]
+                if "information_schema.columns" in sql
+                else ([] if 25394409 in params else [raw])
+            )
+
+        def fetchall(self):
+            return self.rows
+
+    class Connection:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("scripts.confenge_universe.source._connect_dsn", lambda _dsn: Connection())
+    batches = list(iter_contracts_keyset(SourceConfig(mode="dsn", dsn="postgresql://example.invalid/db")))
+    assert batches == [[{"contrato_id": "00028986000108-1-000123/2026", "orgao_cnpj": None, "orgao_nome": None, "fornecedor_cnpj": "00028986000108", "fornecedor_nome": None, "objeto_contrato": None, "valor_total": 1000, "data_inicio": None, "data_fim": None, "data_publicacao": None, "data_assinatura": None, "uf": None, "municipio": None, "is_active": None, "source": None}]]
+    selects = [sql for sql, _params in queries if "FROM public.pncp_supplier_contracts" in sql]
+    assert all("ORDER BY id ASC" in sql for sql in selects)
+
+
+def test_source_refuses_blank_official_id_even_when_surrogate_exists(monkeypatch: pytest.MonkeyPatch) -> None:
+    columns = ["id", "numero_controle_pncp", "ni_fornecedor", "valor_global"]
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def execute(self, sql: str, _params: tuple[object, ...] = ()) -> None:
+            self.rows = (
+                [{"column_name": column} for column in columns]
+                if "information_schema.columns" in sql
+                else [{"id": 1, "numero_controle_pncp": "  ", "ni_fornecedor": "00028986000108", "valor_global": 1}]
+            )
+
+        def fetchall(self):
+            return self.rows
+
+    class Connection:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("scripts.confenge_universe.source._connect_dsn", lambda _dsn: Connection())
+    with pytest.raises(RuntimeError, match="row missing official contract identity"):
+        next(iter_contracts_keyset(SourceConfig(mode="dsn", dsn="postgresql://example.invalid/db")))
+
+
+def test_target_fit_loader_selects_and_uses_pncp_control_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    columns = {"id", "numero_controle_pncp", "ni_fornecedor", "valor_global"}
+    queries: list[str] = []
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def execute(self, sql: str, _params: tuple[object, ...]) -> None:
+            queries.append(sql)
+            self.rows = [{"id": 25394409, "numero_controle_pncp": "00028986000108-1-000123/2026", "ni_fornecedor": "00028986000108", "valor_global": 1000}]
+
+        def fetchall(self):
+            return self.rows
+
+    class Connection:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+    monkeypatch.setattr(target_fit_loader, "_COLS_CACHE", columns)
+    contracts, *_rest = target_fit_loader._load_contracts(Connection(), raiz="00028986", limit=None)
+    assert "numero_controle_pncp" in queries[0]
+    assert contracts[0]["contrato_id"] == "00028986000108-1-000123/2026"


### PR DESCRIPTION
## Contexto

Corrige a divergência que permitia ao universo CONFENGE usar o BIGSERIAL técnico id como identidade contratual pública quando coexistia numero_controle_pncp.

## Mudança

- centraliza precedência de identidade pública: contrato_id, numero_controle_pncp, contract_id;
- mantém id apenas como cursor ou por opt-in legado explícito;
- falha fechado para ID oficial ausente ou em branco;
- corrige loader e fingerprint target-fit e projeções de evidência e bridge;
- preserva rebuild setorial id-only somente por opt-in explícito;
- registra DOD, ADR e handoff; não atualiza artefatos freeze manualmente.

## Evidência local

- 89 testes relevantes verdes;
- ruff PASS;
- generated-artifacts policy PASS;
- draft reviewability PASS.

## Incidente 468

Este PR não libera feed, coorte, SMTP, re-freeze ou deploy. Após merge e CI do SHA exato, o re-freeze deve ser regenerado contra o tip integrado, sem reutilizar PR 533.

Refs 468