### PR TITLE
fix(confenge): preserve persisted watermark bindings for #468

### DIFF
--- a/DOD.md
+++ b/DOD.md
@@ -52,6 +52,11 @@ ADR: ADR-039 Accepted/Effective. Runbook:
 `docs/ops/confenge-commercial-plane-authority.md`.
 Preflight: `python3 -m scripts.ops.check_confenge_commercial_plane`.
 
+- [ ] #468: provar binding CDC/decisões preservado sob telemetria PNCP `FRESH`,
+  inclusive observação anterior ou igual ao full reconcile. A correção não
+  encerra o incidente: exige SHA implantado, novo checkpoint do founder e dois
+  ciclos novos. Evidência: `docs/ops/handoff-2026-09-05-468-persisted-watermark-binding.md`.
+
 ### Identidade contratual CONFENGE / incidente #468 (2026-09-02)
 
 - [ ] Aceitar a correção de identidade somente após merge no `main`, CI do SHA

--- a/docs/architecture/adr/ADR-039-confenge-pncp-outbound-decoupling.md
+++ b/docs/architecture/adr/ADR-039-confenge-pncp-outbound-decoupling.md
@@ -75,9 +75,12 @@ DSN. Agora é incondicional com DSN, independente da saúde da fonte:
 - envelope de source health ausente ou malformado (build inauditável);
 - recência da própria publicação (`generated_at`, watermark do datalake).
 
-Apenas três comportamentos permanecem acoplados ao PNCP, e só quando o contrato
-é `FRESH`: a ordenação `last_full_reconcile >= source_observed_at`, a reescrita
-de `source_watermark` e o carimbo `target_fit_observation_run_id`.
+O binding comercial conserva o watermark CDC e os watermarks de decisão lidos
+do Data Lake. Mesmo `FRESH`, `source_observed_at` é apenas telemetria: não
+substitui esses valores nem carimba um run de observação nas decisões. A
+recência do full reconcile continua sendo provada pelo estado persistido.
+Correção causal do incidente #468; prova e gate de retomada em
+`docs/ops/handoff-2026-09-05-468-persisted-watermark-binding.md`.
 
 ## Escopo explicitamente fora
 

--- a/docs/ops/handoff-2026-09-05-468-persisted-watermark-binding.md
+++ b/docs/ops/handoff-2026-09-05-468-persisted-watermark-binding.md
@@ -1,0 +1,74 @@
+# #468 — persisted watermark binding correction
+
+Status: VERIFIED locally; CI/merge/deploy pending. This is an intermediate gate
+in the same REV-05 campaign, not incident acceptance.
+
+## Cause and scope
+
+At base `d2395642be0c91c21a2216dff005dfee306aecd7`, the artifact SHA verifier
+passes. The runtime defect is separate: `_published_target_fit_snapshot`
+replaces persisted CDC and per-decision watermarks with PNCP `source_observed_at`
+when health is FRESH and the full reconcile timestamp is at least that recent.
+The exporter then binds the result to telemetry without comparing it with CDC.
+Existing tests encoded this rewrite and must instead enforce the persisted
+binding required by DOD, ADR-039 and the founder checkpoint.
+
+The previous read-only probe on real ec-prod state, with explicitly synthetic
+health and no publication, returned `2026-09-05T18:12:44.301337+00:00` instead
+of persisted `2026-09-05T05:24:26.408149+02:00`. The invalid rewrite was also
+confirmed by an independent read-only code trace.
+
+The smallest correction removes telemetry re-stamping and rejects absent CDC
+before the exporter can substitute publication time. Classification,
+membership, coverage thresholds, queue gates and outbound policy are unchanged.
+No acquisition, data-release features, SMTP or dispatch changes are included.
+
+## Evidence and validation
+
+Test-first reproduction:
+
+- `python3 -m pytest tests/test_pncp_outbound_decoupling.py tests/confenge_outreach_pipeline/test_pipeline.py -q --no-cov --tb=short -x`
+  failed on the old FRESH-before-reconcile path: returned observation
+  `2026-08-25T02:42:00Z`, expected persisted CDC `2026-08-24T03:26:43Z`.
+- A missing-CDC regression failed before adding the guard (`DID NOT RAISE`);
+  the old exporter fallback otherwise minted `generated_at` as the watermark.
+- `python3 -m pytest tests/test_confenge_commercial_plane.py -k telemetry_watermark_restamp -q -o addopts= --tb=short`
+  failed twice before the preflight correction: the old preflight allowed both
+  CDC and decision-watermark replacement under FRESH.
+
+After correction: 146 focused tests and 206 commercial tests passed with no
+skips; repository Ruff and canonical mypy selections succeeded. Preflight
+including host OnSuccess readback and campaign-plan linter succeeded.
+The FRESH matrix actually passes observations before/equal/after full reconcile,
+timezone-naive, missing and malformed timestamps; persisted CDC and decision
+watermarks remain unchanged. Missing/blank CDC fails closed. Existing population,
+coverage, unresolved-queue and rejected-publication tests still pass.
+
+No changes to the artifact verifier, freeze policy or historical evidence are
+needed: neither corrected runtime file belongs to the discovered frozen input
+set. Verify the existing artifact binding again at the committed and deployed
+SHA; do not claim historical freeze validation proves new runtime behavior.
+
+The final PR/deployment record must provide exact HEAD, real required checks,
+merged SHA, verifier result and the read-only runtime binding probe. Automated
+CodeRabbit review was unavailable (CLI signed out); the delegated reviewer also
+hit its usage limit. Neither is claimed as a completed review. Local code review
+and actual repository gates remain required.
+
+## Resume gate
+
+The old checkpoint `5553292824` is invalid for changed code. After verified
+merge/deploy, the founder must personally post a new checkpoint in #468 bound
+to the deployed SHA. Until then CYCLE_1 and CYCLE_2 remain
+`WAITING_NEW_FOUNDER_CHECKPOINT`; do not initiate commercial jobs or enable timers.
+
+Previous aborted cohort: `target-confirmed-auto-20260905T181512Z`;
+919 succeeded and 7059 cancelled, no jobs remaining active. Never reuse it as
+acceptance evidence. Existing contact-cycle state still references this aborted
+cohort; a future authorized execution must use fresh cycle state through the
+existing `--state` option, not resume that cohort.
+
+Preserve SHADOW, paused dispatch and auto-send=false. The previous feed manifest
+SHA256 is `41faa0c3028f55c90f6e0865bec33bf765c4146d25ed14771696715a11f8e298`.
+SMTP delta must remain zero. Backout is the prior immutable release pin;
+no database migration is involved.

