### PR TITLE
docs(architecture): persist PNCP async-acquisition boundary as global invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,29 @@ python3 tools/dod_controller.py report
 - Um item por vez (máx. 2 pré-requisitos). Spec Kit: integração `grok`, workflow `dod-convergence`.
 - Constituição: `.specify/memory/constitution.md`.
 
+## Fronteira de aquisição PNCP (invariante global, leitura obrigatória)
+
+A VPS/Data Lake é a fronteira de aquisição da CONFENGE. PNCP live é upstream
+assíncrono: toda família de dados segue `fonte oficial → coletor resiliente
+na VPS → raw/CAS → Data Lake canônico → consumidor`; o consumidor lê apenas
+o estado persistido.
+
+Proibido: qualquer consumidor (campanha, relatório, view, Warmbly, web-cfg,
+meetcfg, ou **esta sessão**) depender de PNCP live. Proibido criar um
+segundo caminho de aquisição fora da VPS/Data Lake. Proibido manter o
+polling manual (`--from-pncp` ou equivalente) como operação permanente: um
+coletor novo, após provado com um payload real, migra para job na VPS com
+timer, retry/backoff, checkpoint/resume e idempotência.
+
+Chamada PNCP live nesta sessão só é legítima para discovery técnico, captura
+do primeiro payload real de uma família nova, teste/canário de nova
+integração, ou diagnóstico excepcional. PNCP indisponível não bloqueia
+trabalho downstream sobre dados já persistidos; ausência de dado novo é
+`UNKNOWN`/`STALE`, nunca inventada.
+
+Lei: ADR-039 §"Extensão — fronteira de aquisição assíncrona (global)".
+Preflight: `python3 -m scripts.ops.check_confenge_campaign_plan --file <arquivo>`.
+
 ## PR governance (fail-closed)
 
 Before opening or marking ready for review:

--- a/docs/architecture/adr/ADR-039-confenge-pncp-outbound-decoupling.md
+++ b/docs/architecture/adr/ADR-039-confenge-pncp-outbound-decoupling.md
@@ -103,6 +103,75 @@ Saúde da fonte ≠ prontidão do Data Lake. Um crawler `STALE` com Data Lake
 íntegro não bloqueia o plano comercial; um crawler `FRESH` com Data Lake
 inválido não o autoriza.
 
