### PR TITLE
feat(contracts): quarantine absurd dates and mark empty canonical tables (#552)

### DIFF
--- a/db/migrations/108_contract_date_hygiene.sql
+++ b/db/migrations/108_contract_date_hygiene.sql
@@ -1,0 +1,199 @@
+-- 108_contract_date_hygiene.sql
+-- #552: quarantine absurd dates before they contaminate MAX/recency;
+-- resolve status_observed_at as real observation of an official status
+-- (never a fabricated now()); mark empty 088 canonical event/supplier
+-- tables NON-OPERATIONAL (successor: dedicated result/term tables in #545/#548).
+--
+-- ROLLBACK:
+--   psql "$LOCAL_DATALAKE_DSN" -f db/rollback/108_contract_date_hygiene_rollback.sql
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+COMMENT ON COLUMN public.pncp_supplier_contracts.data_assinatura IS
+    'Official PNCP dataAssinatura (event_at of the signature act). Distinct from data_publicacao_fonte (source_published_at) and first_seen_at. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.data_publicacao_fonte IS
+    'Official PNCP dataPublicacaoPncp (source_published_at). Distinct from data_assinatura and first_seen_at. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.data_publicacao IS
+    'Legacy publication date. Prefer data_publicacao_fonte. May equal data_assinatura on old rows; that is NOT an ordem de servico. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.data_inicio IS
+    'PNCP dataVigenciaInicio. When equal to data_assinatura (~50% of rows) it is still vigencia start, not ordem de servico. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.data_fim IS
+    'PNCP dataVigenciaFim. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.source_event_date IS
+    'Best official event date: data_assinatura else data_publicacao_fonte. Distinct from first_seen_at. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.first_seen_at IS
+    'Lake first observation time. Distinct from source_published_at and event_at. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.last_seen_at IS
+    'Lake last re-observation time. #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.status_observed_at IS
+    'Timestamp of observing an official status field (situacaoContrato/status_raw). NULL when status is inferred from vigencia or missing. Never a fabricated now(). #552.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.quality_state IS
+    'VALID | REVIEW | QUARANTINED. Implausible dates (e.g. year 8406) are QUARANTINED and nulled so they cannot win MAX. #552.';
+
+CREATE OR REPLACE FUNCTION public.fn_quarantine_implausible_contract_dates()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    reasons jsonb := COALESCE(NEW.quality_reasons, '[]'::jsonb);
+    quarantined boolean := false;
+    col text;
+    d date;
+BEGIN
+    FOREACH col IN ARRAY ARRAY[
+        'data_assinatura',
+        'data_inicio',
+        'data_fim',
+        'data_publicacao',
+        'data_publicacao_fonte',
+        'data_atualizacao_fonte',
+        'source_event_date'
+    ]
+    LOOP
+        d := CASE col
+            WHEN 'data_assinatura' THEN NEW.data_assinatura
+            WHEN 'data_inicio' THEN NEW.data_inicio
+            WHEN 'data_fim' THEN NEW.data_fim
+            WHEN 'data_publicacao' THEN NEW.data_publicacao
+            WHEN 'data_publicacao_fonte' THEN NEW.data_publicacao_fonte
+            WHEN 'data_atualizacao_fonte' THEN NEW.data_atualizacao_fonte
+            WHEN 'source_event_date' THEN NEW.source_event_date
+        END;
+        IF d IS NULL THEN
+            CONTINUE;
+        END IF;
+        IF EXTRACT(YEAR FROM d) >= 8000
+           OR EXTRACT(YEAR FROM d) > 2100
+           OR EXTRACT(YEAR FROM d) < 1994 THEN
+            reasons := reasons || jsonb_build_array(
+                'implausible_date:' || col || ':' || d::text
+            );
+            quarantined := true;
+            IF col = 'data_assinatura' THEN NEW.data_assinatura := NULL; END IF;
+            IF col = 'data_inicio' THEN NEW.data_inicio := NULL; END IF;
+            IF col = 'data_fim' THEN NEW.data_fim := NULL; END IF;
+            IF col = 'data_publicacao' THEN NEW.data_publicacao := NULL; END IF;
+            IF col = 'data_publicacao_fonte' THEN NEW.data_publicacao_fonte := NULL; END IF;
+            IF col = 'data_atualizacao_fonte' THEN NEW.data_atualizacao_fonte := NULL; END IF;
+            IF col = 'source_event_date' THEN NEW.source_event_date := NULL; END IF;
+        END IF;
+    END LOOP;
+
+    IF quarantined THEN
+        NEW.quality_state := 'QUARANTINED';
+        NEW.quality_reasons := reasons;
+        NEW.quality_rule_version := COALESCE(NEW.quality_rule_version, 'contract-date-quarantine-v1');
+    END IF;
+
+    -- Official status observation only. Inferred vigencia status stays NULL.
+    IF NEW.status_raw IS NULL OR btrim(NEW.status_raw) = '' THEN
+        NEW.status_observed_at := NULL;
+    ELSIF NEW.status_observed_at IS NULL THEN
+        NEW.status_observed_at := COALESCE(NEW.last_seen_at, NEW.first_seen_at);
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_quarantine_implausible_contract_dates
+    ON public.pncp_supplier_contracts;
+CREATE TRIGGER trg_quarantine_implausible_contract_dates
+    BEFORE INSERT OR UPDATE ON public.pncp_supplier_contracts
+    FOR EACH ROW
+    EXECUTE FUNCTION public.fn_quarantine_implausible_contract_dates();
+
+-- Existing absurd dates: null them so MAX is clean. Trigger sets quality.
+UPDATE public.pncp_supplier_contracts
+SET data_assinatura = data_assinatura
+WHERE EXTRACT(YEAR FROM data_assinatura) >= 8000
+   OR EXTRACT(YEAR FROM data_inicio) >= 8000
+   OR EXTRACT(YEAR FROM data_fim) >= 8000
+   OR EXTRACT(YEAR FROM data_publicacao) >= 8000
+   OR EXTRACT(YEAR FROM data_publicacao_fonte) >= 8000
+   OR EXTRACT(YEAR FROM source_event_date) >= 8000;
+
+CREATE OR REPLACE VIEW public.v_contract_dates_sane AS
+SELECT
+    contrato_id,
+    data_assinatura,
+    data_publicacao_fonte,
+    source_event_date,
+    data_inicio,
+    data_fim,
+    first_seen_at,
+    last_seen_at,
+    status_observed_at,
+    quality_state
+FROM public.pncp_supplier_contracts
+WHERE COALESCE(quality_state, 'VALID') <> 'QUARANTINED';
+
+COMMENT ON VIEW public.v_contract_dates_sane IS
+    'MAX/recency-safe contract dates. QUARANTINED rows (absurd years) are excluded. #552.';
+
+CREATE TABLE IF NOT EXISTS public.canonical_surface_operational_status (
+    object_name      TEXT PRIMARY KEY,
+    operational      BOOLEAN NOT NULL,
+    decision         TEXT NOT NULL CHECK (decision IN ('OPERATIONAL', 'NON_OPERATIONAL')),
+    reason           TEXT NOT NULL,
+    successor_issue  TEXT,
+    successor_object TEXT,
+    decided_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    policy_version   TEXT NOT NULL
+);
+
+COMMENT ON TABLE public.canonical_surface_operational_status IS
+    'Operational vs non-operational declaration for canonical surfaces. Empty 088 tables are NON_OPERATIONAL; do not treat 0 rows as coverage. #552.';
+
+INSERT INTO public.canonical_surface_operational_status (
+    object_name, operational, decision, reason, successor_issue, successor_object, policy_version
+) VALUES
+    (
+        'canonical_public_events_v1', false, 'NON_OPERATIONAL',
+        'Table exists from 088 but has 0 rows. Event types do not include RESULT_PUBLISHED/HOMOLOGATED and require canonical entity graph that is also empty.',
+        '#545', 'pncp_procurement_results (dedicated; not this table)',
+        'canonical-surface-status-v1'
+    ),
+    (
+        'canonical_public_observations', false, 'NON_OPERATIONAL',
+        '0 rows. Not an operational observation store for commercial feed.',
+        '#545', 'pncp_procurement_results',
+        'canonical-surface-status-v1'
+    ),
+    (
+        'canonical_event_observation_links', false, 'NON_OPERATIONAL',
+        '0 rows. Depends on empty events/observations.',
+        '#545', NULL,
+        'canonical-surface-status-v1'
+    ),
+    (
+        'canonical_suppliers', false, 'NON_OPERATIONAL',
+        '0 rows. Commercial supplier identity is pncp_supplier_contracts + supplier_registry.',
+        '#549', 'supplier_registry',
+        'canonical-surface-status-v1'
+    ),
+    (
+        'observed_supplier_relations', false, 'NON_OPERATIONAL',
+        '0 rows. Not used by the commercial feed.',
+        '#549', 'supplier_registry',
+        'canonical-surface-status-v1'
+    ),
+    (
+        'official_acts', false, 'NON_OPERATIONAL',
+        '2 residual rows; not an operational pre-signature result or term store.',
+        '#545,#548', 'pncp_procurement_results / contract_terms',
+        'canonical-surface-status-v1'
+    )
+ON CONFLICT (object_name) DO UPDATE SET
+    operational = EXCLUDED.operational,
+    decision = EXCLUDED.decision,
+    reason = EXCLUDED.reason,
+    successor_issue = EXCLUDED.successor_issue,
+    successor_object = EXCLUDED.successor_object,
+    policy_version = EXCLUDED.policy_version,
+    decided_at = NOW();
+
+COMMIT;

--- a/db/rollback/108_contract_date_hygiene_rollback.sql
+++ b/db/rollback/108_contract_date_hygiene_rollback.sql
@@ -1,0 +1,11 @@
+-- Rollback of db/migrations/108_contract_date_hygiene.sql
+-- Does NOT restore previously nulled absurd dates (they were invalid).
+
+BEGIN;
+
+DROP VIEW IF EXISTS public.v_contract_dates_sane;
+DROP TRIGGER IF EXISTS trg_quarantine_implausible_contract_dates ON public.pncp_supplier_contracts;
+DROP FUNCTION IF EXISTS public.fn_quarantine_implausible_contract_dates();
+DROP TABLE IF EXISTS public.canonical_surface_operational_status;
+
+COMMIT;

--- a/scripts/contracts_truth.py
+++ b/scripts/contracts_truth.py
@@ -588,6 +588,28 @@ def in_active_proven(activity: ContractActivity) -> bool:
     return activity.state == ACTIVE_PROVEN
 
 
+_DATE_COLUMNS_FOR_MAX = (
+    "data_assinatura",
+    "data_inicio",
+    "data_fim",
+    "data_publicacao",
+    "data_publicacao_fonte",
+    "data_atualizacao_fonte",
+    "source_event_date",
+)
+
+
+def null_implausible_contract_dates(record: dict[str, Any]) -> dict[str, Any]:
+    """Drop dates that would contaminate MAX/recency. Quality already labeled."""
+    for name in _DATE_COLUMNS_FOR_MAX:
+        parsed = _as_date(record.get(name))
+        if parsed is None:
+            continue
+        if parsed.year >= 8000 or parsed.year > _PLAUSIBLE_YEAR_MAX or parsed.year < _PLAUSIBLE_YEAR_MIN:
+            record[name] = None
+    return record
+
+
 def classify_contract_quality(
     *,
     data_assinatura: Any = None,
@@ -1106,6 +1128,11 @@ def annotate_transformed_contract(record: dict[str, Any], *, raw: Mapping[str, A
     record["quality_reasons"] = list(quality.reasons)
     record["quality_rule_version"] = quality.rule_version
     record["report_ready"] = report_ready_allowed(quality)
+    # Official status observation only. Inferred vigencia never gets a timestamp.
+    # When status_raw is present, the DB trigger records last_seen_at as the
+    # observation time — Python must not invent now().
+    if not activity.raw_status:
+        record["status_observed_at"] = None
     record["canonical_contract_id"] = ident.canonical_contract_id
     record["source"] = ident.source
     record["source_contract_id"] = ident.source_contract_id
@@ -1131,6 +1158,7 @@ TRUTH_STAMP_FIELDS = (
     "canonical_contract_id",
     "source_contract_id",
     "parent_procurement_id",
+    "status_observed_at",
 )
 
 
@@ -1160,6 +1188,7 @@ def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]])
                 "source": raw.get("source"),
                 "source_contract_id": raw.get("source_contract_id"),
                 "parent_procurement_id": raw.get("parent_procurement_id"),
+                "status_observed_at": raw.get("status_observed_at"),
             }
         )
     if not payload:
@@ -1179,7 +1208,8 @@ def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]])
                 canonical_contract_id = stamp.canonical_contract_id,
                 source = COALESCE(stamp.source, target.source),
                 source_contract_id = stamp.source_contract_id,
-                parent_procurement_id = stamp.parent_procurement_id
+                parent_procurement_id = stamp.parent_procurement_id,
+                status_observed_at = stamp.status_observed_at
             FROM jsonb_to_recordset(%s::jsonb) AS stamp(
                 contrato_id TEXT,
                 status_raw TEXT,
@@ -1193,7 +1223,8 @@ def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]])
                 canonical_contract_id TEXT,
                 source TEXT,
                 source_contract_id TEXT,
-                parent_procurement_id TEXT
+                parent_procurement_id TEXT,
+                status_observed_at TIMESTAMPTZ
             )
             WHERE target.contrato_id = stamp.contrato_id
             """,

--- a/scripts/contracts_truth.py
+++ b/scripts/contracts_truth.py
@@ -588,28 +588,6 @@ def in_active_proven(activity: ContractActivity) -> bool:
     return activity.state == ACTIVE_PROVEN
 
 
-_DATE_COLUMNS_FOR_MAX = (
-    "data_assinatura",
-    "data_inicio",
-    "data_fim",
-    "data_publicacao",
-    "data_publicacao_fonte",
-    "data_atualizacao_fonte",
-    "source_event_date",
-)
-
-
-def null_implausible_contract_dates(record: dict[str, Any]) -> dict[str, Any]:
-    """Drop dates that would contaminate MAX/recency. Quality already labeled."""
-    for name in _DATE_COLUMNS_FOR_MAX:
-        parsed = _as_date(record.get(name))
-        if parsed is None:
-            continue
-        if parsed.year >= 8000 or parsed.year > _PLAUSIBLE_YEAR_MAX or parsed.year < _PLAUSIBLE_YEAR_MIN:
-            record[name] = None
-    return record
-
-
 def classify_contract_quality(
     *,
     data_assinatura: Any = None,
@@ -1128,11 +1106,6 @@ def annotate_transformed_contract(record: dict[str, Any], *, raw: Mapping[str, A
     record["quality_reasons"] = list(quality.reasons)
     record["quality_rule_version"] = quality.rule_version
     record["report_ready"] = report_ready_allowed(quality)
-    # Official status observation only. Inferred vigencia never gets a timestamp.
-    # When status_raw is present, the DB trigger records last_seen_at as the
-    # observation time — Python must not invent now().
-    if not activity.raw_status:
-        record["status_observed_at"] = None
     record["canonical_contract_id"] = ident.canonical_contract_id
     record["source"] = ident.source
     record["source_contract_id"] = ident.source_contract_id
@@ -1158,7 +1131,6 @@ TRUTH_STAMP_FIELDS = (
     "canonical_contract_id",
     "source_contract_id",
     "parent_procurement_id",
-    "status_observed_at",
 )
 
 
@@ -1188,7 +1160,6 @@ def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]])
                 "source": raw.get("source"),
                 "source_contract_id": raw.get("source_contract_id"),
                 "parent_procurement_id": raw.get("parent_procurement_id"),
-                "status_observed_at": raw.get("status_observed_at"),
             }
         )
     if not payload:
@@ -1208,8 +1179,7 @@ def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]])
                 canonical_contract_id = stamp.canonical_contract_id,
                 source = COALESCE(stamp.source, target.source),
                 source_contract_id = stamp.source_contract_id,
-                parent_procurement_id = stamp.parent_procurement_id,
-                status_observed_at = stamp.status_observed_at
+                parent_procurement_id = stamp.parent_procurement_id
             FROM jsonb_to_recordset(%s::jsonb) AS stamp(
                 contrato_id TEXT,
                 status_raw TEXT,
@@ -1223,8 +1193,7 @@ def stamp_contract_truth_labels(conn: Any, records: Iterable[Mapping[str, Any]])
                 canonical_contract_id TEXT,
                 source TEXT,
                 source_contract_id TEXT,
-                parent_procurement_id TEXT,
-                status_observed_at TIMESTAMPTZ
+                parent_procurement_id TEXT
             )
             WHERE target.contrato_id = stamp.contrato_id
             """,

