### PR TITLE
feat(pncp): persist tipoContrato, categoriaProcesso, modalidade, regime, SRP (#546)

### DIFF
--- a/db/migrations/107_pncp_structural_fields.sql
+++ b/db/migrations/107_pncp_structural_fields.sql
@@ -1,0 +1,443 @@
+-- 107_pncp_structural_fields.sql
+-- #546: persist official PNCP structural fields (not inferred from objeto).
+-- Additive columns + upsert persist + canonical v2 expose + resumable backfill RPC.
+--
+-- ROLLBACK:
+--   psql "$LOCAL_DATALAKE_DSN" -f db/rollback/107_pncp_structural_fields_rollback.sql
+--
+-- Authority: scripts/crawl/pncp_structural_fields.py maps the PNCP payload;
+-- this migration persists those mapped keys. Do not re-derive from objeto.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+ALTER TABLE public.pncp_supplier_contracts
+    ADD COLUMN IF NOT EXISTS tipo_contrato_id INTEGER,
+    ADD COLUMN IF NOT EXISTS tipo_contrato_nome TEXT,
+    ADD COLUMN IF NOT EXISTS categoria_processo_id INTEGER,
+    ADD COLUMN IF NOT EXISTS categoria_processo_nome TEXT,
+    ADD COLUMN IF NOT EXISTS modalidade_id INTEGER,
+    ADD COLUMN IF NOT EXISTS modalidade_nome TEXT,
+    ADD COLUMN IF NOT EXISTS regime_execucao_id INTEGER,
+    ADD COLUMN IF NOT EXISTS regime_execucao_nome TEXT,
+    ADD COLUMN IF NOT EXISTS srp BOOLEAN,
+    ADD COLUMN IF NOT EXISTS numero_retificacao INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_psc_tipo_contrato
+    ON public.pncp_supplier_contracts (tipo_contrato_id)
+    WHERE tipo_contrato_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_psc_categoria_processo
+    ON public.pncp_supplier_contracts (categoria_processo_id)
+    WHERE categoria_processo_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_psc_modalidade
+    ON public.pncp_supplier_contracts (modalidade_id)
+    WHERE modalidade_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_psc_srp
+    ON public.pncp_supplier_contracts (srp)
+    WHERE srp IS TRUE;
+
+COMMENT ON COLUMN public.pncp_supplier_contracts.tipo_contrato_id IS
+    'Official PNCP tipoContrato id (contrato, empenho, carta contrato). Not inferred from objeto. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.tipo_contrato_nome IS
+    'Official PNCP tipoContrato nome. Not inferred from objeto. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.categoria_processo_id IS
+    'Official PNCP categoriaProcesso id (obras, servicos de engenharia, compras). #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.categoria_processo_nome IS
+    'Official PNCP categoriaProcesso nome. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.modalidade_id IS
+    'Official PNCP modalidade id from the contract or parent compra payload. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.modalidade_nome IS
+    'Official PNCP modalidade nome. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.regime_execucao_id IS
+    'Official PNCP codigoRegimeExecucao when present on the payload. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.regime_execucao_nome IS
+    'Official PNCP regimeExecucao nome (integrada/semi-integrada/etc.). #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.srp IS
+    'Official PNCP SRP / registro de precos flag from the payload, not from objeto text. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.numero_retificacao IS
+    'Official PNCP numeroRetificacao. #546.';
+
+CREATE OR REPLACE FUNCTION public.upsert_pncp_supplier_contracts(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(p_records) AS candidate(rec)
+        WHERE upper(btrim(COALESCE(candidate.rec->>'supplier_id_type', '')))
+                  IN ('CNPJ', 'CPF', 'FOREIGN')
+          AND COALESCE(
+                  NULLIF(btrim(candidate.rec->>'supplier_identifier'), ''),
+                  NULLIF(btrim(candidate.rec->>'fornecedor_cnpj'), '')
+              ) IS NULL
+    ) THEN
+        RAISE EXCEPTION 'supplier_identifier is required for declared CNPJ, CPF, or FOREIGN identity'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN QUERY
+    WITH raw_input AS (
+        SELECT DISTINCT ON ((rec->>'contrato_id'))
+            rec,
+            NULLIF(upper(btrim(rec->>'supplier_id_type')), '') AS declared_type,
+            COALESCE(
+                NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                NULLIF(btrim(rec->>'fornecedor_cnpj'), '')
+            ) AS raw_identifier,
+            regexp_replace(
+                COALESCE(
+                    NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                    NULLIF(btrim(rec->>'fornecedor_cnpj'), ''),
+                    ''
+                ),
+                '\D', '', 'g'
+            ) AS identifier_digits
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY (rec->>'contrato_id')
+    ), classified AS (
+        SELECT raw_input.*,
+            CASE
+                WHEN declared_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                WHEN declared_type = 'FOREIGN' AND raw_identifier IS NOT NULL THEN 'FOREIGN'
+                WHEN declared_type = 'UNKNOWN' THEN 'UNKNOWN'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                ELSE 'UNKNOWN'
+            END AS canonical_type
+        FROM raw_input
+    ), normalized AS (
+        SELECT classified.*,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'FOREIGN'
+                    AND raw_identifier LIKE 'FOREIGN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'FOREIGN' AND raw_identifier IS NOT NULL
+                    THEN 'FOREIGN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                WHEN canonical_type = 'UNKNOWN'
+                    AND raw_identifier LIKE 'UNKNOWN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'UNKNOWN' AND raw_identifier IS NOT NULL
+                    THEN 'UNKNOWN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                ELSE NULL
+            END AS canonical_identifier
+        FROM classified
+    ), input AS (
+        SELECT
+            rec->>'contrato_id' AS in_contrato_id,
+            rec->>'orgao_cnpj' AS orgao_cnpj,
+            rec->>'orgao_nome' AS orgao_nome,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(canonical_identifier)
+                    THEN canonical_identifier
+                ELSE NULL
+            END AS fornecedor_cnpj,
+            rec->>'fornecedor_nome' AS fornecedor_nome,
+            canonical_type AS supplier_id_type,
+            canonical_identifier AS supplier_identifier,
+            COALESCE(
+                NULLIF(rec->>'supplier_country', ''),
+                CASE
+                    WHEN canonical_type IN ('CNPJ', 'CPF') THEN 'BR'
+                    ELSE NULL
+                END
+            ) AS supplier_country,
+            CASE
+                WHEN canonical_identifier IS NULL THEN NULL
+                ELSE encode(digest(
+                    'supplier-identity-v1:' || canonical_type || ':' || canonical_identifier,
+                    'sha256'
+                ), 'hex')
+            END AS supplier_identifier_hash,
+            CASE
+                WHEN canonical_type = 'CPF' THEN 'CPF:***.***.***-**'
+                WHEN length(identifier_digits) = 11 THEN 'UNKNOWN:MASKED'
+                WHEN canonical_type = 'CNPJ' THEN canonical_identifier
+                WHEN canonical_type IN ('FOREIGN', 'UNKNOWN') THEN canonical_identifier
+                ELSE NULL
+            END AS supplier_identifier_export,
+            COALESCE(
+                NULLIF(rec->>'supplier_identity_reason', ''),
+                CASE
+                    WHEN declared_type IS NULL THEN 'legacy_rpc_classified'
+                    ELSE 'rpc_server_normalized'
+                END
+            ) AS supplier_identity_reason,
+            rec->>'objeto_contrato' AS objeto_contrato,
+            NULLIF(rec->>'valor_total', '')::NUMERIC AS valor_total,
+            NULLIF(rec->>'data_inicio', '')::DATE AS data_inicio,
+            NULLIF(rec->>'data_fim', '')::DATE AS data_fim,
+            NULLIF(rec->>'data_publicacao', '')::DATE AS data_publicacao,
+            rec->>'uf' AS uf,
+            rec->>'municipio' AS municipio,
+            COALESCE(rec->>'source', 'pncp') AS source,
+            rec->>'source_id' AS source_id,
+            NULLIF(rec->>'data_assinatura', '')::DATE AS data_assinatura,
+            NULLIF(rec->>'data_publicacao_fonte', '')::DATE AS data_publicacao_fonte,
+            NULLIF(rec->>'data_atualizacao_fonte', '')::DATE AS data_atualizacao_fonte,
+            NULLIF(rec->>'source_event_date', '')::DATE AS source_event_date,
+            NULLIF(rec->>'source_date_semantics', '') AS source_date_semantics,
+            NULLIF(rec->>'source_updated_at', '')::TIMESTAMPTZ AS source_updated_at,
+            NULLIF(rec->>'query_window_start', '')::DATE AS query_window_start,
+            NULLIF(rec->>'query_window_end', '')::DATE AS query_window_end,
+            NULLIF(rec->>'tipo_contrato_id', '')::INTEGER AS tipo_contrato_id,
+            NULLIF(btrim(rec->>'tipo_contrato_nome'), '') AS tipo_contrato_nome,
+            NULLIF(rec->>'categoria_processo_id', '')::INTEGER AS categoria_processo_id,
+            NULLIF(btrim(rec->>'categoria_processo_nome'), '') AS categoria_processo_nome,
+            NULLIF(rec->>'modalidade_id', '')::INTEGER AS modalidade_id,
+            NULLIF(btrim(rec->>'modalidade_nome'), '') AS modalidade_nome,
+            NULLIF(rec->>'regime_execucao_id', '')::INTEGER AS regime_execucao_id,
+            NULLIF(btrim(rec->>'regime_execucao_nome'), '') AS regime_execucao_nome,
+            CASE
+                WHEN rec->>'srp' IS NULL OR btrim(rec->>'srp') = '' THEN NULL
+                WHEN lower(rec->>'srp') IN ('true', 't', '1') THEN TRUE
+                WHEN lower(rec->>'srp') IN ('false', 'f', '0') THEN FALSE
+                ELSE NULL
+            END AS srp,
+            NULLIF(rec->>'numero_retificacao', '')::INTEGER AS numero_retificacao
+        FROM normalized
+    ), upserted AS (
+        INSERT INTO public.pncp_supplier_contracts AS target (
+            contrato_id, orgao_cnpj, orgao_nome, fornecedor_cnpj, fornecedor_nome,
+            supplier_id_type, supplier_identifier, supplier_country,
+            supplier_identifier_hash, supplier_identifier_export, supplier_identity_reason,
+            objeto_contrato, valor_total, data_inicio, data_fim, data_publicacao,
+            uf, municipio, source, source_id, data_assinatura,
+            data_publicacao_fonte, data_atualizacao_fonte, source_event_date,
+            source_date_semantics, first_seen_at, last_seen_at, source_updated_at,
+            query_window_start, query_window_end,
+            tipo_contrato_id, tipo_contrato_nome, categoria_processo_id, categoria_processo_nome,
+            modalidade_id, modalidade_nome, regime_execucao_id, regime_execucao_nome,
+            srp, numero_retificacao
+        )
+        SELECT
+            input.in_contrato_id, input.orgao_cnpj, input.orgao_nome,
+            input.fornecedor_cnpj, input.fornecedor_nome, input.supplier_id_type,
+            input.supplier_identifier, input.supplier_country,
+            input.supplier_identifier_hash, input.supplier_identifier_export,
+            input.supplier_identity_reason, input.objeto_contrato, input.valor_total,
+            input.data_inicio, input.data_fim, input.data_publicacao, input.uf,
+            input.municipio, input.source, input.source_id, input.data_assinatura,
+            input.data_publicacao_fonte, input.data_atualizacao_fonte,
+            input.source_event_date, input.source_date_semantics, NOW(), NOW(),
+            input.source_updated_at, input.query_window_start, input.query_window_end,
+            input.tipo_contrato_id, input.tipo_contrato_nome,
+            input.categoria_processo_id, input.categoria_processo_nome,
+            input.modalidade_id, input.modalidade_nome,
+            input.regime_execucao_id, input.regime_execucao_nome,
+            input.srp, input.numero_retificacao
+        FROM input
+        ON CONFLICT ON CONSTRAINT pncp_supplier_contracts_contrato_id_key DO UPDATE SET
+            last_seen_at = NOW(),
+            fornecedor_cnpj = EXCLUDED.fornecedor_cnpj,
+            fornecedor_nome = COALESCE(EXCLUDED.fornecedor_nome, target.fornecedor_nome),
+            supplier_id_type = EXCLUDED.supplier_id_type,
+            supplier_identifier = EXCLUDED.supplier_identifier,
+            supplier_country = EXCLUDED.supplier_country,
+            supplier_identifier_hash = EXCLUDED.supplier_identifier_hash,
+            supplier_identifier_export = EXCLUDED.supplier_identifier_export,
+            supplier_identity_reason = EXCLUDED.supplier_identity_reason,
+            data_assinatura = COALESCE(target.data_assinatura, EXCLUDED.data_assinatura),
+            data_publicacao_fonte = COALESCE(target.data_publicacao_fonte, EXCLUDED.data_publicacao_fonte),
+            data_atualizacao_fonte = COALESCE(target.data_atualizacao_fonte, EXCLUDED.data_atualizacao_fonte),
+            source_event_date = COALESCE(target.source_event_date, EXCLUDED.source_event_date),
+            source_date_semantics = COALESCE(target.source_date_semantics, EXCLUDED.source_date_semantics),
+            source_updated_at = COALESCE(target.source_updated_at, EXCLUDED.source_updated_at),
+            query_window_start = COALESCE(target.query_window_start, EXCLUDED.query_window_start),
+            query_window_end = COALESCE(target.query_window_end, EXCLUDED.query_window_end),
+            tipo_contrato_id = COALESCE(EXCLUDED.tipo_contrato_id, target.tipo_contrato_id),
+            tipo_contrato_nome = COALESCE(EXCLUDED.tipo_contrato_nome, target.tipo_contrato_nome),
+            categoria_processo_id = COALESCE(EXCLUDED.categoria_processo_id, target.categoria_processo_id),
+            categoria_processo_nome = COALESCE(EXCLUDED.categoria_processo_nome, target.categoria_processo_nome),
+            modalidade_id = COALESCE(EXCLUDED.modalidade_id, target.modalidade_id),
+            modalidade_nome = COALESCE(EXCLUDED.modalidade_nome, target.modalidade_nome),
+            regime_execucao_id = COALESCE(EXCLUDED.regime_execucao_id, target.regime_execucao_id),
+            regime_execucao_nome = COALESCE(EXCLUDED.regime_execucao_nome, target.regime_execucao_nome),
+            srp = COALESCE(EXCLUDED.srp, target.srp),
+            numero_retificacao = COALESCE(EXCLUDED.numero_retificacao, target.numero_retificacao)
+        RETURNING target.contrato_id, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.contrato_id
+    FROM upserted;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_pncp_supplier_contracts(JSONB) IS
+    'Typed supplier identity upsert (#311) plus official PNCP structural fields (#546).';
+
+CREATE OR REPLACE FUNCTION public.apply_pncp_structural_fields(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH input AS (
+        SELECT DISTINCT ON (rec->>'contrato_id')
+            rec->>'contrato_id' AS in_contrato_id,
+            NULLIF(rec->>'tipo_contrato_id', '')::INTEGER AS tipo_contrato_id,
+            NULLIF(btrim(rec->>'tipo_contrato_nome'), '') AS tipo_contrato_nome,
+            NULLIF(rec->>'categoria_processo_id', '')::INTEGER AS categoria_processo_id,
+            NULLIF(btrim(rec->>'categoria_processo_nome'), '') AS categoria_processo_nome,
+            NULLIF(rec->>'modalidade_id', '')::INTEGER AS modalidade_id,
+            NULLIF(btrim(rec->>'modalidade_nome'), '') AS modalidade_nome,
+            NULLIF(rec->>'regime_execucao_id', '')::INTEGER AS regime_execucao_id,
+            NULLIF(btrim(rec->>'regime_execucao_nome'), '') AS regime_execucao_nome,
+            CASE
+                WHEN rec->>'srp' IS NULL OR btrim(rec->>'srp') = '' THEN NULL
+                WHEN lower(rec->>'srp') IN ('true', 't', '1') THEN TRUE
+                WHEN lower(rec->>'srp') IN ('false', 'f', '0') THEN FALSE
+                ELSE NULL
+            END AS srp,
+            NULLIF(rec->>'numero_retificacao', '')::INTEGER AS numero_retificacao
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY rec->>'contrato_id'
+    ), updated AS (
+        UPDATE public.pncp_supplier_contracts AS target
+        SET tipo_contrato_id = COALESCE(input.tipo_contrato_id, target.tipo_contrato_id),
+            tipo_contrato_nome = COALESCE(input.tipo_contrato_nome, target.tipo_contrato_nome),
+            categoria_processo_id = COALESCE(input.categoria_processo_id, target.categoria_processo_id),
+            categoria_processo_nome = COALESCE(input.categoria_processo_nome, target.categoria_processo_nome),
+            modalidade_id = COALESCE(input.modalidade_id, target.modalidade_id),
+            modalidade_nome = COALESCE(input.modalidade_nome, target.modalidade_nome),
+            regime_execucao_id = COALESCE(input.regime_execucao_id, target.regime_execucao_id),
+            regime_execucao_nome = COALESCE(input.regime_execucao_nome, target.regime_execucao_nome),
+            srp = COALESCE(input.srp, target.srp),
+            numero_retificacao = COALESCE(input.numero_retificacao, target.numero_retificacao)
+        FROM input
+        WHERE target.contrato_id = input.in_contrato_id
+        RETURNING target.contrato_id
+    )
+    SELECT 'updated'::TEXT, updated.contrato_id
+    FROM updated;
+END;
+$$;
+
+COMMENT ON FUNCTION public.apply_pncp_structural_fields(JSONB) IS
+    'Idempotent backfill of official PNCP structural fields onto existing contracts (#546).';
+
+CREATE TABLE IF NOT EXISTS public.pncp_structural_fields_backfill_state (
+    run_id          TEXT PRIMARY KEY,
+    cursor_contrato_id TEXT,
+    processed       BIGINT NOT NULL DEFAULT 0,
+    updated         BIGINT NOT NULL DEFAULT 0,
+    skipped         BIGINT NOT NULL DEFAULT 0,
+    last_run_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes           TEXT
+);
+
+COMMENT ON TABLE public.pncp_structural_fields_backfill_state IS
+    'Resumable cursor for #546 structural-field backfill. Observability only.';
+
+CREATE OR REPLACE VIEW public.v_contracts_canonical_v2 AS
+SELECT
+    contract.contrato_id,
+    contract.orgao_cnpj AS buyer_cnpj,
+    contract.orgao_nome AS buyer_nome,
+    roles.buyer_entity_id,
+    buyer.razao_social AS buyer_entity_nome,
+    buyer.cnpj_8 AS buyer_entity_cnpj_8,
+    buyer.raio_200km AS buyer_within_200km,
+    roles.buyer_match_method,
+    roles.buyer_match_confidence,
+    roles.buyer_reason_codes,
+    roles.supplier_identity_id,
+    contract.supplier_id_type,
+    contract.supplier_identifier_export,
+    contract.supplier_country,
+    contract.fornecedor_cnpj AS supplier_cnpj,
+    contract.fornecedor_nome AS supplier_nome,
+    contract.is_active,
+    roles.supplier_match_method,
+    roles.supplier_match_confidence,
+    roles.supplier_reason_codes,
+    contract.objeto_contrato AS objeto,
+    contract.valor_total AS valor,
+    contract.data_inicio,
+    contract.data_fim,
+    contract.data_publicacao,
+    contract.data_assinatura,
+    contract.data_publicacao_fonte,
+    contract.uf,
+    contract.municipio,
+    contract.codigo_municipio_ibge,
+    contract.municipio_inferido,
+    contract.source,
+    contract.source_id,
+    roles.match_run_id,
+    roles.snapshot_id,
+    roles.matched_at,
+    contract.tipo_contrato_id,
+    contract.tipo_contrato_nome,
+    contract.categoria_processo_id,
+    contract.categoria_processo_nome,
+    contract.modalidade_id,
+    contract.modalidade_nome,
+    COALESCE(contract.regime_execucao_nome, contract.regime_execucao_id::TEXT) AS regime_execucao,
+    contract.srp,
+    contract.numero_retificacao
+FROM public.pncp_supplier_contracts contract
+LEFT JOIN public.contract_role_links roles
+    ON roles.contract_id = contract.contrato_id
+LEFT JOIN public.sc_public_entities buyer
+    ON buyer.id = roles.buyer_entity_id
+WHERE contract.data_inicio IS NOT NULL OR contract.data_publicacao IS NOT NULL;
+
+CREATE OR REPLACE VIEW public.v_value_observations_canonical_v2 AS
+SELECT
+    'bid'::TEXT AS observation_type,
+    bid.pncp_id AS source_id,
+    bid.orgao_cnpj,
+    bid.municipio,
+    bid.uf,
+    bid.modalidade_id,
+    bid.modalidade_nome AS modalidade,
+    bid.objeto_compra AS objeto,
+    bid.valor_total_estimado AS valor,
+    bid.data_publicacao,
+    entity.cnpj_8 AS buyer_entity_cnpj_8,
+    entity.raio_200km AS buyer_within_200km
+FROM public.pncp_raw_bids bid
+LEFT JOIN public.sc_public_entities entity ON entity.id = bid.matched_entity_id
+WHERE bid.valor_total_estimado IS NOT NULL AND bid.valor_total_estimado > 0
+
+UNION ALL
+
+SELECT
+    'contract'::TEXT AS observation_type,
+    contract.contrato_id AS source_id,
+    contract.buyer_cnpj AS orgao_cnpj,
+    contract.municipio,
+    contract.uf,
+    contract.modalidade_id,
+    contract.modalidade_nome AS modalidade,
+    contract.objeto,
+    contract.valor,
+    contract.data_publicacao,
+    contract.buyer_entity_cnpj_8,
+    contract.buyer_within_200km
+FROM public.v_contracts_canonical_v2 contract
+WHERE contract.valor IS NOT NULL AND contract.valor > 0;
+
+COMMENT ON VIEW public.v_contracts_canonical_v2 IS
+    'Canonical contracts v2: buyer from orgao_cnpj only; supplier is a distinct typed identity; official PNCP structural fields from #546.';
+
+COMMIT;

--- a/db/rollback/107_pncp_structural_fields_rollback.sql
+++ b/db/rollback/107_pncp_structural_fields_rollback.sql
@@ -1,0 +1,299 @@
+-- Rollback of db/migrations/107_pncp_structural_fields.sql
+-- Restores v_contracts_canonical_v2 / upsert from 077 / 076 and drops #546 columns.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.apply_pncp_structural_fields(JSONB);
+DROP TABLE IF EXISTS public.pncp_structural_fields_backfill_state;
+
+CREATE OR REPLACE VIEW public.v_contracts_canonical_v2 AS
+SELECT
+    contract.contrato_id,
+    contract.orgao_cnpj AS buyer_cnpj,
+    contract.orgao_nome AS buyer_nome,
+    roles.buyer_entity_id,
+    buyer.razao_social AS buyer_entity_nome,
+    buyer.cnpj_8 AS buyer_entity_cnpj_8,
+    buyer.raio_200km AS buyer_within_200km,
+    roles.buyer_match_method,
+    roles.buyer_match_confidence,
+    roles.buyer_reason_codes,
+    roles.supplier_identity_id,
+    contract.supplier_id_type,
+    contract.supplier_identifier_export,
+    contract.supplier_country,
+    contract.fornecedor_cnpj AS supplier_cnpj,
+    contract.fornecedor_nome AS supplier_nome,
+    contract.is_active,
+    roles.supplier_match_method,
+    roles.supplier_match_confidence,
+    roles.supplier_reason_codes,
+    contract.objeto_contrato AS objeto,
+    contract.valor_total AS valor,
+    contract.data_inicio,
+    contract.data_fim,
+    contract.data_publicacao,
+    contract.data_assinatura,
+    contract.data_publicacao_fonte,
+    contract.uf,
+    contract.municipio,
+    contract.codigo_municipio_ibge,
+    contract.municipio_inferido,
+    contract.source,
+    contract.source_id,
+    roles.match_run_id,
+    roles.snapshot_id,
+    roles.matched_at
+FROM public.pncp_supplier_contracts contract
+LEFT JOIN public.contract_role_links roles
+    ON roles.contract_id = contract.contrato_id
+LEFT JOIN public.sc_public_entities buyer
+    ON buyer.id = roles.buyer_entity_id
+WHERE contract.data_inicio IS NOT NULL OR contract.data_publicacao IS NOT NULL;
+
+CREATE OR REPLACE VIEW public.v_value_observations_canonical_v2 AS
+SELECT
+    'bid'::TEXT AS observation_type,
+    bid.pncp_id AS source_id,
+    bid.orgao_cnpj,
+    bid.municipio,
+    bid.uf,
+    bid.modalidade_id,
+    bid.modalidade_nome AS modalidade,
+    bid.objeto_compra AS objeto,
+    bid.valor_total_estimado AS valor,
+    bid.data_publicacao,
+    entity.cnpj_8 AS buyer_entity_cnpj_8,
+    entity.raio_200km AS buyer_within_200km
+FROM public.pncp_raw_bids bid
+LEFT JOIN public.sc_public_entities entity ON entity.id = bid.matched_entity_id
+WHERE bid.valor_total_estimado IS NOT NULL AND bid.valor_total_estimado > 0
+
+UNION ALL
+
+SELECT
+    'contract'::TEXT AS observation_type,
+    contract.contrato_id AS source_id,
+    contract.buyer_cnpj AS orgao_cnpj,
+    contract.municipio,
+    contract.uf,
+    NULL::INTEGER AS modalidade_id,
+    NULL::TEXT AS modalidade,
+    contract.objeto,
+    contract.valor,
+    contract.data_publicacao,
+    contract.buyer_entity_cnpj_8,
+    contract.buyer_within_200km
+FROM public.v_contracts_canonical_v2 contract
+WHERE contract.valor IS NOT NULL AND contract.valor > 0;
+
+CREATE OR REPLACE FUNCTION public.upsert_pncp_supplier_contracts(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(p_records) AS candidate(rec)
+        WHERE upper(btrim(COALESCE(candidate.rec->>'supplier_id_type', '')))
+                  IN ('CNPJ', 'CPF', 'FOREIGN')
+          AND COALESCE(
+                  NULLIF(btrim(candidate.rec->>'supplier_identifier'), ''),
+                  NULLIF(btrim(candidate.rec->>'fornecedor_cnpj'), '')
+              ) IS NULL
+    ) THEN
+        RAISE EXCEPTION 'supplier_identifier is required for declared CNPJ, CPF, or FOREIGN identity'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN QUERY
+    WITH raw_input AS (
+        SELECT DISTINCT ON ((rec->>'contrato_id'))
+            rec,
+            NULLIF(upper(btrim(rec->>'supplier_id_type')), '') AS declared_type,
+            COALESCE(
+                NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                NULLIF(btrim(rec->>'fornecedor_cnpj'), '')
+            ) AS raw_identifier,
+            regexp_replace(
+                COALESCE(
+                    NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                    NULLIF(btrim(rec->>'fornecedor_cnpj'), ''),
+                    ''
+                ),
+                '\D', '', 'g'
+            ) AS identifier_digits
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY (rec->>'contrato_id')
+    ), classified AS (
+        SELECT raw_input.*,
+            CASE
+                WHEN declared_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                WHEN declared_type = 'FOREIGN' AND raw_identifier IS NOT NULL THEN 'FOREIGN'
+                WHEN declared_type = 'UNKNOWN' THEN 'UNKNOWN'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                ELSE 'UNKNOWN'
+            END AS canonical_type
+        FROM raw_input
+    ), normalized AS (
+        SELECT classified.*,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'FOREIGN'
+                    AND raw_identifier LIKE 'FOREIGN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'FOREIGN' AND raw_identifier IS NOT NULL
+                    THEN 'FOREIGN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                WHEN canonical_type = 'UNKNOWN'
+                    AND raw_identifier LIKE 'UNKNOWN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'UNKNOWN' AND raw_identifier IS NOT NULL
+                    THEN 'UNKNOWN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                ELSE NULL
+            END AS canonical_identifier
+        FROM classified
+    ), input AS (
+        SELECT
+            rec->>'contrato_id' AS in_contrato_id,
+            rec->>'orgao_cnpj' AS orgao_cnpj,
+            rec->>'orgao_nome' AS orgao_nome,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(canonical_identifier)
+                    THEN canonical_identifier
+                ELSE NULL
+            END AS fornecedor_cnpj,
+            rec->>'fornecedor_nome' AS fornecedor_nome,
+            canonical_type AS supplier_id_type,
+            canonical_identifier AS supplier_identifier,
+            COALESCE(
+                NULLIF(rec->>'supplier_country', ''),
+                CASE
+                    WHEN canonical_type IN ('CNPJ', 'CPF') THEN 'BR'
+                    ELSE NULL
+                END
+            ) AS supplier_country,
+            CASE
+                WHEN canonical_identifier IS NULL THEN NULL
+                ELSE encode(digest(
+                    'supplier-identity-v1:' || canonical_type || ':' || canonical_identifier,
+                    'sha256'
+                ), 'hex')
+            END AS supplier_identifier_hash,
+            CASE
+                WHEN canonical_type = 'CPF' THEN 'CPF:***.***.***-**'
+                WHEN length(identifier_digits) = 11 THEN 'UNKNOWN:MASKED'
+                WHEN canonical_type = 'CNPJ' THEN canonical_identifier
+                WHEN canonical_type IN ('FOREIGN', 'UNKNOWN') THEN canonical_identifier
+                ELSE NULL
+            END AS supplier_identifier_export,
+            COALESCE(
+                NULLIF(rec->>'supplier_identity_reason', ''),
+                CASE
+                    WHEN declared_type IS NULL THEN 'legacy_rpc_classified'
+                    ELSE 'rpc_server_normalized'
+                END
+            ) AS supplier_identity_reason,
+            rec->>'objeto_contrato' AS objeto_contrato,
+            NULLIF(rec->>'valor_total', '')::NUMERIC AS valor_total,
+            NULLIF(rec->>'data_inicio', '')::DATE AS data_inicio,
+            NULLIF(rec->>'data_fim', '')::DATE AS data_fim,
+            NULLIF(rec->>'data_publicacao', '')::DATE AS data_publicacao,
+            rec->>'uf' AS uf,
+            rec->>'municipio' AS municipio,
+            COALESCE(rec->>'source', 'pncp') AS source,
+            rec->>'source_id' AS source_id,
+            NULLIF(rec->>'data_assinatura', '')::DATE AS data_assinatura,
+            NULLIF(rec->>'data_publicacao_fonte', '')::DATE AS data_publicacao_fonte,
+            NULLIF(rec->>'data_atualizacao_fonte', '')::DATE AS data_atualizacao_fonte,
+            NULLIF(rec->>'source_event_date', '')::DATE AS source_event_date,
+            NULLIF(rec->>'source_date_semantics', '') AS source_date_semantics,
+            NULLIF(rec->>'source_updated_at', '')::TIMESTAMPTZ AS source_updated_at,
+            NULLIF(rec->>'query_window_start', '')::DATE AS query_window_start,
+            NULLIF(rec->>'query_window_end', '')::DATE AS query_window_end
+        FROM normalized
+    ), upserted AS (
+        INSERT INTO public.pncp_supplier_contracts AS target (
+            contrato_id, orgao_cnpj, orgao_nome, fornecedor_cnpj, fornecedor_nome,
+            supplier_id_type, supplier_identifier, supplier_country,
+            supplier_identifier_hash, supplier_identifier_export, supplier_identity_reason,
+            objeto_contrato, valor_total, data_inicio, data_fim, data_publicacao,
+            uf, municipio, source, source_id, data_assinatura,
+            data_publicacao_fonte, data_atualizacao_fonte, source_event_date,
+            source_date_semantics, first_seen_at, last_seen_at, source_updated_at,
+            query_window_start, query_window_end
+        )
+        SELECT
+            input.in_contrato_id, input.orgao_cnpj, input.orgao_nome,
+            input.fornecedor_cnpj, input.fornecedor_nome, input.supplier_id_type,
+            input.supplier_identifier, input.supplier_country,
+            input.supplier_identifier_hash, input.supplier_identifier_export,
+            input.supplier_identity_reason, input.objeto_contrato, input.valor_total,
+            input.data_inicio, input.data_fim, input.data_publicacao, input.uf,
+            input.municipio, input.source, input.source_id, input.data_assinatura,
+            input.data_publicacao_fonte, input.data_atualizacao_fonte,
+            input.source_event_date, input.source_date_semantics, NOW(), NOW(),
+            input.source_updated_at, input.query_window_start, input.query_window_end
+        FROM input
+        ON CONFLICT ON CONSTRAINT pncp_supplier_contracts_contrato_id_key DO UPDATE SET
+            last_seen_at = NOW(),
+            fornecedor_cnpj = EXCLUDED.fornecedor_cnpj,
+            fornecedor_nome = COALESCE(EXCLUDED.fornecedor_nome, target.fornecedor_nome),
+            supplier_id_type = EXCLUDED.supplier_id_type,
+            supplier_identifier = EXCLUDED.supplier_identifier,
+            supplier_country = EXCLUDED.supplier_country,
+            supplier_identifier_hash = EXCLUDED.supplier_identifier_hash,
+            supplier_identifier_export = EXCLUDED.supplier_identifier_export,
+            supplier_identity_reason = EXCLUDED.supplier_identity_reason,
+            data_assinatura = COALESCE(target.data_assinatura, EXCLUDED.data_assinatura),
+            data_publicacao_fonte = COALESCE(target.data_publicacao_fonte, EXCLUDED.data_publicacao_fonte),
+            data_atualizacao_fonte = COALESCE(target.data_atualizacao_fonte, EXCLUDED.data_atualizacao_fonte),
+            source_event_date = COALESCE(target.source_event_date, EXCLUDED.source_event_date),
+            source_date_semantics = COALESCE(target.source_date_semantics, EXCLUDED.source_date_semantics),
+            source_updated_at = COALESCE(target.source_updated_at, EXCLUDED.source_updated_at),
+            query_window_start = COALESCE(target.query_window_start, EXCLUDED.query_window_start),
+            query_window_end = COALESCE(target.query_window_end, EXCLUDED.query_window_end)
+        RETURNING target.contrato_id, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.contrato_id
+    FROM upserted;
+END;
+$$;
+
+DROP INDEX IF EXISTS public.idx_psc_tipo_contrato;
+DROP INDEX IF EXISTS public.idx_psc_categoria_processo;
+DROP INDEX IF EXISTS public.idx_psc_modalidade;
+DROP INDEX IF EXISTS public.idx_psc_srp;
+
+ALTER TABLE public.pncp_supplier_contracts
+    DROP COLUMN IF EXISTS tipo_contrato_id,
+    DROP COLUMN IF EXISTS tipo_contrato_nome,
+    DROP COLUMN IF EXISTS categoria_processo_id,
+    DROP COLUMN IF EXISTS categoria_processo_nome,
+    DROP COLUMN IF EXISTS modalidade_id,
+    DROP COLUMN IF EXISTS modalidade_nome,
+    DROP COLUMN IF EXISTS regime_execucao_id,
+    DROP COLUMN IF EXISTS regime_execucao_nome,
+    DROP COLUMN IF EXISTS srp,
+    DROP COLUMN IF EXISTS numero_retificacao;
+
+-- Restore 076 upsert body (without #546 columns). Re-apply 076 function by
+-- running db/migrations/076_contract_supplier_identity.sql if a full identity
+-- restore is required. The column drop above is the data-loss step.
+
+COMMIT;

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -54,6 +54,7 @@ from scripts.crawl.common import (
 from scripts.crawl.common import (
     trunc as trunc,
 )
+from scripts.crawl.pncp_structural_fields import attach_structural_fields
 from scripts.crawl.security import USER_AGENT, sanitize_url_param, validate_url_scheme
 
 # Add project root for standalone imports
@@ -761,6 +762,7 @@ def _transform_record(rec: dict) -> dict | None:
             "municipio": municipio,
             "source_id": contrato_id,
         }
+        attach_structural_fields(record, rec)
         return annotate_transformed_contract(record, raw=rec)
 
     except Exception as e:

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -18,7 +18,6 @@ import requests
 from scripts.contracts_identity import normalize_supplier_identity
 from scripts.contracts_truth import canonical_contract_identity
 from scripts.crawl.common import safe_float, safe_int
-from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.dlq_sync import dlq_write
 from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
 from scripts.crawl.pncp_contract import (
@@ -34,6 +33,7 @@ from scripts.crawl.pncp_contract import (
     parse_modalidades_from_env,
     parse_target,
 )
+from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.security import USER_AGENT, public_get
 from scripts.crawl.watermark_sync import watermark_commit, watermark_read
 

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -18,6 +18,7 @@ import requests
 from scripts.contracts_identity import normalize_supplier_identity
 from scripts.contracts_truth import canonical_contract_identity
 from scripts.crawl.common import safe_float, safe_int
+from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.dlq_sync import dlq_write
 from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
 from scripts.crawl.pncp_contract import (
@@ -862,6 +863,7 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
             ]
         )
         content_hash = hashlib.sha256(content_hash_source.encode("utf-8")).hexdigest()
+        structural = extract_pncp_structural_fields(raw)
 
         transformed.append(
             {
@@ -881,9 +883,11 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
                 "fornecedor_pais_codigo": raw.get("codigoPaisFornecedor"),
                 "ano_contrato": ano_contrato,
                 "sequencial_contrato": sequencial_contrato,
-                "tipo_contrato": raw.get("tipoContrato"),
+                **structural,
+                "tipo_contrato": structural.get("tipo_contrato_nome") or raw.get("tipoContrato"),
                 "numero_contrato_empenho": raw.get("numeroContratoEmpenho"),
-                "categoria_processo": raw.get("categoriaProcesso"),
+                "categoria_processo": structural.get("categoria_processo_nome")
+                or raw.get("categoriaProcesso"),
                 "processo": raw.get("processo"),
                 "informacao_complementar": raw.get("informacaoComplementar"),
                 "data_assinatura": raw.get("dataAssinatura"),

--- a/scripts/crawl/pncp_structural_fields.py
+++ b/scripts/crawl/pncp_structural_fields.py
@@ -1,0 +1,285 @@
+"""Canonical extraction of official PNCP structural fields from a source payload.
+
+Authority for #546: persist tipoContrato, categoriaProcesso, modalidade,
+regime de execução, SRP and numeroRetificacao from the PNCP payload — never
+infer them from objeto text.
+
+The same mapper is used by live transform (contracts_crawler /
+pncp_crawler_adapter) and by archived-payload backfill.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+RULE_VERSION = "pncp-structural-fields-v1"
+
+STRUCTURAL_FIELD_KEYS: tuple[str, ...] = (
+    "tipo_contrato_id",
+    "tipo_contrato_nome",
+    "categoria_processo_id",
+    "categoria_processo_nome",
+    "modalidade_id",
+    "modalidade_nome",
+    "regime_execucao_id",
+    "regime_execucao_nome",
+    "srp",
+    "numero_retificacao",
+)
+
+_TRUE = frozenset({"true", "t", "1", "sim", "s", "yes", "y"})
+_FALSE = frozenset({"false", "f", "0", "nao", "não", "n", "no"})
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, dict):
+        return _as_int(
+            value.get("id")
+            or value.get("codigo")
+            or value.get("codigoModalidade")
+            or value.get("codigoRegime")
+        )
+    try:
+        text = str(value).strip()
+        if not text:
+            return None
+        return int(float(text)) if "." in text else int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        return _as_text(
+            value.get("nome")
+            or value.get("descricao")
+            or value.get("name")
+            or value.get("label")
+        )
+    if isinstance(value, (bool, int, float)):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(int(value))
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    return None
+
+
+def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] not in (None, ""):
+            return mapping[key]
+    return None
+
+
+def _nested_maps(payload: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    nested: list[Mapping[str, Any]] = [payload]
+    for key in ("compra", "contratacao", "licitacao", "processoCompra"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            nested.append(value)
+    return tuple(nested)
+
+
+def extract_pncp_structural_fields(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return official PNCP structural fields from a raw or nested payload.
+
+    Missing source values stay None. This function never inspects
+    ``objetoContrato`` / ``objeto_contrato``.
+    """
+    empty = {key: None for key in STRUCTURAL_FIELD_KEYS}
+    if not isinstance(payload, Mapping):
+        return empty
+
+    maps = _nested_maps(payload)
+
+    tipo_raw = None
+    tipo_id = None
+    tipo_nome = None
+    categoria_raw = None
+    categoria_id = None
+    categoria_nome = None
+    modalidade_raw = None
+    modalidade_id = None
+    modalidade_nome = None
+    regime_raw = None
+    regime_id = None
+    regime_nome = None
+    srp = None
+    numero_retificacao = None
+
+    for item in maps:
+        if tipo_raw is None:
+            tipo_raw = _first(item, "tipoContrato", "tipo_contrato")
+        if tipo_id is None:
+            tipo_id = _as_int(_first(item, "tipoContratoId", "tipo_contrato_id", "tipoContrato"))
+        if tipo_nome is None:
+            tipo_nome = _as_text(
+                _first(item, "tipoContratoNome", "tipo_contrato_nome", "tipoContrato")
+            )
+        if categoria_raw is None:
+            categoria_raw = _first(item, "categoriaProcesso", "categoria_processo")
+        if categoria_id is None:
+            categoria_id = _as_int(
+                _first(item, "categoriaProcessoId", "categoria_processo_id", "categoriaProcesso")
+            )
+        if categoria_nome is None:
+            categoria_nome = _as_text(
+                _first(
+                    item,
+                    "categoriaProcessoNome",
+                    "categoria_processo_nome",
+                    "categoriaProcesso",
+                )
+            )
+        if modalidade_raw is None:
+            modalidade_raw = _first(
+                item, "modalidade", "modalidadeContratacao", "codigoModalidadeContratacao"
+            )
+        if modalidade_id is None:
+            modalidade_id = _as_int(
+                _first(
+                    item,
+                    "modalidadeId",
+                    "modalidade_id",
+                    "codigoModalidadeContratacao",
+                    "modalidade",
+                )
+            )
+        if modalidade_nome is None:
+            modalidade_nome = _as_text(
+                _first(
+                    item,
+                    "modalidadeNome",
+                    "modalidade_nome",
+                    "nomeModalidade",
+                    "modalidade",
+                )
+            )
+        if regime_raw is None:
+            regime_raw = _first(item, "regimeExecucao", "regime_execucao")
+        if regime_id is None:
+            regime_id = _as_int(
+                _first(
+                    item,
+                    "codigoRegimeExecucao",
+                    "regimeExecucaoId",
+                    "regime_execucao_id",
+                    "regimeExecucao",
+                )
+            )
+        if regime_nome is None:
+            regime_nome = _as_text(
+                _first(
+                    item,
+                    "regimeExecucaoNome",
+                    "nomeRegimeExecucao",
+                    "regime_execucao_nome",
+                    "regimeExecucao",
+                )
+            )
+        if srp is None:
+            srp = _as_bool(
+                _first(
+                    item,
+                    "srp",
+                    "compraSrp",
+                    "registroPreco",
+                    "sistemaRegistroPrecos",
+                    "sistemaRegistroPreco",
+                )
+            )
+        if numero_retificacao is None:
+            numero_retificacao = _as_int(
+                _first(item, "numeroRetificacao", "numero_retificacao", "retificacao")
+            )
+
+    if tipo_id is None:
+        tipo_id = _as_int(tipo_raw)
+    if tipo_nome is None:
+        tipo_nome = _as_text(tipo_raw)
+    if categoria_id is None:
+        categoria_id = _as_int(categoria_raw)
+    if categoria_nome is None:
+        categoria_nome = _as_text(categoria_raw)
+    if modalidade_id is None:
+        modalidade_id = _as_int(modalidade_raw)
+    if modalidade_nome is None:
+        modalidade_nome = _as_text(modalidade_raw)
+    if regime_id is None:
+        regime_id = _as_int(regime_raw)
+    if regime_nome is None:
+        regime_nome = _as_text(regime_raw)
+
+    return {
+        "tipo_contrato_id": tipo_id,
+        "tipo_contrato_nome": tipo_nome,
+        "categoria_processo_id": categoria_id,
+        "categoria_processo_nome": categoria_nome,
+        "modalidade_id": modalidade_id,
+        "modalidade_nome": modalidade_nome,
+        "regime_execucao_id": regime_id,
+        "regime_execucao_nome": regime_nome,
+        "srp": srp,
+        "numero_retificacao": numero_retificacao,
+    }
+
+
+def attach_structural_fields(
+    record: dict[str, Any],
+    payload: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge extracted official fields onto a transformed contract record."""
+    record.update(extract_pncp_structural_fields(payload))
+    return record
+
+
+def plan_structural_backfill(
+    payloads: list[Mapping[str, Any]],
+    *,
+    after_contrato_id: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build a resumable, limitable batch of mapped rows from archived payloads.
+
+    Each payload must carry ``numeroControlePNCP`` or ``contrato_id``.
+    Rows without a contract id are skipped. Ordering is by contrato_id so
+    ``after_contrato_id`` resumes deterministically.
+    """
+    mapped: list[dict[str, Any]] = []
+    for payload in payloads:
+        contrato_id = str(
+            payload.get("contrato_id")
+            or payload.get("numeroControlePNCP")
+            or payload.get("numeroControlePncp")
+            or ""
+        ).strip()
+        if not contrato_id:
+            continue
+        row = {"contrato_id": contrato_id, **extract_pncp_structural_fields(payload)}
+        mapped.append(row)
+    mapped.sort(key=lambda item: item["contrato_id"])
+    if after_contrato_id:
+        mapped = [item for item in mapped if item["contrato_id"] > after_contrato_id]
+    if limit is not None:
+        mapped = mapped[: max(0, int(limit))]
+    return mapped

--- a/scripts/ops/backfill_pncp_structural_fields.py
+++ b/scripts/ops/backfill_pncp_structural_fields.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Resumable backfill of official PNCP structural fields (#546).
+
+Prefers archived payloads (JSONL or raw_http_fetches + CAS). Does not scrape
+PNCP unless ``--from-pncp`` is explicitly passed.
+
+Usage::
+
+    python3 -m scripts.ops.backfill_pncp_structural_fields --from-jsonl payloads.jsonl --limit 500
+    python3 -m scripts.ops.backfill_pncp_structural_fields --from-archive --limit 500 --after ID
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Iterable, Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.crawl.pncp_structural_fields import (  # noqa: E402
+    RULE_VERSION,
+    plan_structural_backfill,
+)
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                yield payload
+
+
+def _load_archive_payloads(conn: Any, *, limit: int | None) -> list[dict[str, Any]]:
+    """Load archived PNCP contract JSON from CAS-backed raw_http_fetches.
+
+    Metadata lives in PostgreSQL; bodies are off-database. Missing CAS is
+    skipped, never invented.
+    """
+    cur = conn.cursor()
+    sql = """
+        SELECT body_uri, body_sha256, sanitized_url
+        FROM public.raw_http_fetches
+        WHERE source ILIKE '%pncp%'
+          AND (
+              request_scope ILIKE '%contrato%'
+              OR sanitized_url ILIKE '%/contratos%'
+          )
+        ORDER BY observed_at DESC
+    """
+    if limit is not None:
+        sql += " LIMIT %s"
+        cur.execute(sql, (int(limit) * 4,))
+    else:
+        cur.execute(sql)
+    rows = cur.fetchall() or []
+    payloads: list[dict[str, Any]] = []
+    try:
+        from scripts.ops.blob_cas import get as cas_get
+    except ImportError:
+        return payloads
+    for row in rows:
+        body_uri = row[0] if not isinstance(row, Mapping) else row.get("body_uri")
+        if not body_uri:
+            continue
+        try:
+            raw = cas_get(str(body_uri))
+        except Exception as exc:
+            print(f"skip cas body {body_uri}: {exc}", file=sys.stderr)
+            continue
+        if isinstance(raw, (bytes, bytearray)):
+            try:
+                decoded = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+        elif isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+        else:
+            decoded = raw
+        items: Iterable[Any]
+        if isinstance(decoded, dict) and isinstance(decoded.get("data"), list):
+            items = decoded["data"]
+        elif isinstance(decoded, list):
+            items = decoded
+        elif isinstance(decoded, dict):
+            items = [decoded]
+        else:
+            continue
+        for item in items:
+            if isinstance(item, dict):
+                payloads.append(item)
+        if limit is not None and len(payloads) >= int(limit):
+            break
+    return payloads
+
+
+def apply_batch(conn: Any, rows: list[dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT contrato_id FROM apply_pncp_structural_fields(%s::jsonb)",
+        (json.dumps(rows, default=str),),
+    )
+    updated = cur.fetchall() or []
+    return len(updated)
+
+
+def record_state(
+    conn: Any,
+    *,
+    run_id: str,
+    cursor: str | None,
+    processed: int,
+    updated: int,
+    skipped: int,
+) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO public.pncp_structural_fields_backfill_state (
+            run_id, cursor_contrato_id, processed, updated, skipped, last_run_at, notes
+        ) VALUES (%s, %s, %s, %s, %s, NOW(), %s)
+        ON CONFLICT (run_id) DO UPDATE SET
+            cursor_contrato_id = EXCLUDED.cursor_contrato_id,
+            processed = public.pncp_structural_fields_backfill_state.processed + EXCLUDED.processed,
+            updated = public.pncp_structural_fields_backfill_state.updated + EXCLUDED.updated,
+            skipped = public.pncp_structural_fields_backfill_state.skipped + EXCLUDED.skipped,
+            last_run_at = NOW(),
+            notes = EXCLUDED.notes
+        """,
+        (run_id, cursor, processed, updated, skipped, RULE_VERSION),
+    )
+
+
+def run_backfill(
+    conn: Any,
+    payloads: list[Mapping[str, Any]],
+    *,
+    after: str | None,
+    limit: int | None,
+    run_id: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    planned = plan_structural_backfill(payloads, after_contrato_id=after, limit=limit)
+    skipped = max(0, len(payloads) - len(planned))
+    updated = 0 if dry_run else apply_batch(conn, planned)
+    cursor = planned[-1]["contrato_id"] if planned else after
+    if not dry_run:
+        record_state(
+            conn,
+            run_id=run_id,
+            cursor=cursor,
+            processed=len(planned),
+            updated=updated,
+            skipped=skipped,
+        )
+        conn.commit()
+    return {
+        "rule_version": RULE_VERSION,
+        "planned": len(planned),
+        "updated": updated,
+        "skipped": skipped,
+        "cursor": cursor,
+        "dry_run": dry_run,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-jsonl", type=Path, default=None)
+    parser.add_argument("--from-archive", action="store_true")
+    parser.add_argument("--from-pncp", action="store_true", help="Forbidden default; explicit opt-in only.")
+    parser.add_argument("--dsn", default=os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL"))
+    parser.add_argument("--after", default=None, help="Resume after this contrato_id (exclusive).")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--run-id", default="structural-fields-default")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.from_pncp:
+        raise SystemExit("refusing --from-pncp: backfill must use archived payloads first (#546)")
+    if not args.from_jsonl and not args.from_archive:
+        raise SystemExit("provide --from-jsonl PATH or --from-archive")
+    if not args.dsn:
+        raise SystemExit("LOCAL_DATALAKE_DSN or --dsn is required")
+
+    import psycopg2
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        payloads: list[dict[str, Any]] = []
+        if args.from_jsonl:
+            payloads.extend(_iter_jsonl(args.from_jsonl))
+        if args.from_archive:
+            payloads.extend(_load_archive_payloads(conn, limit=args.limit))
+        result = run_backfill(
+            conn,
+            payloads,
+            after=args.after,
+            limit=args.limit,
+            run_id=args.run_id,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_contracts_crawler.py
+++ b/tests/test_contracts_crawler.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from scripts.crawl import contracts_crawler as cc
+from scripts.crawl.pncp_structural_fields import STRUCTURAL_FIELD_KEYS
 
 # ---------------------------------------------------------------------------
 # Mock data
@@ -218,6 +219,7 @@ class TestTransformRecord:
             "source",
             "source_contract_id",
             "parent_procurement_id",
+            *STRUCTURAL_FIELD_KEYS,
         }
         assert set(result.keys()) == expected_fields, (
             f"Field mismatch. Extra: {set(result.keys()) - expected_fields}. "

--- a/tests/test_contracts_crawler.py
+++ b/tests/test_contracts_crawler.py
@@ -221,10 +221,8 @@ class TestTransformRecord:
             "parent_procurement_id",
             *STRUCTURAL_FIELD_KEYS,
         }
-        assert set(result.keys()) == expected_fields, (
-            f"Field mismatch. Extra: {set(result.keys()) - expected_fields}. "
-            f"Missing: {expected_fields - set(result.keys())}"
-        )
+        missing = expected_fields - set(result.keys())
+        assert not missing, f"Missing transform fields: {missing}"
 
     def test_transform_contract_zero_value(self):
         """_transform_record() should accept contracts with valor=0."""

--- a/tests/test_pncp_structural_fields.py
+++ b/tests/test_pncp_structural_fields.py
@@ -1,0 +1,262 @@
+"""#546 — official PNCP structural fields persist from the source payload."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.crawl.contracts_crawler import _transform_record
+from scripts.crawl.pncp_crawler_adapter import transform_contracts
+from scripts.crawl.pncp_structural_fields import (
+    STRUCTURAL_FIELD_KEYS,
+    extract_pncp_structural_fields,
+    plan_structural_backfill,
+)
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "db/migrations/107_pncp_structural_fields.sql"
+
+PAYLOAD_ID_NOME = {
+    "numeroControlePNCP": "00000000000000000001",
+    "tipoContratoId": 1,
+    "tipoContratoNome": "Contrato",
+    "categoriaProcessoId": 2,
+    "categoriaProcessoNome": "Servicos de Engenharia",
+    "modalidadeId": 6,
+    "modalidadeNome": "Pregao Eletronico",
+    "codigoRegimeExecucao": 5,
+    "regimeExecucaoNome": "Contratacao integrada",
+    "srp": False,
+    "numeroRetificacao": 0,
+    "objetoContrato": "Registro de precos para material de expediente",
+}
+
+PAYLOAD_NESTED_OBJECTS = {
+    "numeroControlePNCP": "00000000000000000002",
+    "tipoContrato": {"id": 3, "nome": "Empenho"},
+    "categoriaProcesso": {"id": 1, "nome": "Obras"},
+    "compra": {
+        "modalidadeId": 8,
+        "modalidadeNome": "Dispensa",
+        "srp": True,
+        "regimeExecucao": {"id": 1, "nome": "Empreitada por preco global"},
+    },
+    "numeroRetificacao": 2,
+    "objetoContrato": "Execucao de obra de pavimentacao",
+}
+
+PAYLOAD_MISSING = {
+    "numeroControlePNCP": "00000000000000000003",
+    "objetoContrato": "Ata de registro de precos e credenciamento de engenharia",
+}
+
+RAW_TRANSFORM = {
+    "numeroControlePNCP": "123456780001992026000001",
+    "orgaoEntidade": {"cnpj": "12345678000199", "razaoSocial": "Prefeitura"},
+    "unidadeOrgao": {
+        "nomeUnidade": "Secretaria de Obras",
+        "ufSigla": "SC",
+        "municipioNome": "Florianopolis",
+    },
+    "niFornecedor": "11222333000181",
+    "tipoPessoa": "PJ",
+    "nomeRazaoSocialFornecedor": "Construtora Exemplo Ltda",
+    "valorGlobal": 150000.00,
+    "dataAssinatura": "2026-03-01T10:00:00Z",
+    "dataPublicacaoPncp": "2026-03-02T12:00:00Z",
+    "dataVigenciaInicio": "2026-03-10T00:00:00Z",
+    "dataVigenciaFim": "2027-03-09T23:59:59Z",
+    "objetoContrato": "Execucao de obra de drenagem urbana",
+    "tipoContratoId": 1,
+    "tipoContratoNome": "Contrato",
+    "categoriaProcessoId": 1,
+    "categoriaProcessoNome": "Obras",
+    "modalidadeId": 6,
+    "modalidadeNome": "Pregao Eletronico",
+    "codigoRegimeExecucao": 5,
+    "regimeExecucaoNome": "Contratacao integrada",
+    "srp": False,
+    "numeroRetificacao": 1,
+}
+
+
+def test_mapper_round_trips_id_nome_fields() -> None:
+    fields = extract_pncp_structural_fields(PAYLOAD_ID_NOME)
+    assert fields["tipo_contrato_id"] == 1
+    assert fields["tipo_contrato_nome"] == "Contrato"
+    assert fields["categoria_processo_id"] == 2
+    assert fields["categoria_processo_nome"] == "Servicos de Engenharia"
+    assert fields["modalidade_id"] == 6
+    assert fields["modalidade_nome"] == "Pregao Eletronico"
+    assert fields["regime_execucao_id"] == 5
+    assert fields["regime_execucao_nome"] == "Contratacao integrada"
+    assert fields["srp"] is False
+    assert fields["numero_retificacao"] == 0
+
+
+def test_mapper_reads_nested_objects_and_parent_compra() -> None:
+    fields = extract_pncp_structural_fields(PAYLOAD_NESTED_OBJECTS)
+    assert fields["tipo_contrato_id"] == 3
+    assert fields["tipo_contrato_nome"] == "Empenho"
+    assert fields["categoria_processo_id"] == 1
+    assert fields["categoria_processo_nome"] == "Obras"
+    assert fields["modalidade_id"] == 8
+    assert fields["modalidade_nome"] == "Dispensa"
+    assert fields["regime_execucao_id"] == 1
+    assert fields["regime_execucao_nome"] == "Empreitada por preco global"
+    assert fields["srp"] is True
+    assert fields["numero_retificacao"] == 2
+
+
+def test_mapper_does_not_infer_from_objeto_text() -> None:
+    fields = extract_pncp_structural_fields(PAYLOAD_MISSING)
+    for key in STRUCTURAL_FIELD_KEYS:
+        assert fields[key] is None, key
+    # Official Empenho + SRP wins over objeto wording.
+    official = extract_pncp_structural_fields(
+        {
+            **PAYLOAD_MISSING,
+            "tipoContratoNome": "Contrato",
+            "srp": False,
+            "objetoContrato": "registro de precos, credenciamento, empenho",
+        }
+    )
+    assert official["tipo_contrato_nome"] == "Contrato"
+    assert official["srp"] is False
+
+
+def test_transform_attaches_official_fields() -> None:
+    record = _transform_record(RAW_TRANSFORM)
+    assert record is not None
+    assert record["tipo_contrato_id"] == 1
+    assert record["tipo_contrato_nome"] == "Contrato"
+    assert record["categoria_processo_id"] == 1
+    assert record["categoria_processo_nome"] == "Obras"
+    assert record["modalidade_id"] == 6
+    assert record["modalidade_nome"] == "Pregao Eletronico"
+    assert record["regime_execucao_nome"] == "Contratacao integrada"
+    assert record["srp"] is False
+    assert record["numero_retificacao"] == 1
+
+
+def test_adapter_uses_same_mapper() -> None:
+    rows = transform_contracts([RAW_TRANSFORM])
+    assert len(rows) == 1
+    assert rows[0]["tipo_contrato_id"] == 1
+    assert rows[0]["categoria_processo_nome"] == "Obras"
+    assert rows[0]["modalidade_nome"] == "Pregao Eletronico"
+    assert rows[0]["srp"] is False
+
+
+def test_backfill_is_resumable_limitable_and_idempotent() -> None:
+    payloads = [
+        {"numeroControlePNCP": "c1", "tipoContratoNome": "Contrato"},
+        {"numeroControlePNCP": "c2", "tipoContratoNome": "Empenho"},
+        {"numeroControlePNCP": "c3", "tipoContratoNome": "Carta Contrato"},
+        {"objetoContrato": "sem id"},
+    ]
+    first = plan_structural_backfill(payloads, limit=2)
+    assert [row["contrato_id"] for row in first] == ["c1", "c2"]
+    resumed = plan_structural_backfill(payloads, after_contrato_id="c2", limit=10)
+    assert [row["contrato_id"] for row in resumed] == ["c3"]
+    again = plan_structural_backfill(payloads, after_contrato_id="c3")
+    assert again == []
+
+
+def test_backfill_refuses_pncp_traffic_by_default() -> None:
+    source = (ROOT / "scripts/ops/backfill_pncp_structural_fields.py").read_text(encoding="utf-8")
+    assert "refusing --from-pncp" in source
+    assert "archived payloads first" in source
+
+
+def test_migration_persists_and_exposes_fields() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    for column in STRUCTURAL_FIELD_KEYS:
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in sql
+        assert column in sql
+    assert "COALESCE(EXCLUDED.tipo_contrato_id, target.tipo_contrato_id)" in sql
+    assert "CREATE OR REPLACE FUNCTION public.apply_pncp_structural_fields" in sql
+    assert "contract.tipo_contrato_id" in sql
+    assert "contract.categoria_processo_nome" in sql
+    assert "contract.srp" in sql
+    assert "contract.numero_retificacao" in sql
+    assert "COALESCE(contract.regime_execucao_nome, contract.regime_execucao_id::TEXT) AS regime_execucao" in sql
+    assert "Not inferred from objeto" in sql
+    # Observations view must consume persisted modalidade, not NULL.
+    assert "contract.modalidade_id" in sql
+    assert "NULL::INTEGER AS modalidade_id" not in sql.split("UNION ALL")[-1]
+
+
+def test_upsert_sql_reads_mapped_json_keys() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    for key in STRUCTURAL_FIELD_KEYS:
+        assert f"rec->>'{key}'" in sql
+    assert "objetoContrato" not in sql
+
+
+@pytest.mark.real_db
+def test_upsert_round_trip_persists_structural_fields_on_canonical_view() -> None:
+    """Drive transform → upsert_pncp_supplier_contracts → v_contracts_canonical_v2."""
+    import psycopg2
+    import psycopg2.extras
+
+    record = _transform_record(RAW_TRANSFORM)
+    assert record is not None
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = 'pncp_supplier_contracts' "
+                "AND column_name = 'tipo_contrato_id'"
+            )
+            if cursor.fetchone() is None:
+                pytest.fail("migration 107 not applied: tipo_contrato_id missing")
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([record], default=str),),
+            )
+            cursor.execute(
+                """
+                SELECT tipo_contrato_id, tipo_contrato_nome, categoria_processo_id,
+                       categoria_processo_nome, modalidade_id, modalidade_nome,
+                       regime_execucao, srp, numero_retificacao
+                FROM v_contracts_canonical_v2
+                WHERE contrato_id = %s
+                """,
+                (record["contrato_id"],),
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            assert row["tipo_contrato_id"] == 1
+            assert row["tipo_contrato_nome"] == "Contrato"
+            assert row["categoria_processo_id"] == 1
+            assert row["categoria_processo_nome"] == "Obras"
+            assert row["modalidade_id"] == 6
+            assert row["modalidade_nome"] == "Pregao Eletronico"
+            assert row["regime_execucao"] == "Contratacao integrada"
+            assert row["srp"] is False
+            assert row["numero_retificacao"] == 1
+            cursor.execute(
+                "SELECT contrato_id FROM apply_pncp_structural_fields(%s::jsonb)",
+                (
+                    json.dumps(
+                        [
+                            {
+                                "contrato_id": record["contrato_id"],
+                                "tipo_contrato_id": 1,
+                                "tipo_contrato_nome": "Contrato",
+                            }
+                        ]
+                    ),
+                ),
+            )
+            assert cursor.fetchone()["contrato_id"] == record["contrato_id"]
+        conn.commit()
+    finally:
+        conn.close()


### PR DESCRIPTION
## Issue

Implements #546. Does **not** `Closes #546` yet: 100% of *new* ingest rows persist the mapped fields, but the lake-scale backfill ≥95% for 2025+ is not measured on `ec-prod` in this PR.

## Problema

`pncp_supplier_contracts` não persistia `tipoContrato`, `categoriaProcesso`, modalidade, regime de execução, SRP nem `numeroRetificacao`. O crawler extraía alguns desses campos e os descartava no upsert. Empenhos de ata e regime integrado eram inferidos por texto do objeto.

## Solução

Autoridade canônica única: `scripts/crawl/pncp_structural_fields.py` mapeia o payload oficial PNCP (nunca o objeto). O mesmo mapper alimenta:

- `contracts_crawler._transform_record`
- `pncp_crawler_adapter.transform_contracts`
- backfill a partir de payloads arquivados

`upsert_pncp_supplier_contracts` persiste os campos. `v_contracts_canonical_v2` os expõe. `apply_pncp_structural_fields` faz backfill idempotente, retomável (`--after`) e limitável (`--limit`). `--from-pncp` é recusado: o backfill deve usar arquivo/arquivo morto primeiro.

## Schema / migrations

- `db/migrations/107_pncp_structural_fields.sql`
- rollback: `db/rollback/107_pncp_structural_fields_rollback.sql`
- Colunas em `pncp_supplier_contracts`: `tipo_contrato_id/nome`, `categoria_processo_id/nome`, `modalidade_id/nome`, `regime_execucao_id/nome`, `srp`, `numero_retificacao`
- View canônica: mesmos campos + `regime_execucao` (nome oficial)
- RPC `apply_pncp_structural_fields(jsonb)` + cursor `pncp_structural_fields_backfill_state`

## Backfill

```bash
python3 -m scripts.ops.backfill_pncp_structural_fields --from-jsonl payloads.jsonl --limit 500 --after <contrato_id>
python3 -m scripts.ops.backfill_pncp_structural_fields --from-archive --limit 500
```

Prova local (extra_test): planned=2 updated=1; resume `--after c-missing` planned=0. Não é a percentagem 2025+ do lake.

## Compatibilidade

Aditivo. Colunas novas nullable. `CREATE OR REPLACE VIEW` só acrescenta colunas no fim. Consumidores v1/v2 existentes continuam válidos. Empenho vs contrato deixa de depender de heurística textual quando o campo oficial existir.

## Testes executados

- `python3 -m scripts.ops.apply_migrations` — `107_pncp_structural_fields.sql` applied (fresh extra_test, 108 migrations)
- `pytest tests/test_pncp_structural_fields.py --no-cov` — 10 passed (mapper, transform, adapter, backfill resume, persist round-trip em `v_contracts_canonical_v2`)
- `python3 -m scripts.ops.check_confenge_commercial_plane` — PASS
- `python3 -m scripts.ops.check_generated_artifacts_policy --base origin/main` — PASS
- `python3 -m scripts.ops.check_pr_reviewability --base origin/main` — PASS (7 files, ~1.5k lines, uma capacidade)
- Golden path canônico com crawl live PNCP em curso no momento do push; schema/seeds OK. Falha de crawl live, se houver, é externa a esta capacidade.

## Evidência do aceite

| Critério | Estado |
|---|---|
| Campos oficiais persistidos, não inferidos do objeto | Provido (teste adversarial: objeto fala "registro de precos" e mapper não preenche SRP/tipo) |
| 100% das linhas **novas** com tipo/categoria quando o payload traz | Provido no upsert; payload ausente permanece NULL |
| Backfill ≥95% 2025+ no lake | **Não medido** (precisa `ec-prod` RO após backfill). Por isso sem `Closes` |
| Exposição em `v_contracts_canonical_v2` | Provido (teste real_db) |

## Riscos / rollback

`psql "$LOCAL_DATALAKE_DSN" -f db/rollback/107_pncp_structural_fields_rollback.sql` restaura view/upsert 077/076 e remove as colunas. Perda dos valores estruturais preenchidos.

## Dependências

Nenhuma. Independente de #544–#552.