+## Extensão — fronteira de aquisição assíncrona (global, 2026-09-05)
+
+*Origem: EXTRA-HOMOLOGATION-LIVE-EVIDENCE-DISCOVERY-01 (#545/#554/#568).
+Generaliza a Decisão acima — não a substitui, não cria autoridade concorrente.*
+
+A Decisão original tratou o plano **comercial** (systemd cascade, target-fit,
+contact-cycle, feed-cycle). O mesmo princípio é, por construção, uma
+invariante de arquitetura do extra-cli inteiro, não uma regra local do
+outbound comercial:
+
+1. **A VPS/Data Lake é a fronteira de aquisição da CONFENGE.** Proibido
+   qualquer consumidor — campanhas comerciais, relatórios, views, Warmbly,
+   web-cfg, meetcfg, ou sessões de coding agents — depender da
+   disponibilidade síncrona do PNCP.
+2. **PNCP live é upstream assíncrono do Data Lake.** Sua indisponibilidade
+   pode atrasar a atualização de uma família de dados, mas não pode
+   transformar uma sessão CLI nem um consumidor downstream em cliente direto
+   obrigatório do PNCP.
+3. **Toda nova família de dados segue o mesmo fluxo:**
+   `PNCP/fonte oficial → coletor resiliente executado na VPS → raw/CAS quando
+   aplicável → persistência canônica no Data Lake → consumidores`. O
+   consumidor lê **apenas** o estado persistido.
+4. **Chamadas PNCP live feitas por coding agents são permitidas SOMENTE
+   para:** discovery técnico; captura do primeiro payload real; teste/canário
+   de uma nova integração; diagnóstico excepcional. Elas **não** constituem
+   arquitetura operacional, freshness comercial, requisito recorrente de
+   sessão, nem fonte normal de um consumidor.
+5. **Após um novo coletor ser validado contra pelo menos um payload oficial
+   real, a próxima etapa obrigatória é operacionalizá-lo na VPS** com:
+   timer/job próprio e resiliente; retry/backoff; checkpoint/resume; raw
+   archive/CAS quando cabível; observabilidade/freshness próprios;
+   idempotência; persistência no Data Lake. Proibido manter um caminho
+   manual de captura (ex.: `--from-pncp` opt-in por linha de comando) como
+   caminho operacional permanente — ele é apenas o canário que prova o
+   parser antes do job.
+6. **Se o PNCP estiver indisponível:** consumidores continuam usando o
+   último estado persistido, com recência/freshness declaradas; ausência de
+   dado novo permanece `UNKNOWN`/`STALE` conforme o contrato da família;
+   nenhuma informação é inventada; a indisponibilidade upstream não bloqueia
+   trabalho downstream que possa legitimamente usar dados já persistidos.
+7. **Exceção explícita (gate de aceitação, não dependência arquitetural):**
+   para uma família nova que nunca foi coletada (caso #545), é legítimo dizer
+   que `LIVE_PARSER_PROVEN` ainda falta até existir um payload oficial real.
+   Isso é um gate de **aceitação do coletor**, não uma dependência
+   arquitetural do produto. Depois de provado uma vez, a coleta migra para a
+   VPS e deixa de depender de sessões CLI.
+
+**Terminologia adicional (soma à tabela acima, não a substitui):**
+
+| Termo | Uso |
+|-------|-----|
+| Segundo caminho de aquisição | **proibido** — toda coleta PNCP passa pelo coletor resiliente na VPS |
+| Canário de payload | prova o parser uma vez; **não** é operação permanente |
+| Polling PNCP por sessão | **proibido** como operação normal de qualquer consumidor |
+
+**Preflight:** `python3 -m scripts.ops.check_confenge_campaign_plan --file <arquivo>`
+passa a rejeitar (regras `consumer_depends_on_pncp_live`,
+`session_pncp_polling_as_normal_operation`,
+`second_acquisition_path_outside_lake`,
+`canary_payload_as_permanent_operation`) qualquer plano que reintroduza estas
+quatro violações, para qualquer consumidor — não só o outbound comercial.
+
+**Para #568 especificamente:** o polling CLI usado para validar o candidato
+isolado de #545 foi apenas canário de validação (ponto 4 acima). Não deve
+continuar como polling indefinido por sessão. Após o primeiro payload real e
+o parser provado, a próxima ação é projetar o job VPS que coleta resultados
+periodicamente para `pncp_procurement_results`. Consumidores futuros de
+homologação devem ler essa tabela — nunca chamar o PNCP diretamente.
+
 ## Consequências
 
 - Uma indisponibilidade do PNCP degrada observabilidade, não receita.

--- a/scripts/ops/confenge_commercial_plane.py
+++ b/scripts/ops/confenge_commercial_plane.py
@@ -498,6 +498,40 @@ RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
             r"(?i)(PNCP\s+FRESH|status\s*=\s*FRESH).{0,80}(contact discovery|CONTACT_DISCOVERY)"
         ),
     ),
+    # PNCP async acquisition boundary (extends ADR-039 beyond the commercial
+    # plane: same invariant applies to every consumer — Warmbly, web-cfg,
+    # meetcfg, reports/views, and coding agent sessions).
+    (
+        "consumer_depends_on_pncp_live",
+        re.compile(
+            r"(?is)(consumidor|warmbly|web-?cfg|meetcfg|ciclo\s+comercial|commercial\s+cycle|"
+            r"campanha|sess[aã]o)"
+            r".{0,120}(depend\w*|requer\w*|precisa\w*|obrigat[oó]rio)"
+            r".{0,80}PNCP\s+(live|ao\s+vivo)"
+        ),
+    ),
+    (
+        "session_pncp_polling_as_normal_operation",
+        re.compile(
+            r"(?is)((toda|cada)\s+sess[aã]o.{0,80}(polling|consultar?|chamar?).{0,40}PNCP"
+            r"|PNCP\s+live\s+(é|e)\s+fonte\s+normal\s+d[oa]\s+consumidor)"
+        ),
+    ),
+    (
+        "second_acquisition_path_outside_lake",
+        re.compile(
+            r"(?is)segund[oa]\s+(caminho|fonte|pipeline)\s+de\s+aquisi[cç][aã]o"
+            r".{0,100}(fora|sem\s+passar).{0,60}(VPS|Data\s*Lake)"
+        ),
+    ),
+    (
+        "canary_payload_as_permanent_operation",
+        re.compile(
+            r"(?is)(--from-pncp|polling\s+manual|can[aá]rio)"
+            r".{0,100}(opera[cç][aã]o\s+permanente|caminho\s+operacional\s+permanente|"
+            r"substitui\s+o\s+coletor)"
+        ),
+    ),
 )
 
 