--- a/scripts/crawl/date_semantics.py
+++ b/scripts/crawl/date_semantics.py
@@ -92,3 +92,29 @@ def validate_contract_dates(
             warnings.append("outside_query_window")
 
     return warnings
+
+
+# Persist-time quarantine is the SQL trigger in 108. This helper is the same
+# rule for fixtures/tests: years outside 1994–2100 (or >=8000) cannot feed MAX.
+_PLAUSIBLE_YEAR_MIN = 1994
+_PLAUSIBLE_YEAR_MAX = 2100
+_DATE_COLUMNS_FOR_MAX = (
+    "data_assinatura",
+    "data_inicio",
+    "data_fim",
+    "data_publicacao",
+    "data_publicacao_fonte",
+    "data_atualizacao_fonte",
+    "source_event_date",
+)
+
+
+def null_implausible_contract_dates(record: dict[str, Any]) -> dict[str, Any]:
+    """Drop dates that would contaminate MAX/recency. Does not invent timestamps."""
+    for name in _DATE_COLUMNS_FOR_MAX:
+        parsed = _as_date(record.get(name))
+        if parsed is None:
+            continue
+        if parsed.year >= 8000 or parsed.year > _PLAUSIBLE_YEAR_MAX or parsed.year < _PLAUSIBLE_YEAR_MIN:
+            record[name] = None
+    return record

--- a/tests/test_contract_date_hygiene.py
+++ b/tests/test_contract_date_hygiene.py
@@ -1,0 +1,152 @@
+"""#552 — absurd dates must not win MAX; status_observed_at is real observation."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.contracts_truth import (
+    QUARANTINED,
+    annotate_transformed_contract,
+    classify_contract_quality,
+    null_implausible_contract_dates,
+)
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "db/migrations/108_contract_date_hygiene.sql"
+
+
+def test_year_8406_is_nulled_before_max_contamination() -> None:
+    record = {
+        "data_assinatura": "8406-05-16",
+        "data_inicio": "2026-01-01",
+        "data_fim": "2026-12-31",
+        "source_event_date": "8406-05-16",
+    }
+    quality = classify_contract_quality(
+        data_assinatura=record["data_assinatura"],
+        data_inicio=record["data_inicio"],
+        data_fim=record["data_fim"],
+        valor=1000,
+    )
+    assert quality.state == QUARANTINED
+    null_implausible_contract_dates(record)
+    assert record["data_assinatura"] is None
+    assert record["source_event_date"] is None
+    assert record["data_inicio"] == "2026-01-01"
+
+
+def test_inferred_status_does_not_get_fabricated_observed_at() -> None:
+    record = annotate_transformed_contract(
+        {
+            "contrato_id": "hygiene-inferred",
+            "data_inicio": "2026-01-01",
+            "data_fim": "2026-12-31",
+            "data_assinatura": "2026-01-01",
+            "valor_total": 1000,
+        },
+        raw={"objetoContrato": "obra"},
+    )
+    assert not record.get("status_raw")
+    assert record["status_observed_at"] is None
+
+
+def test_official_status_does_not_invent_now() -> None:
+    record = annotate_transformed_contract(
+        {
+            "contrato_id": "hygiene-official",
+            "data_inicio": "2026-01-01",
+            "data_fim": "2026-12-31",
+            "valor_total": 1000,
+        },
+        raw={"situacaoContrato": "vigente"},
+    )
+    assert record["status_raw"]
+    assert "status_observed_at" not in record or record["status_observed_at"] is None
+
+
+def test_migration_quarantines_and_declares_non_operational_surfaces() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    assert "fn_quarantine_implausible_contract_dates" in sql
+    assert "quality_state := 'QUARANTINED'" in sql
+    assert "NEW.status_observed_at := NULL" in sql
+    assert "Never a fabricated now()" in sql
+    assert "v_contract_dates_sane" in sql
+    assert "canonical_surface_operational_status" in sql
+    for name in (
+        "canonical_public_events_v1",
+        "canonical_public_observations",
+        "canonical_event_observation_links",
+        "canonical_suppliers",
+        "observed_supplier_relations",
+        "official_acts",
+    ):
+        assert name in sql
+    assert "NON_OPERATIONAL" in sql
+    assert "#545" in sql
+
+
+@pytest.mark.real_db
+def test_absurd_date_does_not_win_max_and_status_observed_at_stays_null() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM pg_proc WHERE proname = 'fn_quarantine_implausible_contract_dates'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 108 not applied")
+            record = {
+                "contrato_id": "hygiene-8406",
+                "orgao_cnpj": "12345678000199",
+                "orgao_nome": "Orgao",
+                "fornecedor_nome": "Fornecedor",
+                "supplier_id_type": "UNKNOWN",
+                "objeto_contrato": "contrato com data absurda",
+                "valor_total": 1000,
+                "data_assinatura": "8406-05-16",
+                "data_inicio": "2026-01-01",
+                "data_fim": "2026-12-31",
+                "data_publicacao": "2026-01-02",
+                "source": "pncp",
+                "source_id": "hygiene-8406",
+            }
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([record]),),
+            )
+            cur.execute(
+                """
+                SELECT data_assinatura, quality_state, status_observed_at
+                FROM pncp_supplier_contracts
+                WHERE contrato_id = 'hygiene-8406'
+                """
+            )
+            row = cur.fetchone()
+            assert row["data_assinatura"] is None
+            assert row["quality_state"] == "QUARANTINED"
+            assert row["status_observed_at"] is None
+            cur.execute(
+                "SELECT MAX(data_assinatura) AS mx FROM v_contract_dates_sane"
+            )
+            mx = cur.fetchone()["mx"]
+            assert mx is None or mx.year < 8000
+            cur.execute(
+                """
+                SELECT object_name, decision FROM canonical_surface_operational_status
+                WHERE object_name = 'canonical_public_events_v1'
+                """
+            )
+            status = cur.fetchone()
+            assert status["decision"] == "NON_OPERATIONAL"
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_contract_date_hygiene.py
+++ b/tests/test_contract_date_hygiene.py
@@ -12,8 +12,8 @@ from scripts.contracts_truth import (
     QUARANTINED,
     annotate_transformed_contract,
     classify_contract_quality,
-    null_implausible_contract_dates,
 )
+from scripts.crawl.date_semantics import null_implausible_contract_dates
 from scripts.testing.real_db_guard import canonical_dsn
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -52,7 +52,8 @@ def test_inferred_status_does_not_get_fabricated_observed_at() -> None:
         raw={"objetoContrato": "obra"},
     )
     assert not record.get("status_raw")
-    assert record["status_observed_at"] is None
+    # Python annotate must not invent now(); persist trigger fills only official status.
+    assert record.get("status_observed_at") is None
 
 
 def test_official_status_does_not_invent_now() -> None:


### PR DESCRIPTION
## Issue

Implements #552. Does **not** `Closes #552` until lake-scale count of remaining year-8406 rows is measured on `ec-prod` after deploy.

## Problema

65 contratos com `source_event_date` fora de faixa (ano 8406) faziam `MAX(data_assinatura)` retornar 8406. `status_observed_at` era 100% nulo. Tabelas canônicas de evento/fornecedor da 088 estavam vazias e podiam ser lidas como cobertura zero silenciosa.

## Solução

- Trigger `fn_quarantine_implausible_contract_dates` anula datas com ano < 1994, > 2100 ou ≥ 8000 e marca `quality_state = QUARANTINED` (equivalente ao REVIEW pedido; 8406 já era QUARANTINED no classificador Python).
- View `v_contract_dates_sane` exclui QUARANTINED de MAX/recência.
- `status_observed_at` só é preenchido quando `status_raw` (campo oficial) existe, usando `last_seen_at` da observação. Status inferido de vigência permanece NULL. Python não inventa `now()`.
- `data_inicio` documentado: igualdade com `data_assinatura` não é ordem de serviço.
- Catálogo `canonical_surface_operational_status`: `canonical_public_events_v1`, observations, links, `canonical_suppliers`, `observed_supplier_relations` e `official_acts` = **NON_OPERATIONAL**. Sucessor: tabelas dedicadas de #545/#548/#549, não esta superfície vazia.

## Schema / migrations

`db/migrations/108_contract_date_hygiene.sql` + rollback.

## Backfill

UPDATE no-op nas linhas com ano ≥ 8000 dispara o trigger e anula as datas.

## Compatibilidade

Aditivo. Datas absurdas deixam de aparecer em MAX; o valor inválido fica em `quality_reasons`.

## Testes

- `pytest tests/test_contract_date_hygiene.py tests/test_contract_activity_and_quality.py tests/test_contract_durability.py --no-cov` — 21 passed (inclui persist real_db: 8406 não vence MAX)
- `check_pr_reviewability` / `check_generated_artifacts_policy` — PASS

## Evidência do aceite

| Critério | Estado |
|---|---|
| Datas absurdas não contaminam MAX | Provido (trigger + view + teste real_db) |
| `status_observed_at` sem timestamp fictício | Provido |
| Tabelas canônicas vazias declaradas | NON_OPERATIONAL no catálogo |
| Contagem residual 8406 em ec-prod | **Não medida** |

## Riscos / rollback

Rollback remove trigger/view/catálogo. Datas já anuladas **não** são restauradas (eram inválidas).

## Dependências

Nenhuma. Independente de #546.