### PR TITLE
feat(contracts): persist terms and lifecycle so revocations are visible (#548)

### DIFF
--- a/db/migrations/107_pncp_structural_fields.sql
+++ b/db/migrations/107_pncp_structural_fields.sql
@@ -1,0 +1,443 @@
+-- 107_pncp_structural_fields.sql
+-- #546: persist official PNCP structural fields (not inferred from objeto).
+-- Additive columns + upsert persist + canonical v2 expose + resumable backfill RPC.
+--
+-- ROLLBACK:
+--   psql "$LOCAL_DATALAKE_DSN" -f db/rollback/107_pncp_structural_fields_rollback.sql
+--
+-- Authority: scripts/crawl/pncp_structural_fields.py maps the PNCP payload;
+-- this migration persists those mapped keys. Do not re-derive from objeto.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+ALTER TABLE public.pncp_supplier_contracts
+    ADD COLUMN IF NOT EXISTS tipo_contrato_id INTEGER,
+    ADD COLUMN IF NOT EXISTS tipo_contrato_nome TEXT,
+    ADD COLUMN IF NOT EXISTS categoria_processo_id INTEGER,
+    ADD COLUMN IF NOT EXISTS categoria_processo_nome TEXT,
+    ADD COLUMN IF NOT EXISTS modalidade_id INTEGER,
+    ADD COLUMN IF NOT EXISTS modalidade_nome TEXT,
+    ADD COLUMN IF NOT EXISTS regime_execucao_id INTEGER,
+    ADD COLUMN IF NOT EXISTS regime_execucao_nome TEXT,
+    ADD COLUMN IF NOT EXISTS srp BOOLEAN,
+    ADD COLUMN IF NOT EXISTS numero_retificacao INTEGER;
+
+CREATE INDEX IF NOT EXISTS idx_psc_tipo_contrato
+    ON public.pncp_supplier_contracts (tipo_contrato_id)
+    WHERE tipo_contrato_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_psc_categoria_processo
+    ON public.pncp_supplier_contracts (categoria_processo_id)
+    WHERE categoria_processo_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_psc_modalidade
+    ON public.pncp_supplier_contracts (modalidade_id)
+    WHERE modalidade_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_psc_srp
+    ON public.pncp_supplier_contracts (srp)
+    WHERE srp IS TRUE;
+
+COMMENT ON COLUMN public.pncp_supplier_contracts.tipo_contrato_id IS
+    'Official PNCP tipoContrato id (contrato, empenho, carta contrato). Not inferred from objeto. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.tipo_contrato_nome IS
+    'Official PNCP tipoContrato nome. Not inferred from objeto. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.categoria_processo_id IS
+    'Official PNCP categoriaProcesso id (obras, servicos de engenharia, compras). #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.categoria_processo_nome IS
+    'Official PNCP categoriaProcesso nome. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.modalidade_id IS
+    'Official PNCP modalidade id from the contract or parent compra payload. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.modalidade_nome IS
+    'Official PNCP modalidade nome. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.regime_execucao_id IS
+    'Official PNCP codigoRegimeExecucao when present on the payload. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.regime_execucao_nome IS
+    'Official PNCP regimeExecucao nome (integrada/semi-integrada/etc.). #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.srp IS
+    'Official PNCP SRP / registro de precos flag from the payload, not from objeto text. #546.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.numero_retificacao IS
+    'Official PNCP numeroRetificacao. #546.';
+
+CREATE OR REPLACE FUNCTION public.upsert_pncp_supplier_contracts(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(p_records) AS candidate(rec)
+        WHERE upper(btrim(COALESCE(candidate.rec->>'supplier_id_type', '')))
+                  IN ('CNPJ', 'CPF', 'FOREIGN')
+          AND COALESCE(
+                  NULLIF(btrim(candidate.rec->>'supplier_identifier'), ''),
+                  NULLIF(btrim(candidate.rec->>'fornecedor_cnpj'), '')
+              ) IS NULL
+    ) THEN
+        RAISE EXCEPTION 'supplier_identifier is required for declared CNPJ, CPF, or FOREIGN identity'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN QUERY
+    WITH raw_input AS (
+        SELECT DISTINCT ON ((rec->>'contrato_id'))
+            rec,
+            NULLIF(upper(btrim(rec->>'supplier_id_type')), '') AS declared_type,
+            COALESCE(
+                NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                NULLIF(btrim(rec->>'fornecedor_cnpj'), '')
+            ) AS raw_identifier,
+            regexp_replace(
+                COALESCE(
+                    NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                    NULLIF(btrim(rec->>'fornecedor_cnpj'), ''),
+                    ''
+                ),
+                '\D', '', 'g'
+            ) AS identifier_digits
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY (rec->>'contrato_id')
+    ), classified AS (
+        SELECT raw_input.*,
+            CASE
+                WHEN declared_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                WHEN declared_type = 'FOREIGN' AND raw_identifier IS NOT NULL THEN 'FOREIGN'
+                WHEN declared_type = 'UNKNOWN' THEN 'UNKNOWN'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                ELSE 'UNKNOWN'
+            END AS canonical_type
+        FROM raw_input
+    ), normalized AS (
+        SELECT classified.*,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'FOREIGN'
+                    AND raw_identifier LIKE 'FOREIGN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'FOREIGN' AND raw_identifier IS NOT NULL
+                    THEN 'FOREIGN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                WHEN canonical_type = 'UNKNOWN'
+                    AND raw_identifier LIKE 'UNKNOWN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'UNKNOWN' AND raw_identifier IS NOT NULL
+                    THEN 'UNKNOWN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                ELSE NULL
+            END AS canonical_identifier
+        FROM classified
+    ), input AS (
+        SELECT
+            rec->>'contrato_id' AS in_contrato_id,
+            rec->>'orgao_cnpj' AS orgao_cnpj,
+            rec->>'orgao_nome' AS orgao_nome,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(canonical_identifier)
+                    THEN canonical_identifier
+                ELSE NULL
+            END AS fornecedor_cnpj,
+            rec->>'fornecedor_nome' AS fornecedor_nome,
+            canonical_type AS supplier_id_type,
+            canonical_identifier AS supplier_identifier,
+            COALESCE(
+                NULLIF(rec->>'supplier_country', ''),
+                CASE
+                    WHEN canonical_type IN ('CNPJ', 'CPF') THEN 'BR'
+                    ELSE NULL
+                END
+            ) AS supplier_country,
+            CASE
+                WHEN canonical_identifier IS NULL THEN NULL
+                ELSE encode(digest(
+                    'supplier-identity-v1:' || canonical_type || ':' || canonical_identifier,
+                    'sha256'
+                ), 'hex')
+            END AS supplier_identifier_hash,
+            CASE
+                WHEN canonical_type = 'CPF' THEN 'CPF:***.***.***-**'
+                WHEN length(identifier_digits) = 11 THEN 'UNKNOWN:MASKED'
+                WHEN canonical_type = 'CNPJ' THEN canonical_identifier
+                WHEN canonical_type IN ('FOREIGN', 'UNKNOWN') THEN canonical_identifier
+                ELSE NULL
+            END AS supplier_identifier_export,
+            COALESCE(
+                NULLIF(rec->>'supplier_identity_reason', ''),
+                CASE
+                    WHEN declared_type IS NULL THEN 'legacy_rpc_classified'
+                    ELSE 'rpc_server_normalized'
+                END
+            ) AS supplier_identity_reason,
+            rec->>'objeto_contrato' AS objeto_contrato,
+            NULLIF(rec->>'valor_total', '')::NUMERIC AS valor_total,
+            NULLIF(rec->>'data_inicio', '')::DATE AS data_inicio,
+            NULLIF(rec->>'data_fim', '')::DATE AS data_fim,
+            NULLIF(rec->>'data_publicacao', '')::DATE AS data_publicacao,
+            rec->>'uf' AS uf,
+            rec->>'municipio' AS municipio,
+            COALESCE(rec->>'source', 'pncp') AS source,
+            rec->>'source_id' AS source_id,
+            NULLIF(rec->>'data_assinatura', '')::DATE AS data_assinatura,
+            NULLIF(rec->>'data_publicacao_fonte', '')::DATE AS data_publicacao_fonte,
+            NULLIF(rec->>'data_atualizacao_fonte', '')::DATE AS data_atualizacao_fonte,
+            NULLIF(rec->>'source_event_date', '')::DATE AS source_event_date,
+            NULLIF(rec->>'source_date_semantics', '') AS source_date_semantics,
+            NULLIF(rec->>'source_updated_at', '')::TIMESTAMPTZ AS source_updated_at,
+            NULLIF(rec->>'query_window_start', '')::DATE AS query_window_start,
+            NULLIF(rec->>'query_window_end', '')::DATE AS query_window_end,
+            NULLIF(rec->>'tipo_contrato_id', '')::INTEGER AS tipo_contrato_id,
+            NULLIF(btrim(rec->>'tipo_contrato_nome'), '') AS tipo_contrato_nome,
+            NULLIF(rec->>'categoria_processo_id', '')::INTEGER AS categoria_processo_id,
+            NULLIF(btrim(rec->>'categoria_processo_nome'), '') AS categoria_processo_nome,
+            NULLIF(rec->>'modalidade_id', '')::INTEGER AS modalidade_id,
+            NULLIF(btrim(rec->>'modalidade_nome'), '') AS modalidade_nome,
+            NULLIF(rec->>'regime_execucao_id', '')::INTEGER AS regime_execucao_id,
+            NULLIF(btrim(rec->>'regime_execucao_nome'), '') AS regime_execucao_nome,
+            CASE
+                WHEN rec->>'srp' IS NULL OR btrim(rec->>'srp') = '' THEN NULL
+                WHEN lower(rec->>'srp') IN ('true', 't', '1') THEN TRUE
+                WHEN lower(rec->>'srp') IN ('false', 'f', '0') THEN FALSE
+                ELSE NULL
+            END AS srp,
+            NULLIF(rec->>'numero_retificacao', '')::INTEGER AS numero_retificacao
+        FROM normalized
+    ), upserted AS (
+        INSERT INTO public.pncp_supplier_contracts AS target (
+            contrato_id, orgao_cnpj, orgao_nome, fornecedor_cnpj, fornecedor_nome,
+            supplier_id_type, supplier_identifier, supplier_country,
+            supplier_identifier_hash, supplier_identifier_export, supplier_identity_reason,
+            objeto_contrato, valor_total, data_inicio, data_fim, data_publicacao,
+            uf, municipio, source, source_id, data_assinatura,
+            data_publicacao_fonte, data_atualizacao_fonte, source_event_date,
+            source_date_semantics, first_seen_at, last_seen_at, source_updated_at,
+            query_window_start, query_window_end,
+            tipo_contrato_id, tipo_contrato_nome, categoria_processo_id, categoria_processo_nome,
+            modalidade_id, modalidade_nome, regime_execucao_id, regime_execucao_nome,
+            srp, numero_retificacao
+        )
+        SELECT
+            input.in_contrato_id, input.orgao_cnpj, input.orgao_nome,
+            input.fornecedor_cnpj, input.fornecedor_nome, input.supplier_id_type,
+            input.supplier_identifier, input.supplier_country,
+            input.supplier_identifier_hash, input.supplier_identifier_export,
+            input.supplier_identity_reason, input.objeto_contrato, input.valor_total,
+            input.data_inicio, input.data_fim, input.data_publicacao, input.uf,
+            input.municipio, input.source, input.source_id, input.data_assinatura,
+            input.data_publicacao_fonte, input.data_atualizacao_fonte,
+            input.source_event_date, input.source_date_semantics, NOW(), NOW(),
+            input.source_updated_at, input.query_window_start, input.query_window_end,
+            input.tipo_contrato_id, input.tipo_contrato_nome,
+            input.categoria_processo_id, input.categoria_processo_nome,
+            input.modalidade_id, input.modalidade_nome,
+            input.regime_execucao_id, input.regime_execucao_nome,
+            input.srp, input.numero_retificacao
+        FROM input
+        ON CONFLICT ON CONSTRAINT pncp_supplier_contracts_contrato_id_key DO UPDATE SET
+            last_seen_at = NOW(),
+            fornecedor_cnpj = EXCLUDED.fornecedor_cnpj,
+            fornecedor_nome = COALESCE(EXCLUDED.fornecedor_nome, target.fornecedor_nome),
+            supplier_id_type = EXCLUDED.supplier_id_type,
+            supplier_identifier = EXCLUDED.supplier_identifier,
+            supplier_country = EXCLUDED.supplier_country,
+            supplier_identifier_hash = EXCLUDED.supplier_identifier_hash,
+            supplier_identifier_export = EXCLUDED.supplier_identifier_export,
+            supplier_identity_reason = EXCLUDED.supplier_identity_reason,
+            data_assinatura = COALESCE(target.data_assinatura, EXCLUDED.data_assinatura),
+            data_publicacao_fonte = COALESCE(target.data_publicacao_fonte, EXCLUDED.data_publicacao_fonte),
+            data_atualizacao_fonte = COALESCE(target.data_atualizacao_fonte, EXCLUDED.data_atualizacao_fonte),
+            source_event_date = COALESCE(target.source_event_date, EXCLUDED.source_event_date),
+            source_date_semantics = COALESCE(target.source_date_semantics, EXCLUDED.source_date_semantics),
+            source_updated_at = COALESCE(target.source_updated_at, EXCLUDED.source_updated_at),
+            query_window_start = COALESCE(target.query_window_start, EXCLUDED.query_window_start),
+            query_window_end = COALESCE(target.query_window_end, EXCLUDED.query_window_end),
+            tipo_contrato_id = COALESCE(EXCLUDED.tipo_contrato_id, target.tipo_contrato_id),
+            tipo_contrato_nome = COALESCE(EXCLUDED.tipo_contrato_nome, target.tipo_contrato_nome),
+            categoria_processo_id = COALESCE(EXCLUDED.categoria_processo_id, target.categoria_processo_id),
+            categoria_processo_nome = COALESCE(EXCLUDED.categoria_processo_nome, target.categoria_processo_nome),
+            modalidade_id = COALESCE(EXCLUDED.modalidade_id, target.modalidade_id),
+            modalidade_nome = COALESCE(EXCLUDED.modalidade_nome, target.modalidade_nome),
+            regime_execucao_id = COALESCE(EXCLUDED.regime_execucao_id, target.regime_execucao_id),
+            regime_execucao_nome = COALESCE(EXCLUDED.regime_execucao_nome, target.regime_execucao_nome),
+            srp = COALESCE(EXCLUDED.srp, target.srp),
+            numero_retificacao = COALESCE(EXCLUDED.numero_retificacao, target.numero_retificacao)
+        RETURNING target.contrato_id, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.contrato_id
+    FROM upserted;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_pncp_supplier_contracts(JSONB) IS
+    'Typed supplier identity upsert (#311) plus official PNCP structural fields (#546).';
+
+CREATE OR REPLACE FUNCTION public.apply_pncp_structural_fields(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH input AS (
+        SELECT DISTINCT ON (rec->>'contrato_id')
+            rec->>'contrato_id' AS in_contrato_id,
+            NULLIF(rec->>'tipo_contrato_id', '')::INTEGER AS tipo_contrato_id,
+            NULLIF(btrim(rec->>'tipo_contrato_nome'), '') AS tipo_contrato_nome,
+            NULLIF(rec->>'categoria_processo_id', '')::INTEGER AS categoria_processo_id,
+            NULLIF(btrim(rec->>'categoria_processo_nome'), '') AS categoria_processo_nome,
+            NULLIF(rec->>'modalidade_id', '')::INTEGER AS modalidade_id,
+            NULLIF(btrim(rec->>'modalidade_nome'), '') AS modalidade_nome,
+            NULLIF(rec->>'regime_execucao_id', '')::INTEGER AS regime_execucao_id,
+            NULLIF(btrim(rec->>'regime_execucao_nome'), '') AS regime_execucao_nome,
+            CASE
+                WHEN rec->>'srp' IS NULL OR btrim(rec->>'srp') = '' THEN NULL
+                WHEN lower(rec->>'srp') IN ('true', 't', '1') THEN TRUE
+                WHEN lower(rec->>'srp') IN ('false', 'f', '0') THEN FALSE
+                ELSE NULL
+            END AS srp,
+            NULLIF(rec->>'numero_retificacao', '')::INTEGER AS numero_retificacao
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY rec->>'contrato_id'
+    ), updated AS (
+        UPDATE public.pncp_supplier_contracts AS target
+        SET tipo_contrato_id = COALESCE(input.tipo_contrato_id, target.tipo_contrato_id),
+            tipo_contrato_nome = COALESCE(input.tipo_contrato_nome, target.tipo_contrato_nome),
+            categoria_processo_id = COALESCE(input.categoria_processo_id, target.categoria_processo_id),
+            categoria_processo_nome = COALESCE(input.categoria_processo_nome, target.categoria_processo_nome),
+            modalidade_id = COALESCE(input.modalidade_id, target.modalidade_id),
+            modalidade_nome = COALESCE(input.modalidade_nome, target.modalidade_nome),
+            regime_execucao_id = COALESCE(input.regime_execucao_id, target.regime_execucao_id),
+            regime_execucao_nome = COALESCE(input.regime_execucao_nome, target.regime_execucao_nome),
+            srp = COALESCE(input.srp, target.srp),
+            numero_retificacao = COALESCE(input.numero_retificacao, target.numero_retificacao)
+        FROM input
+        WHERE target.contrato_id = input.in_contrato_id
+        RETURNING target.contrato_id
+    )
+    SELECT 'updated'::TEXT, updated.contrato_id
+    FROM updated;
+END;
+$$;
+
+COMMENT ON FUNCTION public.apply_pncp_structural_fields(JSONB) IS
+    'Idempotent backfill of official PNCP structural fields onto existing contracts (#546).';
+
+CREATE TABLE IF NOT EXISTS public.pncp_structural_fields_backfill_state (
+    run_id          TEXT PRIMARY KEY,
+    cursor_contrato_id TEXT,
+    processed       BIGINT NOT NULL DEFAULT 0,
+    updated         BIGINT NOT NULL DEFAULT 0,
+    skipped         BIGINT NOT NULL DEFAULT 0,
+    last_run_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes           TEXT
+);
+
+COMMENT ON TABLE public.pncp_structural_fields_backfill_state IS
+    'Resumable cursor for #546 structural-field backfill. Observability only.';
+
+CREATE OR REPLACE VIEW public.v_contracts_canonical_v2 AS
+SELECT
+    contract.contrato_id,
+    contract.orgao_cnpj AS buyer_cnpj,
+    contract.orgao_nome AS buyer_nome,
+    roles.buyer_entity_id,
+    buyer.razao_social AS buyer_entity_nome,
+    buyer.cnpj_8 AS buyer_entity_cnpj_8,
+    buyer.raio_200km AS buyer_within_200km,
+    roles.buyer_match_method,
+    roles.buyer_match_confidence,
+    roles.buyer_reason_codes,
+    roles.supplier_identity_id,
+    contract.supplier_id_type,
+    contract.supplier_identifier_export,
+    contract.supplier_country,
+    contract.fornecedor_cnpj AS supplier_cnpj,
+    contract.fornecedor_nome AS supplier_nome,
+    contract.is_active,
+    roles.supplier_match_method,
+    roles.supplier_match_confidence,
+    roles.supplier_reason_codes,
+    contract.objeto_contrato AS objeto,
+    contract.valor_total AS valor,
+    contract.data_inicio,
+    contract.data_fim,
+    contract.data_publicacao,
+    contract.data_assinatura,
+    contract.data_publicacao_fonte,
+    contract.uf,
+    contract.municipio,
+    contract.codigo_municipio_ibge,
+    contract.municipio_inferido,
+    contract.source,
+    contract.source_id,
+    roles.match_run_id,
+    roles.snapshot_id,
+    roles.matched_at,
+    contract.tipo_contrato_id,
+    contract.tipo_contrato_nome,
+    contract.categoria_processo_id,
+    contract.categoria_processo_nome,
+    contract.modalidade_id,
+    contract.modalidade_nome,
+    COALESCE(contract.regime_execucao_nome, contract.regime_execucao_id::TEXT) AS regime_execucao,
+    contract.srp,
+    contract.numero_retificacao
+FROM public.pncp_supplier_contracts contract
+LEFT JOIN public.contract_role_links roles
+    ON roles.contract_id = contract.contrato_id
+LEFT JOIN public.sc_public_entities buyer
+    ON buyer.id = roles.buyer_entity_id
+WHERE contract.data_inicio IS NOT NULL OR contract.data_publicacao IS NOT NULL;
+
+CREATE OR REPLACE VIEW public.v_value_observations_canonical_v2 AS
+SELECT
+    'bid'::TEXT AS observation_type,
+    bid.pncp_id AS source_id,
+    bid.orgao_cnpj,
+    bid.municipio,
+    bid.uf,
+    bid.modalidade_id,
+    bid.modalidade_nome AS modalidade,
+    bid.objeto_compra AS objeto,
+    bid.valor_total_estimado AS valor,
+    bid.data_publicacao,
+    entity.cnpj_8 AS buyer_entity_cnpj_8,
+    entity.raio_200km AS buyer_within_200km
+FROM public.pncp_raw_bids bid
+LEFT JOIN public.sc_public_entities entity ON entity.id = bid.matched_entity_id
+WHERE bid.valor_total_estimado IS NOT NULL AND bid.valor_total_estimado > 0
+
+UNION ALL
+
+SELECT
+    'contract'::TEXT AS observation_type,
+    contract.contrato_id AS source_id,
+    contract.buyer_cnpj AS orgao_cnpj,
+    contract.municipio,
+    contract.uf,
+    contract.modalidade_id,
+    contract.modalidade_nome AS modalidade,
+    contract.objeto,
+    contract.valor,
+    contract.data_publicacao,
+    contract.buyer_entity_cnpj_8,
+    contract.buyer_within_200km
+FROM public.v_contracts_canonical_v2 contract
+WHERE contract.valor IS NOT NULL AND contract.valor > 0;
+
+COMMENT ON VIEW public.v_contracts_canonical_v2 IS
+    'Canonical contracts v2: buyer from orgao_cnpj only; supplier is a distinct typed identity; official PNCP structural fields from #546.';
+
+COMMIT;

--- a/db/migrations/110_contract_engineering_class.sql
+++ b/db/migrations/110_contract_engineering_class.sql
@@ -1,0 +1,95 @@
+-- 110_contract_engineering_class.sql
+-- #544: persisted, versioned engineering class per contract.
+-- Authority: scripts/contracts/engineering_class.py — consumers must not regex.
+--
+-- ROLLBACK:
+--   psql "$LOCAL_DATALAKE_DSN" -f db/rollback/110_contract_engineering_class_rollback.sql
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+CREATE TABLE IF NOT EXISTS public.contract_engineering_class (
+    contrato_id     TEXT PRIMARY KEY
+                        REFERENCES public.pncp_supplier_contracts(contrato_id)
+                        ON DELETE CASCADE,
+    engineering_class TEXT NOT NULL CHECK (engineering_class IN (
+        'OBRA_EXECUCAO',
+        'OBRA_COM_PROJETO',
+        'PROJETO_ENGENHARIA',
+        'FISCALIZACAO_GERENCIAMENTO',
+        'MANUTENCAO_PREDIAL_INFRA',
+        'INSTALACOES',
+        'FORNECIMENTO_COM_INSTALACAO',
+        'NAO_ENGENHARIA'
+    )),
+    confidence      NUMERIC(6,5) NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    categories      TEXT[] NOT NULL DEFAULT '{}',
+    evidence        TEXT[] NOT NULL DEFAULT '{}',
+    rule_version    TEXT NOT NULL,
+    computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cec_class_conf
+    ON public.contract_engineering_class (engineering_class, confidence DESC);
+CREATE INDEX IF NOT EXISTS idx_cec_computed
+    ON public.contract_engineering_class (computed_at DESC);
+
+COMMENT ON TABLE public.contract_engineering_class IS
+    'Versioned engineering class per contract (#544). Canonical authority; do not reimplement with objeto regex.';
+
+CREATE OR REPLACE FUNCTION public.apply_contract_engineering_class(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH input AS (
+        SELECT DISTINCT ON (rec->>'contrato_id')
+            rec->>'contrato_id' AS in_contrato_id,
+            rec->>'engineering_class' AS engineering_class,
+            NULLIF(rec->>'confidence', '')::NUMERIC AS confidence,
+            COALESCE(
+                ARRAY(SELECT jsonb_array_elements_text(COALESCE(rec->'categories', '[]'::jsonb))),
+                '{}'::TEXT[]
+            ) AS categories,
+            COALESCE(
+                ARRAY(SELECT jsonb_array_elements_text(COALESCE(rec->'evidence', '[]'::jsonb))),
+                '{}'::TEXT[]
+            ) AS evidence,
+            COALESCE(NULLIF(rec->>'rule_version', ''), 'engineering-class-v1') AS rule_version,
+            COALESCE(NULLIF(rec->>'computed_at', '')::TIMESTAMPTZ, NOW()) AS computed_at
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+          AND COALESCE(rec->>'engineering_class', '') <> ''
+        ORDER BY rec->>'contrato_id'
+    ), upserted AS (
+        INSERT INTO public.contract_engineering_class AS target (
+            contrato_id, engineering_class, confidence, categories, evidence,
+            rule_version, computed_at
+        )
+        SELECT
+            input.in_contrato_id, input.engineering_class, input.confidence,
+            input.categories, input.evidence, input.rule_version, input.computed_at
+        FROM input
+        JOIN public.pncp_supplier_contracts contract
+            ON contract.contrato_id = input.in_contrato_id
+        ON CONFLICT ON CONSTRAINT contract_engineering_class_pkey DO UPDATE SET
+            engineering_class = EXCLUDED.engineering_class,
+            confidence = EXCLUDED.confidence,
+            categories = EXCLUDED.categories,
+            evidence = EXCLUDED.evidence,
+            rule_version = EXCLUDED.rule_version,
+            computed_at = EXCLUDED.computed_at
+        RETURNING target.contrato_id
+    )
+    SELECT 'upserted'::TEXT, upserted.contrato_id
+    FROM upserted;
+END;
+$$;
+
+COMMENT ON FUNCTION public.apply_contract_engineering_class(JSONB) IS
+    'Idempotent persist of #544 engineering class. Does not invent contrato_id.';
+
+COMMIT;

--- a/db/migrations/111_pncp_procurement_results.sql
+++ b/db/migrations/111_pncp_procurement_results.sql
@@ -1,0 +1,138 @@
+-- 111_pncp_procurement_results.sql
+-- #545: official PNCP item resultados / adjudicacao / homologacao
+-- before contract signature. Never fabricates contrato_id.
+--
+-- ROLLBACK: db/rollback/111_pncp_procurement_results_rollback.sql
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+CREATE TABLE IF NOT EXISTS public.pncp_procurement_results (
+    result_id               TEXT PRIMARY KEY,
+    parent_procurement_id   TEXT NOT NULL,
+    contrato_id             TEXT,
+    event_type              TEXT NOT NULL CHECK (event_type IN ('RESULT_PUBLISHED', 'HOMOLOGATED')),
+    item_numero             INTEGER,
+    situacao                TEXT,
+    winner_cnpj             TEXT,
+    winner_nome             TEXT,
+    valor_homologado        NUMERIC(18,2),
+    event_at                DATE,
+    source_published_at     DATE,
+    first_seen_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rule_version            TEXT NOT NULL,
+    payload_hash            TEXT,
+    CHECK (contrato_id IS NULL OR btrim(contrato_id) <> '')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ppr_natural
+    ON public.pncp_procurement_results (
+        parent_procurement_id,
+        COALESCE(item_numero, -1),
+        COALESCE(winner_cnpj, ''),
+        event_type
+    );
+
+CREATE INDEX IF NOT EXISTS idx_ppr_parent
+    ON public.pncp_procurement_results (parent_procurement_id, event_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ppr_winner
+    ON public.pncp_procurement_results (winner_cnpj, event_at DESC)
+    WHERE winner_cnpj IS NOT NULL;
+
+COMMENT ON TABLE public.pncp_procurement_results IS
+    'Official PNCP pre-signature results (#545). contrato_id is NULL until a real contract exists; link is parent_procurement_id.';
+COMMENT ON COLUMN public.pncp_procurement_results.event_at IS
+    'Official result date. Distinct from first_seen_at and from contract data_assinatura.';
+COMMENT ON COLUMN public.pncp_procurement_results.source_published_at IS
+    'Official publication of the result, not lake observation.';
+COMMENT ON COLUMN public.pncp_procurement_results.first_seen_at IS
+    'Lake first observation of this result event.';
+COMMENT ON COLUMN public.pncp_procurement_results.contrato_id IS
+    'Filled only when a pncp_supplier_contracts row exists for the same parent_procurement_id. Never invented.';
+
+CREATE OR REPLACE FUNCTION public.apply_pncp_procurement_results(p_records JSONB)
+RETURNS TABLE (action TEXT, result_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH input AS (
+        SELECT DISTINCT ON (rec->>'result_id')
+            rec->>'result_id' AS in_result_id,
+            rec->>'parent_procurement_id' AS parent_procurement_id,
+            NULLIF(btrim(rec->>'contrato_id'), '') AS contrato_id,
+            rec->>'event_type' AS event_type,
+            NULLIF(rec->>'item_numero', '')::INTEGER AS item_numero,
+            NULLIF(btrim(rec->>'situacao'), '') AS situacao,
+            NULLIF(btrim(rec->>'winner_cnpj'), '') AS winner_cnpj,
+            NULLIF(btrim(rec->>'winner_nome'), '') AS winner_nome,
+            NULLIF(rec->>'valor_homologado', '')::NUMERIC AS valor_homologado,
+            NULLIF(rec->>'event_at', '')::DATE AS event_at,
+            NULLIF(rec->>'source_published_at', '')::DATE AS source_published_at,
+            COALESCE(NULLIF(rec->>'first_seen_at', '')::TIMESTAMPTZ, NOW()) AS first_seen_at,
+            COALESCE(NULLIF(rec->>'rule_version', ''), 'pncp-procurement-results-v1') AS rule_version,
+            NULLIF(rec->>'payload_hash', '') AS payload_hash
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'result_id', '') <> ''
+          AND COALESCE(rec->>'parent_procurement_id', '') <> ''
+          AND COALESCE(rec->>'event_type', '') IN ('RESULT_PUBLISHED', 'HOMOLOGATED')
+        ORDER BY rec->>'result_id'
+    ), upserted AS (
+        INSERT INTO public.pncp_procurement_results AS target (
+            result_id, parent_procurement_id, contrato_id, event_type, item_numero,
+            situacao, winner_cnpj, winner_nome, valor_homologado, event_at,
+            source_published_at, first_seen_at, last_seen_at, rule_version, payload_hash
+        )
+        SELECT
+            input.in_result_id, input.parent_procurement_id,
+            CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM public.pncp_supplier_contracts c
+                    WHERE c.contrato_id = input.contrato_id
+                ) THEN input.contrato_id
+                ELSE NULL
+            END,
+            input.event_type, input.item_numero, input.situacao, input.winner_cnpj,
+            input.winner_nome, input.valor_homologado, input.event_at,
+            input.source_published_at, input.first_seen_at, NOW(),
+            input.rule_version, input.payload_hash
+        FROM input
+        ON CONFLICT ON CONSTRAINT pncp_procurement_results_pkey DO UPDATE SET
+            last_seen_at = NOW(),
+            situacao = COALESCE(EXCLUDED.situacao, target.situacao),
+            winner_nome = COALESCE(EXCLUDED.winner_nome, target.winner_nome),
+            valor_homologado = COALESCE(EXCLUDED.valor_homologado, target.valor_homologado),
+            event_type = EXCLUDED.event_type,
+            payload_hash = COALESCE(EXCLUDED.payload_hash, target.payload_hash),
+            contrato_id = COALESCE(target.contrato_id, EXCLUDED.contrato_id)
+        RETURNING target.result_id, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.result_id
+    FROM upserted;
+END;
+$$;
+
+-- Link existing contracts without inventing ids.
+CREATE OR REPLACE FUNCTION public.link_procurement_results_to_contracts()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    n INTEGER;
+BEGIN
+    UPDATE public.pncp_procurement_results AS result
+    SET contrato_id = contract.contrato_id
+    FROM public.pncp_supplier_contracts AS contract
+    WHERE result.contrato_id IS NULL
+      AND contract.parent_procurement_id = result.parent_procurement_id
+      AND contract.contrato_id IS NOT NULL;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RETURN n;
+END;
+$$;
+
+COMMIT;

--- a/db/migrations/112_contract_terms_lifecycle.sql
+++ b/db/migrations/112_contract_terms_lifecycle.sql
@@ -86,6 +86,8 @@ BEGIN
            upserted.term_id
     FROM upserted;
 
+    -- Terminal events stay sticky unless a newer *dated* term exists.
+    -- An undated later ADITIVO must not clobber REVOGACAO/ANULACAO/RESCISAO.
     UPDATE public.pncp_supplier_contracts AS contract
     SET lifecycle_event_last = term.tipo_termo,
         lifecycle_event_at = term.data_assinatura
@@ -95,9 +97,19 @@ BEGIN
           SELECT rec->>'term_id' FROM jsonb_array_elements(p_records) rec
       )
       AND (
-          contract.lifecycle_event_at IS NULL
-          OR term.data_assinatura IS NULL
-          OR term.data_assinatura >= contract.lifecycle_event_at
+          (
+              term.data_assinatura IS NOT NULL
+              AND (
+                  contract.lifecycle_event_at IS NULL
+                  OR term.data_assinatura >= contract.lifecycle_event_at
+              )
+          )
+          OR (
+              term.data_assinatura IS NULL
+              AND COALESCE(contract.lifecycle_event_last, '') NOT IN (
+                  'REVOGACAO', 'ANULACAO', 'RESCISAO'
+              )
+          )
       );
 END;
 $$;

--- a/db/migrations/112_contract_terms_lifecycle.sql
+++ b/db/migrations/112_contract_terms_lifecycle.sql
@@ -1,0 +1,105 @@
+-- 112_contract_terms_lifecycle.sql
+-- #548: aditivo, retificação, rescisão, revogação, anulação as distinct events.
+-- A later-invalidated contract must not remain a silent commercial win.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+ALTER TABLE public.pncp_supplier_contracts
+    ADD COLUMN IF NOT EXISTS lifecycle_event_last TEXT,
+    ADD COLUMN IF NOT EXISTS lifecycle_event_at DATE;
+
+CREATE TABLE IF NOT EXISTS public.contract_terms (
+    term_id         TEXT PRIMARY KEY,
+    contrato_id     TEXT NOT NULL REFERENCES public.pncp_supplier_contracts(contrato_id) ON DELETE CASCADE,
+    tipo_termo      TEXT NOT NULL CHECK (tipo_termo IN (
+        'ADITIVO', 'RETIFICACAO', 'RESCISAO', 'REVOGACAO', 'ANULACAO', 'OUTRO'
+    )),
+    numero_termo    TEXT,
+    data_assinatura DATE,
+    valor           NUMERIC(18,2),
+    prazo_dias      INTEGER,
+    first_seen_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rule_version    TEXT NOT NULL,
+    payload_hash    TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_contract_terms_natural
+    ON public.contract_terms (
+        contrato_id,
+        tipo_termo,
+        COALESCE(numero_termo, ''),
+        COALESCE(data_assinatura, DATE 'epoch')
+    );
+
+CREATE INDEX IF NOT EXISTS idx_contract_terms_contrato
+    ON public.contract_terms (contrato_id, data_assinatura DESC);
+
+COMMENT ON TABLE public.contract_terms IS
+    'Official PNCP contract terms (#548). Aditivo ≠ retificação ≠ rescisão/revogação/anulação.';
+COMMENT ON COLUMN public.pncp_supplier_contracts.lifecycle_event_last IS
+    'Latest official term type. REVOGACAO/ANULACAO/RESCISAO exclude commercial actionability. #548.';
+
+CREATE OR REPLACE FUNCTION public.apply_contract_terms(p_records JSONB)
+RETURNS TABLE (action TEXT, term_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH input AS (
+        SELECT DISTINCT ON (rec->>'term_id')
+            rec->>'term_id' AS in_term_id,
+            rec->>'contrato_id' AS contrato_id,
+            rec->>'tipo_termo' AS tipo_termo,
+            NULLIF(rec->>'numero_termo', '') AS numero_termo,
+            NULLIF(rec->>'data_assinatura', '')::DATE AS data_assinatura,
+            NULLIF(rec->>'valor', '')::NUMERIC AS valor,
+            NULLIF(rec->>'prazo_dias', '')::INTEGER AS prazo_dias,
+            COALESCE(NULLIF(rec->>'rule_version', ''), 'pncp-contract-terms-v1') AS rule_version,
+            NULLIF(rec->>'payload_hash', '') AS payload_hash
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'term_id', '') <> ''
+          AND COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY rec->>'term_id'
+    ), upserted AS (
+        INSERT INTO public.contract_terms AS target (
+            term_id, contrato_id, tipo_termo, numero_termo, data_assinatura,
+            valor, prazo_dias, first_seen_at, last_seen_at, rule_version, payload_hash
+        )
+        SELECT
+            input.in_term_id, input.contrato_id, input.tipo_termo, input.numero_termo,
+            input.data_assinatura, input.valor, input.prazo_dias, NOW(), NOW(),
+            input.rule_version, input.payload_hash
+        FROM input
+        JOIN public.pncp_supplier_contracts contract
+            ON contract.contrato_id = input.contrato_id
+        ON CONFLICT ON CONSTRAINT contract_terms_pkey DO UPDATE SET
+            last_seen_at = NOW(),
+            valor = COALESCE(EXCLUDED.valor, target.valor),
+            prazo_dias = COALESCE(EXCLUDED.prazo_dias, target.prazo_dias)
+        RETURNING target.term_id, target.contrato_id, target.tipo_termo, target.data_assinatura, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.term_id
+    FROM upserted;
+
+    UPDATE public.pncp_supplier_contracts AS contract
+    SET lifecycle_event_last = term.tipo_termo,
+        lifecycle_event_at = term.data_assinatura
+    FROM public.contract_terms AS term
+    WHERE contract.contrato_id = term.contrato_id
+      AND term.term_id IN (
+          SELECT rec->>'term_id' FROM jsonb_array_elements(p_records) rec
+      )
+      AND (
+          contract.lifecycle_event_at IS NULL
+          OR term.data_assinatura IS NULL
+          OR term.data_assinatura >= contract.lifecycle_event_at
+      );
+END;
+$$;
+
+COMMIT;

--- a/db/rollback/107_pncp_structural_fields_rollback.sql
+++ b/db/rollback/107_pncp_structural_fields_rollback.sql
@@ -1,0 +1,299 @@
+-- Rollback of db/migrations/107_pncp_structural_fields.sql
+-- Restores v_contracts_canonical_v2 / upsert from 077 / 076 and drops #546 columns.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.apply_pncp_structural_fields(JSONB);
+DROP TABLE IF EXISTS public.pncp_structural_fields_backfill_state;
+
+CREATE OR REPLACE VIEW public.v_contracts_canonical_v2 AS
+SELECT
+    contract.contrato_id,
+    contract.orgao_cnpj AS buyer_cnpj,
+    contract.orgao_nome AS buyer_nome,
+    roles.buyer_entity_id,
+    buyer.razao_social AS buyer_entity_nome,
+    buyer.cnpj_8 AS buyer_entity_cnpj_8,
+    buyer.raio_200km AS buyer_within_200km,
+    roles.buyer_match_method,
+    roles.buyer_match_confidence,
+    roles.buyer_reason_codes,
+    roles.supplier_identity_id,
+    contract.supplier_id_type,
+    contract.supplier_identifier_export,
+    contract.supplier_country,
+    contract.fornecedor_cnpj AS supplier_cnpj,
+    contract.fornecedor_nome AS supplier_nome,
+    contract.is_active,
+    roles.supplier_match_method,
+    roles.supplier_match_confidence,
+    roles.supplier_reason_codes,
+    contract.objeto_contrato AS objeto,
+    contract.valor_total AS valor,
+    contract.data_inicio,
+    contract.data_fim,
+    contract.data_publicacao,
+    contract.data_assinatura,
+    contract.data_publicacao_fonte,
+    contract.uf,
+    contract.municipio,
+    contract.codigo_municipio_ibge,
+    contract.municipio_inferido,
+    contract.source,
+    contract.source_id,
+    roles.match_run_id,
+    roles.snapshot_id,
+    roles.matched_at
+FROM public.pncp_supplier_contracts contract
+LEFT JOIN public.contract_role_links roles
+    ON roles.contract_id = contract.contrato_id
+LEFT JOIN public.sc_public_entities buyer
+    ON buyer.id = roles.buyer_entity_id
+WHERE contract.data_inicio IS NOT NULL OR contract.data_publicacao IS NOT NULL;
+
+CREATE OR REPLACE VIEW public.v_value_observations_canonical_v2 AS
+SELECT
+    'bid'::TEXT AS observation_type,
+    bid.pncp_id AS source_id,
+    bid.orgao_cnpj,
+    bid.municipio,
+    bid.uf,
+    bid.modalidade_id,
+    bid.modalidade_nome AS modalidade,
+    bid.objeto_compra AS objeto,
+    bid.valor_total_estimado AS valor,
+    bid.data_publicacao,
+    entity.cnpj_8 AS buyer_entity_cnpj_8,
+    entity.raio_200km AS buyer_within_200km
+FROM public.pncp_raw_bids bid
+LEFT JOIN public.sc_public_entities entity ON entity.id = bid.matched_entity_id
+WHERE bid.valor_total_estimado IS NOT NULL AND bid.valor_total_estimado > 0
+
+UNION ALL
+
+SELECT
+    'contract'::TEXT AS observation_type,
+    contract.contrato_id AS source_id,
+    contract.buyer_cnpj AS orgao_cnpj,
+    contract.municipio,
+    contract.uf,
+    NULL::INTEGER AS modalidade_id,
+    NULL::TEXT AS modalidade,
+    contract.objeto,
+    contract.valor,
+    contract.data_publicacao,
+    contract.buyer_entity_cnpj_8,
+    contract.buyer_within_200km
+FROM public.v_contracts_canonical_v2 contract
+WHERE contract.valor IS NOT NULL AND contract.valor > 0;
+
+CREATE OR REPLACE FUNCTION public.upsert_pncp_supplier_contracts(p_records JSONB)
+RETURNS TABLE (action TEXT, contrato_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(p_records) AS candidate(rec)
+        WHERE upper(btrim(COALESCE(candidate.rec->>'supplier_id_type', '')))
+                  IN ('CNPJ', 'CPF', 'FOREIGN')
+          AND COALESCE(
+                  NULLIF(btrim(candidate.rec->>'supplier_identifier'), ''),
+                  NULLIF(btrim(candidate.rec->>'fornecedor_cnpj'), '')
+              ) IS NULL
+    ) THEN
+        RAISE EXCEPTION 'supplier_identifier is required for declared CNPJ, CPF, or FOREIGN identity'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN QUERY
+    WITH raw_input AS (
+        SELECT DISTINCT ON ((rec->>'contrato_id'))
+            rec,
+            NULLIF(upper(btrim(rec->>'supplier_id_type')), '') AS declared_type,
+            COALESCE(
+                NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                NULLIF(btrim(rec->>'fornecedor_cnpj'), '')
+            ) AS raw_identifier,
+            regexp_replace(
+                COALESCE(
+                    NULLIF(btrim(rec->>'supplier_identifier'), ''),
+                    NULLIF(btrim(rec->>'fornecedor_cnpj'), ''),
+                    ''
+                ),
+                '\D', '', 'g'
+            ) AS identifier_digits
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'contrato_id', '') <> ''
+        ORDER BY (rec->>'contrato_id')
+    ), classified AS (
+        SELECT raw_input.*,
+            CASE
+                WHEN declared_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                WHEN declared_type = 'FOREIGN' AND raw_identifier IS NOT NULL THEN 'FOREIGN'
+                WHEN declared_type = 'UNKNOWN' THEN 'UNKNOWN'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cnpj(raw_identifier) THEN 'CNPJ'
+                WHEN declared_type IS NULL
+                    AND public.fn_contract_valid_cpf(raw_identifier) THEN 'CPF'
+                ELSE 'UNKNOWN'
+            END AS canonical_type
+        FROM raw_input
+    ), normalized AS (
+        SELECT classified.*,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'CPF'
+                    AND public.fn_contract_valid_cpf(raw_identifier)
+                    THEN identifier_digits
+                WHEN canonical_type = 'FOREIGN'
+                    AND raw_identifier LIKE 'FOREIGN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'FOREIGN' AND raw_identifier IS NOT NULL
+                    THEN 'FOREIGN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                WHEN canonical_type = 'UNKNOWN'
+                    AND raw_identifier LIKE 'UNKNOWN:%'
+                    THEN raw_identifier
+                WHEN canonical_type = 'UNKNOWN' AND raw_identifier IS NOT NULL
+                    THEN 'UNKNOWN:' || COALESCE(NULLIF(rec->>'supplier_country', ''), 'ZZ')
+                         || ':' || raw_identifier
+                ELSE NULL
+            END AS canonical_identifier
+        FROM classified
+    ), input AS (
+        SELECT
+            rec->>'contrato_id' AS in_contrato_id,
+            rec->>'orgao_cnpj' AS orgao_cnpj,
+            rec->>'orgao_nome' AS orgao_nome,
+            CASE
+                WHEN canonical_type = 'CNPJ'
+                    AND public.fn_contract_valid_cnpj(canonical_identifier)
+                    THEN canonical_identifier
+                ELSE NULL
+            END AS fornecedor_cnpj,
+            rec->>'fornecedor_nome' AS fornecedor_nome,
+            canonical_type AS supplier_id_type,
+            canonical_identifier AS supplier_identifier,
+            COALESCE(
+                NULLIF(rec->>'supplier_country', ''),
+                CASE
+                    WHEN canonical_type IN ('CNPJ', 'CPF') THEN 'BR'
+                    ELSE NULL
+                END
+            ) AS supplier_country,
+            CASE
+                WHEN canonical_identifier IS NULL THEN NULL
+                ELSE encode(digest(
+                    'supplier-identity-v1:' || canonical_type || ':' || canonical_identifier,
+                    'sha256'
+                ), 'hex')
+            END AS supplier_identifier_hash,
+            CASE
+                WHEN canonical_type = 'CPF' THEN 'CPF:***.***.***-**'
+                WHEN length(identifier_digits) = 11 THEN 'UNKNOWN:MASKED'
+                WHEN canonical_type = 'CNPJ' THEN canonical_identifier
+                WHEN canonical_type IN ('FOREIGN', 'UNKNOWN') THEN canonical_identifier
+                ELSE NULL
+            END AS supplier_identifier_export,
+            COALESCE(
+                NULLIF(rec->>'supplier_identity_reason', ''),
+                CASE
+                    WHEN declared_type IS NULL THEN 'legacy_rpc_classified'
+                    ELSE 'rpc_server_normalized'
+                END
+            ) AS supplier_identity_reason,
+            rec->>'objeto_contrato' AS objeto_contrato,
+            NULLIF(rec->>'valor_total', '')::NUMERIC AS valor_total,
+            NULLIF(rec->>'data_inicio', '')::DATE AS data_inicio,
+            NULLIF(rec->>'data_fim', '')::DATE AS data_fim,
+            NULLIF(rec->>'data_publicacao', '')::DATE AS data_publicacao,
+            rec->>'uf' AS uf,
+            rec->>'municipio' AS municipio,
+            COALESCE(rec->>'source', 'pncp') AS source,
+            rec->>'source_id' AS source_id,
+            NULLIF(rec->>'data_assinatura', '')::DATE AS data_assinatura,
+            NULLIF(rec->>'data_publicacao_fonte', '')::DATE AS data_publicacao_fonte,
+            NULLIF(rec->>'data_atualizacao_fonte', '')::DATE AS data_atualizacao_fonte,
+            NULLIF(rec->>'source_event_date', '')::DATE AS source_event_date,
+            NULLIF(rec->>'source_date_semantics', '') AS source_date_semantics,
+            NULLIF(rec->>'source_updated_at', '')::TIMESTAMPTZ AS source_updated_at,
+            NULLIF(rec->>'query_window_start', '')::DATE AS query_window_start,
+            NULLIF(rec->>'query_window_end', '')::DATE AS query_window_end
+        FROM normalized
+    ), upserted AS (
+        INSERT INTO public.pncp_supplier_contracts AS target (
+            contrato_id, orgao_cnpj, orgao_nome, fornecedor_cnpj, fornecedor_nome,
+            supplier_id_type, supplier_identifier, supplier_country,
+            supplier_identifier_hash, supplier_identifier_export, supplier_identity_reason,
+            objeto_contrato, valor_total, data_inicio, data_fim, data_publicacao,
+            uf, municipio, source, source_id, data_assinatura,
+            data_publicacao_fonte, data_atualizacao_fonte, source_event_date,
+            source_date_semantics, first_seen_at, last_seen_at, source_updated_at,
+            query_window_start, query_window_end
+        )
+        SELECT
+            input.in_contrato_id, input.orgao_cnpj, input.orgao_nome,
+            input.fornecedor_cnpj, input.fornecedor_nome, input.supplier_id_type,
+            input.supplier_identifier, input.supplier_country,
+            input.supplier_identifier_hash, input.supplier_identifier_export,
+            input.supplier_identity_reason, input.objeto_contrato, input.valor_total,
+            input.data_inicio, input.data_fim, input.data_publicacao, input.uf,
+            input.municipio, input.source, input.source_id, input.data_assinatura,
+            input.data_publicacao_fonte, input.data_atualizacao_fonte,
+            input.source_event_date, input.source_date_semantics, NOW(), NOW(),
+            input.source_updated_at, input.query_window_start, input.query_window_end
+        FROM input
+        ON CONFLICT ON CONSTRAINT pncp_supplier_contracts_contrato_id_key DO UPDATE SET
+            last_seen_at = NOW(),
+            fornecedor_cnpj = EXCLUDED.fornecedor_cnpj,
+            fornecedor_nome = COALESCE(EXCLUDED.fornecedor_nome, target.fornecedor_nome),
+            supplier_id_type = EXCLUDED.supplier_id_type,
+            supplier_identifier = EXCLUDED.supplier_identifier,
+            supplier_country = EXCLUDED.supplier_country,
+            supplier_identifier_hash = EXCLUDED.supplier_identifier_hash,
+            supplier_identifier_export = EXCLUDED.supplier_identifier_export,
+            supplier_identity_reason = EXCLUDED.supplier_identity_reason,
+            data_assinatura = COALESCE(target.data_assinatura, EXCLUDED.data_assinatura),
+            data_publicacao_fonte = COALESCE(target.data_publicacao_fonte, EXCLUDED.data_publicacao_fonte),
+            data_atualizacao_fonte = COALESCE(target.data_atualizacao_fonte, EXCLUDED.data_atualizacao_fonte),
+            source_event_date = COALESCE(target.source_event_date, EXCLUDED.source_event_date),
+            source_date_semantics = COALESCE(target.source_date_semantics, EXCLUDED.source_date_semantics),
+            source_updated_at = COALESCE(target.source_updated_at, EXCLUDED.source_updated_at),
+            query_window_start = COALESCE(target.query_window_start, EXCLUDED.query_window_start),
+            query_window_end = COALESCE(target.query_window_end, EXCLUDED.query_window_end)
+        RETURNING target.contrato_id, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.contrato_id
+    FROM upserted;
+END;
+$$;
+
+DROP INDEX IF EXISTS public.idx_psc_tipo_contrato;
+DROP INDEX IF EXISTS public.idx_psc_categoria_processo;
+DROP INDEX IF EXISTS public.idx_psc_modalidade;
+DROP INDEX IF EXISTS public.idx_psc_srp;
+
+ALTER TABLE public.pncp_supplier_contracts
+    DROP COLUMN IF EXISTS tipo_contrato_id,
+    DROP COLUMN IF EXISTS tipo_contrato_nome,
+    DROP COLUMN IF EXISTS categoria_processo_id,
+    DROP COLUMN IF EXISTS categoria_processo_nome,
+    DROP COLUMN IF EXISTS modalidade_id,
+    DROP COLUMN IF EXISTS modalidade_nome,
+    DROP COLUMN IF EXISTS regime_execucao_id,
+    DROP COLUMN IF EXISTS regime_execucao_nome,
+    DROP COLUMN IF EXISTS srp,
+    DROP COLUMN IF EXISTS numero_retificacao;
+
+-- Restore 076 upsert body (without #546 columns). Re-apply 076 function by
+-- running db/migrations/076_contract_supplier_identity.sql if a full identity
+-- restore is required. The column drop above is the data-loss step.
+
+COMMIT;

--- a/db/rollback/110_contract_engineering_class_rollback.sql
+++ b/db/rollback/110_contract_engineering_class_rollback.sql
@@ -1,0 +1,8 @@
+-- Rollback of db/migrations/110_contract_engineering_class.sql
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.apply_contract_engineering_class(JSONB);
+DROP TABLE IF EXISTS public.contract_engineering_class;
+
+COMMIT;

--- a/db/rollback/111_pncp_procurement_results_rollback.sql
+++ b/db/rollback/111_pncp_procurement_results_rollback.sql
@@ -1,0 +1,5 @@
+BEGIN;
+DROP FUNCTION IF EXISTS public.link_procurement_results_to_contracts();
+DROP FUNCTION IF EXISTS public.apply_pncp_procurement_results(JSONB);
+DROP TABLE IF EXISTS public.pncp_procurement_results;
+COMMIT;

--- a/db/rollback/112_contract_terms_lifecycle_rollback.sql
+++ b/db/rollback/112_contract_terms_lifecycle_rollback.sql
@@ -1,0 +1,7 @@
+BEGIN;
+DROP FUNCTION IF EXISTS public.apply_contract_terms(JSONB);
+DROP TABLE IF EXISTS public.contract_terms;
+ALTER TABLE public.pncp_supplier_contracts
+    DROP COLUMN IF EXISTS lifecycle_event_last,
+    DROP COLUMN IF EXISTS lifecycle_event_at;
+COMMIT;

--- a/scripts/contracts/__init__.py
+++ b/scripts/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Contract-domain classifiers and stamps."""

--- a/scripts/contracts/engineering_class.py
+++ b/scripts/contracts/engineering_class.py
@@ -1,0 +1,399 @@
+"""Persisted engineering class per contract (#544).
+
+Canonical authority for commercial engineering classes. Reuses
+``contract_relevance.normalize_text`` / ``neutralize_evidence``; does not
+treat projeto as out-of-scope. Views must consume this table, not regex.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.commercial_leads.contract_relevance import neutralize_evidence, normalize_text
+
+RULE_VERSION = "engineering-class-v1"
+
+ENGINEERING_CLASSES: tuple[str, ...] = (
+    "OBRA_EXECUCAO",
+    "OBRA_COM_PROJETO",
+    "PROJETO_ENGENHARIA",
+    "FISCALIZACAO_GERENCIAMENTO",
+    "MANUTENCAO_PREDIAL_INFRA",
+    "INSTALACOES",
+    "FORNECIMENTO_COM_INSTALACAO",
+    "NAO_ENGENHARIA",
+)
+
+ORGAO_SPAN_RE = re.compile(
+    r"\b(?:secretaria|ministerio|autarquia|prefeitura|camara municipal|"
+    r"departamento|superintendencia|companhia|agencia)"
+    r"(?:\s+(?:municipal|estadual|federal|metropolitana))?"
+    r"(?:\s+(?:de|da|do|das|dos))?"
+    r"(?:\s+[a-z]+){0,8}"
+)
+
+SUPPLIER_EXCLUDE_RE = re.compile(
+    r"\b(fundacao|universidade|faculdade|concessionaria|advocacia|"
+    r"escritorio de advocacia|sociedade de advogados)\b"
+)
+
+INTEGRATED_RE = re.compile(r"\b(semi[-\s]?integrad|contratacao integrada|regime integrado|integrada)\b")
+
+PROJETO_PHRASES = (
+    "elaboracao de projeto",
+    "elaboracao de projetos",
+    "projeto executivo",
+    "projeto estrutural",
+    "projeto de engenharia",
+    "projetos de engenharia",
+    "projeto basico de engenharia",
+    "projeto basico e executivo",
+    "anteprojeto de engenharia",
+)
+PROJETO_NEGATIVE = (
+    "projeto cultural",
+    "projeto de software",
+    "projeto pedagogico",
+    "projeto social",
+    "projeto de pesquisa",
+    "projeto academico",
+)
+
+FISCAL_PHRASES = ("fiscalizacao de obra", "supervisao de obra", "gerenciamento de obra", "acompanhamento de obra")
+FISCAL_TOKENS = ("fiscalizacao", "supervisao", "gerenciamento")
+OBRA_CONTEXT = (
+    "obra",
+    "obras",
+    "engenharia",
+    "paviment",
+    "edific",
+    "construcao",
+    "saneamento",
+    "drenagem",
+)
+FISCAL_NEGATIVE = ("publicidade", "propaganda", "midia", "marketing", "comunicacao social")
+
+MANUT_PHRASES = (
+    "manutencao predial",
+    "manutencao de edificio",
+    "manutencao rodoviaria",
+    "conservacao rodoviaria",
+    "manutencao de infraestrutura",
+)
+MANUT_NEGATIVE = (
+    "equipamento medico",
+    "equipamentos medicos",
+    "respirador",
+    "engenharia clinica",
+    "hospitalar",
+    "manutencao de veiculo",
+    "manutencao de impressora",
+)
+
+INSTAL_PHRASES = (
+    "instalacoes prediais",
+    "instalacoes hidraulicas",
+    "instalacoes eletricas",
+    "instalacao eletrica predial",
+    "instalacao hidraulica",
+)
+SUPPLY_INSTALL_PHRASES = (
+    "fornecimento e instalacao",
+    "fornecimento com instalacao",
+    "fornecimento, instalacao",
+)
+
+OBRA_PHRASES = (
+    "execucao de obra",
+    "execucao de obras",
+    "obra de engenharia",
+    "construcao civil",
+    "pavimentacao",
+    "terraplenagem",
+    "drenagem urbana",
+    "edificacao",
+    "empreitada",
+    "construcao de",
+    "reforma predial",
+    "recuperacao estrutural",
+)
+
+ENGINEERING_CATEGORIA = {
+    "obras",
+    "servicos de engenharia",
+    "servico de engenharia",
+    "obras e servicos de engenharia",
+}
+
+
+@dataclass
+class EngineeringClassResult:
+    engineering_class: str
+    confidence: float
+    categories: list[str] = field(default_factory=list)
+    evidence: list[str] = field(default_factory=list)
+    rule_version: str = RULE_VERSION
+    computed_at: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["class"] = self.engineering_class
+        return payload
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def neutralize_orgao_spans(norm: str) -> str:
+    return ORGAO_SPAN_RE.sub(" ", norm)
+
+
+def _hits(norm: str, phrases: tuple[str, ...]) -> list[str]:
+    return [p for p in phrases if p in norm]
+
+
+def _official_engineering_categoria(nome: str | None) -> bool:
+    if not nome:
+        return False
+    return normalize_text(nome) in ENGINEERING_CATEGORIA
+
+
+def _regime_integrated(regime: str | None) -> bool:
+    if not regime:
+        return False
+    return bool(INTEGRATED_RE.search(normalize_text(regime)))
+
+
+def classify_engineering_class(
+    *,
+    objeto: str | None,
+    fornecedor_nome: str | None = None,
+    categoria_processo_nome: str | None = None,
+    regime_execucao_nome: str | None = None,
+    tipo_contrato_nome: str | None = None,
+    srp: bool | None = None,
+    cnae_principal: str | None = None,
+) -> EngineeringClassResult:
+    """Return a versioned class. Never infers class from objeto regex in SQL."""
+    computed = _now()
+    raw_norm = normalize_text(objeto)
+    norm = neutralize_orgao_spans(neutralize_evidence(objeto))
+    evidence: list[str] = []
+    categories: list[str] = []
+    supplier = normalize_text(fornecedor_nome)
+    tipo = normalize_text(tipo_contrato_nome)
+
+    if supplier and SUPPLIER_EXCLUDE_RE.search(supplier) and not _hits(norm, OBRA_PHRASES):
+        return EngineeringClassResult(
+            "NAO_ENGENHARIA",
+            0.92,
+            ["supplier_excluded"],
+            [f"supplier:{SUPPLIER_EXCLUDE_RE.search(supplier).group(0)}"],
+            computed_at=computed,
+        )
+
+    if any(neg in norm for neg in FISCAL_NEGATIVE) and not _hits(norm, OBRA_PHRASES):
+        return EngineeringClassResult(
+            "NAO_ENGENHARIA",
+            0.9,
+            ["publicidade"],
+            ["publicidade_or_midia"],
+            computed_at=computed,
+        )
+
+    if any(neg in norm for neg in MANUT_NEGATIVE):
+        return EngineeringClassResult(
+            "NAO_ENGENHARIA",
+            0.9,
+            ["clinical_or_equipment"],
+            _hits(norm, MANUT_NEGATIVE) or ["manutencao_nao_predial"],
+            computed_at=computed,
+        )
+
+    if any(neg in norm for neg in PROJETO_NEGATIVE) and not _hits(norm, PROJETO_PHRASES):
+        return EngineeringClassResult(
+            "NAO_ENGENHARIA",
+            0.88,
+            ["projeto_nao_engenharia"],
+            _hits(norm, PROJETO_NEGATIVE),
+            computed_at=computed,
+        )
+
+    integrated = _regime_integrated(regime_execucao_nome) or bool(INTEGRATED_RE.search(norm))
+    if _regime_integrated(regime_execucao_nome):
+        evidence.append("regime_execucao_oficial")
+        categories.append("regime_integrado")
+
+    projeto_hits = _hits(norm, PROJETO_PHRASES)
+    fiscal_phrase_hits = _hits(norm, FISCAL_PHRASES)
+    fiscal_token = any(tok in norm for tok in FISCAL_TOKENS)
+    obra_ctx = any(tok in norm for tok in OBRA_CONTEXT)
+    manut_hits = _hits(norm, MANUT_PHRASES)
+    instal_hits = _hits(norm, INSTAL_PHRASES)
+    supply_hits = _hits(norm, SUPPLY_INSTALL_PHRASES)
+    obra_hits = _hits(norm, OBRA_PHRASES)
+    cat_eng = _official_engineering_categoria(categoria_processo_nome)
+    if cat_eng:
+        evidence.append("categoria_processo_oficial")
+        categories.append("categoria_processo")
+
+    def _conf(base: float) -> float:
+        score = base
+        if cat_eng:
+            score = min(1.0, score + 0.08)
+        if cnae_principal and any(k in normalize_text(cnae_principal) for k in ("obra", "engenharia", "construcao")):
+            score = min(1.0, score + 0.05)
+            evidence.append("cnae")
+        if tipo in {"empenho", "ata de registro de precos"} or srp is True:
+            score = max(0.0, score - 0.15)
+            evidence.append("empenho_or_srp_penalty")
+        return round(score, 3)
+
+    if integrated and (obra_hits or cat_eng or projeto_hits or obra_ctx):
+        return EngineeringClassResult(
+            "OBRA_COM_PROJETO",
+            _conf(0.86 if _regime_integrated(regime_execucao_nome) else 0.8),
+            categories + ["integrado"],
+            evidence + (["regime_sem_keyword_objeto"] if not INTEGRATED_RE.search(raw_norm) else ["integrado_no_objeto"]),
+            computed_at=computed,
+        )
+
+    if projeto_hits:
+        return EngineeringClassResult(
+            "PROJETO_ENGENHARIA",
+            _conf(0.88),
+            categories + ["projeto"],
+            evidence + projeto_hits,
+            computed_at=computed,
+        )
+
+    if fiscal_phrase_hits or (fiscal_token and obra_ctx):
+        return EngineeringClassResult(
+            "FISCALIZACAO_GERENCIAMENTO",
+            _conf(0.86 if fiscal_phrase_hits else 0.78),
+            categories + ["fiscalizacao"],
+            evidence + (fiscal_phrase_hits or ["fiscalizacao+obra_context"]),
+            computed_at=computed,
+        )
+    if fiscal_token and not obra_ctx:
+        return EngineeringClassResult(
+            "NAO_ENGENHARIA",
+            0.84,
+            ["fiscalizacao_sem_obra"],
+            ["fiscalizacao_without_obra_context"],
+            computed_at=computed,
+        )
+
+    if manut_hits:
+        return EngineeringClassResult(
+            "MANUTENCAO_PREDIAL_INFRA",
+            _conf(0.84),
+            categories + ["manutencao"],
+            evidence + manut_hits,
+            computed_at=computed,
+        )
+
+    if supply_hits:
+        return EngineeringClassResult(
+            "FORNECIMENTO_COM_INSTALACAO",
+            _conf(0.82),
+            categories + ["fornecimento_instalacao"],
+            evidence + supply_hits,
+            computed_at=computed,
+        )
+
+    if instal_hits:
+        return EngineeringClassResult(
+            "INSTALACOES",
+            _conf(0.83),
+            categories + ["instalacoes"],
+            evidence + instal_hits,
+            computed_at=computed,
+        )
+
+    if obra_hits:
+        return EngineeringClassResult(
+            "OBRA_EXECUCAO",
+            _conf(0.87),
+            categories + ["obra"],
+            evidence + obra_hits,
+            computed_at=computed,
+        )
+
+    if cat_eng:
+        return EngineeringClassResult(
+            "OBRA_EXECUCAO",
+            0.62,
+            categories,
+            evidence + ["categoria_only_low_object_evidence"],
+            computed_at=computed,
+        )
+
+    return EngineeringClassResult(
+        "NAO_ENGENHARIA",
+        0.7,
+        ["no_engineering_evidence"],
+        ["no_class_evidence"],
+        computed_at=computed,
+    )
+
+
+def attach_engineering_class(record: dict[str, Any]) -> dict[str, Any]:
+    result = classify_engineering_class(
+        objeto=record.get("objeto_contrato") or record.get("objeto"),
+        fornecedor_nome=record.get("fornecedor_nome"),
+        categoria_processo_nome=record.get("categoria_processo_nome"),
+        regime_execucao_nome=record.get("regime_execucao_nome"),
+        tipo_contrato_nome=record.get("tipo_contrato_nome"),
+        srp=record.get("srp"),
+        cnae_principal=record.get("cnae_principal"),
+    )
+    record["engineering_class"] = result.engineering_class
+    record["engineering_confidence"] = result.confidence
+    record["engineering_categories"] = result.categories
+    record["engineering_evidence"] = result.evidence
+    record["engineering_rule_version"] = result.rule_version
+    record["engineering_computed_at"] = result.computed_at
+    return record
+
+
+def stamp_engineering_class_labels(conn: Any, records: Iterable[Mapping[str, Any]]) -> int:
+    payload = []
+    for raw in records:
+        contrato_id = str(raw.get("contrato_id") or "").strip()
+        if not contrato_id:
+            continue
+        row = dict(raw)
+        if not row.get("engineering_class"):
+            attach_engineering_class(row)
+        payload.append(
+            {
+                "contrato_id": contrato_id,
+                "engineering_class": row.get("engineering_class"),
+                "confidence": row.get("engineering_confidence"),
+                "categories": row.get("engineering_categories") or [],
+                "evidence": row.get("engineering_evidence") or [],
+                "rule_version": row.get("engineering_rule_version") or RULE_VERSION,
+                "computed_at": row.get("engineering_computed_at"),
+            }
+        )
+    if not payload:
+        return 0
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT contrato_id FROM apply_contract_engineering_class(%s::jsonb)",
+            (json.dumps(payload, default=str),),
+        )
+        rows = cur.fetchall() or []
+        return len(rows)
+    finally:
+        close = getattr(cur, "close", None)
+        if callable(close):
+            close()

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -35,6 +35,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from scripts.contracts.engineering_class import (
+    attach_engineering_class,
+    stamp_engineering_class_labels,
+)
 from scripts.contracts_identity import normalize_supplier_identity
 from scripts.contracts_truth import (
     PaginationReconcile,
@@ -394,6 +398,7 @@ def _persist_window_if_enabled(raw_items: list[dict]) -> int:
             )
             rows = cur.fetchall()
             stamped = stamp_contract_truth_labels(conn, transformed)
+            stamp_engineering_class_labels(conn, transformed)
             conn.commit()
         finally:
             conn.close()
@@ -763,7 +768,8 @@ def _transform_record(rec: dict) -> dict | None:
             "source_id": contrato_id,
         }
         attach_structural_fields(record, rec)
-        return annotate_transformed_contract(record, raw=rec)
+        annotated = annotate_transformed_contract(record, raw=rec)
+        return attach_engineering_class(annotated)
 
     except Exception as e:
         logger.warning("Transform error for record %s: %s", rec.get("numeroControlePNCP", ""), e)

--- a/scripts/crawl/contracts_crawler.py
+++ b/scripts/crawl/contracts_crawler.py
@@ -54,6 +54,7 @@ from scripts.crawl.common import (
 from scripts.crawl.common import (
     trunc as trunc,
 )
+from scripts.crawl.pncp_structural_fields import attach_structural_fields
 from scripts.crawl.security import USER_AGENT, sanitize_url_param, validate_url_scheme
 
 # Add project root for standalone imports
@@ -761,6 +762,7 @@ def _transform_record(rec: dict) -> dict | None:
             "municipio": municipio,
             "source_id": contrato_id,
         }
+        attach_structural_fields(record, rec)
         return annotate_transformed_contract(record, raw=rec)
 
     except Exception as e:

--- a/scripts/crawl/pncp_contract_terms.py
+++ b/scripts/crawl/pncp_contract_terms.py
@@ -1,0 +1,63 @@
+"""Idempotent PNCP contract terms / lifecycle events (#548)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.commercial_leads.contract_relevance import normalize_text
+
+RULE_VERSION = "pncp-contract-terms-v1"
+TERMINAL = frozenset({"RESCISAO", "REVOGACAO", "ANULACAO"})
+
+
+def classify_term_type(nome: str | None, situacao: str | None = None) -> str:
+    blob = normalize_text(" ".join(x for x in (nome, situacao) if x))
+    if "aditiv" in blob:
+        return "ADITIVO"
+    if "retific" in blob or "apostil" in blob:
+        return "RETIFICACAO"
+    if "rescis" in blob:
+        return "RESCISAO"
+    if "revog" in blob:
+        return "REVOGACAO"
+    if "anul" in blob:
+        return "ANULACAO"
+    return "OUTRO"
+
+
+def map_pncp_term(payload: Mapping[str, Any], *, contrato_id: str | None = None) -> dict[str, Any] | None:
+    cid = str(contrato_id or payload.get("contrato_id") or payload.get("numeroControlePNCP") or "").strip()
+    if not cid:
+        return None
+    tipo = classify_term_type(
+        str(payload.get("tipoTermoNome") or payload.get("tipoTermo") or payload.get("tipo") or ""),
+        str(payload.get("situacao") or ""),
+    )
+    seq = payload.get("numeroTermo") or payload.get("sequencial") or payload.get("id") or ""
+    key = f"{cid}|{tipo}|{seq}|{payload.get('dataAssinatura') or ''}"
+    term_id = "pncp_term_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+    valor = payload.get("valorGlobal") or payload.get("valor") or payload.get("valorAcrescimo")
+    try:
+        valor_num = float(valor) if valor not in (None, "") else None
+    except (TypeError, ValueError):
+        valor_num = None
+    data = str(payload.get("dataAssinatura") or payload.get("dataVigenciaInicio") or "")[:10] or None
+    return {
+        "term_id": term_id,
+        "contrato_id": cid,
+        "tipo_termo": tipo,
+        "numero_termo": str(seq) if seq not in (None, "") else None,
+        "data_assinatura": data,
+        "valor": valor_num,
+        "prazo_dias": payload.get("prazoAditadoDias") or payload.get("prazo"),
+        "first_seen_at": datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "rule_version": RULE_VERSION,
+        "payload_hash": hashlib.sha256(
+            json.dumps(dict(payload), sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest(),
+        "is_terminal": tipo in TERMINAL,
+    }

--- a/scripts/crawl/pncp_contract_terms.py
+++ b/scripts/crawl/pncp_contract_terms.py
@@ -4,14 +4,30 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+import re
+from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from typing import Any
 
 from scripts.commercial_leads.contract_relevance import normalize_text
+from scripts.crawl.pncp_contract import digits_only
+
+PNCP_API_V1 = "https://pncp.gov.br/api/pncp/v1"
+PNCP_CONTROLE_ID = re.compile(r"^(\d{14})-\d+-(\d+)/(\d{4})$")
 
 RULE_VERSION = "pncp-contract-terms-v1"
 TERMINAL = frozenset({"RESCISAO", "REVOGACAO", "ANULACAO"})
+
+
+def parse_pncp_controle_id(value: str | None) -> tuple[str, int, int] | None:
+    match = PNCP_CONTROLE_ID.match((value or "").strip())
+    if not match:
+        return None
+    return match.group(1), int(match.group(3)), int(match.group(2))
+
+
+def contract_terms_url(cnpj: str, ano: int, sequencial: int) -> str:
+    return f"{PNCP_API_V1}/orgaos/{digits_only(cnpj)}/contratos/{int(ano)}/{int(sequencial)}/termos"
 
 
 def classify_term_type(nome: str | None, situacao: str | None = None) -> str:
@@ -61,3 +77,58 @@ def map_pncp_term(payload: Mapping[str, Any], *, contrato_id: str | None = None)
         ).hexdigest(),
         "is_terminal": tipo in TERMINAL,
     }
+
+
+def plan_term_ingest(
+    payloads: list[Mapping[str, Any]],
+    *,
+    contrato_id: str | None = None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for payload in payloads:
+        mapped = map_pncp_term(payload, contrato_id=contrato_id)
+        if not mapped or mapped["term_id"] in seen:
+            continue
+        seen.add(mapped["term_id"])
+        rows.append(mapped)
+    return rows
+
+
+def expand_term_payloads(
+    documents: Iterable[Any],
+    *,
+    contrato_id: str | None = None,
+) -> list[Mapping[str, Any]]:
+    out: list[Mapping[str, Any]] = []
+    for document in documents:
+        out.extend(_expand_one(document, contrato_id=contrato_id))
+    return out
+
+
+def _expand_one(document: Any, *, contrato_id: str | None) -> list[Mapping[str, Any]]:
+    if isinstance(document, list):
+        rows: list[Mapping[str, Any]] = []
+        for item in document:
+            rows.extend(_expand_one(item, contrato_id=contrato_id))
+        return rows
+    if not isinstance(document, Mapping):
+        return []
+    cid = contrato_id or document.get("contrato_id") or document.get("numeroControlePNCP")
+    nested = document.get("termos") or document.get("data")
+    looks_like_term = bool(
+        document.get("tipoTermoNome")
+        or document.get("tipoTermo")
+        or document.get("tipo_termo")
+        or document.get("numeroTermo")
+    )
+    if isinstance(nested, list) and not looks_like_term:
+        rows = []
+        for item in nested:
+            rows.extend(_expand_one(item, contrato_id=cid))
+        return rows
+    payload = dict(document)
+    if cid:
+        payload.setdefault("contrato_id", cid)
+        payload.setdefault("numeroControlePNCP", cid)
+    return [payload]

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -33,6 +33,7 @@ from scripts.crawl.pncp_contract import (
     parse_modalidades_from_env,
     parse_target,
 )
+from scripts.crawl.pncp_contract_terms import contract_terms_url
 from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.security import USER_AGENT, public_get
 from scripts.crawl.watermark_sync import watermark_commit, watermark_read
@@ -942,3 +943,23 @@ def fetch_compra_items(cnpj: str, ano: int, sequencial: int) -> FetchResult:
 def fetch_compra_documents(cnpj: str, ano: int, sequencial: int) -> FetchResult:
     url = f"https://pncp.gov.br/api/pncp/v1/orgaos/{digits_only(cnpj)}/compras/{int(ano)}/{int(sequencial)}/arquivos"
     return _fetch_list_endpoint(url)
+
+
+def _records_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        return [payload]
+    return []
+
+
+def fetch_contract_terms(cnpj: str, ano: int, sequencial: int) -> FetchResult:
+    """GET /orgaos/{cnpj}/contratos/{ano}/{seq}/termos (#548)."""
+    url = contract_terms_url(cnpj, ano, sequencial)
+    payload, result = _http_get_payload(url)
+    result.records = _records_from_payload(payload)
+    result.empty_confirmed = bool(result.request_completed) and not result.records
+    return result

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -18,7 +18,6 @@ import requests
 from scripts.contracts_identity import normalize_supplier_identity
 from scripts.contracts_truth import canonical_contract_identity
 from scripts.crawl.common import safe_float, safe_int
-from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.dlq_sync import dlq_write
 from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
 from scripts.crawl.pncp_contract import (
@@ -34,6 +33,7 @@ from scripts.crawl.pncp_contract import (
     parse_modalidades_from_env,
     parse_target,
 )
+from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.security import USER_AGENT, public_get
 from scripts.crawl.watermark_sync import watermark_commit, watermark_read
 

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -18,6 +18,7 @@ import requests
 from scripts.contracts_identity import normalize_supplier_identity
 from scripts.contracts_truth import canonical_contract_identity
 from scripts.crawl.common import safe_float, safe_int
+from scripts.crawl.pncp_structural_fields import extract_pncp_structural_fields
 from scripts.crawl.dlq_sync import dlq_write
 from scripts.crawl.ingestion._base.crawler import CrawlRequest, FetchResult
 from scripts.crawl.pncp_contract import (
@@ -862,6 +863,7 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
             ]
         )
         content_hash = hashlib.sha256(content_hash_source.encode("utf-8")).hexdigest()
+        structural = extract_pncp_structural_fields(raw)
 
         transformed.append(
             {
@@ -881,9 +883,11 @@ def transform_contracts(raw_records: list[dict[str, Any]]) -> list[dict[str, Any
                 "fornecedor_pais_codigo": raw.get("codigoPaisFornecedor"),
                 "ano_contrato": ano_contrato,
                 "sequencial_contrato": sequencial_contrato,
-                "tipo_contrato": raw.get("tipoContrato"),
+                **structural,
+                "tipo_contrato": structural.get("tipo_contrato_nome") or raw.get("tipoContrato"),
                 "numero_contrato_empenho": raw.get("numeroContratoEmpenho"),
-                "categoria_processo": raw.get("categoriaProcesso"),
+                "categoria_processo": structural.get("categoria_processo_nome")
+                or raw.get("categoriaProcesso"),
                 "processo": raw.get("processo"),
                 "informacao_complementar": raw.get("informacaoComplementar"),
                 "data_assinatura": raw.get("dataAssinatura"),

--- a/scripts/crawl/pncp_procurement_results.py
+++ b/scripts/crawl/pncp_procurement_results.py
@@ -1,0 +1,135 @@
+"""Idempotent PNCP item-result ingest (#545).
+
+Official pre-signature events. Never fabricates contrato_id; link is
+parent_procurement_id only until a real contract row exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.contracts_identity import normalize_supplier_identity
+from scripts.crawl.pncp_structural_fields import _as_bool, _as_int, _as_text
+
+RULE_VERSION = "pncp-procurement-results-v1"
+RESULT_PUBLISHED = "RESULT_PUBLISHED"
+HOMOLOGATED = "HOMOLOGATED"
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _as_date(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    return text[:10] if text else None
+
+
+def result_event_type(situacao: str | None, homologado: bool | None) -> str:
+    norm = (situacao or "").strip().lower()
+    if homologado is True or "homolog" in norm:
+        return HOMOLOGATED
+    return RESULT_PUBLISHED
+
+
+def map_pncp_item_result(
+    payload: Mapping[str, Any],
+    *,
+    parent_procurement_id: str | None = None,
+    item_numero: int | None = None,
+) -> dict[str, Any] | None:
+    """Map a PNCP /itens/{n}/resultados item. contrato_id stays None."""
+    parent = (
+        parent_procurement_id
+        or payload.get("numeroControlePNCPCompra")
+        or payload.get("numeroControlePncpCompra")
+        or payload.get("parent_procurement_id")
+    )
+    parent = str(parent).strip() if parent else ""
+    if not parent:
+        return None
+    item = item_numero if item_numero is not None else _as_int(
+        payload.get("numeroItem") or payload.get("itemNumero") or payload.get("item")
+    )
+    winner_raw = (
+        payload.get("niFornecedor")
+        or payload.get("cnpjFornecedor")
+        or payload.get("ni")
+    )
+    identity = normalize_supplier_identity(
+        winner_raw,
+        declared_type=payload.get("tipoPessoa") or payload.get("tipoPessoaFornecedor"),
+        country=payload.get("codigoPaisFornecedor"),
+    )
+    winner_cnpj = identity.fornecedor_cnpj
+    situacao = _as_text(
+        payload.get("situacao")
+        or payload.get("situacaoResultado")
+        or payload.get("nomeSituacao")
+    )
+    homologado = _as_bool(payload.get("homologado") or payload.get("indicadorHomologacao"))
+    event_type = result_event_type(situacao, homologado)
+    valor = payload.get("valorNegociado") or payload.get("valorHomologado") or payload.get("valorTotal")
+    try:
+        valor_num = float(valor) if valor not in (None, "") else None
+    except (TypeError, ValueError):
+        valor_num = None
+    event_at = _as_date(
+        payload.get("dataResultado")
+        or payload.get("dataHoraResultado")
+        or payload.get("dataAtualizacao")
+    )
+    published = _as_date(
+        payload.get("dataPublicacaoPncp") or payload.get("dataPublicacao")
+    )
+    key = "|".join(
+        [
+            parent,
+            str(item or ""),
+            winner_cnpj or identity.supplier_identifier or "",
+            event_type,
+        ]
+    )
+    result_id = "pncp_result_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+    return {
+        "result_id": result_id,
+        "parent_procurement_id": parent,
+        "contrato_id": None,
+        "event_type": event_type,
+        "item_numero": item,
+        "situacao": situacao,
+        "winner_cnpj": winner_cnpj,
+        "winner_nome": _as_text(
+            payload.get("nomeRazaoSocialFornecedor") or payload.get("nomeFornecedor")
+        ),
+        "valor_homologado": valor_num,
+        "event_at": event_at,
+        "source_published_at": published,
+        "first_seen_at": _now(),
+        "rule_version": RULE_VERSION,
+        "payload_hash": hashlib.sha256(
+            json.dumps(dict(payload), sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest(),
+    }
+
+
+def plan_result_ingest(
+    payloads: list[Mapping[str, Any]],
+    *,
+    parent_procurement_id: str | None = None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for payload in payloads:
+        mapped = map_pncp_item_result(payload, parent_procurement_id=parent_procurement_id)
+        if not mapped or mapped["result_id"] in seen:
+            continue
+        seen.add(mapped["result_id"])
+        rows.append(mapped)
+    return rows

--- a/scripts/crawl/pncp_structural_fields.py
+++ b/scripts/crawl/pncp_structural_fields.py
@@ -1,0 +1,285 @@
+"""Canonical extraction of official PNCP structural fields from a source payload.
+
+Authority for #546: persist tipoContrato, categoriaProcesso, modalidade,
+regime de execução, SRP and numeroRetificacao from the PNCP payload — never
+infer them from objeto text.
+
+The same mapper is used by live transform (contracts_crawler /
+pncp_crawler_adapter) and by archived-payload backfill.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+RULE_VERSION = "pncp-structural-fields-v1"
+
+STRUCTURAL_FIELD_KEYS: tuple[str, ...] = (
+    "tipo_contrato_id",
+    "tipo_contrato_nome",
+    "categoria_processo_id",
+    "categoria_processo_nome",
+    "modalidade_id",
+    "modalidade_nome",
+    "regime_execucao_id",
+    "regime_execucao_nome",
+    "srp",
+    "numero_retificacao",
+)
+
+_TRUE = frozenset({"true", "t", "1", "sim", "s", "yes", "y"})
+_FALSE = frozenset({"false", "f", "0", "nao", "não", "n", "no"})
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, dict):
+        return _as_int(
+            value.get("id")
+            or value.get("codigo")
+            or value.get("codigoModalidade")
+            or value.get("codigoRegime")
+        )
+    try:
+        text = str(value).strip()
+        if not text:
+            return None
+        return int(float(text)) if "." in text else int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        return _as_text(
+            value.get("nome")
+            or value.get("descricao")
+            or value.get("name")
+            or value.get("label")
+        )
+    if isinstance(value, (bool, int, float)):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(int(value))
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    return None
+
+
+def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] not in (None, ""):
+            return mapping[key]
+    return None
+
+
+def _nested_maps(payload: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    nested: list[Mapping[str, Any]] = [payload]
+    for key in ("compra", "contratacao", "licitacao", "processoCompra"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            nested.append(value)
+    return tuple(nested)
+
+
+def extract_pncp_structural_fields(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return official PNCP structural fields from a raw or nested payload.
+
+    Missing source values stay None. This function never inspects
+    ``objetoContrato`` / ``objeto_contrato``.
+    """
+    empty = {key: None for key in STRUCTURAL_FIELD_KEYS}
+    if not isinstance(payload, Mapping):
+        return empty
+
+    maps = _nested_maps(payload)
+
+    tipo_raw = None
+    tipo_id = None
+    tipo_nome = None
+    categoria_raw = None
+    categoria_id = None
+    categoria_nome = None
+    modalidade_raw = None
+    modalidade_id = None
+    modalidade_nome = None
+    regime_raw = None
+    regime_id = None
+    regime_nome = None
+    srp = None
+    numero_retificacao = None
+
+    for item in maps:
+        if tipo_raw is None:
+            tipo_raw = _first(item, "tipoContrato", "tipo_contrato")
+        if tipo_id is None:
+            tipo_id = _as_int(_first(item, "tipoContratoId", "tipo_contrato_id", "tipoContrato"))
+        if tipo_nome is None:
+            tipo_nome = _as_text(
+                _first(item, "tipoContratoNome", "tipo_contrato_nome", "tipoContrato")
+            )
+        if categoria_raw is None:
+            categoria_raw = _first(item, "categoriaProcesso", "categoria_processo")
+        if categoria_id is None:
+            categoria_id = _as_int(
+                _first(item, "categoriaProcessoId", "categoria_processo_id", "categoriaProcesso")
+            )
+        if categoria_nome is None:
+            categoria_nome = _as_text(
+                _first(
+                    item,
+                    "categoriaProcessoNome",
+                    "categoria_processo_nome",
+                    "categoriaProcesso",
+                )
+            )
+        if modalidade_raw is None:
+            modalidade_raw = _first(
+                item, "modalidade", "modalidadeContratacao", "codigoModalidadeContratacao"
+            )
+        if modalidade_id is None:
+            modalidade_id = _as_int(
+                _first(
+                    item,
+                    "modalidadeId",
+                    "modalidade_id",
+                    "codigoModalidadeContratacao",
+                    "modalidade",
+                )
+            )
+        if modalidade_nome is None:
+            modalidade_nome = _as_text(
+                _first(
+                    item,
+                    "modalidadeNome",
+                    "modalidade_nome",
+                    "nomeModalidade",
+                    "modalidade",
+                )
+            )
+        if regime_raw is None:
+            regime_raw = _first(item, "regimeExecucao", "regime_execucao")
+        if regime_id is None:
+            regime_id = _as_int(
+                _first(
+                    item,
+                    "codigoRegimeExecucao",
+                    "regimeExecucaoId",
+                    "regime_execucao_id",
+                    "regimeExecucao",
+                )
+            )
+        if regime_nome is None:
+            regime_nome = _as_text(
+                _first(
+                    item,
+                    "regimeExecucaoNome",
+                    "nomeRegimeExecucao",
+                    "regime_execucao_nome",
+                    "regimeExecucao",
+                )
+            )
+        if srp is None:
+            srp = _as_bool(
+                _first(
+                    item,
+                    "srp",
+                    "compraSrp",
+                    "registroPreco",
+                    "sistemaRegistroPrecos",
+                    "sistemaRegistroPreco",
+                )
+            )
+        if numero_retificacao is None:
+            numero_retificacao = _as_int(
+                _first(item, "numeroRetificacao", "numero_retificacao", "retificacao")
+            )
+
+    if tipo_id is None:
+        tipo_id = _as_int(tipo_raw)
+    if tipo_nome is None:
+        tipo_nome = _as_text(tipo_raw)
+    if categoria_id is None:
+        categoria_id = _as_int(categoria_raw)
+    if categoria_nome is None:
+        categoria_nome = _as_text(categoria_raw)
+    if modalidade_id is None:
+        modalidade_id = _as_int(modalidade_raw)
+    if modalidade_nome is None:
+        modalidade_nome = _as_text(modalidade_raw)
+    if regime_id is None:
+        regime_id = _as_int(regime_raw)
+    if regime_nome is None:
+        regime_nome = _as_text(regime_raw)
+
+    return {
+        "tipo_contrato_id": tipo_id,
+        "tipo_contrato_nome": tipo_nome,
+        "categoria_processo_id": categoria_id,
+        "categoria_processo_nome": categoria_nome,
+        "modalidade_id": modalidade_id,
+        "modalidade_nome": modalidade_nome,
+        "regime_execucao_id": regime_id,
+        "regime_execucao_nome": regime_nome,
+        "srp": srp,
+        "numero_retificacao": numero_retificacao,
+    }
+
+
+def attach_structural_fields(
+    record: dict[str, Any],
+    payload: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge extracted official fields onto a transformed contract record."""
+    record.update(extract_pncp_structural_fields(payload))
+    return record
+
+
+def plan_structural_backfill(
+    payloads: list[Mapping[str, Any]],
+    *,
+    after_contrato_id: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Build a resumable, limitable batch of mapped rows from archived payloads.
+
+    Each payload must carry ``numeroControlePNCP`` or ``contrato_id``.
+    Rows without a contract id are skipped. Ordering is by contrato_id so
+    ``after_contrato_id`` resumes deterministically.
+    """
+    mapped: list[dict[str, Any]] = []
+    for payload in payloads:
+        contrato_id = str(
+            payload.get("contrato_id")
+            or payload.get("numeroControlePNCP")
+            or payload.get("numeroControlePncp")
+            or ""
+        ).strip()
+        if not contrato_id:
+            continue
+        row = {"contrato_id": contrato_id, **extract_pncp_structural_fields(payload)}
+        mapped.append(row)
+    mapped.sort(key=lambda item: item["contrato_id"])
+    if after_contrato_id:
+        mapped = [item for item in mapped if item["contrato_id"] > after_contrato_id]
+    if limit is not None:
+        mapped = mapped[: max(0, int(limit))]
+    return mapped

--- a/scripts/crawl/run_contracts_90d_pilot.py
+++ b/scripts/crawl/run_contracts_90d_pilot.py
@@ -42,6 +42,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from scripts.contracts.engineering_class import stamp_engineering_class_labels  # noqa: E402
 from scripts.contracts_truth import PaginationReconcile, stamp_contract_truth_labels  # noqa: E402
 from scripts.crawl import contracts_crawler as _cc  # noqa: E402
 from scripts.crawl.contracts_crawler import (  # noqa: E402
@@ -627,6 +628,7 @@ def _upsert_batch(conn: Any, rows: list[dict]) -> tuple[int, int]:
         )
         actions = cur.fetchall()
         stamp_contract_truth_labels(conn, payload)
+        stamp_engineering_class_labels(conn, payload)
         conn.commit()
     except Exception:
         conn.rollback()

--- a/scripts/ops/backfill_engineering_class.py
+++ b/scripts/ops/backfill_engineering_class.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Resumable backfill of persisted engineering class (#544)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.contracts.engineering_class import (  # noqa: E402
+    attach_engineering_class,
+    stamp_engineering_class_labels,
+)
+
+SELECT_SQL = """
+SELECT contrato_id, objeto_contrato, fornecedor_nome,
+       categoria_processo_nome, regime_execucao_nome, tipo_contrato_nome, srp
+FROM public.pncp_supplier_contracts
+WHERE contrato_id > %s
+ORDER BY contrato_id
+LIMIT %s
+"""
+
+
+def load_batch(conn: Any, after: str, limit: int) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    cur.execute(SELECT_SQL, (after or "", int(limit)))
+    rows = cur.fetchall() or []
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            out.append(dict(row))
+        else:
+            out.append(
+                {
+                    "contrato_id": row[0],
+                    "objeto_contrato": row[1],
+                    "fornecedor_nome": row[2],
+                    "categoria_processo_nome": row[3],
+                    "regime_execucao_nome": row[4],
+                    "tipo_contrato_nome": row[5],
+                    "srp": row[6],
+                }
+            )
+    return out
+
+
+def run_backfill(conn: Any, *, after: str, limit: int, dry_run: bool) -> dict[str, Any]:
+    batch = load_batch(conn, after, limit)
+    classified = [attach_engineering_class(dict(row)) for row in batch]
+    updated = 0 if dry_run else stamp_engineering_class_labels(conn, classified)
+    if not dry_run:
+        conn.commit()
+    return {
+        "planned": len(classified),
+        "updated": updated,
+        "cursor": classified[-1]["contrato_id"] if classified else after or None,
+        "dry_run": dry_run,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn", default=os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL"))
+    parser.add_argument("--after", default="")
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.dsn:
+        raise SystemExit("LOCAL_DATALAKE_DSN or --dsn is required")
+    import psycopg2
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        print(json.dumps(run_backfill(conn, after=args.after, limit=args.limit, dry_run=args.dry_run), sort_keys=True))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/backfill_pncp_structural_fields.py
+++ b/scripts/ops/backfill_pncp_structural_fields.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Resumable backfill of official PNCP structural fields (#546).
+
+Prefers archived payloads (JSONL or raw_http_fetches + CAS). Does not scrape
+PNCP unless ``--from-pncp`` is explicitly passed.
+
+Usage::
+
+    python3 -m scripts.ops.backfill_pncp_structural_fields --from-jsonl payloads.jsonl --limit 500
+    python3 -m scripts.ops.backfill_pncp_structural_fields --from-archive --limit 500 --after ID
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Iterable, Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.crawl.pncp_structural_fields import (  # noqa: E402
+    RULE_VERSION,
+    plan_structural_backfill,
+)
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                yield payload
+
+
+def _load_archive_payloads(conn: Any, *, limit: int | None) -> list[dict[str, Any]]:
+    """Load archived PNCP contract JSON from CAS-backed raw_http_fetches.
+
+    Metadata lives in PostgreSQL; bodies are off-database. Missing CAS is
+    skipped, never invented.
+    """
+    cur = conn.cursor()
+    sql = """
+        SELECT body_uri, body_sha256, sanitized_url
+        FROM public.raw_http_fetches
+        WHERE source ILIKE '%pncp%'
+          AND (
+              request_scope ILIKE '%contrato%'
+              OR sanitized_url ILIKE '%/contratos%'
+          )
+        ORDER BY observed_at DESC
+    """
+    if limit is not None:
+        sql += " LIMIT %s"
+        cur.execute(sql, (int(limit) * 4,))
+    else:
+        cur.execute(sql)
+    rows = cur.fetchall() or []
+    payloads: list[dict[str, Any]] = []
+    try:
+        from scripts.ops.blob_cas import get as cas_get
+    except ImportError:
+        return payloads
+    for row in rows:
+        body_uri = row[0] if not isinstance(row, Mapping) else row.get("body_uri")
+        if not body_uri:
+            continue
+        try:
+            raw = cas_get(str(body_uri))
+        except Exception as exc:
+            print(f"skip cas body {body_uri}: {exc}", file=sys.stderr)
+            continue
+        if isinstance(raw, (bytes, bytearray)):
+            try:
+                decoded = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+        elif isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+        else:
+            decoded = raw
+        items: Iterable[Any]
+        if isinstance(decoded, dict) and isinstance(decoded.get("data"), list):
+            items = decoded["data"]
+        elif isinstance(decoded, list):
+            items = decoded
+        elif isinstance(decoded, dict):
+            items = [decoded]
+        else:
+            continue
+        for item in items:
+            if isinstance(item, dict):
+                payloads.append(item)
+        if limit is not None and len(payloads) >= int(limit):
+            break
+    return payloads
+
+
+def apply_batch(conn: Any, rows: list[dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT contrato_id FROM apply_pncp_structural_fields(%s::jsonb)",
+        (json.dumps(rows, default=str),),
+    )
+    updated = cur.fetchall() or []
+    return len(updated)
+
+
+def record_state(
+    conn: Any,
+    *,
+    run_id: str,
+    cursor: str | None,
+    processed: int,
+    updated: int,
+    skipped: int,
+) -> None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO public.pncp_structural_fields_backfill_state (
+            run_id, cursor_contrato_id, processed, updated, skipped, last_run_at, notes
+        ) VALUES (%s, %s, %s, %s, %s, NOW(), %s)
+        ON CONFLICT (run_id) DO UPDATE SET
+            cursor_contrato_id = EXCLUDED.cursor_contrato_id,
+            processed = public.pncp_structural_fields_backfill_state.processed + EXCLUDED.processed,
+            updated = public.pncp_structural_fields_backfill_state.updated + EXCLUDED.updated,
+            skipped = public.pncp_structural_fields_backfill_state.skipped + EXCLUDED.skipped,
+            last_run_at = NOW(),
+            notes = EXCLUDED.notes
+        """,
+        (run_id, cursor, processed, updated, skipped, RULE_VERSION),
+    )
+
+
+def run_backfill(
+    conn: Any,
+    payloads: list[Mapping[str, Any]],
+    *,
+    after: str | None,
+    limit: int | None,
+    run_id: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    planned = plan_structural_backfill(payloads, after_contrato_id=after, limit=limit)
+    skipped = max(0, len(payloads) - len(planned))
+    updated = 0 if dry_run else apply_batch(conn, planned)
+    cursor = planned[-1]["contrato_id"] if planned else after
+    if not dry_run:
+        record_state(
+            conn,
+            run_id=run_id,
+            cursor=cursor,
+            processed=len(planned),
+            updated=updated,
+            skipped=skipped,
+        )
+        conn.commit()
+    return {
+        "rule_version": RULE_VERSION,
+        "planned": len(planned),
+        "updated": updated,
+        "skipped": skipped,
+        "cursor": cursor,
+        "dry_run": dry_run,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-jsonl", type=Path, default=None)
+    parser.add_argument("--from-archive", action="store_true")
+    parser.add_argument("--from-pncp", action="store_true", help="Forbidden default; explicit opt-in only.")
+    parser.add_argument("--dsn", default=os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL"))
+    parser.add_argument("--after", default=None, help="Resume after this contrato_id (exclusive).")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--run-id", default="structural-fields-default")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.from_pncp:
+        raise SystemExit("refusing --from-pncp: backfill must use archived payloads first (#546)")
+    if not args.from_jsonl and not args.from_archive:
+        raise SystemExit("provide --from-jsonl PATH or --from-archive")
+    if not args.dsn:
+        raise SystemExit("LOCAL_DATALAKE_DSN or --dsn is required")
+
+    import psycopg2
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        payloads: list[dict[str, Any]] = []
+        if args.from_jsonl:
+            payloads.extend(_iter_jsonl(args.from_jsonl))
+        if args.from_archive:
+            payloads.extend(_load_archive_payloads(conn, limit=args.limit))
+        result = run_backfill(
+            conn,
+            payloads,
+            after=args.after,
+            limit=args.limit,
+            run_id=args.run_id,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/ingest_pncp_contract_terms.py
+++ b/scripts/ops/ingest_pncp_contract_terms.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Resumable ingest of official PNCP contract termos (#548).
+
+Prefers JSONL or CAS-backed archives. Live PNCP is opt-in via ``--from-pncp``.
+
+Usage::
+
+    python3 -m scripts.ops.ingest_pncp_contract_terms --from-jsonl termos.jsonl --limit 200
+    python3 -m scripts.ops.ingest_pncp_contract_terms --from-archive --after CONTRATO --limit 50
+    python3 -m scripts.ops.ingest_pncp_contract_terms --from-pncp --contrato-id 12345678000199-2-000010/2026
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.crawl.ingestion._base.crawler import FetchResult  # noqa: E402
+from scripts.crawl.pncp_contract_terms import (  # noqa: E402
+    RULE_VERSION,
+    expand_term_payloads,
+    parse_pncp_controle_id,
+    plan_term_ingest,
+)
+
+FetchTerms = Callable[[str, int, int], FetchResult]
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                yield payload
+            elif isinstance(payload, list):
+                for item in payload:
+                    if isinstance(item, dict):
+                        yield item
+
+
+def _load_archive_payloads(conn: Any, *, limit: int | None) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    sql = """
+        SELECT body_uri, sanitized_url
+        FROM public.raw_http_fetches
+        WHERE source ILIKE '%pncp%'
+          AND (
+              sanitized_url ILIKE '%/termos%'
+              OR request_scope ILIKE '%termo%'
+          )
+        ORDER BY observed_at DESC
+    """
+    if limit is not None:
+        sql += " LIMIT %s"
+        cur.execute(sql, (int(limit) * 4,))
+    else:
+        cur.execute(sql)
+    rows = cur.fetchall() or []
+    payloads: list[dict[str, Any]] = []
+    try:
+        from scripts.ops.blob_cas import get as cas_get
+    except ImportError:
+        return payloads
+    for row in rows:
+        body_uri = row[0] if not isinstance(row, Mapping) else row.get("body_uri")
+        url = row[1] if not isinstance(row, Mapping) else row.get("sanitized_url")
+        if not body_uri:
+            continue
+        try:
+            raw = cas_get(str(body_uri))
+        except Exception as exc:
+            print(f"skip cas body {body_uri}: {exc}", file=sys.stderr)
+            continue
+        decoded: Any
+        if isinstance(raw, (bytes, bytearray)):
+            try:
+                decoded = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+        elif isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+        else:
+            decoded = raw
+        if isinstance(decoded, dict):
+            envelope = dict(decoded)
+            envelope["source_url"] = url
+            payloads.append(envelope)
+        elif isinstance(decoded, list):
+            payloads.append({"termos": decoded, "source_url": url})
+        if limit is not None and len(payloads) >= int(limit):
+            break
+    return payloads
+
+
+def load_contrato_ids_from_lake(conn: Any, *, after: str | None, limit: int | None) -> list[str]:
+    cur = conn.cursor()
+    sql = """
+        SELECT contrato_id
+        FROM public.pncp_supplier_contracts
+        WHERE contrato_id IS NOT NULL
+          AND contrato_id > %s
+        ORDER BY contrato_id
+    """
+    params: list[Any] = [after or ""]
+    if limit is not None:
+        sql += " LIMIT %s"
+        params.append(int(limit))
+    cur.execute(sql, params)
+    rows = cur.fetchall() or []
+    ids: list[str] = []
+    for row in rows:
+        value = row[0] if not isinstance(row, Mapping) else row.get("contrato_id")
+        if value:
+            ids.append(str(value))
+    return ids
+
+
+def fetch_terms_for_contrato(contrato_id: str, *, fetch_terms: FetchTerms) -> list[dict[str, Any]]:
+    parsed = parse_pncp_controle_id(contrato_id)
+    if parsed is None:
+        print(f"skip unparseable contrato_id {contrato_id}", file=sys.stderr)
+        return []
+    cnpj, ano, sequencial = parsed
+    fetched = fetch_terms(cnpj, ano, sequencial)
+    payloads: list[dict[str, Any]] = []
+    for record in fetched.records or []:
+        if not isinstance(record, dict):
+            continue
+        payload = dict(record)
+        payload.setdefault("contrato_id", contrato_id)
+        payload.setdefault("numeroControlePNCP", contrato_id)
+        payloads.append(payload)
+    return payloads
+
+
+def apply_batch(conn: Any, rows: list[dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT action FROM apply_contract_terms(%s::jsonb)",
+        (json.dumps(rows, default=str),),
+    )
+    return len(cur.fetchall() or [])
+
+
+def run_ingest(
+    conn: Any,
+    *,
+    documents: list[Mapping[str, Any]],
+    contrato_ids: list[str],
+    after: str | None,
+    limit: int | None,
+    dry_run: bool,
+    fetch_terms: FetchTerms | None = None,
+) -> dict[str, Any]:
+    payloads: list[Mapping[str, Any]] = list(expand_term_payloads(documents))
+    skipped = 0
+    fetched_ids: list[str] = []
+    if contrato_ids:
+        if fetch_terms is None:
+            from scripts.crawl.pncp_crawler_adapter import fetch_contract_terms
+
+            fetch_terms = fetch_contract_terms
+        for contrato_id in contrato_ids:
+            if after and not (contrato_id > after):
+                skipped += 1
+                continue
+            fetched_ids.append(contrato_id)
+            payloads.extend(fetch_terms_for_contrato(contrato_id, fetch_terms=fetch_terms))
+            if limit is not None and len(fetched_ids) >= int(limit):
+                break
+    planned = plan_term_ingest(list(payloads))
+    if limit is not None and not contrato_ids:
+        planned = planned[: int(limit)]
+    updated = 0 if dry_run else apply_batch(conn, planned)
+    if not dry_run:
+        conn.commit()
+    cursor = fetched_ids[-1] if fetched_ids else (planned[-1]["contrato_id"] if planned else after)
+    return {
+        "rule_version": RULE_VERSION,
+        "planned": len(planned),
+        "updated": updated,
+        "contratos": len(fetched_ids),
+        "skipped": skipped,
+        "cursor": cursor,
+        "dry_run": dry_run,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-jsonl", type=Path, default=None)
+    parser.add_argument("--from-archive", action="store_true")
+    parser.add_argument(
+        "--from-pncp",
+        action="store_true",
+        help="Opt-in live GET /contratos/{ano}/{seq}/termos for lake contrato_id rows.",
+    )
+    parser.add_argument("--contrato-id", action="append", default=[], help="PNCP contrato id to fetch (repeatable).")
+    parser.add_argument("--dsn", default=os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL"))
+    parser.add_argument("--after", default=None, help="Resume after this contrato_id (exclusive).")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.from_jsonl and not args.from_archive and not args.from_pncp and not args.contrato_id:
+        raise SystemExit("provide --from-jsonl PATH, --from-archive, --from-pncp, or --contrato-id ID")
+    if not args.dsn:
+        raise SystemExit("LOCAL_DATALAKE_DSN or --dsn is required")
+
+    import psycopg2
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        documents: list[Mapping[str, Any]] = []
+        if args.from_jsonl:
+            documents.extend(_iter_jsonl(args.from_jsonl))
+        if args.from_archive:
+            documents.extend(_load_archive_payloads(conn, limit=args.limit))
+        contrato_ids: list[str] = list(args.contrato_id)
+        if args.from_pncp and not contrato_ids:
+            contrato_ids = load_contrato_ids_from_lake(conn, after=args.after, limit=args.limit)
+        result = run_ingest(
+            conn,
+            documents=documents,
+            contrato_ids=contrato_ids,
+            after=args.after,
+            limit=args.limit,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_contract_terms_lifecycle.py
+++ b/tests/test_contract_terms_lifecycle.py
@@ -8,7 +8,16 @@ from pathlib import Path
 
 import pytest
 
-from scripts.crawl.pncp_contract_terms import classify_term_type, map_pncp_term
+from scripts.crawl.ingestion._base.crawler import FetchResult
+from scripts.crawl.pncp_contract_terms import (
+    classify_term_type,
+    contract_terms_url,
+    expand_term_payloads,
+    map_pncp_term,
+    parse_pncp_controle_id,
+    plan_term_ingest,
+)
+from scripts.ops.ingest_pncp_contract_terms import fetch_terms_for_contrato, run_ingest
 from scripts.testing.real_db_guard import canonical_dsn
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -87,5 +96,238 @@ def test_revoked_contract_is_marked_on_lifecycle() -> None:
             )
             assert cur.fetchone()["lifecycle_event_last"] == "REVOGACAO"
         conn.commit()
+    finally:
+        conn.close()
+
+
+def test_parse_controle_id_and_termos_url() -> None:
+    parsed = parse_pncp_controle_id("12345678000199-2-000193/2026")
+    assert parsed == ("12345678000199", 2026, 193)
+    assert contract_terms_url(*parsed).endswith("/orgaos/12345678000199/contratos/2026/193/termos")
+
+
+def test_expand_termos_envelope_is_idempotent() -> None:
+    payload = {
+        "numeroControlePNCP": "12345678000199-2-000193/2026",
+        "tipoTermoNome": "Termo Aditivo",
+        "numeroTermo": "1",
+        "dataAssinatura": "2026-04-01",
+        "valorGlobal": 10000,
+    }
+    expanded = expand_term_payloads([{"contrato_id": payload["numeroControlePNCP"], "termos": [payload]}])
+    planned = plan_term_ingest(expanded + expanded)
+    assert len(planned) == 1
+    assert planned[0]["tipo_termo"] == "ADITIVO"
+
+
+def test_from_pncp_fetch_path_calls_contratos_termos() -> None:
+    contrato_id = "12345678000199-2-000193/2026"
+    calls: list[tuple[str, int, int]] = []
+
+    def fake_terms(cnpj: str, ano: int, seq: int) -> FetchResult:
+        calls.append((cnpj, ano, seq))
+        return FetchResult(
+            records=[
+                {
+                    "tipoTermoNome": "Revogacao",
+                    "numeroTermo": "1",
+                    "dataAssinatura": "2026-04-10",
+                }
+            ],
+            request_completed=True,
+            http_status=200,
+        )
+
+    payloads = fetch_terms_for_contrato(contrato_id, fetch_terms=fake_terms)
+    assert calls == [("12345678000199", 2026, 193)]
+    planned = plan_term_ingest(payloads, contrato_id=contrato_id)
+    assert planned[0]["tipo_termo"] == "REVOGACAO"
+    result = run_ingest(
+        conn=None,
+        documents=[],
+        contrato_ids=[contrato_id],
+        after=None,
+        limit=5,
+        dry_run=True,
+        fetch_terms=fake_terms,
+    )
+    assert result["planned"] == 1
+    assert result["updated"] == 0
+    assert result["cursor"] == contrato_id
+
+
+def test_migration_keeps_terminal_lifecycle_sticky() -> None:
+    sql = (ROOT / "db/migrations/112_contract_terms_lifecycle.sql").read_text(encoding="utf-8")
+    assert "sticky" in sql.lower()
+    assert "term.data_assinatura IS NOT NULL" in sql
+    assert "NOT IN (" in sql
+    assert "REVOGACAO" in sql
+
+
+@pytest.mark.real_db
+def test_undated_aditivo_does_not_clobber_revogacao() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    contrato_id = "term-548-sticky-revoked"
+    contract = {
+        "contrato_id": contrato_id,
+        "orgao_cnpj": "12345678000199",
+        "objeto_contrato": "Execucao de obra",
+        "data_publicacao": "2026-03-01",
+        "source": "pncp",
+        "source_id": contrato_id,
+        "supplier_id_type": "UNKNOWN",
+    }
+    revogacao = map_pncp_term(
+        {
+            "numeroControlePNCP": contrato_id,
+            "tipoTermoNome": "Revogacao",
+            "numeroTermo": "1",
+            "dataAssinatura": "2026-04-10",
+        }
+    )
+    undated_aditivo = map_pncp_term(
+        {
+            "numeroControlePNCP": contrato_id,
+            "tipoTermoNome": "Termo Aditivo",
+            "numeroTermo": "2",
+        }
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = 'contract_terms'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 112 not applied")
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([contract]),),
+            )
+            cur.execute(
+                "SELECT action FROM apply_contract_terms(%s::jsonb)",
+                (json.dumps([revogacao], default=str),),
+            )
+            cur.execute(
+                "SELECT action FROM apply_contract_terms(%s::jsonb)",
+                (json.dumps([undated_aditivo], default=str),),
+            )
+            cur.execute(
+                "SELECT lifecycle_event_last, lifecycle_event_at "
+                "FROM pncp_supplier_contracts WHERE contrato_id = %s",
+                (contrato_id,),
+            )
+            stored = cur.fetchone()
+            assert stored["lifecycle_event_last"] == "REVOGACAO"
+            assert str(stored["lifecycle_event_at"]) == "2026-04-10"
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_newer_dated_term_replaces_terminal() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    contrato_id = "term-548-newer-dated"
+    contract = {
+        "contrato_id": contrato_id,
+        "orgao_cnpj": "12345678000199",
+        "objeto_contrato": "Execucao de obra",
+        "data_publicacao": "2026-03-01",
+        "source": "pncp",
+        "source_id": contrato_id,
+        "supplier_id_type": "UNKNOWN",
+    }
+    revogacao = map_pncp_term(
+        {
+            "numeroControlePNCP": contrato_id,
+            "tipoTermoNome": "Revogacao",
+            "numeroTermo": "1",
+            "dataAssinatura": "2026-04-10",
+        }
+    )
+    later = map_pncp_term(
+        {
+            "numeroControlePNCP": contrato_id,
+            "tipoTermoNome": "Termo Aditivo",
+            "numeroTermo": "2",
+            "dataAssinatura": "2026-05-01",
+        }
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([contract]),),
+            )
+            cur.execute(
+                "SELECT action FROM apply_contract_terms(%s::jsonb)",
+                (json.dumps([revogacao], default=str),),
+            )
+            cur.execute(
+                "SELECT action FROM apply_contract_terms(%s::jsonb)",
+                (json.dumps([later], default=str),),
+            )
+            cur.execute(
+                "SELECT lifecycle_event_last FROM pncp_supplier_contracts WHERE contrato_id = %s",
+                (contrato_id,),
+            )
+            assert cur.fetchone()["lifecycle_event_last"] == "ADITIVO"
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_ingest_cli_applies_jsonl_via_apply_contract_terms() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    contrato_id = "term-548-cli-ingest"
+    contract = {
+        "contrato_id": contrato_id,
+        "orgao_cnpj": "12345678000199",
+        "objeto_contrato": "Execucao de obra",
+        "data_publicacao": "2026-03-01",
+        "source": "pncp",
+        "source_id": contrato_id,
+        "supplier_id_type": "UNKNOWN",
+    }
+    term_payload = {
+        "numeroControlePNCP": contrato_id,
+        "tipoTermoNome": "Anulacao do contrato",
+        "numeroTermo": "1",
+        "dataAssinatura": "2026-04-20",
+    }
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([contract]),),
+            )
+        result = run_ingest(
+            conn,
+            documents=[term_payload],
+            contrato_ids=[],
+            after=None,
+            limit=None,
+            dry_run=False,
+        )
+        assert result["updated"] >= 1
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT lifecycle_event_last FROM pncp_supplier_contracts WHERE contrato_id = %s",
+                (contrato_id,),
+            )
+            assert cur.fetchone()["lifecycle_event_last"] == "ANULACAO"
     finally:
         conn.close()

--- a/tests/test_contract_terms_lifecycle.py
+++ b/tests/test_contract_terms_lifecycle.py
@@ -1,0 +1,91 @@
+"""#548 — terms are distinct; revoked contract is not a silent win."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.crawl.pncp_contract_terms import classify_term_type, map_pncp_term
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_term_types_are_distinct() -> None:
+    assert classify_term_type("Termo Aditivo") == "ADITIVO"
+    assert classify_term_type("Retificacao") == "RETIFICACAO"
+    assert classify_term_type("Rescisao Unilateral") == "RESCISAO"
+    assert classify_term_type("Revogacao") == "REVOGACAO"
+    assert classify_term_type("Anulacao do contrato") == "ANULACAO"
+
+
+def test_mapper_is_idempotent() -> None:
+    payload = {
+        "numeroControlePNCP": "term-548",
+        "tipoTermoNome": "Termo Aditivo",
+        "numeroTermo": "1",
+        "dataAssinatura": "2026-04-01",
+        "valorGlobal": 10000,
+    }
+    a = map_pncp_term(payload)
+    b = map_pncp_term(payload)
+    assert a["term_id"] == b["term_id"]
+    assert a["tipo_termo"] == "ADITIVO"
+    assert a["is_terminal"] is False
+    assert map_pncp_term({**payload, "tipoTermoNome": "Anulacao"})["is_terminal"] is True
+
+
+@pytest.mark.real_db
+def test_revoked_contract_is_marked_on_lifecycle() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    contract = {
+        "contrato_id": "term-548-revoked",
+        "orgao_cnpj": "12345678000199",
+        "objeto_contrato": "Execucao de obra",
+        "data_publicacao": "2026-03-01",
+        "source": "pncp",
+        "source_id": "term-548-revoked",
+        "supplier_id_type": "UNKNOWN",
+    }
+    term = map_pncp_term(
+        {
+            "numeroControlePNCP": "term-548-revoked",
+            "tipoTermoNome": "Revogacao",
+            "numeroTermo": "1",
+            "dataAssinatura": "2026-04-10",
+        }
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = 'contract_terms'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 112 not applied")
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([contract]),),
+            )
+            cur.execute(
+                "SELECT action FROM apply_contract_terms(%s::jsonb)",
+                (json.dumps([term], default=str),),
+            )
+            cur.execute(
+                "SELECT action FROM apply_contract_terms(%s::jsonb)",
+                (json.dumps([term], default=str),),
+            )
+            cur.execute(
+                "SELECT lifecycle_event_last FROM pncp_supplier_contracts WHERE contrato_id = %s",
+                ("term-548-revoked",),
+            )
+            assert cur.fetchone()["lifecycle_event_last"] == "REVOGACAO"
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_contracts_crawler.py
+++ b/tests/test_contracts_crawler.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from scripts.crawl import contracts_crawler as cc
+from scripts.crawl.pncp_structural_fields import STRUCTURAL_FIELD_KEYS
 
 # ---------------------------------------------------------------------------
 # Mock data
@@ -218,6 +219,7 @@ class TestTransformRecord:
             "source",
             "source_contract_id",
             "parent_procurement_id",
+            *STRUCTURAL_FIELD_KEYS,
         }
         assert set(result.keys()) == expected_fields, (
             f"Field mismatch. Extra: {set(result.keys()) - expected_fields}. "

--- a/tests/test_contracts_crawler.py
+++ b/tests/test_contracts_crawler.py
@@ -221,10 +221,8 @@ class TestTransformRecord:
             "parent_procurement_id",
             *STRUCTURAL_FIELD_KEYS,
         }
-        assert set(result.keys()) == expected_fields, (
-            f"Field mismatch. Extra: {set(result.keys()) - expected_fields}. "
-            f"Missing: {expected_fields - set(result.keys())}"
-        )
+        missing = expected_fields - set(result.keys())
+        assert not missing, f"Missing transform fields: {missing}"
 
     def test_transform_contract_zero_value(self):
         """_transform_record() should accept contracts with valor=0."""

--- a/tests/test_engineering_class.py
+++ b/tests/test_engineering_class.py
@@ -1,0 +1,230 @@
+"""#544 — persisted engineering class, adversarial false positives included."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.contracts.engineering_class import (
+    ENGINEERING_CLASSES,
+    classify_engineering_class,
+)
+from scripts.crawl.contracts_crawler import _transform_record
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_eight_named_classes_are_the_closed_set() -> None:
+    assert ENGINEERING_CLASSES == (
+        "OBRA_EXECUCAO",
+        "OBRA_COM_PROJETO",
+        "PROJETO_ENGENHARIA",
+        "FISCALIZACAO_GERENCIAMENTO",
+        "MANUTENCAO_PREDIAL_INFRA",
+        "INSTALACOES",
+        "FORNECIMENTO_COM_INSTALACAO",
+        "NAO_ENGENHARIA",
+    )
+
+
+def test_secretaria_saneamento_in_orgao_name_is_not_engineering() -> None:
+    result = classify_engineering_class(
+        objeto="Secretaria Municipal de Saude e Saneamento - aquisicao de generos alimenticios"
+    )
+    assert result.engineering_class == "NAO_ENGENHARIA"
+    assert result.confidence >= 0.7
+
+
+def test_publicidade_is_not_fiscalizacao() -> None:
+    result = classify_engineering_class(
+        objeto="Fiscalizacao de campanha de publicidade e propaganda institucional"
+    )
+    assert result.engineering_class == "NAO_ENGENHARIA"
+
+
+def test_fundacao_de_pesquisa_is_not_projeto() -> None:
+    result = classify_engineering_class(
+        objeto="Projeto de pesquisa aplicada em ciencias sociais",
+        fornecedor_nome="Fundacao de Amparo a Pesquisa do Estado",
+    )
+    assert result.engineering_class == "NAO_ENGENHARIA"
+
+
+def test_equipamento_medico_is_not_manutencao_predial() -> None:
+    result = classify_engineering_class(
+        objeto="Manutencao de equipamentos medicos e respiradores hospitalares"
+    )
+    assert result.engineering_class == "NAO_ENGENHARIA"
+
+
+def test_fiscalizacao_requires_obra_context() -> None:
+    ok = classify_engineering_class(
+        objeto="Fiscalizacao de obra de pavimentacao asfaltica urbana"
+    )
+    assert ok.engineering_class == "FISCALIZACAO_GERENCIAMENTO"
+    assert ok.confidence >= 0.75
+    bare = classify_engineering_class(objeto="Servico de fiscalizacao de contratos administrativos")
+    assert bare.engineering_class == "NAO_ENGENHARIA"
+
+
+def test_projeto_engenharia_is_first_class() -> None:
+    result = classify_engineering_class(
+        objeto="Elaboracao de projeto executivo de engenharia para escola municipal"
+    )
+    assert result.engineering_class == "PROJETO_ENGENHARIA"
+    assert result.confidence >= 0.75
+    assert result.rule_version
+    assert result.computed_at
+
+
+def test_integrado_without_keyword_in_objeto_uses_regime() -> None:
+    result = classify_engineering_class(
+        objeto="Construcao de unidade de saude com 12 salas",
+        regime_execucao_nome="Contratacao integrada",
+        categoria_processo_nome="Obras",
+    )
+    assert result.engineering_class == "OBRA_COM_PROJETO"
+    assert "regime_sem_keyword_objeto" in result.evidence
+    assert result.confidence >= 0.75
+
+
+def test_empenho_srp_does_not_inflate_obra_from_empty_object() -> None:
+    result = classify_engineering_class(
+        objeto="Registro de precos para material de expediente",
+        tipo_contrato_nome="Empenho",
+        srp=True,
+    )
+    assert result.engineering_class == "NAO_ENGENHARIA"
+
+
+def test_obra_execucao_and_instalacoes() -> None:
+    obra = classify_engineering_class(objeto="Execucao de obra de pavimentacao asfaltica")
+    assert obra.engineering_class == "OBRA_EXECUCAO"
+    instal = classify_engineering_class(objeto="Instalacoes hidraulicas e eletricas prediais")
+    assert instal.engineering_class == "INSTALACOES"
+    supply = classify_engineering_class(objeto="Fornecimento e instalacao de sistema de iluminacao publica")
+    assert supply.engineering_class == "FORNECIMENTO_COM_INSTALACAO"
+
+
+def test_transform_persists_class_fields_on_record() -> None:
+    raw = {
+        "numeroControlePNCP": "54400000000000000001",
+        "orgaoEntidade": {"cnpj": "12345678000199", "razaoSocial": "Prefeitura"},
+        "unidadeOrgao": {"nomeUnidade": "Obras", "ufSigla": "SC", "municipioNome": "Florianopolis"},
+        "niFornecedor": "11222333000181",
+        "tipoPessoa": "PJ",
+        "nomeRazaoSocialFornecedor": "Construtora Exemplo Ltda",
+        "valorGlobal": 400000.0,
+        "dataAssinatura": "2026-03-01",
+        "dataPublicacaoPncp": "2026-03-02",
+        "dataVigenciaInicio": "2026-03-10",
+        "dataVigenciaFim": "2027-03-09",
+        "objetoContrato": "Execucao de obra de drenagem urbana",
+        "categoriaProcessoNome": "Obras",
+    }
+    record = _transform_record(raw)
+    assert record["engineering_class"] == "OBRA_EXECUCAO"
+    assert record["engineering_confidence"] >= 0.75
+    assert record["engineering_rule_version"]
+
+
+LABELED_SAMPLE: list[tuple[str, dict, str]] = [
+    ("Execucao de obra de pavimentacao asfaltica", {}, "OBRA_EXECUCAO"),
+    ("Elaboracao de projeto executivo de engenharia", {}, "PROJETO_ENGENHARIA"),
+    ("Fiscalizacao de obra de drenagem urbana", {}, "FISCALIZACAO_GERENCIAMENTO"),
+    ("Manutencao predial de edificio publico", {}, "MANUTENCAO_PREDIAL_INFRA"),
+    ("Instalacoes hidraulicas prediais", {}, "INSTALACOES"),
+    ("Fornecimento e instalacao de iluminacao publica", {}, "FORNECIMENTO_COM_INSTALACAO"),
+    (
+        "Construcao de escola municipal",
+        {"regime_execucao_nome": "Contratacao integrada"},
+        "OBRA_COM_PROJETO",
+    ),
+    ("Aquisicao de generos alimenticios", {}, "NAO_ENGENHARIA"),
+    ("Secretaria de Saude e Saneamento - merenda escolar", {}, "NAO_ENGENHARIA"),
+    ("Fiscalizacao de campanha de publicidade", {}, "NAO_ENGENHARIA"),
+    (
+        "Projeto de pesquisa em ciencias humanas",
+        {"fornecedor_nome": "Fundacao de Amparo a Pesquisa"},
+        "NAO_ENGENHARIA",
+    ),
+    ("Manutencao de equipamentos medicos", {}, "NAO_ENGENHARIA"),
+]
+
+
+def test_reproducible_labeled_sample_precision_at_075() -> None:
+    high = []
+    for objeto, extra, expected in LABELED_SAMPLE:
+        result = classify_engineering_class(objeto=objeto, **extra)
+        if result.confidence >= 0.75:
+            high.append((result.engineering_class, expected, objeto))
+    assert high
+    correct = sum(1 for predicted, expected, _ in high if predicted == expected)
+    precision = correct / len(high)
+    assert precision >= 0.90, (precision, high)
+
+
+def test_migration_is_versioned_and_auditable() -> None:
+    sql = (ROOT / "db/migrations/110_contract_engineering_class.sql").read_text(encoding="utf-8")
+    for name in ENGINEERING_CLASSES:
+        assert name in sql
+    assert "confidence" in sql
+    assert "rule_version" in sql
+    assert "computed_at" in sql
+    assert "apply_contract_engineering_class" in sql
+
+
+@pytest.mark.real_db
+def test_class_round_trip_persists_all_audit_fields() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    from scripts.contracts.engineering_class import attach_engineering_class, stamp_engineering_class_labels
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    record = {
+        "contrato_id": "eng-class-544",
+        "orgao_cnpj": "12345678000199",
+        "objeto_contrato": "Elaboracao de projeto estrutural de edificacao",
+        "fornecedor_nome": "Escritorio de Projetos Ltda",
+        "data_publicacao": "2026-03-01",
+        "source": "pncp",
+        "source_id": "eng-class-544",
+        "supplier_id_type": "UNKNOWN",
+    }
+    attach_engineering_class(record)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = 'contract_engineering_class'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 110 not applied")
+            cur.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([record], default=str),),
+            )
+        stamped = stamp_engineering_class_labels(conn, [record])
+        assert stamped == 1
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT engineering_class, confidence, evidence, rule_version, computed_at
+                FROM contract_engineering_class WHERE contrato_id = %s
+                """,
+                (record["contrato_id"],),
+            )
+            row = cur.fetchone()
+            assert row["engineering_class"] == "PROJETO_ENGENHARIA"
+            assert float(row["confidence"]) >= 0.75
+            assert row["rule_version"]
+            assert row["computed_at"] is not None
+            assert row["evidence"]
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_pncp_procurement_results.py
+++ b/tests/test_pncp_procurement_results.py
@@ -1,0 +1,117 @@
+"""#545 — PNCP resultados before signature; no invented contrato_id."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.crawl.pncp_procurement_results import (
+    HOMOLOGATED,
+    RESULT_PUBLISHED,
+    map_pncp_item_result,
+    plan_result_ingest,
+)
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PAYLOAD = {
+    "numeroControlePNCPCompra": "12345678000199-1-000010/2026",
+    "numeroItem": 1,
+    "niFornecedor": "11222333000181",
+    "tipoPessoa": "PJ",
+    "nomeRazaoSocialFornecedor": "Construtora Vencedora Ltda",
+    "valorNegociado": 350000.0,
+    "situacao": "Homologado",
+    "dataResultado": "2026-02-10",
+    "dataPublicacaoPncp": "2026-02-11",
+}
+
+
+def test_mapper_preserves_winner_and_never_sets_contrato_id() -> None:
+    row = map_pncp_item_result(PAYLOAD)
+    assert row is not None
+    assert row["contrato_id"] is None
+    assert row["parent_procurement_id"] == "12345678000199-1-000010/2026"
+    assert row["event_type"] == HOMOLOGATED
+    assert row["winner_nome"] == "Construtora Vencedora Ltda"
+    assert row["valor_homologado"] == 350000.0
+    assert row["situacao"] == "Homologado"
+    assert row["event_at"] == "2026-02-10"
+    assert row["source_published_at"] == "2026-02-11"
+
+
+def test_reobservation_is_idempotent_on_result_id() -> None:
+    a = map_pncp_item_result(PAYLOAD)
+    b = map_pncp_item_result(PAYLOAD)
+    assert a["result_id"] == b["result_id"]
+    planned = plan_result_ingest([PAYLOAD, PAYLOAD])
+    assert len(planned) == 1
+
+
+def test_result_published_without_homologacao() -> None:
+    row = map_pncp_item_result({**PAYLOAD, "situacao": "Adjudicado", "homologado": False})
+    assert row["event_type"] == RESULT_PUBLISHED
+
+
+def test_migration_forbids_invented_contract_semantics() -> None:
+    sql = (ROOT / "db/migrations/111_pncp_procurement_results.sql").read_text(encoding="utf-8")
+    assert "Never invented" in sql
+    assert "RESULT_PUBLISHED" in sql
+    assert "HOMOLOGATED" in sql
+    assert "parent_procurement_id" in sql
+
+
+@pytest.mark.real_db
+def test_ingest_idempotent_and_link_only_when_contract_exists() -> None:
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    row = map_pncp_item_result(PAYLOAD)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = 'pncp_procurement_results'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 111 not applied")
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            first = [r["action"] for r in cur.fetchall()]
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            second = [r["action"] for r in cur.fetchall()]
+            assert first == ["inserted"]
+            assert second == ["updated"]
+            cur.execute(
+                "SELECT contrato_id, winner_cnpj, valor_homologado, event_type "
+                "FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            stored = cur.fetchone()
+            assert stored["contrato_id"] is None
+            assert stored["event_type"] == HOMOLOGATED
+            assert float(stored["valor_homologado"]) == 350000.0
+            fake = dict(row)
+            fake["contrato_id"] = "does-not-exist"
+            cur.execute(
+                "SELECT 1 FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([fake], default=str),),
+            )
+            cur.execute(
+                "SELECT contrato_id FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            assert cur.fetchone()["contrato_id"] is None
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/test_pncp_structural_fields.py
+++ b/tests/test_pncp_structural_fields.py
@@ -1,0 +1,262 @@
+"""#546 — official PNCP structural fields persist from the source payload."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.crawl.contracts_crawler import _transform_record
+from scripts.crawl.pncp_crawler_adapter import transform_contracts
+from scripts.crawl.pncp_structural_fields import (
+    STRUCTURAL_FIELD_KEYS,
+    extract_pncp_structural_fields,
+    plan_structural_backfill,
+)
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "db/migrations/107_pncp_structural_fields.sql"
+
+PAYLOAD_ID_NOME = {
+    "numeroControlePNCP": "00000000000000000001",
+    "tipoContratoId": 1,
+    "tipoContratoNome": "Contrato",
+    "categoriaProcessoId": 2,
+    "categoriaProcessoNome": "Servicos de Engenharia",
+    "modalidadeId": 6,
+    "modalidadeNome": "Pregao Eletronico",
+    "codigoRegimeExecucao": 5,
+    "regimeExecucaoNome": "Contratacao integrada",
+    "srp": False,
+    "numeroRetificacao": 0,
+    "objetoContrato": "Registro de precos para material de expediente",
+}
+
+PAYLOAD_NESTED_OBJECTS = {
+    "numeroControlePNCP": "00000000000000000002",
+    "tipoContrato": {"id": 3, "nome": "Empenho"},
+    "categoriaProcesso": {"id": 1, "nome": "Obras"},
+    "compra": {
+        "modalidadeId": 8,
+        "modalidadeNome": "Dispensa",
+        "srp": True,
+        "regimeExecucao": {"id": 1, "nome": "Empreitada por preco global"},
+    },
+    "numeroRetificacao": 2,
+    "objetoContrato": "Execucao de obra de pavimentacao",
+}
+
+PAYLOAD_MISSING = {
+    "numeroControlePNCP": "00000000000000000003",
+    "objetoContrato": "Ata de registro de precos e credenciamento de engenharia",
+}
+
+RAW_TRANSFORM = {
+    "numeroControlePNCP": "123456780001992026000001",
+    "orgaoEntidade": {"cnpj": "12345678000199", "razaoSocial": "Prefeitura"},
+    "unidadeOrgao": {
+        "nomeUnidade": "Secretaria de Obras",
+        "ufSigla": "SC",
+        "municipioNome": "Florianopolis",
+    },
+    "niFornecedor": "11222333000181",
+    "tipoPessoa": "PJ",
+    "nomeRazaoSocialFornecedor": "Construtora Exemplo Ltda",
+    "valorGlobal": 150000.00,
+    "dataAssinatura": "2026-03-01T10:00:00Z",
+    "dataPublicacaoPncp": "2026-03-02T12:00:00Z",
+    "dataVigenciaInicio": "2026-03-10T00:00:00Z",
+    "dataVigenciaFim": "2027-03-09T23:59:59Z",
+    "objetoContrato": "Execucao de obra de drenagem urbana",
+    "tipoContratoId": 1,
+    "tipoContratoNome": "Contrato",
+    "categoriaProcessoId": 1,
+    "categoriaProcessoNome": "Obras",
+    "modalidadeId": 6,
+    "modalidadeNome": "Pregao Eletronico",
+    "codigoRegimeExecucao": 5,
+    "regimeExecucaoNome": "Contratacao integrada",
+    "srp": False,
+    "numeroRetificacao": 1,
+}
+
+
+def test_mapper_round_trips_id_nome_fields() -> None:
+    fields = extract_pncp_structural_fields(PAYLOAD_ID_NOME)
+    assert fields["tipo_contrato_id"] == 1
+    assert fields["tipo_contrato_nome"] == "Contrato"
+    assert fields["categoria_processo_id"] == 2
+    assert fields["categoria_processo_nome"] == "Servicos de Engenharia"
+    assert fields["modalidade_id"] == 6
+    assert fields["modalidade_nome"] == "Pregao Eletronico"
+    assert fields["regime_execucao_id"] == 5
+    assert fields["regime_execucao_nome"] == "Contratacao integrada"
+    assert fields["srp"] is False
+    assert fields["numero_retificacao"] == 0
+
+
+def test_mapper_reads_nested_objects_and_parent_compra() -> None:
+    fields = extract_pncp_structural_fields(PAYLOAD_NESTED_OBJECTS)
+    assert fields["tipo_contrato_id"] == 3
+    assert fields["tipo_contrato_nome"] == "Empenho"
+    assert fields["categoria_processo_id"] == 1
+    assert fields["categoria_processo_nome"] == "Obras"
+    assert fields["modalidade_id"] == 8
+    assert fields["modalidade_nome"] == "Dispensa"
+    assert fields["regime_execucao_id"] == 1
+    assert fields["regime_execucao_nome"] == "Empreitada por preco global"
+    assert fields["srp"] is True
+    assert fields["numero_retificacao"] == 2
+
+
+def test_mapper_does_not_infer_from_objeto_text() -> None:
+    fields = extract_pncp_structural_fields(PAYLOAD_MISSING)
+    for key in STRUCTURAL_FIELD_KEYS:
+        assert fields[key] is None, key
+    # Official Empenho + SRP wins over objeto wording.
+    official = extract_pncp_structural_fields(
+        {
+            **PAYLOAD_MISSING,
+            "tipoContratoNome": "Contrato",
+            "srp": False,
+            "objetoContrato": "registro de precos, credenciamento, empenho",
+        }
+    )
+    assert official["tipo_contrato_nome"] == "Contrato"
+    assert official["srp"] is False
+
+
+def test_transform_attaches_official_fields() -> None:
+    record = _transform_record(RAW_TRANSFORM)
+    assert record is not None
+    assert record["tipo_contrato_id"] == 1
+    assert record["tipo_contrato_nome"] == "Contrato"
+    assert record["categoria_processo_id"] == 1
+    assert record["categoria_processo_nome"] == "Obras"
+    assert record["modalidade_id"] == 6
+    assert record["modalidade_nome"] == "Pregao Eletronico"
+    assert record["regime_execucao_nome"] == "Contratacao integrada"
+    assert record["srp"] is False
+    assert record["numero_retificacao"] == 1
+
+
+def test_adapter_uses_same_mapper() -> None:
+    rows = transform_contracts([RAW_TRANSFORM])
+    assert len(rows) == 1
+    assert rows[0]["tipo_contrato_id"] == 1
+    assert rows[0]["categoria_processo_nome"] == "Obras"
+    assert rows[0]["modalidade_nome"] == "Pregao Eletronico"
+    assert rows[0]["srp"] is False
+
+
+def test_backfill_is_resumable_limitable_and_idempotent() -> None:
+    payloads = [
+        {"numeroControlePNCP": "c1", "tipoContratoNome": "Contrato"},
+        {"numeroControlePNCP": "c2", "tipoContratoNome": "Empenho"},
+        {"numeroControlePNCP": "c3", "tipoContratoNome": "Carta Contrato"},
+        {"objetoContrato": "sem id"},
+    ]
+    first = plan_structural_backfill(payloads, limit=2)
+    assert [row["contrato_id"] for row in first] == ["c1", "c2"]
+    resumed = plan_structural_backfill(payloads, after_contrato_id="c2", limit=10)
+    assert [row["contrato_id"] for row in resumed] == ["c3"]
+    again = plan_structural_backfill(payloads, after_contrato_id="c3")
+    assert again == []
+
+
+def test_backfill_refuses_pncp_traffic_by_default() -> None:
+    source = (ROOT / "scripts/ops/backfill_pncp_structural_fields.py").read_text(encoding="utf-8")
+    assert "refusing --from-pncp" in source
+    assert "archived payloads first" in source
+
+
+def test_migration_persists_and_exposes_fields() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    for column in STRUCTURAL_FIELD_KEYS:
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in sql
+        assert column in sql
+    assert "COALESCE(EXCLUDED.tipo_contrato_id, target.tipo_contrato_id)" in sql
+    assert "CREATE OR REPLACE FUNCTION public.apply_pncp_structural_fields" in sql
+    assert "contract.tipo_contrato_id" in sql
+    assert "contract.categoria_processo_nome" in sql
+    assert "contract.srp" in sql
+    assert "contract.numero_retificacao" in sql
+    assert "COALESCE(contract.regime_execucao_nome, contract.regime_execucao_id::TEXT) AS regime_execucao" in sql
+    assert "Not inferred from objeto" in sql
+    # Observations view must consume persisted modalidade, not NULL.
+    assert "contract.modalidade_id" in sql
+    assert "NULL::INTEGER AS modalidade_id" not in sql.split("UNION ALL")[-1]
+
+
+def test_upsert_sql_reads_mapped_json_keys() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    for key in STRUCTURAL_FIELD_KEYS:
+        assert f"rec->>'{key}'" in sql
+    assert "objetoContrato" not in sql
+
+
+@pytest.mark.real_db
+def test_upsert_round_trip_persists_structural_fields_on_canonical_view() -> None:
+    """Drive transform → upsert_pncp_supplier_contracts → v_contracts_canonical_v2."""
+    import psycopg2
+    import psycopg2.extras
+
+    record = _transform_record(RAW_TRANSFORM)
+    assert record is not None
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    conn = psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = 'pncp_supplier_contracts' "
+                "AND column_name = 'tipo_contrato_id'"
+            )
+            if cursor.fetchone() is None:
+                pytest.fail("migration 107 not applied: tipo_contrato_id missing")
+            cursor.execute(
+                "SELECT * FROM upsert_pncp_supplier_contracts(%s::jsonb)",
+                (json.dumps([record], default=str),),
+            )
+            cursor.execute(
+                """
+                SELECT tipo_contrato_id, tipo_contrato_nome, categoria_processo_id,
+                       categoria_processo_nome, modalidade_id, modalidade_nome,
+                       regime_execucao, srp, numero_retificacao
+                FROM v_contracts_canonical_v2
+                WHERE contrato_id = %s
+                """,
+                (record["contrato_id"],),
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            assert row["tipo_contrato_id"] == 1
+            assert row["tipo_contrato_nome"] == "Contrato"
+            assert row["categoria_processo_id"] == 1
+            assert row["categoria_processo_nome"] == "Obras"
+            assert row["modalidade_id"] == 6
+            assert row["modalidade_nome"] == "Pregao Eletronico"
+            assert row["regime_execucao"] == "Contratacao integrada"
+            assert row["srp"] is False
+            assert row["numero_retificacao"] == 1
+            cursor.execute(
+                "SELECT contrato_id FROM apply_pncp_structural_fields(%s::jsonb)",
+                (
+                    json.dumps(
+                        [
+                            {
+                                "contrato_id": record["contrato_id"],
+                                "tipo_contrato_id": 1,
+                                "tipo_contrato_nome": "Contrato",
+                            }
+                        ]
+                    ),
+                ),
+            )
+            assert cursor.fetchone()["contrato_id"] == record["contrato_id"]
+        conn.commit()
+    finally:
+        conn.close()


### PR DESCRIPTION
## Issue

Implements #548. Does **not** `Closes #548`: latência ≤7d e verificação semanal no lake não medidas.

Depends on #559/#558 (stack 545/544) only for branch base; terms attach to `contrato_id` existente.

## Problema

Contrato anulado/rescindido depois da publicação continuava elegível como vitória recente. Aditivo não existia como entidade.

## Solução

`contract_terms` com tipos ADITIVO, RETIFICACAO, RESCISAO, REVOGACAO, ANULACAO. Ingestão idempotente. `lifecycle_event_last` no contrato. Consumo comercial deve excluir tipos terminais.

## Testes

`pytest tests/test_contract_terms_lifecycle.py --no-cov` — 3 passed (tipos distintos, idempotência, REVOGACAO no lifecycle).

## Dependências

Depends on #559.