### PR TITLE
feat(pncp): isolated #545 candidate — resultados/homologacao before signature

### DIFF
--- a/db/migrations/111_pncp_procurement_results.sql
+++ b/db/migrations/111_pncp_procurement_results.sql
@@ -1,0 +1,219 @@
+-- 111_pncp_procurement_results.sql
+-- #545: official PNCP item resultados / adjudicacao / homologacao
+-- before contract signature. Never fabricates contrato_id.
+--
+-- engineering_object is resolved by an EXACT natural-key join against the
+-- parent compra (pncp_raw_bids.numero_controle_pncp, falling back to
+-- pncp_supplier_contracts.parent_procurement_id). No fuzzy text matching;
+-- absent parent leaves it NULL (UNKNOWN), never invented.
+--
+-- ROLLBACK: db/rollback/111_pncp_procurement_results_rollback.sql
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '120s';
+
+CREATE TABLE IF NOT EXISTS public.pncp_procurement_results (
+    result_id               TEXT PRIMARY KEY,
+    parent_procurement_id   TEXT NOT NULL,
+    contrato_id             TEXT,
+    event_type              TEXT NOT NULL CHECK (event_type IN ('RESULT_PUBLISHED', 'HOMOLOGATED')),
+    item_numero             INTEGER,
+    situacao                TEXT,
+    winner_cnpj             TEXT,
+    winner_nome             TEXT,
+    valor_homologado        NUMERIC(18,2),
+    engineering_object       TEXT,
+    engineering_object_source TEXT CHECK (
+        engineering_object_source IS NULL
+        OR engineering_object_source IN ('pncp_raw_bids', 'pncp_supplier_contracts')
+    ),
+    event_at                DATE,
+    source_published_at     DATE,
+    first_seen_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rule_version            TEXT NOT NULL,
+    payload_hash            TEXT,
+    CHECK (contrato_id IS NULL OR btrim(contrato_id) <> ''),
+    CHECK (engineering_object_source IS NULL OR engineering_object IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ppr_natural
+    ON public.pncp_procurement_results (
+        parent_procurement_id,
+        COALESCE(item_numero, -1),
+        COALESCE(winner_cnpj, ''),
+        event_type
+    );
+
+CREATE INDEX IF NOT EXISTS idx_ppr_parent
+    ON public.pncp_procurement_results (parent_procurement_id, event_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ppr_winner
+    ON public.pncp_procurement_results (winner_cnpj, event_at DESC)
+    WHERE winner_cnpj IS NOT NULL;
+
+COMMENT ON TABLE public.pncp_procurement_results IS
+    'Official PNCP pre-signature results (#545). contrato_id is NULL until a real contract exists; link is parent_procurement_id.';
+COMMENT ON COLUMN public.pncp_procurement_results.event_at IS
+    'Official result date. Distinct from first_seen_at and from contract data_assinatura.';
+COMMENT ON COLUMN public.pncp_procurement_results.source_published_at IS
+    'Official publication of the result, not lake observation.';
+COMMENT ON COLUMN public.pncp_procurement_results.first_seen_at IS
+    'Lake first observation of this result event.';
+COMMENT ON COLUMN public.pncp_procurement_results.contrato_id IS
+    'Filled only when a pncp_supplier_contracts row exists for the same parent_procurement_id. Never invented.';
+COMMENT ON COLUMN public.pncp_procurement_results.engineering_object IS
+    'objetoCompra/objeto_contrato of the parent compra, resolved by exact parent_procurement_id join. NULL when the parent is not present in either source table — never inferred or copied from unlinked text.';
+COMMENT ON COLUMN public.pncp_procurement_results.engineering_object_source IS
+    'Which table resolved engineering_object: pncp_raw_bids (compra pai) preferred, pncp_supplier_contracts as fallback.';
+
+CREATE OR REPLACE FUNCTION public.apply_pncp_procurement_results(p_records JSONB)
+RETURNS TABLE (action TEXT, result_id TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH input AS (
+        SELECT DISTINCT ON (rec->>'result_id')
+            rec->>'result_id' AS in_result_id,
+            rec->>'parent_procurement_id' AS parent_procurement_id,
+            NULLIF(btrim(rec->>'contrato_id'), '') AS contrato_id,
+            rec->>'event_type' AS event_type,
+            NULLIF(rec->>'item_numero', '')::INTEGER AS item_numero,
+            NULLIF(btrim(rec->>'situacao'), '') AS situacao,
+            NULLIF(btrim(rec->>'winner_cnpj'), '') AS winner_cnpj,
+            NULLIF(btrim(rec->>'winner_nome'), '') AS winner_nome,
+            NULLIF(rec->>'valor_homologado', '')::NUMERIC AS valor_homologado,
+            NULLIF(rec->>'event_at', '')::DATE AS event_at,
+            NULLIF(rec->>'source_published_at', '')::DATE AS source_published_at,
+            COALESCE(NULLIF(rec->>'first_seen_at', '')::TIMESTAMPTZ, NOW()) AS first_seen_at,
+            COALESCE(NULLIF(rec->>'rule_version', ''), 'pncp-procurement-results-v1') AS rule_version,
+            NULLIF(rec->>'payload_hash', '') AS payload_hash
+        FROM jsonb_array_elements(p_records) AS rec
+        WHERE COALESCE(rec->>'result_id', '') <> ''
+          AND COALESCE(rec->>'parent_procurement_id', '') <> ''
+          AND COALESCE(rec->>'event_type', '') IN ('RESULT_PUBLISHED', 'HOMOLOGATED')
+        ORDER BY rec->>'result_id'
+    ), contracts_by_parent AS (
+        -- pncp_supplier_contracts has many rows per parent_procurement_id
+        -- (one per item/contract). Collapse to a single deterministic
+        -- objeto_contrato per parent before joining, so the join below
+        -- cannot fan out and duplicate result_id rows.
+        SELECT DISTINCT ON (parent_procurement_id)
+            parent_procurement_id, objeto_contrato
+        FROM public.pncp_supplier_contracts
+        WHERE parent_procurement_id IS NOT NULL
+          AND objeto_contrato IS NOT NULL
+        ORDER BY parent_procurement_id, objeto_contrato
+    ), resolved AS (
+        SELECT
+            input.*,
+            COALESCE(bids.objeto_compra, contracts.objeto_contrato) AS resolved_engineering_object,
+            CASE
+                WHEN bids.objeto_compra IS NOT NULL THEN 'pncp_raw_bids'
+                WHEN contracts.objeto_contrato IS NOT NULL THEN 'pncp_supplier_contracts'
+                ELSE NULL
+            END AS resolved_engineering_object_source
+        FROM input
+        LEFT JOIN public.pncp_raw_bids AS bids
+            ON bids.numero_controle_pncp = input.parent_procurement_id
+        LEFT JOIN contracts_by_parent AS contracts
+            ON contracts.parent_procurement_id = input.parent_procurement_id
+    ), upserted AS (
+        INSERT INTO public.pncp_procurement_results AS target (
+            result_id, parent_procurement_id, contrato_id, event_type, item_numero,
+            situacao, winner_cnpj, winner_nome, valor_homologado,
+            engineering_object, engineering_object_source, event_at,
+            source_published_at, first_seen_at, last_seen_at, rule_version, payload_hash
+        )
+        SELECT
+            resolved.in_result_id, resolved.parent_procurement_id,
+            CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM public.pncp_supplier_contracts c
+                    WHERE c.contrato_id = resolved.contrato_id
+                ) THEN resolved.contrato_id
+                ELSE NULL
+            END,
+            resolved.event_type, resolved.item_numero, resolved.situacao, resolved.winner_cnpj,
+            resolved.winner_nome, resolved.valor_homologado,
+            resolved.resolved_engineering_object, resolved.resolved_engineering_object_source,
+            resolved.event_at, resolved.source_published_at, resolved.first_seen_at, NOW(),
+            resolved.rule_version, resolved.payload_hash
+        FROM resolved
+        ON CONFLICT ON CONSTRAINT pncp_procurement_results_pkey DO UPDATE SET
+            last_seen_at = NOW(),
+            situacao = COALESCE(EXCLUDED.situacao, target.situacao),
+            winner_nome = COALESCE(EXCLUDED.winner_nome, target.winner_nome),
+            valor_homologado = COALESCE(EXCLUDED.valor_homologado, target.valor_homologado),
+            engineering_object = COALESCE(target.engineering_object, EXCLUDED.engineering_object),
+            engineering_object_source = COALESCE(target.engineering_object_source, EXCLUDED.engineering_object_source),
+            event_type = EXCLUDED.event_type,
+            payload_hash = COALESCE(EXCLUDED.payload_hash, target.payload_hash),
+            contrato_id = COALESCE(target.contrato_id, EXCLUDED.contrato_id)
+        RETURNING target.result_id, (xmax = 0) AS is_insert
+    )
+    SELECT CASE WHEN upserted.is_insert THEN 'inserted' ELSE 'updated' END,
+           upserted.result_id
+    FROM upserted;
+END;
+$$;
+
+-- Link existing contracts without inventing ids.
+CREATE OR REPLACE FUNCTION public.link_procurement_results_to_contracts()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    n INTEGER;
+BEGIN
+    UPDATE public.pncp_procurement_results AS result
+    SET contrato_id = contract.contrato_id
+    FROM public.pncp_supplier_contracts AS contract
+    WHERE result.contrato_id IS NULL
+      AND contract.parent_procurement_id = result.parent_procurement_id
+      AND contract.contrato_id IS NOT NULL;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RETURN n;
+END;
+$$;
+
+-- Backfill engineering_object for rows resolved before the join existed
+-- (idempotent; only ever fills NULL, never overwrites).
+CREATE OR REPLACE FUNCTION public.backfill_procurement_results_engineering_object()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    n_bids INTEGER;
+    n_contracts INTEGER;
+BEGIN
+    UPDATE public.pncp_procurement_results AS result
+    SET engineering_object = bids.objeto_compra,
+        engineering_object_source = 'pncp_raw_bids'
+    FROM public.pncp_raw_bids AS bids
+    WHERE result.engineering_object IS NULL
+      AND bids.numero_controle_pncp = result.parent_procurement_id
+      AND bids.objeto_compra IS NOT NULL;
+    GET DIAGNOSTICS n_bids = ROW_COUNT;
+
+    UPDATE public.pncp_procurement_results AS result
+    SET engineering_object = contracts.objeto_contrato,
+        engineering_object_source = 'pncp_supplier_contracts'
+    FROM (
+        SELECT DISTINCT ON (parent_procurement_id)
+            parent_procurement_id, objeto_contrato
+        FROM public.pncp_supplier_contracts
+        WHERE parent_procurement_id IS NOT NULL
+          AND objeto_contrato IS NOT NULL
+        ORDER BY parent_procurement_id, objeto_contrato
+    ) AS contracts
+    WHERE result.engineering_object IS NULL
+      AND contracts.parent_procurement_id = result.parent_procurement_id;
+    GET DIAGNOSTICS n_contracts = ROW_COUNT;
+    RETURN n_bids + n_contracts;
+END;
+$$;
+
+COMMIT;

--- a/db/rollback/111_pncp_procurement_results_rollback.sql
+++ b/db/rollback/111_pncp_procurement_results_rollback.sql
@@ -1,0 +1,6 @@
+BEGIN;
+DROP FUNCTION IF EXISTS public.backfill_procurement_results_engineering_object();
+DROP FUNCTION IF EXISTS public.link_procurement_results_to_contracts();
+DROP FUNCTION IF EXISTS public.apply_pncp_procurement_results(JSONB);
+DROP TABLE IF EXISTS public.pncp_procurement_results;
+COMMIT;

--- a/scripts/crawl/pncp_crawler_adapter.py
+++ b/scripts/crawl/pncp_crawler_adapter.py
@@ -33,6 +33,7 @@ from scripts.crawl.pncp_contract import (
     parse_modalidades_from_env,
     parse_target,
 )
+from scripts.crawl.pncp_procurement_results import item_resultados_url
 from scripts.crawl.security import USER_AGENT, public_get
 from scripts.crawl.watermark_sync import watermark_commit, watermark_read
 
@@ -933,6 +934,26 @@ def _fetch_list_endpoint(url: str) -> FetchResult:
 def fetch_compra_items(cnpj: str, ano: int, sequencial: int) -> FetchResult:
     url = f"https://pncp.gov.br/api/pncp/v1/orgaos/{digits_only(cnpj)}/compras/{int(ano)}/{int(sequencial)}/itens"
     return _fetch_list_endpoint(url)
+
+
+def _records_from_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        return [payload]
+    return []
+
+
+def fetch_item_resultados(cnpj: str, ano: int, sequencial: int, item_numero: int) -> FetchResult:
+    """GET /orgaos/{cnpj}/compras/{ano}/{seq}/itens/{n}/resultados (#545)."""
+    url = item_resultados_url(cnpj, ano, sequencial, item_numero)
+    payload, result = _http_get_payload(url)
+    result.records = _records_from_payload(payload)
+    result.empty_confirmed = bool(result.request_completed) and not result.records
+    return result
 
 
 def fetch_compra_documents(cnpj: str, ano: int, sequencial: int) -> FetchResult:

--- a/scripts/crawl/pncp_procurement_results.py
+++ b/scripts/crawl/pncp_procurement_results.py
@@ -1,0 +1,280 @@
+"""Idempotent PNCP item-result ingest (#545).
+
+Official pre-signature events. Never fabricates contrato_id; link is
+parent_procurement_id only until a real contract row exists. engineering_object
+is resolved by an exact natural-key join against the parent compra
+(pncp_raw_bids / pncp_supplier_contracts), never by fuzzy text matching and
+never invented when the parent is absent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from scripts.contracts_identity import normalize_supplier_identity
+from scripts.crawl.pncp_contract import digits_only
+
+PNCP_API_V1 = "https://pncp.gov.br/api/pncp/v1"
+PNCP_CONTROLE_ID = re.compile(r"^(\d{14})-\d+-(\d+)/(\d{4})$")
+
+RULE_VERSION = "pncp-procurement-results-v1"
+RESULT_PUBLISHED = "RESULT_PUBLISHED"
+HOMOLOGATED = "HOMOLOGATED"
+
+# Isolation note (EXTRA-HOMOLOGATION-LIVE-EVIDENCE-DISCOVERY-01): these three
+# coercion helpers were originally added by #546's pncp_structural_fields.py.
+# They are generic type coercion with no dependency on structural-fields
+# domain logic, so they are inlined here rather than pulling the unmerged
+# #546/#544 stack into this isolated #545 candidate.
+_TRUE = frozenset({"true", "t", "1", "sim", "s", "yes", "y"})
+_FALSE = frozenset({"false", "f", "0", "nao", "não", "n", "no"})
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, dict):
+        return _as_int(
+            value.get("id")
+            or value.get("codigo")
+            or value.get("codigoModalidade")
+            or value.get("codigoRegime")
+        )
+    try:
+        text = str(value).strip()
+        if not text:
+            return None
+        return int(float(text)) if "." in text else int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, dict):
+        return _as_text(
+            value.get("nome")
+            or value.get("descricao")
+            or value.get("name")
+            or value.get("label")
+        )
+    if isinstance(value, (bool, int, float)):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _as_bool(value: Any) -> bool | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(int(value))
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    return None
+
+
+def _now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _as_date(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    return text[:10] if text else None
+
+
+def parse_pncp_controle_id(value: str | None) -> tuple[str, int, int] | None:
+    """Parse ``{cnpj}-{kind}-{sequencial}/{ano}`` into ``(cnpj, ano, sequencial)``."""
+    match = PNCP_CONTROLE_ID.match((value or "").strip())
+    if not match:
+        return None
+    return match.group(1), int(match.group(3)), int(match.group(2))
+
+
+def item_resultados_url(cnpj: str, ano: int, sequencial: int, item_numero: int) -> str:
+    return (
+        f"{PNCP_API_V1}/orgaos/{digits_only(cnpj)}/compras/{int(ano)}/{int(sequencial)}"
+        f"/itens/{int(item_numero)}/resultados"
+    )
+
+
+def result_event_type(situacao: str | None, homologado: bool | None) -> str:
+    norm = (situacao or "").strip().lower()
+    if homologado is True or "homolog" in norm:
+        return HOMOLOGATED
+    return RESULT_PUBLISHED
+
+
+def map_pncp_item_result(
+    payload: Mapping[str, Any],
+    *,
+    parent_procurement_id: str | None = None,
+    item_numero: int | None = None,
+) -> dict[str, Any] | None:
+    """Map a PNCP /itens/{n}/resultados item. contrato_id stays None.
+
+    event_at is sourced ONLY from official result fields (dataResultado /
+    dataHoraResultado / dataAtualizacao). If none are present, event_at is
+    None (UNKNOWN) — it is never backfilled from first_seen_at/ingested_at.
+    """
+    parent = (
+        parent_procurement_id
+        or payload.get("numeroControlePNCPCompra")
+        or payload.get("numeroControlePncpCompra")
+        or payload.get("parent_procurement_id")
+    )
+    parent = str(parent).strip() if parent else ""
+    if not parent:
+        return None
+    item = item_numero if item_numero is not None else _as_int(
+        payload.get("numeroItem") or payload.get("itemNumero") or payload.get("item")
+    )
+    winner_raw = (
+        payload.get("niFornecedor")
+        or payload.get("cnpjFornecedor")
+        or payload.get("ni")
+    )
+    identity = normalize_supplier_identity(
+        winner_raw,
+        declared_type=payload.get("tipoPessoa") or payload.get("tipoPessoaFornecedor"),
+        country=payload.get("codigoPaisFornecedor"),
+    )
+    winner_cnpj = identity.fornecedor_cnpj
+    situacao = _as_text(
+        payload.get("situacao")
+        or payload.get("situacaoResultado")
+        or payload.get("nomeSituacao")
+    )
+    homologado = _as_bool(payload.get("homologado") or payload.get("indicadorHomologacao"))
+    event_type = result_event_type(situacao, homologado)
+    valor = payload.get("valorNegociado") or payload.get("valorHomologado") or payload.get("valorTotal")
+    try:
+        valor_num = float(valor) if valor not in (None, "") else None
+    except (TypeError, ValueError):
+        valor_num = None
+    event_at = _as_date(
+        payload.get("dataResultado")
+        or payload.get("dataHoraResultado")
+        or payload.get("dataAtualizacao")
+    )
+    published = _as_date(
+        payload.get("dataPublicacaoPncp") or payload.get("dataPublicacao")
+    )
+    key = "|".join(
+        [
+            parent,
+            str(item or ""),
+            winner_cnpj or identity.supplier_identifier or "",
+            event_type,
+        ]
+    )
+    result_id = "pncp_result_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+    return {
+        "result_id": result_id,
+        "parent_procurement_id": parent,
+        "contrato_id": None,
+        "event_type": event_type,
+        "item_numero": item,
+        "situacao": situacao,
+        "winner_cnpj": winner_cnpj,
+        "winner_nome": _as_text(
+            payload.get("nomeRazaoSocialFornecedor") or payload.get("nomeFornecedor")
+        ),
+        "valor_homologado": valor_num,
+        "event_at": event_at,
+        "source_published_at": published,
+        "first_seen_at": _now(),
+        "rule_version": RULE_VERSION,
+        "payload_hash": hashlib.sha256(
+            json.dumps(dict(payload), sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest(),
+    }
+
+
+def plan_result_ingest(
+    payloads: list[Mapping[str, Any]],
+    *,
+    parent_procurement_id: str | None = None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for payload in payloads:
+        mapped = map_pncp_item_result(payload, parent_procurement_id=parent_procurement_id)
+        if not mapped or mapped["result_id"] in seen:
+            continue
+        seen.add(mapped["result_id"])
+        rows.append(mapped)
+    return rows
+
+
+def expand_result_payloads(
+    documents: Iterable[Any],
+    *,
+    parent_procurement_id: str | None = None,
+) -> list[Mapping[str, Any]]:
+    """Flatten JSONL/archive envelopes into raw PNCP resultado objects."""
+    out: list[Mapping[str, Any]] = []
+    for document in documents:
+        out.extend(_expand_one(document, parent_procurement_id=parent_procurement_id, item_numero=None))
+    return out
+
+
+def _expand_one(
+    document: Any,
+    *,
+    parent_procurement_id: str | None,
+    item_numero: int | None,
+) -> list[Mapping[str, Any]]:
+    if isinstance(document, list):
+        rows: list[Mapping[str, Any]] = []
+        for item in document:
+            rows.extend(
+                _expand_one(item, parent_procurement_id=parent_procurement_id, item_numero=item_numero)
+            )
+        return rows
+    if not isinstance(document, Mapping):
+        return []
+    parent = (
+        parent_procurement_id
+        or document.get("parent_procurement_id")
+        or document.get("numeroControlePNCPCompra")
+        or document.get("numeroControlePncpCompra")
+    )
+    item = item_numero
+    if item is None:
+        raw_item = document.get("numeroItem") or document.get("item_numero") or document.get("item")
+        item = _as_int(raw_item)
+    nested = document.get("resultados")
+    if isinstance(nested, list):
+        rows = []
+        for result in nested:
+            rows.extend(_expand_one(result, parent_procurement_id=parent, item_numero=item))
+        return rows
+    data = document.get("data")
+    if isinstance(data, list) and not document.get("niFornecedor") and not document.get("cnpjFornecedor"):
+        rows = []
+        for result in data:
+            rows.extend(_expand_one(result, parent_procurement_id=parent, item_numero=item))
+        return rows
+    payload = dict(document)
+    if parent:
+        payload.setdefault("numeroControlePNCPCompra", parent)
+        payload.setdefault("parent_procurement_id", parent)
+    if item is not None:
+        payload.setdefault("numeroItem", item)
+    return [payload]

--- a/scripts/ops/ingest_pncp_procurement_results.py
+++ b/scripts/ops/ingest_pncp_procurement_results.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Resumable ingest of official PNCP item resultados (#545).
+
+Prefers JSONL or CAS-backed archives. Live PNCP is opt-in via ``--from-pncp``.
+
+Usage::
+
+    python3 -m scripts.ops.ingest_pncp_procurement_results --from-jsonl resultados.jsonl --limit 200
+    python3 -m scripts.ops.ingest_pncp_procurement_results --from-archive --after PARENT --limit 50
+    python3 -m scripts.ops.ingest_pncp_procurement_results --from-pncp --parent 12345678000199-1-000010/2026
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.crawl.ingestion._base.crawler import FetchResult  # noqa: E402
+from scripts.crawl.pncp_procurement_results import (  # noqa: E402
+    RULE_VERSION,
+    expand_result_payloads,
+    parse_pncp_controle_id,
+    plan_result_ingest,
+)
+
+FetchItems = Callable[[str, int, int], FetchResult]
+FetchResultados = Callable[[str, int, int, int], FetchResult]
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                yield payload
+            elif isinstance(payload, list):
+                for item in payload:
+                    if isinstance(item, dict):
+                        yield item
+
+
+def _load_archive_payloads(conn: Any, *, limit: int | None) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    sql = """
+        SELECT body_uri, sanitized_url
+        FROM public.raw_http_fetches
+        WHERE source ILIKE '%pncp%'
+          AND (
+              sanitized_url ILIKE '%/resultados%'
+              OR request_scope ILIKE '%resultado%'
+          )
+        ORDER BY observed_at DESC
+    """
+    if limit is not None:
+        sql += " LIMIT %s"
+        cur.execute(sql, (int(limit) * 4,))
+    else:
+        cur.execute(sql)
+    rows = cur.fetchall() or []
+    payloads: list[dict[str, Any]] = []
+    try:
+        from scripts.ops.blob_cas import get as cas_get
+    except ImportError:
+        return payloads
+    for row in rows:
+        body_uri = row[0] if not isinstance(row, Mapping) else row.get("body_uri")
+        url = row[1] if not isinstance(row, Mapping) else row.get("sanitized_url")
+        if not body_uri:
+            continue
+        try:
+            raw = cas_get(str(body_uri))
+        except Exception as exc:
+            print(f"skip cas body {body_uri}: {exc}", file=sys.stderr)
+            continue
+        decoded: Any
+        if isinstance(raw, (bytes, bytearray)):
+            try:
+                decoded = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+        elif isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+        else:
+            decoded = raw
+        envelope: dict[str, Any] = {"source_url": url}
+        if isinstance(decoded, dict):
+            envelope.update(decoded)
+            payloads.append(envelope)
+        elif isinstance(decoded, list):
+            payloads.append({"resultados": decoded, "source_url": url})
+        if limit is not None and len(payloads) >= int(limit):
+            break
+    return payloads
+
+
+def load_parents_from_lake(conn: Any, *, after: str | None, limit: int | None) -> list[str]:
+    cur = conn.cursor()
+    sql = """
+        SELECT DISTINCT parent_procurement_id
+        FROM public.pncp_supplier_contracts
+        WHERE parent_procurement_id IS NOT NULL
+          AND btrim(parent_procurement_id) <> ''
+          AND parent_procurement_id > %s
+        ORDER BY parent_procurement_id
+    """
+    params: list[Any] = [after or ""]
+    if limit is not None:
+        sql += " LIMIT %s"
+        params.append(int(limit))
+    cur.execute(sql, params)
+    rows = cur.fetchall() or []
+    parents: list[str] = []
+    for row in rows:
+        value = row[0] if not isinstance(row, Mapping) else row.get("parent_procurement_id")
+        if value:
+            parents.append(str(value))
+    return parents
+
+
+def fetch_results_for_parent(
+    parent_id: str,
+    *,
+    fetch_items: FetchItems,
+    fetch_resultados: FetchResultados,
+) -> list[dict[str, Any]]:
+    parsed = parse_pncp_controle_id(parent_id)
+    if parsed is None:
+        print(f"skip unparseable parent_procurement_id {parent_id}", file=sys.stderr)
+        return []
+    cnpj, ano, sequencial = parsed
+    items_result = fetch_items(cnpj, ano, sequencial)
+    items = _as_item_list(items_result.records)
+    payloads: list[dict[str, Any]] = []
+    for item in items:
+        numero = item.get("numeroItem") or item.get("item") or item.get("item_numero")
+        if numero in (None, ""):
+            continue
+        try:
+            item_numero = int(numero)
+        except (TypeError, ValueError):
+            continue
+        fetched = fetch_resultados(cnpj, ano, sequencial, item_numero)
+        for record in fetched.records or []:
+            if not isinstance(record, dict):
+                continue
+            payload = dict(record)
+            payload.setdefault("numeroControlePNCPCompra", parent_id)
+            payload.setdefault("parent_procurement_id", parent_id)
+            payload.setdefault("numeroItem", item_numero)
+            payloads.append(payload)
+    return payloads
+
+
+def _as_item_list(records: Iterable[Any] | None) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for record in records or []:
+        if isinstance(record, list):
+            out.extend(_as_item_list(record))
+        elif isinstance(record, dict):
+            nested = record.get("data") or record.get("itens")
+            if isinstance(nested, list) and "numeroItem" not in record:
+                out.extend(_as_item_list(nested))
+            else:
+                out.append(record)
+    return out
+
+
+def apply_batch(conn: Any, rows: list[dict[str, Any]]) -> int:
+    if not rows:
+        return 0
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+        (json.dumps(rows, default=str),),
+    )
+    applied = len(cur.fetchall() or [])
+    cur.execute("SELECT public.link_procurement_results_to_contracts()")
+    return applied
+
+
+def run_ingest(
+    conn: Any,
+    *,
+    documents: list[Mapping[str, Any]],
+    parents: list[str],
+    after: str | None,
+    limit: int | None,
+    dry_run: bool,
+    fetch_items: FetchItems | None = None,
+    fetch_resultados: FetchResultados | None = None,
+) -> dict[str, Any]:
+    payloads: list[Mapping[str, Any]] = list(expand_result_payloads(documents))
+    skipped_parents = 0
+    fetched_parents: list[str] = []
+    if parents:
+        if fetch_items is None or fetch_resultados is None:
+            from scripts.crawl.pncp_crawler_adapter import fetch_compra_items, fetch_item_resultados
+
+            fetch_items = fetch_items or fetch_compra_items
+            fetch_resultados = fetch_resultados or fetch_item_resultados
+        for parent_id in parents:
+            if after and not (parent_id > after):
+                skipped_parents += 1
+                continue
+            fetched_parents.append(parent_id)
+            payloads.extend(
+                fetch_results_for_parent(
+                    parent_id,
+                    fetch_items=fetch_items,
+                    fetch_resultados=fetch_resultados,
+                )
+            )
+            if limit is not None and len(fetched_parents) >= int(limit):
+                break
+    planned = plan_result_ingest(list(payloads))
+    if limit is not None and not parents:
+        planned = planned[: int(limit)]
+    updated = 0 if dry_run else apply_batch(conn, planned)
+    if not dry_run:
+        conn.commit()
+    cursor = fetched_parents[-1] if fetched_parents else (planned[-1]["parent_procurement_id"] if planned else after)
+    return {
+        "rule_version": RULE_VERSION,
+        "planned": len(planned),
+        "updated": updated,
+        "parents": len(fetched_parents),
+        "skipped_parents": skipped_parents,
+        "cursor": cursor,
+        "dry_run": dry_run,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-jsonl", type=Path, default=None)
+    parser.add_argument("--from-archive", action="store_true")
+    parser.add_argument(
+        "--from-pncp",
+        action="store_true",
+        help="Opt-in live GET /itens/{n}/resultados for lake parent_procurement_id rows.",
+    )
+    parser.add_argument("--parent", action="append", default=[], help="PNCP compra id to fetch (repeatable).")
+    parser.add_argument("--dsn", default=os.getenv("LOCAL_DATALAKE_DSN") or os.getenv("DATABASE_URL"))
+    parser.add_argument("--after", default=None, help="Resume after this parent_procurement_id (exclusive).")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.from_jsonl and not args.from_archive and not args.from_pncp and not args.parent:
+        raise SystemExit("provide --from-jsonl PATH, --from-archive, --from-pncp, or --parent ID")
+    if not args.dsn:
+        raise SystemExit("LOCAL_DATALAKE_DSN or --dsn is required")
+
+    import psycopg2
+
+    conn = psycopg2.connect(args.dsn)
+    try:
+        documents: list[Mapping[str, Any]] = []
+        if args.from_jsonl:
+            documents.extend(_iter_jsonl(args.from_jsonl))
+        if args.from_archive:
+            documents.extend(_load_archive_payloads(conn, limit=args.limit))
+        parents: list[str] = list(args.parent)
+        if args.from_pncp and not parents:
+            parents = load_parents_from_lake(conn, after=args.after, limit=args.limit)
+        result = run_ingest(
+            conn,
+            documents=documents,
+            parents=parents,
+            after=args.after,
+            limit=args.limit,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pncp_procurement_results.py
+++ b/tests/test_pncp_procurement_results.py
@@ -1,0 +1,436 @@
+"""#545 — PNCP resultados before signature; no invented contrato_id.
+
+Isolated candidate (EXTRA-HOMOLOGATION-LIVE-EVIDENCE-DISCOVERY-01): transplanted
+from feat/545-pncp-results onto contemporary main, without the unmerged
+#544/#546 stack, plus an explicit engineering_object join.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+from scripts.crawl.ingestion._base.crawler import FetchResult
+from scripts.crawl.pncp_procurement_results import (
+    HOMOLOGATED,
+    RESULT_PUBLISHED,
+    expand_result_payloads,
+    item_resultados_url,
+    map_pncp_item_result,
+    parse_pncp_controle_id,
+    plan_result_ingest,
+)
+from scripts.ops.ingest_pncp_procurement_results import fetch_results_for_parent, run_ingest
+from scripts.testing.real_db_guard import canonical_dsn
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PAYLOAD = {
+    "numeroControlePNCPCompra": "12345678000199-1-000010/2026",
+    "numeroItem": 1,
+    "niFornecedor": "11222333000181",
+    "tipoPessoa": "PJ",
+    "nomeRazaoSocialFornecedor": "Construtora Vencedora Ltda",
+    "valorNegociado": 350000.0,
+    "situacao": "Homologado",
+    "dataResultado": "2026-02-10",
+    "dataPublicacaoPncp": "2026-02-11",
+}
+
+
+def _conn():
+    import psycopg2
+    import psycopg2.extras
+
+    dsn = os.getenv("LOCAL_DATALAKE_DSN") or canonical_dsn()
+    return psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def test_mapper_preserves_winner_and_never_sets_contrato_id() -> None:
+    row = map_pncp_item_result(PAYLOAD)
+    assert row is not None
+    assert row["contrato_id"] is None
+    assert row["parent_procurement_id"] == "12345678000199-1-000010/2026"
+    assert row["event_type"] == HOMOLOGATED
+    assert row["winner_nome"] == "Construtora Vencedora Ltda"
+    assert row["valor_homologado"] == 350000.0
+    assert row["situacao"] == "Homologado"
+    assert row["event_at"] == "2026-02-10"
+    assert row["source_published_at"] == "2026-02-11"
+
+
+def test_reobservation_is_idempotent_on_result_id() -> None:
+    a = map_pncp_item_result(PAYLOAD)
+    b = map_pncp_item_result(PAYLOAD)
+    assert a["result_id"] == b["result_id"]
+    planned = plan_result_ingest([PAYLOAD, PAYLOAD])
+    assert len(planned) == 1
+
+
+def test_result_published_without_homologacao() -> None:
+    row = map_pncp_item_result({**PAYLOAD, "situacao": "Adjudicado", "homologado": False})
+    assert row["event_type"] == RESULT_PUBLISHED
+
+
+def test_event_at_is_none_when_no_official_date_present() -> None:
+    """Adversarial: absent official date fields must yield UNKNOWN, never invented."""
+    payload = {k: v for k, v in PAYLOAD.items() if k not in ("dataResultado",)}
+    row = map_pncp_item_result(payload)
+    assert row is not None
+    assert row["event_at"] is None
+    # first_seen_at is always populated but must never leak into event_at.
+    assert row["first_seen_at"] is not None
+    assert row["event_at"] != row["first_seen_at"]
+
+
+def test_same_winner_different_items_are_distinct_rows() -> None:
+    """Adversarial: same winner across distinct items must not collide."""
+    item1 = {**PAYLOAD, "numeroItem": 1}
+    item2 = {**PAYLOAD, "numeroItem": 2}
+    planned = plan_result_ingest([item1, item2])
+    assert len(planned) == 2
+    ids = {row["result_id"] for row in planned}
+    assert len(ids) == 2
+    assert {row["item_numero"] for row in planned} == {1, 2}
+
+
+def test_contract_signature_vocabulary_never_becomes_an_event_type() -> None:
+    """Adversarial: signature/publication wording must never be confused with homologation."""
+    payload = {**PAYLOAD, "situacao": "Assinado", "homologado": None}
+    row = map_pncp_item_result(payload)
+    assert row is not None
+    assert row["event_type"] in (RESULT_PUBLISHED, HOMOLOGATED)
+    # "Assinado" (signed) is not a homologation marker: falls back to RESULT_PUBLISHED,
+    # never a third, contract-signature event_type — the DB CHECK also enforces this.
+    assert row["event_type"] == RESULT_PUBLISHED
+
+
+def test_migration_forbids_invented_contract_semantics() -> None:
+    sql = (ROOT / "db/migrations/111_pncp_procurement_results.sql").read_text(encoding="utf-8")
+    assert "Never invented" in sql
+    assert "RESULT_PUBLISHED" in sql
+    assert "HOMOLOGATED" in sql
+    assert "parent_procurement_id" in sql
+    assert "engineering_object" in sql
+
+
+@pytest.mark.real_db
+def test_ingest_idempotent_and_link_only_when_contract_exists() -> None:
+    conn = _conn()
+    row = map_pncp_item_result(PAYLOAD)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.tables WHERE table_name = 'pncp_procurement_results'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 111 not applied")
+            cur.execute(
+                "DELETE FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            first = [r["action"] for r in cur.fetchall()]
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            second = [r["action"] for r in cur.fetchall()]
+            assert first == ["inserted"]
+            assert second == ["updated"]
+            cur.execute(
+                "SELECT contrato_id, winner_cnpj, valor_homologado, event_type "
+                "FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            stored = cur.fetchone()
+            assert stored["contrato_id"] is None
+            assert stored["event_type"] == HOMOLOGATED
+            assert float(stored["valor_homologado"]) == 350000.0
+            fake = dict(row)
+            fake["contrato_id"] = "does-not-exist"
+            cur.execute(
+                "SELECT 1 FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([fake], default=str),),
+            )
+            cur.execute(
+                "SELECT contrato_id FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            assert cur.fetchone()["contrato_id"] is None
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_engineering_object_resolved_from_pncp_raw_bids() -> None:
+    """Real payload + real parent compra -> engineering_object populated by exact join."""
+    conn = _conn()
+    parent = f"{uuid.uuid4().hex[:14]}-1-000{uuid.uuid4().int % 900 + 100}/2026"
+    objeto = f"OBRA DE PAVIMENTACAO TESTE {uuid.uuid4().hex[:8]}"
+    payload = {**PAYLOAD, "numeroControlePNCPCompra": parent}
+    row = map_pncp_item_result(payload)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO pncp_raw_bids (pncp_id, numero_controle_pncp, objeto_compra, orgao_cnpj, is_active)
+                VALUES (%s, %s, %s, '00000000000000', true)
+                ON CONFLICT (pncp_id) DO NOTHING
+                """,
+                (parent, parent, objeto),
+            )
+            cur.execute(
+                "DELETE FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            cur.fetchall()
+            cur.execute(
+                "SELECT engineering_object, engineering_object_source "
+                "FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            stored = cur.fetchone()
+            assert stored["engineering_object"] == objeto
+            assert stored["engineering_object_source"] == "pncp_raw_bids"
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_engineering_object_absent_parent_is_unknown_not_invented() -> None:
+    """Adversarial: parent with no compra row anywhere -> engineering_object stays NULL."""
+    conn = _conn()
+    parent = f"{uuid.uuid4().hex[:14]}-1-999{uuid.uuid4().int % 900 + 100}/2026"
+    payload = {**PAYLOAD, "numeroControlePNCPCompra": parent}
+    row = map_pncp_item_result(payload)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            cur.fetchall()
+            cur.execute(
+                "SELECT engineering_object, engineering_object_source "
+                "FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            stored = cur.fetchone()
+            assert stored["engineering_object"] is None
+            assert stored["engineering_object_source"] is None
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_engineering_object_fanout_from_contracts_does_not_duplicate_or_crash() -> None:
+    """Adversarial: parent with MANY contract rows must not fan out the upsert."""
+    conn = _conn()
+    parent = f"{uuid.uuid4().hex[:14]}-1-000{uuid.uuid4().int % 900 + 100}/2026"
+    objeto = f"CONSTRUCAO DE ESCOLA TESTE {uuid.uuid4().hex[:8]}"
+    payload = {**PAYLOAD, "numeroControlePNCPCompra": parent, "numeroItem": 7}
+    row = map_pncp_item_result(payload)
+    try:
+        with conn.cursor() as cur:
+            for i in range(5):
+                cur.execute(
+                    """
+                    INSERT INTO pncp_supplier_contracts
+                        (contrato_id, parent_procurement_id, objeto_contrato, orgao_cnpj,
+                         fornecedor_cnpj, supplier_id_type)
+                    VALUES (%s, %s, %s, '00000000000000', NULL, 'UNKNOWN')
+                    """,
+                    (f"{parent}-fanout-{i}", parent, objeto),
+                )
+            cur.execute(
+                "DELETE FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            cur.execute(
+                "SELECT action, result_id FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([row], default=str),),
+            )
+            applied = cur.fetchall()
+            assert len(applied) == 1
+            cur.execute(
+                "SELECT count(*) AS n, engineering_object, engineering_object_source "
+                "FROM pncp_procurement_results WHERE result_id = %s "
+                "GROUP BY engineering_object, engineering_object_source",
+                (row["result_id"],),
+            )
+            stored = cur.fetchone()
+            assert stored["n"] == 1
+            assert stored["engineering_object"] == objeto
+            assert stored["engineering_object_source"] == "pncp_supplier_contracts"
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_replay_does_not_duplicate_rows() -> None:
+    """Adversarial: replaying the same batch (e.g. crash-retry) must not duplicate."""
+    conn = _conn()
+    payload = {**PAYLOAD, "numeroControlePNCPCompra": f"{uuid.uuid4().hex[:14]}-1-000777/2026"}
+    row = map_pncp_item_result(payload)
+    try:
+        with conn.cursor() as cur:
+            for _ in range(3):
+                cur.execute(
+                    "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                    (json.dumps([row, row], default=str),),
+                )
+                cur.fetchall()
+            cur.execute(
+                "SELECT count(*) AS n FROM pncp_procurement_results WHERE result_id = %s",
+                (row["result_id"],),
+            )
+            assert cur.fetchone()["n"] == 1
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.mark.real_db
+def test_invalid_event_type_is_rejected_not_silently_coerced() -> None:
+    """Adversarial: a CONTRACT_SIGNED-shaped record must never enter this table."""
+    conn = _conn()
+    fake = dict(map_pncp_item_result(PAYLOAD))
+    fake["result_id"] = "pncp_result_" + uuid.uuid4().hex[:32]
+    fake["event_type"] = "CONTRACT_SIGNED"
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT action FROM apply_pncp_procurement_results(%s::jsonb)",
+                (json.dumps([fake], default=str),),
+            )
+            applied = cur.fetchall()
+            assert applied == []
+            cur.execute(
+                "SELECT 1 FROM pncp_procurement_results WHERE result_id = %s",
+                (fake["result_id"],),
+            )
+            assert cur.fetchone() is None
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_parse_controle_id_and_resultados_url() -> None:
+    parsed = parse_pncp_controle_id("12345678000199-1-000010/2026")
+    assert parsed == ("12345678000199", 2026, 10)
+    assert item_resultados_url(*parsed, 3).endswith(
+        "/orgaos/12345678000199/compras/2026/10/itens/3/resultados"
+    )
+    assert parse_pncp_controle_id("not-a-pncp-id") is None
+
+
+def test_expand_nested_resultados_envelope() -> None:
+    docs = [
+        {
+            "parent_procurement_id": "12345678000199-1-000010/2026",
+            "numeroItem": 1,
+            "resultados": [PAYLOAD],
+        }
+    ]
+    expanded = expand_result_payloads(docs)
+    planned = plan_result_ingest(expanded)
+    assert len(planned) == 1
+    assert planned[0]["contrato_id"] is None
+    assert planned[0]["event_type"] == HOMOLOGATED
+
+
+def test_from_pncp_fetch_path_calls_item_resultados() -> None:
+    parent = "12345678000199-1-000010/2026"
+    calls: list[tuple[str, int, int, int]] = []
+
+    def fake_items(cnpj: str, ano: int, seq: int) -> FetchResult:
+        assert (cnpj, ano, seq) == ("12345678000199", 2026, 10)
+        return FetchResult(records=[{"numeroItem": 1}], request_completed=True, http_status=200)
+
+    def fake_resultados(cnpj: str, ano: int, seq: int, item: int) -> FetchResult:
+        calls.append((cnpj, ano, seq, item))
+        return FetchResult(records=[PAYLOAD], request_completed=True, http_status=200)
+
+    payloads = fetch_results_for_parent(
+        parent, fetch_items=fake_items, fetch_resultados=fake_resultados
+    )
+    assert calls == [("12345678000199", 2026, 10, 1)]
+    planned = plan_result_ingest(payloads)
+    assert len(planned) == 1
+    assert planned[0]["parent_procurement_id"] == parent
+
+    result = run_ingest(
+        conn=None,
+        documents=[],
+        parents=[parent],
+        after=None,
+        limit=10,
+        dry_run=True,
+        fetch_items=fake_items,
+        fetch_resultados=fake_resultados,
+    )
+    assert result["planned"] == 1
+    assert result["updated"] == 0
+    assert result["dry_run"] is True
+    assert result["cursor"] == parent
+
+
+@pytest.mark.real_db
+def test_ingest_cli_applies_jsonl_via_apply_function() -> None:
+    conn = _conn()
+    payload = {
+        **PAYLOAD,
+        "numeroControlePNCPCompra": "12345678000199-1-000545/2026",
+        "niFornecedor": "99888777000166",
+    }
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM information_schema.routines WHERE routine_name = 'apply_pncp_procurement_results'"
+            )
+            if cur.fetchone() is None:
+                pytest.fail("migration 111 not applied")
+            mapped_preview = map_pncp_item_result(payload)
+            if mapped_preview is not None:
+                cur.execute(
+                    "DELETE FROM pncp_procurement_results WHERE result_id = %s",
+                    (mapped_preview["result_id"],),
+                )
+        result = run_ingest(
+            conn,
+            documents=[payload],
+            parents=[],
+            after=None,
+            limit=None,
+            dry_run=False,
+        )
+        assert result["updated"] >= 1
+        mapped = map_pncp_item_result(payload)
+        assert mapped is not None
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT contrato_id, event_type FROM pncp_procurement_results WHERE result_id = %s",
+                (mapped["result_id"],),
+            )
+            stored = cur.fetchone()
+            assert stored is not None
+            assert stored["contrato_id"] is None
+            assert stored["event_type"] == HOMOLOGATED
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Isolated, minimal candidate for #545 (pre-signature RESULT_PUBLISHED/HOMOLOGATED), continuing the discovery in #554/#559.

- Transplants only the #545-exclusive commits from `feat/545-pncp-results` (`7ff757d2`, `e99d096d`) onto contemporary `main`, instead of the full stacked PR #559 (which also carries the unmerged #544/#546 commits).
- The one real functional dependency on #546 (three generic type-coercion helpers in `pncp_structural_fields.py`) is inlined rather than pulling that unmerged feature in.
- Closes the `engineering_object` gap flagged in the #554/#545/#559 discovery: resolved by an **exact** natural-key join on `parent_procurement_id` against `pncp_raw_bids` (preferred) falling back to `pncp_supplier_contracts`, NULL (UNKNOWN) when the parent is in neither — no fuzzy matching, no invented text.
- Caught and fixed a real bug during validation: `pncp_supplier_contracts.parent_procurement_id` has up to 48k rows per parent in prod (many contracts/items share one compra). A naive join would have fanned out and duplicated `result_id` rows, breaking the upsert's `ON CONFLICT`. Fixed with a deduplicated lookup CTE.

## Validation (no production mutation)

- 17/17 tests pass against a disposable local Postgres container (not ec-prod), including 7 adversarial scenarios: real payload + object join, absent-parent fail-closed to UNKNOWN, idempotent reobservation, same winner across distinct items, no invented `event_at`, signature vocabulary never becomes an `event_type`, replay does not duplicate.
- **Live payload: NOT YET obtained.** `https://pncp.gov.br/api/pncp/v1/orgaos/{cnpj}/compras/{ano}/{seq}...` (the direct-object tier that hosts `/itens/{n}/resultados`) returned `502`/`503`/connection-reset on every attempt across a 25+ minute reproducible polling window (multiple compras, multiple orgs, both the compra-root and sub-resources). The neighboring `api/consulta/v1` tier stayed healthy throughout (verified repeatedly, e.g. `GET /api/consulta/v1/orgaos/{cnpj}/compras/{ano}/{seq}` returns 200 with `valorTotalHomologado`/`existeResultado` populated for the target compra `01612847000190-1-000100/2026`) — this is a real, currently-reproducible outage of one specific PNCP microservice, not a request bug or a "0 resultados" non-finding.
- Ready to capture the moment the endpoint recovers: `python3 -m scripts.ops.ingest_pncp_procurement_results --from-pncp --parent 01612847000190-1-000100/2026 --dsn <staging>` (this compra is independently confirmed via `pncp_supplier_contracts`/consulta-tier to have `existeResultado=true`), or the standalone capture helper used during this session.

## Not in scope / not done here

- Does not merge or deploy. Migration `111_pncp_procurement_results.sql` is not applied anywhere but the disposable staging container used for this validation.
- Does not close #545 — its acceptance criteria (≥80% coverage of engineering contracts ≥R$300k with a linked pre-signature result event, p95 publication→first_seen latency ≤4 days) require measurement after a real ingestion run against the full lake, which this PR does not perform.
- Does not touch #544 or #546 — those remain separate, unmerged concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5WwtWgTATnLM7eucvnJmW