--- a/docs/stories/story-468-persisted-watermark-binding.md
+++ b/docs/stories/story-468-persisted-watermark-binding.md
@@ -1,0 +1,40 @@
+# #468 — Preserve persisted watermarks in commercial binding
+
+Status: Ready for Review
+
+## Scope and authority
+
+The founder authorized the smallest causal correction after the REV-05 Phase A
+abort at `d2395642be0c91c21a2216dff005dfee306aecd7`. PNCP health is telemetry;
+commercial bindings must identify persisted Data Lake state. The old checkpoint
+is invalid for changed code. No cycles until a new founder checkpoint is posted.
+
+This fix changes only invalid binding provenance. Classification, target-fit
+membership, coverage, commercial policy, SMTP and dispatch are outside scope.
+No data-release features or other PR patches belong in this change.
+
+## Acceptance
+
+- Reproduce a FRESH telemetry observation replacing persisted CDC and decision
+  watermarks before the fix; preserve both persisted values after the fix.
+- Adversarial tests cover telemetry before/equal/after the full reconcile,
+  absent/malformed telemetry, and invalid Data Lake states without weakening gates.
+- Artifact binding verifier and commercial-plane preflights pass; required
+  GitHub checks actually succeed on the final PR HEAD before merge.
+- Deploy the merged SHA immutably, recheck runtime provenance and binding,
+  preserve the feed and paused outbound, and return the exact new checkpoint text.
+- #468 acceptance remains pending two wholly new post-checkpoint cycles.
+
+## File ownership
+
+- Implementation: `scripts/confenge_outreach_pipeline/pipeline.py` and directly
+  affected regression tests.
+- Coordinator: DOD, ADR-039, this story, operational handoff, PR and deployment.
+
+## Validation
+
+Red reproduced telemetry replacement of persisted CDC and acceptance of absent
+CDC. Green: 146 focused regression tests plus 206 commercial tests; repository
+Ruff and canonical mypy selections succeed. Commercial-plane preflight including
+host OnSuccess readback succeeds. CI, merge, deployment and a new founder
+checkpoint remain pending; this story does not accept #468.