--- a/tests/fixtures/confenge_campaign_plans/bad/08-consumer-depends-on-pncp-live.md
+++ b/tests/fixtures/confenge_campaign_plans/bad/08-consumer-depends-on-pncp-live.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+O ciclo comercial do Warmbly depende de PNCP live estar disponível antes de publicar contatos e feed.

--- a/tests/fixtures/confenge_campaign_plans/bad/09-session-pncp-polling-normal.md
+++ b/tests/fixtures/confenge_campaign_plans/bad/09-session-pncp-polling-normal.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+Toda sessão de coding agent deve consultar PNCP diretamente como parte da operação normal do produto.

--- a/tests/fixtures/confenge_campaign_plans/bad/10-second-acquisition-path.md
+++ b/tests/fixtures/confenge_campaign_plans/bad/10-second-acquisition-path.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+Vamos criar um segundo caminho de aquisição fora da VPS, chamando PNCP direto sem passar pelo Data Lake.

--- a/tests/fixtures/confenge_campaign_plans/bad/11-canary-as-permanent-operation.md
+++ b/tests/fixtures/confenge_campaign_plans/bad/11-canary-as-permanent-operation.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+O polling manual via --from-pncp passa a ser a operação permanente do coletor de resultados de homologação.

--- a/tests/fixtures/confenge_campaign_plans/good/07-consumer-reads-datalake-only.md
+++ b/tests/fixtures/confenge_campaign_plans/good/07-consumer-reads-datalake-only.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+Proibido qualquer consumidor (Warmbly, web-cfg, meetcfg, campanha) depender de PNCP live; ciclo comercial lê apenas o Data Lake persistido.

--- a/tests/fixtures/confenge_campaign_plans/good/08-no-session-polling.md
+++ b/tests/fixtures/confenge_campaign_plans/good/08-no-session-polling.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+Proibido tratar polling PNCP por sessão como operação normal do produto; cada sessão de coding agent chama PNCP apenas para diagnóstico excepcional.

--- a/tests/fixtures/confenge_campaign_plans/good/09-single-acquisition-path.md
+++ b/tests/fixtures/confenge_campaign_plans/good/09-single-acquisition-path.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+Proibido criar um segundo caminho de aquisição fora da VPS ou do Data Lake; toda coleta PNCP passa pelo coletor resiliente na VPS.

--- a/tests/fixtures/confenge_campaign_plans/good/10-canary-not-permanent.md
+++ b/tests/fixtures/confenge_campaign_plans/good/10-canary-not-permanent.md
@@ -1,0 +1,3 @@
+# Plano ativo — CURRENT
+
+Proibido manter o polling manual via --from-pncp como operação permanente; é apenas canário de validação do primeiro payload real, e após provado migra para job na VPS.

