### PR TITLE
fix(confenge): do not abort commercial feed on newer PNCP FRESH

### DIFF
--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -526,13 +526,14 @@ def _published_target_fit_snapshot(
         unresolved = sum(int(queue.get(status) or 0) for status in ("pending", "processing", "retry", "dead"))
         if unresolved:
             raise ValueError(f"target-fit store has {unresolved} unresolved queue items")
-        if observed_dt is not None:
-            # Only the ordering against the live observation is PNCP-coupled.
-            if last_full_dt < observed_dt:
-                raise ValueError("target-fit full reconcile must complete after the authoritative PNCP observation")
-            # This is the observation watermark for the fully reconciled target-fit
-            # snapshot.  The evidence-change watermark remains on each decision.
+        project_live_observation = False
+        if observed_dt is not None and last_full_dt >= observed_dt:
+            # Reconcile already covers this PNCP observation: stamp it.
+            # A newer FRESH observation is telemetry only — ADR-039: the
+            # commercial plane publishes the last complete persisted reconcile
+            # and does not wait for another target-fit pass after PNCP live.
             datalake_watermark = source_observed_at
+            project_live_observation = True
     finally:
         conn.close()
 
@@ -547,7 +548,7 @@ def _published_target_fit_snapshot(
         if not str(decision.get("source_watermark") or decision.get("target_fit_source_watermark") or "").strip():
             continue
         projected = dict(decision)
-        if source_observed_at:
+        if project_live_observation and source_observed_at:
             projected["target_fit_evidence_watermark"] = str(
                 decision.get("source_watermark") or decision.get("target_fit_source_watermark") or ""
             )

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -592,16 +592,76 @@ def test_target_fit_reobservation_fails_closed_until_full_reconcile_and_queue_dr
         ),
     )
     monkeypatch.setattr(pipeline, "queue_counts", lambda connection: {"done": 407_513})
-    with __import__("pytest").raises(ValueError, match="full reconcile must complete after"):
-        _published_target_fit_snapshot(
-            [{"cnpj14": "11222333000181"}],
-            dsn="postgresql://unused",
-            authoritative_source_freshness={
-                "status": "FRESH",
-                "source_observed_at": "2026-08-25T02:50:00Z",
-                "run_id": "contracts-live-1",
-            },
-        )
+    snapshot, authority, watermark = _published_target_fit_snapshot(
+        [{"cnpj14": "11222333000181"}],
+        dsn="postgresql://unused",
+        authoritative_source_freshness={
+            "status": "FRESH",
+            "source_observed_at": "2026-08-25T02:50:00Z",
+            "run_id": "contracts-live-1",
+        },
+    )
+    # Newer PNCP FRESH is telemetry. Complete persisted reconcile remains authority.
+    assert authority == "published_target_fit_store"
+    assert snapshot == []
+    assert watermark == "2026-08-24T03:26:43Z"
+
+
+def test_fresh_pncp_observation_after_complete_reconcile_does_not_abort_publication(
+    monkeypatch,
+) -> None:
+    """Live #468 cycle-1 feed failed here: FRESH observed_at > last_full_reconcile.
+
+    ADR-039: commercial publication reads the persisted Data Lake. PNCP live
+    observation after a complete reconcile must not abort the feed.
+    """
+    import scripts.confenge_outreach_pipeline.pipeline as pipeline
+    import scripts.confenge_target_fit.db as target_fit_db
+
+    class FakeConnection:
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(target_fit_db, "connect", lambda dsn, readonly: FakeConnection())
+    monkeypatch.setattr(
+        pipeline,
+        "load_published_index",
+        lambda connection, cnpj14s: {
+            "11222333": {
+                "source_watermark": "2026-08-24T03:26:43Z",
+                "target_fit_class": "TARGET_CONFIRMED",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "get_control",
+        lambda connection, key: (
+            {"watermark": "2026-08-24T03:26:43Z"}
+            if key == "cdc_watermark"
+            else {
+                "coverage_ratio": 1.0,
+                "pagination_exhausted_normally": True,
+                "last_full_reconcile_unexplained_missing": 0,
+                "last_full_reconcile_completed_at": "2026-09-05T02:15:43+00:00",
+            }
+        ),
+    )
+    monkeypatch.setattr(pipeline, "queue_counts", lambda connection: {"done": 411_778})
+
+    snapshot, authority, watermark = _published_target_fit_snapshot(
+        [{"cnpj14": "11222333000181"}],
+        dsn="postgresql://unused",
+        authoritative_source_freshness={
+            "status": "FRESH",
+            "source_observed_at": "2026-09-05T04:00:00+00:00",
+            "run_id": "contracts-live-after-reconcile",
+        },
+    )
+    assert authority == "published_target_fit_store"
+    assert watermark == "2026-08-24T03:26:43Z"
+    assert snapshot[0]["cnpj_raiz"] == "11222333"
+    assert snapshot[0]["source_watermark"] == "2026-08-24T03:26:43Z"
 
 
 def test_production_activation_does_not_use_limit_downstream_as_capacity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Live extra-cli#468 REV-05 cycle-1 feed failed closed with:

`ValueError: target-fit full reconcile must complete after the authoritative PNCP observation`

The publisher correctly kept the previous `current` (no partial promotion). SMTP was not touched.

ADR-039 / commercial-plane authority: PNCP FRESH is telemetry. A complete persisted Data Lake reconcile remains the operational source even when a later PNCP observation arrives.

**HEAD SHA:** `cb7f8df34a5836429825c481e42dffb8799e0ce0`

## Isolation

- CAMPAIGN_ID=REV-05
- REPOSITORY=tjsasakifln/extra-cli
- ACTUAL_BRANCH=ops/revenue-20260905-incident-468-exit
- WORKTREE=/home/tjsasakifln/code/confenge/.worktrees/extra-cli/rev-05-extra-incident-468
- origin/main at branch open: `3919f4d9af1363e2db641c7edadb8a8404874ec4`
- PR tip under test is the HEAD SHA above.

## Test

Drives shipped `_published_target_fit_snapshot` with FRESH `source_observed_at` after `last_full_reconcile_completed_at`. Queue incompleteness still fails closed.

Refs #468
