### PR TITLE
fix(confenge): resolve systemd templates during release readback

### DIFF
--- a/deploy/confenge/pin_release.py
+++ b/deploy/confenge/pin_release.py
@@ -312,6 +312,19 @@ def timer_states() -> dict[str, dict[str, str]]:
     }
 
 
+def _systemd_readback_unit(unit: str) -> str:
+    """Return a concrete unit name that systemd can resolve for readback.
+
+    ``systemctl show foo@.service`` succeeds but returns empty properties on
+    the production systemd version.  A synthetic, inactive instance resolves
+    the same template and drop-ins without starting it or changing its enabled
+    state, so verification observes the effective configuration fail-closed.
+    """
+    if unit.endswith("@.service"):
+        return f"{unit.removesuffix('@.service')}@pin-readback.service"
+    return unit
+
+
 def apply(
     sha: str,
     *,
@@ -376,7 +389,8 @@ def verify(
     timeout_start_drift: list[dict[str, str]] = []
     release = f"{RELEASE_ROOT}/{sha}"
     for unit in CHAIN_UNITS:
-        result = _run(["systemctl", "show", unit, "-p", "ExecStart", "--value"], check=False)
+        readback_unit = _systemd_readback_unit(unit)
+        result = _run(["systemctl", "show", readback_unit, "-p", "ExecStart", "--value"], check=False)
         resolved = (result.stdout or "").strip()
         if release not in resolved:
             drift.append({"unit": unit, "resolved": resolved[:400]})
@@ -385,7 +399,8 @@ def verify(
             unsafe_python_path.append({"unit": unit, "resolved": resolved[:400]})
 
         environment = (
-            _run(["systemctl", "show", unit, "-p", "Environment", "--value"], check=False).stdout or ""
+            _run(["systemctl", "show", readback_unit, "-p", "Environment", "--value"], check=False).stdout
+            or ""
         ).strip()
         if f"PYTHONPATH={release}" not in environment:
             drift.append({"unit": unit, "resolved": environment[:400]})
@@ -395,9 +410,12 @@ def verify(
             unsafe_python_path.append({"unit": unit, "resolved": environment[:400]})
 
         working_directory = (
-            _run(["systemctl", "show", unit, "-p", "WorkingDirectory", "--value"], check=False).stdout or ""
+            _run(["systemctl", "show", readback_unit, "-p", "WorkingDirectory", "--value"], check=False).stdout
+            or ""
         ).strip()
-        user = (_run(["systemctl", "show", unit, "-p", "User", "--value"], check=False).stdout or "").strip()
+        user = (
+            _run(["systemctl", "show", readback_unit, "-p", "User", "--value"], check=False).stdout or ""
+        ).strip()
         if not working_directory or working_directory == release or working_directory.startswith(f"{release}/"):
             working_directory_drift.append({"unit": unit, "working_directory": working_directory or "MISSING"})
         else:
@@ -413,7 +431,10 @@ def verify(
         has_timeout, expected_timeout = _source_timeout_start_seconds(unit)
         if has_timeout:
             observed_timeout = (
-                _run(["systemctl", "show", unit, "-p", "TimeoutStartUSec", "--value"], check=False).stdout
+                _run(
+                    ["systemctl", "show", readback_unit, "-p", "TimeoutStartUSec", "--value"],
+                    check=False,
+                ).stdout
                 or ""
             ).strip()
             try:

--- a/tests/test_confenge_release_pin.py
+++ b/tests/test_confenge_release_pin.py
@@ -420,12 +420,15 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
     workdir = tmp_path / "writable"
     workdir.mkdir()
     monkeypatch.setattr(pin, "RELEASE_ROOT", release_root)
+    shown_units: list[str] = []
 
     def fake_run(argv: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
         del check
         if argv[:2] == ["systemctl", "show"]:
+            shown_units.append(argv[2])
             prop = argv[argv.index("-p") + 1]
-            has_timeout, timeout = pin._source_timeout_start_seconds(argv[2])
+            source_unit = argv[2].replace("@pin-readback.service", "@.service")
+            has_timeout, timeout = pin._source_timeout_start_seconds(source_unit)
             values = {
                 "ExecStart": f"{release}/.venv/bin/python -P -m scripts.example",
                 "Environment": f"PYTHONPATH={release} EXTRA_DEPLOYED_SHA={SHA} PYTHONDONTWRITEBYTECODE=1 PYTHONSAFEPATH=1",
@@ -459,6 +462,8 @@ def test_verify_reads_back_isolation_release_and_writable_working_directory(tmp_
     assert report["timeout_start_drift"] == []
     assert report["downstream_timers_scheduled"] == []
     assert report["pncp_service_semantic_drift"] == []
+    assert "extra-contact-discovery-worker@.service" not in shown_units
+    assert "extra-contact-discovery-worker@pin-readback.service" in shown_units
 
 
 @pytest.mark.parametrize(
@@ -489,7 +494,8 @@ def test_verify_fails_closed_on_runtime_isolation_drift(tmp_path, monkeypatch, f
         del check
         if argv[:2] == ["systemctl", "show"]:
             prop = argv[argv.index("-p") + 1]
-            has_timeout, timeout = pin._source_timeout_start_seconds(argv[2])
+            source_unit = argv[2].replace("@pin-readback.service", "@.service")
+            has_timeout, timeout = pin._source_timeout_start_seconds(source_unit)
             values = {
                 "ExecStart": (
                     f"{release}/.venv/bin/python -m scripts.example"


### PR DESCRIPTION
## Recovery #468

Minimal follow-up discovered by the real canonical deploy of `b894d7ddf445d81411d8d46701734d2630b27878`.

`systemctl show extra-contact-discovery-worker@.service` returns empty effective properties on the production systemd version even though its template and concrete instances are correctly loaded. This made the release verifier fail closed after installing the correct drop-in.

This patch reads an inactive synthetic instance of a template (`@pin-readback.service`) so systemd resolves the exact template plus drop-ins without starting or enabling any service. Findings remain reported against the canonical template name.

Validation:
- `tests/test_confenge_release_pin.py`: 63 passed
- ruff: pass
- generated-artifact policy: pass
- PR reviewability: pass

No cycle, feed publication, dispatch, migration, or architecture change.