--- a/tests/test_confenge_campaign_plan.py
+++ b/tests/test_confenge_campaign_plan.py
@@ -25,9 +25,9 @@ def _run(path: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_seven_negative_fixtures_rejected_twice() -> None:
+def test_eleven_negative_fixtures_rejected_twice() -> None:
     files = sorted(BAD.glob("*.md"))
-    assert len(files) == 7
+    assert len(files) == 11
     for path in files:
         first = _run(path)
         second = _run(path)
@@ -37,9 +37,9 @@ def test_seven_negative_fixtures_rejected_twice() -> None:
         assert linter_main(["--file", str(path)]) == 1
 
 
-def test_six_positive_fixtures_accepted_twice() -> None:
+def test_ten_positive_fixtures_accepted_twice() -> None:
     files = sorted(GOOD.glob("*.md"))
-    assert len(files) == 6
+    assert len(files) == 10
     for path in files:
         first = _run(path)
         second = _run(path)
@@ -54,6 +54,34 @@ def test_wait_for_pncp_plan_is_rejected() -> None:
     verdict = classify_plan(text, path="wait")
     assert verdict.accepted is False
     assert "wait_pncp_before_feed" in verdict.violations
+
+
+def test_consumer_depends_on_pncp_live_is_rejected() -> None:
+    text = (BAD / "08-consumer-depends-on-pncp-live.md").read_text(encoding="utf-8")
+    verdict = classify_plan(text, path="consumer-dep")
+    assert verdict.accepted is False
+    assert "consumer_depends_on_pncp_live" in verdict.violations
+
+
+def test_session_pncp_polling_as_normal_operation_is_rejected() -> None:
+    text = (BAD / "09-session-pncp-polling-normal.md").read_text(encoding="utf-8")
+    verdict = classify_plan(text, path="session-poll")
+    assert verdict.accepted is False
+    assert "session_pncp_polling_as_normal_operation" in verdict.violations
+
+
+def test_second_acquisition_path_outside_lake_is_rejected() -> None:
+    text = (BAD / "10-second-acquisition-path.md").read_text(encoding="utf-8")
+    verdict = classify_plan(text, path="second-path")
+    assert verdict.accepted is False
+    assert "second_acquisition_path_outside_lake" in verdict.violations
+
+
+def test_canary_payload_as_permanent_operation_is_rejected() -> None:
+    text = (BAD / "11-canary-as-permanent-operation.md").read_text(encoding="utf-8")
+    verdict = classify_plan(text, path="canary-permanent")
+    assert verdict.accepted is False
+    assert "canary_payload_as_permanent_operation" in verdict.violations
 
 
 def test_historical_cascade_is_accepted() -> None:


### PR DESCRIPTION
## Summary

Persists, as a global architectural invariant (not #545-specific documentation), the deliberation reached while working #545/#554/#568: the VPS/Data Lake is CONFENGE's single acquisition boundary for *every* consumer, and PNCP live is always an async upstream to it.

- **Extends ADR-039** (no competing authority) with a new section generalizing its Decision from the commercial-plane cascade to the whole product: consumers (commercial campaigns, reports/views, Warmbly, web-cfg, meetcfg, and coding agent sessions) never depend on synchronous PNCP; a new collector, once proven against a real payload, must migrate to a resilient VPS job — manual polling is a canary, never the permanent path.
- **Adds a short imperative section to root `AGENTS.md`** so every coding agent reads the invariant at session start.
- **Extends the existing campaign-plan linter** (`scripts/ops/confenge_commercial_plane.py`) with four new regex rules, each with a dedicated regression test and bad/good fixture pair:
  - `consumer_depends_on_pncp_live`
  - `session_pncp_polling_as_normal_operation`
  - `second_acquisition_path_outside_lake`
  - `canary_payload_as_permanent_operation`

## Validation

- 19/19 tests pass (`tests/test_confenge_commercial_plane.py` + `tests/test_confenge_campaign_plan.py`), including all 4 new violation-specific tests and the updated 11-bad/10-good fixture counts.
- `ruff check` clean.
- `python3 -m scripts.ops.check_confenge_campaign_plan --root .` still ACCEPTs the existing active plan docs.
- Both edited docs (`AGENTS.md`, ADR-039) were run through `classify_plan` themselves and ACCEPT — the invariant's own text doesn't trip the rules it defines.

## Context

References #545 (new PNCP-results family, still being proven live), #554 (the discovery that surfaced the gap), and #568 (the isolated #545 candidate whose manual `--from-pncp` CLI polling was the canary that prompted this generalization — it must not become a permanent operational path once proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5WwtWgTATnLM7eucvnJmW