--- a/scripts/confenge_outreach_pipeline/pipeline.py
+++ b/scripts/confenge_outreach_pipeline/pipeline.py
@@ -481,28 +481,13 @@ def _published_target_fit_snapshot(
 
     raw_cnpjs = [str(row.get("cnpj14") or row.get("cnpj") or "") for row in rows]
     lookup_cnpjs = sorted({cnpj for raw in raw_cnpjs for cnpj in (raw, canonical_cnpj14(raw)) if cnpj})
-    # A FRESH source lets the snapshot be re-stamped with the live observation.
-    # A STALE/UNKNOWN/absent source only means there is no new observation to
-    # project: the persisted decisions below remain the operational authority.
-    freshness = authoritative_source_freshness or {}
-    source_observed_at = ""
-    observed_dt: datetime | None = None
-    if freshness.get("status") == "FRESH":
-        source_observed_at = str(freshness.get("source_observed_at") or "").strip()
-        if not source_observed_at:
-            raise ValueError("FRESH authoritative PNCP source is missing source_observed_at")
-        try:
-            observed_dt = datetime.fromisoformat(source_observed_at.replace("Z", "+00:00"))
-        except ValueError as exc:
-            raise ValueError("authoritative PNCP source_observed_at is invalid") from exc
-        if observed_dt.tzinfo is None:
-            raise ValueError("authoritative PNCP source_observed_at must be timezone-aware")
-
     conn = connect(dsn, readonly=True)
     try:
         published = load_published_index(conn, cnpj14s=lookup_cnpjs)
         control = get_control(conn, "cdc_watermark")
         datalake_watermark = str(control.get("watermark") or "").strip() or None
+        if not datalake_watermark:
+            raise ValueError("persisted CDC watermark is missing")
         # Datalake integrity is unconditional. These are the fail-closed gates
         # over the persisted population itself, so they must hold whatever the
         # live source is doing: an incomplete national reconcile, an unexplained
@@ -526,14 +511,6 @@ def _published_target_fit_snapshot(
         unresolved = sum(int(queue.get(status) or 0) for status in ("pending", "processing", "retry", "dead"))
         if unresolved:
             raise ValueError(f"target-fit store has {unresolved} unresolved queue items")
-        project_live_observation = False
-        if observed_dt is not None and last_full_dt >= observed_dt:
-            # Reconcile already covers this PNCP observation: stamp it.
-            # A newer FRESH observation is telemetry only — ADR-039: the
-            # commercial plane publishes the last complete persisted reconcile
-            # and does not wait for another target-fit pass after PNCP live.
-            datalake_watermark = source_observed_at
-            project_live_observation = True
     finally:
         conn.close()
 
@@ -547,16 +524,9 @@ def _published_target_fit_snapshot(
             continue
         if not str(decision.get("source_watermark") or decision.get("target_fit_source_watermark") or "").strip():
             continue
-        projected = dict(decision)
-        if project_live_observation and source_observed_at:
-            projected["target_fit_evidence_watermark"] = str(
-                decision.get("source_watermark") or decision.get("target_fit_source_watermark") or ""
-            )
-            projected["source_watermark"] = source_observed_at
-            projected["target_fit_observation_run_id"] = str((authoritative_source_freshness or {}).get("run_id") or "")
         snapshot.append(
             {
-                **projected,
+                **decision,
                 "cnpj14": canonical,
                 "cnpj_raiz": canonical[:8],
                 "company_key": f"cnpj_root:{canonical[:8]}",

--- a/scripts/ops/confenge_commercial_plane.py
+++ b/scripts/ops/confenge_commercial_plane.py
@@ -322,12 +322,16 @@ def evaluate_commercial_code(root: Path) -> list[Check]:
             envelope_ok = True
         if _FRESH_ABORT.search(text):
             hits.append(str(rel))
-    # pipeline.py restamps watermark only when status == FRESH; that is allowed.
+    # Even FRESH telemetry must not replace persisted binding watermarks.
     pipeline = root / "scripts/confenge_outreach_pipeline/pipeline.py"
     if pipeline.is_file():
         text = _read(pipeline)
-        if "if freshness.get(\"status\") == \"FRESH\"" not in text:
-            hits.append("pipeline_missing_fresh_restamp_guard")
+        if re.search(
+            r'''(?:\bdatalake_watermark|\[["'](?:source_watermark|target_fit_source_watermark)["']\])'''
+            r"\s*=\s*source_observed_at\b",
+            text,
+        ):
+            hits.append("pipeline_telemetry_rewrites_persisted_watermark")
         abort_on_non_fresh = re.search(
             r'if freshness\.get\("status"\) != "FRESH"',
             text,

--- a/tests/confenge_outreach_pipeline/test_pipeline.py
+++ b/tests/confenge_outreach_pipeline/test_pipeline.py
@@ -479,7 +479,7 @@ def test_published_decision_without_a_watermark_is_tombstoned_not_exported(monke
     assert [row["cnpj_raiz"] for row in snapshot] == ["11222333"]
 
 
-def test_fresh_closed_source_reobserves_full_target_fit_without_erasing_evidence_watermark(
+def test_fresh_closed_source_preserves_persisted_target_fit_binding(
     monkeypatch,
 ) -> None:
     import scripts.confenge_outreach_pipeline.pipeline as pipeline
@@ -532,10 +532,10 @@ def test_fresh_closed_source_reobserves_full_target_fit_without_erasing_evidence
 
     assert conn.closed is True
     assert authority == "published_target_fit_store"
-    assert watermark == "2026-08-25T02:42:00Z"
-    assert snapshot[0]["source_watermark"] == "2026-08-25T02:42:00Z"
-    assert snapshot[0]["target_fit_evidence_watermark"] == "2026-08-16T08:30:23Z"
-    assert snapshot[0]["target_fit_observation_run_id"] == "contracts-live-1"
+    assert watermark == "2026-08-24T03:26:43Z"
+    assert snapshot[0]["source_watermark"] == "2026-08-16T08:30:23Z"
+    assert "target_fit_evidence_watermark" not in snapshot[0]
+    assert "target_fit_observation_run_id" not in snapshot[0]
 
 
 def test_target_fit_reobservation_fails_closed_until_full_reconcile_and_queue_drain(

--- a/tests/test_confenge_commercial_plane.py
+++ b/tests/test_confenge_commercial_plane.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts.ops.check_confenge_commercial_plane import main as preflight_main
 from scripts.ops.confenge_commercial_plane import (
     apply_host_readback,
@@ -123,6 +125,25 @@ def test_stale_as_commercial_block_fails(tmp_path: Path) -> None:
     pipeline.write_text(
         pipeline.read_text(encoding="utf-8")
         + '\nif freshness.get("status") != "FRESH":\n    raise ValueError("stale blocks commerce")\n',
+        encoding="utf-8",
+    )
+    ev = evaluate_repo(clone)
+    assert any(c.name == "pncp_fresh_not_commercial_gate" and not c.ok for c in ev.checks)
+
+
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        "datalake_watermark = source_observed_at",
+        'projected["source_watermark"] = source_observed_at',
+    ],
+)
+def test_telemetry_watermark_restamp_fails(tmp_path: Path, assignment: str) -> None:
+    clone = _minimal_tree(tmp_path)
+    pipeline = clone / "scripts/confenge_outreach_pipeline/pipeline.py"
+    pipeline.write_text(
+        pipeline.read_text(encoding="utf-8")
+        + '\nif freshness.get("status") == "FRESH":\n    ' + assignment + "\n",
         encoding="utf-8",
     )
     ev = evaluate_repo(clone)

--- a/tests/test_pncp_outbound_decoupling.py
+++ b/tests/test_pncp_outbound_decoupling.py
@@ -34,7 +34,13 @@ def _healthy_coverage() -> dict[str, object]:
     }
 
 
-def _wire(monkeypatch, *, coverage: dict[str, object], queue: dict[str, int]) -> _FakeConnection:
+def _wire(
+    monkeypatch,
+    *,
+    coverage: dict[str, object],
+    queue: dict[str, int],
+    cdc_watermark: str | None = "2026-08-24T03:26:43Z",
+) -> _FakeConnection:
     import scripts.confenge_outreach_pipeline.pipeline as pipeline
     import scripts.confenge_target_fit.db as target_fit_db
 
@@ -55,7 +61,7 @@ def _wire(monkeypatch, *, coverage: dict[str, object], queue: dict[str, int]) ->
     monkeypatch.setattr(
         pipeline,
         "get_control",
-        lambda connection, key: ({"watermark": "2026-08-24T03:26:43Z"} if key == "cdc_watermark" else coverage),
+        lambda connection, key: ({"watermark": cdc_watermark} if key == "cdc_watermark" else coverage),
     )
     monkeypatch.setattr(pipeline, "queue_counts", lambda connection: queue)
     return conn
@@ -98,8 +104,22 @@ def test_an_unreachable_source_is_indistinguishable_from_a_degraded_one(monkeypa
     assert [row["cnpj_raiz"] for row in snapshot] == ["11222333"]
 
 
-def test_a_fresh_source_still_reobserves_the_snapshot(monkeypatch) -> None:
-    """Regression guard: the FRESH path must stay byte-for-byte compatible."""
+@pytest.mark.parametrize(
+    "source_observed_at",
+    [
+        "2026-08-25T02:42:00Z",  # before the persisted full reconcile
+        "2026-08-25T02:45:00Z",  # equal to the persisted full reconcile
+        "2026-08-25T02:50:00Z",  # after the persisted full reconcile
+        "2026-08-25T02:42:00",  # timezone-naive telemetry must not gate it
+        "",  # absent telemetry must not gate the persisted snapshot
+        "not-a-timestamp",  # malformed telemetry must not gate it either
+    ],
+)
+def test_source_telemetry_never_rewrites_persisted_binding(
+    source_observed_at: str,
+    monkeypatch,
+) -> None:
+    """PNCP freshness is telemetry, never persisted binding provenance."""
     _wire(monkeypatch, coverage=_healthy_coverage(), queue={"done": 407_513})
 
     snapshot, _, watermark = _published_target_fit_snapshot(
@@ -108,15 +128,36 @@ def test_a_fresh_source_still_reobserves_the_snapshot(monkeypatch) -> None:
         authoritative_source_freshness={
             "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
             "status": "FRESH",
-            "source_observed_at": "2026-08-25T02:42:00Z",
+            "source_observed_at": source_observed_at,
             "run_id": "contracts-live-1",
         },
     )
 
-    assert watermark == "2026-08-25T02:42:00Z"
-    assert snapshot[0]["source_watermark"] == "2026-08-25T02:42:00Z"
-    assert snapshot[0]["target_fit_evidence_watermark"] == "2026-08-16T08:30:23Z"
-    assert snapshot[0]["target_fit_observation_run_id"] == "contracts-live-1"
+    assert watermark == "2026-08-24T03:26:43Z"
+    assert snapshot[0]["source_watermark"] == "2026-08-16T08:30:23Z"
+    assert "target_fit_evidence_watermark" not in snapshot[0]
+    assert "target_fit_observation_run_id" not in snapshot[0]
+
+
+@pytest.mark.parametrize("cdc_watermark", [None, "", "   "])
+def test_a_missing_persisted_cdc_watermark_fails_closed(cdc_watermark: str | None, monkeypatch) -> None:
+    _wire(
+        monkeypatch,
+        coverage=_healthy_coverage(),
+        queue={"done": 407_513},
+        cdc_watermark=cdc_watermark,
+    )
+
+    with pytest.raises(ValueError, match="persisted CDC watermark is missing"):
+        _published_target_fit_snapshot(
+            [{"cnpj14": "11222333000181"}],
+            dsn="postgresql://unused",
+            authoritative_source_freshness={
+                "contract_version": "PNCP_CONTRACT_FRESHNESS/1.0",
+                "status": "FRESH",
+                "source_observed_at": "2026-08-25T02:42:00Z",
+            },
+        )
 
 
 @pytest.mark.parametrize("status", [*DEGRADED_STATUSES, "FRESH"])


### PR DESCRIPTION
## Problem and correction

With PNCP telemetry marked FRESH, the commercial snapshot replaced persisted CDC and decision watermarks with `source_observed_at` when the observation preceded the full reconcile. The feed could therefore claim a binding absent from the Data Lake. This PR preserves both persisted watermarks for every telemetry state and rejects missing CDC before the exporter's timestamp fallback. The commercial-plane preflight now rejects the prohibited rewrite it previously required.

HEAD SHA: `04489e8aa70e09145235c1c3059baa357e218170`

Classification, target membership, coverage thresholds and unresolved-queue checks are unchanged. No migrations, acquisition changes, SMTP, dispatch, data-release features or source-PR patches are included. Historical frozen evidence is unchanged; the artifact binding verifier succeeds for this HEAD without stale-evidence allowance.

## Validation

Regression tests reproduced the invalid telemetry replacement and absent-CDC fallback before correction. The preflight regression also failed before correction. After correction: 146 focused tests and 206 commercial tests passed with no skips; repository Ruff, canonical mypy selections, commercial-plane preflight with host OnSuccess readback, and campaign-plan lint succeeded. GitHub checks must complete on the exact HEAD before merge.

The source-observation matrix covers before/equal/after reconcile, timezone-naive, absent and malformed telemetry. Existing incomplete-coverage, unresolved-queue, stale/partial/error and publication-preservation cases remain covered.

CodeRabbit CLI is signed out and the delegated review hit its usage limit; neither is claimed as completed review. Manual diff review and actual repository checks are the recorded validation.

## Operations and rollback

After green checks, merge and deploy the immutable merged SHA without starting commercial cycles or enabling timers. Verify artifact and runtime binding again, retain SHADOW and paused outbound, then return a new founder-checkpoint text. The founder must post it personally before two wholly new REV-05 cycles. The old checkpoint and aborted cohort cannot be reused. Backout: repin the previous immutable release; no database rollback is needed.

Refs #468. This PR does not close the incident.

Story: `docs/stories/story-468-persisted-watermark-binding.md`
Handoff: `docs/ops/handoff-2026-09-05-468-persisted-watermark-binding.md`
